### PR TITLE
generic.tests.cfg: Add image_snapshot config for stress_boot

### DIFF
--- a/generic/tests/cfg/stress_boot.cfg
+++ b/generic/tests/cfg/stress_boot.cfg
@@ -8,5 +8,6 @@
     kill_vm_vm1 = no
     kill_vm_gracefully = no
     extra_params += " -snapshot"
+    image_snapshot = yes
     used_cpus = 5
     used_mem = 2560


### PR DESCRIPTION
sharing an image need to boot with "snapshot=on".

Signed-off-by: Shuping Cui scui@redhat.com
