### PR TITLE
qemu.tests.enforce_quit: Update some config for different qemu-kvm version

### DIFF
--- a/qemu/tests/cfg/enforce_quit.cfg
+++ b/qemu/tests/cfg/enforce_quit.cfg
@@ -3,6 +3,12 @@
     start_vm = "no"
     no Host_RHEL.5
     cpu_model_flags = ",enforce"
+    Host_RHEL.6:
+        msg_unavailable = "flag restricted to guest:lacks requested flag"
+        msg_unknow = "not found"
+    Host_RHEL.7:
+        msg_unavailable = "host doesn't support requested feature"
+        msg_unknow = "not found"
     variants:
         - intel_model:
             auto_cpu_model = "no"


### PR DESCRIPTION
since enforce output are different in different qemu-kvm version, so update
these config.

Signed-off-by: Shuping Cui scui@redhat.com
