### PR TITLE
qemu.pci_devices: Remove incorrect configuration

### DIFF
--- a/qemu/tests/cfg/pci_devices.cfg
+++ b/qemu/tests/cfg/pci_devices.cfg
@@ -40,10 +40,6 @@
                     test_setup = "root->bridge->switch->devices"
                 - root_bridge_switch_switch:
                     test_setup = "root->bridge->switch->switch->devices"
-                - root_parallel_root_bridge_switch:
-                    test_setup = "root->devices\n"
-                    test_setup += "   ->bridge->devices\n"
-                    test_setup += "   ->bridge->switch->devices"
     variants:
         - xhci_controller:
             test_device_type = xhci


### PR DESCRIPTION
Hi guys,

I discussed this variant with qemu pci/pcie bus developer and it seems this variant doesn't follow PCI specification nor real-hw usecase, thus it's not and will not be supported by kernel.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
