### PR TITLE
test.iofuzz: some modifications of iofuzz

### DIFF
--- a/generic/tests/cfg/iofuzz.cfg
+++ b/generic/tests/cfg/iofuzz.cfg
@@ -1,4 +1,8 @@
 - iofuzz: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu libvirt
+    backup_image_before_testing = yes
+    backup_image_on_check_error = yes
+    restore_image = yes
+    restore_image_on_check_error = yes
     only Linux
     type = iofuzz


### PR DESCRIPTION
This patch make some modifications on iofuzz:
1. When session is not response, check whether qemu or guest kernel
   crash occurs.
2. Check whether qemu or guest kernel crash occurs after fuzz test.
3. Make the script follow pep8 rules
4. enable image snapshot.

Signed-off-by: Yunping Zheng yunzheng@redhat.com
