### PR TITLE
control_files.control.kernel-version: Make it works with new folder stru...

### DIFF
--- a/qemu/control_files/control.kernel-version
+++ b/qemu/control_files/control.kernel-version
@@ -14,7 +14,7 @@ adapting the tests executed to the host machine.
 Online docs: https://github.com/autotest/virt-test/wiki
 """
 
-import sys, os, logging, re, commands, inspect
+import sys, os, logging, re, commands, inspect, shutil
 from distutils import version
 
 virt_test_dir = os.path.join(os.environ['AUTODIR'],'tests/virt')
@@ -23,6 +23,8 @@ sys.path.insert(0, virt_test_dir)
 from virttest import utils_misc, cartesian_config, data_dir, bootstrap
 from autotest.client.shared import logging_manager
 os.environ['LANG'] = 'en_US.UTF-8'
+cur_file = inspect.getfile(inspect.currentframe())
+qemu_test_dir = "/".join(cur_file.split("/")[:-2])
 
 
 def update_config(verbose=None):
@@ -34,13 +36,18 @@ def update_config(verbose=None):
     # cur_file = inspect.getfile(inspect.currentframe())
     # t_type = os.path.basename(os.path.dirname(cur_file))
     t_type = "qemu"
-    test_dir = os.path.join(data_dir.get_root_dir(), t_type)
+    cfg_folder = os.path.join(qemu_test_dir, "cfg")
     shared_dir = os.path.join(data_dir.get_root_dir(), "shared")
-    bootstrap.create_config_files(test_dir, shared_dir,
+    bootstrap.create_config_files(qemu_test_dir, shared_dir,
                                   interactive=False,
                                   force_update=True)
     bootstrap.create_subtests_cfg(t_type)
     bootstrap.create_guest_os_cfg(t_type)
+    backend_cfg = test_dir = os.path.join(data_dir.get_root_dir(), "backends",
+                                          t_type, "cfg")
+    for src in os.listdir(backend_cfg):
+        src = os.path.join(backend_cfg, src)
+        shutil.copy(src, cfg_folder)
 
 
 def package_check(dict_test, verbose=False):
@@ -106,7 +113,6 @@ def package_check(dict_test, verbose=False):
 
     return True
 
-qemu_test_dir = os.path.join(os.environ['AUTODIR'],'tests/virt/qemu')
 update_config()
 parser = cartesian_config.Parser()
 


### PR DESCRIPTION
...cture

Now we put qemu test scripts folder under test-providers.d.
Put some configures file under backends/qemu/cfg/

Signed-off-by: Feng Yang fyang@redhat.com
