### PR TITLE
qemu.tests.change_media: Add sleep time after change cdrom in guest

### DIFF
--- a/qemu/tests/change_media.py
+++ b/qemu/tests/change_media.py
@@ -68,7 +68,7 @@ def run(test, params, env):
     monitor.send_args_cmd(change_insert_cmd)
     logging.info("Wait until device is ready")
     blocks_info = lambda: orig_img_name in str(monitor.info("block"))
-    if not utils_misc.wait_for(blocks_info, 10):
+    if not utils_misc.wait_for(blocks_info, 10, first=3):
         msg = "Fail to insert device %s to guest" % orig_img_name
         raise error.TestFail(msg)
 


### PR DESCRIPTION
Sometimes, need to wait a minute after inserting cdrom in guest.

Signed-off-by: Shuping Cui scui@redhat.com
