### PR TITLE
netperf: collect host/guest sysinfo by custom-built scripts

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -55,6 +55,15 @@
     netperf_download_link = ftp://ftp.netperf.org/netperf/netperf-2.6.0.tar.bz2
     pkg_md5sum = 9654ffdfd4c4f2c93ce3733cd9ed9236
     setup_cmd = "cd /tmp && rm -rf netperf-2.6.0 && tar xvfj netperf-2.6.0.tar.bz2 && cd netperf-2.6.0 && ./configure --enable-burst --enable-demo=yes && make"
+    log_hostinfo_script = scripts/rh_perf_log_hostinfo_script.sh
+    #Linux:
+    #    log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.sh
+    #    log_guestinfo_exec = bash
+    #    log_guestinfo_path = /tmp/log_guestinfo.sh
+    #Windows:
+    #    log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.bat
+    #    log_guestinfo_exec = cmd /c
+    #    log_guestinfo_path = C:\log_guestinfo.bat
     variants:
         - guest_guest:
             no Jeos

--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -226,6 +226,22 @@ def run(test, params, env):
                netserver_port=params.get('netserver_port', "12865"),
                params=params, server_cyg=server_cyg, test=test)
 
+    if params.get("log_hostinfo_script"):
+        src = os.path.join(test.virtdir, params.get("log_hostinfo_script"))
+        path = os.path.join(test.resultsdir, "sysinfo")
+        utils.system_output("bash %s %s &> %s" % (src, test.resultsdir, path))
+
+    if params.get("log_guestinfo_script") and params.get("log_guestinfo_exec"):
+        src = os.path.join(test.virtdir, params.get("log_guestinfo_script"))
+        path = os.path.join(test.resultsdir, "sysinfo")
+        destpath = params.get("log_guestinfo_path", "/tmp/log_guestinfo.sh")
+        vm.copy_files_to(src, destpath)
+        logexec = params.get("log_guestinfo_exec", "bash")
+        output = server_ctl.cmd_output("%s %s" % (logexec, destpath))
+        logfile = open(path, "a+")
+        logfile.write(output)
+        logfile.close()
+
 
 @error.context_aware
 def start_test(server, server_ctl, host, clients, resultsdir, l=60,


### PR DESCRIPTION
User wants to collect sysinfo of host/guest, but different users
might have different requests, and many kinds of system might be
used. So I would like to use custom-built scripts to collect the
information that will make users happy.

User needs to add shell scripts to autotest/client/tests/virt/shared/scripts/,
and set the script path in config file.

eg:
 #log_hostinfo_script = scripts/rh_perf_log_hostinfo_script.sh
 #log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.sh

Then the script output will be saved to two files in $test.resultsdir
(host_sysinfo, guest_sysinfo)

We can consider to add two general scripts to virt-tests repo if
they are needed.

Signed-off-by: Amos Kong akong@redhat.com
