### PR TITLE
qemu.tests: Add env parameter for vm.migrate() function call.

### DIFF
--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -176,7 +176,7 @@ def run(test, params, env):
                 vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay,
                            offline, check,
                            migration_exec_cmd_src=mig_exec_cmd_src,
-                           migration_exec_cmd_dst=mig_exec_cmd_dst)
+                           migration_exec_cmd_dst=mig_exec_cmd_dst, env=env)
 
             # Set deamon thread action to stop after migrate
             params["action"] = "stop"

--- a/qemu/tests/migration_after_nichotplug.py
+++ b/qemu/tests/migration_after_nichotplug.py
@@ -90,7 +90,7 @@ def run(test, params, env):
     set_link(nic_name, up=True)
 
     error.context("Migrate from source VM to Destination VM", logging.info)
-    vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay)
+    vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay, env=env)
 
     error.context("Disable the primary link", logging.info)
     set_link(nic_name, up=False)

--- a/qemu/tests/migration_with_dst_problem.py
+++ b/qemu/tests/migration_with_dst_problem.py
@@ -360,7 +360,8 @@ def run(test, params, env):
                   "-o hard,timeo=14,rsize=8192,wsize=8192")
             vm_guest.migrate(mig_timeout, mig_protocol,
                              not_wait_for_migration=True,
-                             migration_exec_cmd_src=migration_exec_cmd_src)
+                             migration_exec_cmd_src=migration_exec_cmd_src,
+                             env=env)
 
             if not utils_misc.wait_for(lambda: process_output_check(
                                        vm_guest.process, exp_str),
@@ -409,7 +410,8 @@ def run(test, params, env):
 
             vm_guest.migrate(mig_timeout, mig_protocol,
                              not_wait_for_migration=True,
-                             migration_exec_cmd_src=migration_exec_cmd_src)
+                             migration_exec_cmd_src=migration_exec_cmd_src,
+                             env=env)
 
             if not utils_misc.wait_for(lambda: process_output_check(
                                        vm_guest.process, exp_str),
@@ -490,7 +492,7 @@ def run(test, params, env):
 
             self.restart_server()
 
-            self.vm_guest.migrate(mig_timeout, mig_protocol)
+            self.vm_guest.migrate(mig_timeout, mig_protocol, env=env)
 
             try:
                 self.vm_guest.verify_alive()

--- a/qemu/tests/migration_with_file_transfer.py
+++ b/qemu/tests/migration_with_file_transfer.py
@@ -53,7 +53,8 @@ def run(test, params, env):
                             vm.params["vhost"] = "vhost=off"
                         elif vhost_status == "vhost=off":
                             vm.params["vhost"] = "vhost=on"
-                    vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay)
+                    vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay,
+                               env=env)
             except Exception:
                 # If something bad happened in the main thread, ignore
                 # exceptions raised in the background thread

--- a/qemu/tests/migration_with_netperf.py
+++ b/qemu/tests/migration_with_netperf.py
@@ -83,7 +83,7 @@ def run(test, params, env):
             m_count += 1
             error.context("Start migration iterations: %s " % m_count,
                           logging.info)
-            vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay)
+            vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay, env=env)
     finally:
         netperf_server.stop()
         netperf_server.env_cleanup(True)

--- a/qemu/tests/migration_with_reboot.py
+++ b/qemu/tests/migration_with_reboot.py
@@ -32,7 +32,8 @@ def run(test, params, env):
         bg.start()
         try:
             while bg.isAlive():
-                vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay)
+                vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay,
+                           env=env)
         except Exception:
             # If something bad happened in the main thread, ignore exceptions
             # raised in the background thread

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -96,7 +96,7 @@ def run(test, params, env):
         time.sleep(2)
 
         clonevm = vm.migrate(mig_timeout, mig_protocol,
-                             not_wait_for_migration=True)
+                             not_wait_for_migration=True, env=env)
 
         mig_speed = utils.convert_data_size(mig_speed, "M")
 


### PR DESCRIPTION
This could help use record dst vm to env. Then we can record
screendump for it.

Signed-off-by: Feng Yang fyang@redhat.com
