### PR TITLE
add support extra_cdrom_ks testi for WinNT6.0 guest

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -96,7 +96,7 @@
     variants:
         # Additional iso with kickstart is attached into the guest
         - extra_cdrom_ks:
-            only Linux
+            no WinXP Win2000 Win2003 WinVista
             unattended_delivery_method = cdrom
             cdroms += " unattended"
             drive_index_unattended = 1


### PR DESCRIPTION
This pull request depend on  pull request https://github.com/autotest/virt-test/pull/1495

Signed-off-by: Xu Tian xutian@redhat.com
