### PR TITLE
qemu.tests: Add enable_msix_vectors in hotplug_nic

### DIFF
--- a/qemu/tests/migration_after_nichotplug.py
+++ b/qemu/tests/migration_after_nichotplug.py
@@ -54,9 +54,11 @@ def run(test, params, env):
 
     error.context("Add network devices through monitor cmd", logging.info)
     nic_name = 'hotadded'
+    enable_msix_vectors = params.get("enable_msix_vectors")
     nic_info = vm.hotplug_nic(nic_model=pci_model, nic_name=nic_name,
                               netdst=netdst, nettype=nettype,
-                              queues=params.get('queues'))
+                              queues=params.get('queues'),
+                              enable_msix_vectors=enable_msix_vectors)
     nic_mac = nic_info['mac']
     vm.params['nics'] += " %s" % nic_name
     vm.params['nic_model_%s' % nic_name] = nic_info['nic_model']


### PR DESCRIPTION
The parameters of this function already updated. Need add this too.
Otherwise run this case with multi queues and enable_msix_vectors = yes
will failed.
