### PR TITLE
qemu.tests.usb_hotplug: Do not need to verify usb device on guest for negative test

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -147,7 +147,7 @@
                 - usb_negative_test:
                     only ehci
                     only usb_hub
-                    only usb_default
+                    only without_usb_hub
                     # Note: This is a workaround for the multifunction
                     # code in qemu_vm module.
                     usb_type_usbtest = usb-ehci

--- a/qemu/tests/usb_hotplug.py
+++ b/qemu/tests/usb_hotplug.py
@@ -76,7 +76,8 @@ def run(test, params, env):
     for i in range(repeat_times):
         error.context("Hotplug (iteration %i)" % (i + 1), logging.info)
         usb_dev_hotplug()
-        usb_dev_verify()
-        usb_dev_unplug()
+        if not params.get("usb_negative_test") == "yes":
+            usb_dev_verify()
+            usb_dev_unplug()
 
     session.close()


### PR DESCRIPTION
Do not need to verify usb device is pluged/unpluged on guest for negative test.
