### PR TITLE
pci_hotplug: Fix a minor syntax bug

### DIFF
--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -142,7 +142,7 @@ def run(test, params, env):
         pci_info[pci_num].append(pci_model)
 
         after_add = vm.monitor.info("pci")
-        if pci_info[pci_num][1] not in after_add:
+        if pci_info[pci_num][1] not in str(after_add):
             logging.error("Could not find matched id in monitor:"
                           " %s" % pci_info[pci_num][1])
             raise error.TestFail("Add device failed. Monitor command is: %s"


### PR DESCRIPTION
The value of a dictionary should switch to the string when match it.

Signed-off-by: Cong Li coli@redhat.com
