### PR TITLE
qemu.tests.cfg: Add image format filter in qemu_iotests

### DIFF
--- a/qemu/tests/cfg/qemu_iotests.cfg
+++ b/qemu/tests/cfg/qemu_iotests.cfg
@@ -11,13 +11,16 @@
     #qemu_io_extra_options =
     variants:
         - raw_format:
+            only raw raw_dd
             qemu_io_image_format = raw
         - qcow_format:
             no Host_RHEL
             qemu_io_image_format = qcow
         - qcow2_format:
+            only qcow2 qcow2v3
             qemu_io_image_format = qcow2
         - qed_format:
+            only qed
             no Host_RHEL
             qemu_io_image_format = qed
         - vdi_format:
@@ -27,5 +30,6 @@
             no Host_RHEL
             qemu_io_image_format = vpc
         - vmdk_format:
+            only vmdk
             no Host_RHEL
             qemu_io_image_format = vmdk


### PR DESCRIPTION
Add image format filter for qemu_iotests. So we can filter the right
test cases when we run it.
