### PR TITLE
qemu.tests.cfg: Disable readonly disk for ide and ahci disks

### DIFF
--- a/qemu/tests/cfg/readonly_disk.cfg
+++ b/qemu/tests/cfg/readonly_disk.cfg
@@ -1,6 +1,7 @@
 - readonly_disk:
     virt_test_type = qemu
     only Windows
+    no ide ahci
     type = readonly_disk
     images += " data"
     image_name_data = "images/data_disk"


### PR DESCRIPTION
This is not support for ide and ahci disks.
