### PR TITLE
Set gracefully=False while destroying a guest which running under rescue mode

### DIFF
--- a/qemu/tests/boot_time.py
+++ b/qemu/tests/boot_time.py
@@ -52,7 +52,7 @@ def run(test, params, env):
             restore_level_cmd = params['restore_level_cmd']
             session.cmd(restore_level_cmd)
             session.cmd('sync')
-            vm.destroy()
+            vm.destroy(gracefully=False)
             vm.create()
             vm.verify_alive()
             vm.wait_for_login(timeout=timeout)


### PR DESCRIPTION
By default, There is no network support in rescue mode. So use vm.destroy(gracefully=False)
instead of vm.destroy() for boot_time test.

Signed-off-by: Lin Ma lma@suse.com
