### PR TITLE
Create vm with correct mac for boot_time test

### DIFF
--- a/qemu/tests/boot_time.py
+++ b/qemu/tests/boot_time.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     from autotest.client.shared import utils_memory
 
+from virttest import env_process
 
 @error.context_aware
 def run(test, params, env):
@@ -53,7 +54,7 @@ def run(test, params, env):
             session.cmd(restore_level_cmd)
             session.cmd('sync')
             vm.destroy()
-            vm.create()
+            env_process.preprocess_vm(test, params, env, vm.name)
             vm.verify_alive()
             vm.wait_for_login(timeout=timeout)
         except Exception:


### PR DESCRIPTION
In boot_time test, After vm.destroy(), The script calls vm.create().
It will generate the vm parameters with new mac address. But the mac parameter that passing
to qemu command line is still the old one.
This causes the script looking for IP in incorrect MAC-IP address mapping,
so the script doesn't think the guest got ip address and blocks at the stage of attempting to log
into guest until timeout.

Signed-off-by: Lin Ma lma@suse.com
