### PR TITLE
qemu.tests.cfg: adjust the timeout in transfer_file_over_ipv6

### DIFF
--- a/qemu/tests/cfg/transfer_file_over_ipv6.cfg
+++ b/qemu/tests/cfg/transfer_file_over_ipv6.cfg
@@ -5,6 +5,6 @@
     vms += " vm2"
     image_snapshot = yes
     filesize = 4096
-    file_trans_timeout = 1200
+    file_trans_timeout = 2400
     file_md5_check_timeout = 600
     dd_cmd = "dd if=/dev/zero of=%s oflag=direct bs=1M count=%d"


### PR DESCRIPTION
Tranfer file over ipv6 needs more time to finish.

Signed-off-by: Xiangmin Han xhan@redhat.com
