### PR TITLE
qemu.enospc: Create new VM with new params

### DIFF
--- a/qemu/tests/enospc.py
+++ b/qemu/tests/enospc.py
@@ -127,7 +127,7 @@ def run(test, params, env):
 
     error.context("Boot up guest with two disks")
     vm = env.get_vm(params["main_vm"])
-    vm.create()
+    vm.create(params=params)
     login_timeout = int(params.get("login_timeout", 360))
     session_serial = vm.wait_for_serial_login(timeout=login_timeout)
 


### PR DESCRIPTION
When we run a series cases, and the case before enospc has no params
'kill_vm = yes', there will be problem. The new created VM will be
the same as old one, because the params used in the function create()
will be the old from the old VM which created by previous test case.

This patch is to create the new VM with new params

Signed-off-by: Mike Qiu qiudayu@linux.vnet.ibm.com
