### PR TITLE
generic.tests.cfg: multi queues only support from RHEL7

### DIFF
--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -2,6 +2,7 @@
     virt_test_type = qemu libvirt
     no smp2
     only Linux
+    no RHEL.3, RHEL.4, RHEL.5, RHEL.6
     type = multi_queues_test
     queues = 4
     enable_msix_vectors = yes


### PR DESCRIPTION
multi queues only support from RHEL7, so disable this case before rhel7 guest.
