### PR TITLE
generic.tests: Let lvm get disk names from command

### DIFF
--- a/generic/tests/cfg/lvm.cfg
+++ b/generic/tests/cfg/lvm.cfg
@@ -11,7 +11,6 @@
     image_size_stg2 = 1G
     image_format_stg2 = qcow2
     guest_testdir = /mnt
-    disks = "/dev/sdb /dev/sdc"
     kill_vm = no
     post_command_noncritical = no
     variants:

--- a/generic/tests/lvm.py
+++ b/generic/tests/lvm.py
@@ -40,9 +40,11 @@ def run(test, params, env):
     vg_name = "vg_kvm_test"
     lv_name = "lv_kvm_test"
     lv_path = "/dev/%s/%s" % (vg_name, lv_name)
-    disks = params.get("disks", "/dev/hdb /dev/hdc")
     clean = params.get("clean", "yes")
     timeout = params.get("lvm_timeout", "600")
+    output = session.cmd_output("ls /dev/[hvs]da")
+    disk_prefix = output.strip()[:len('/dev/hd')]
+    disks = "%sb %sc" % (disk_prefix, disk_prefix)
 
     try:
         error.context("adding physical volumes %s" % disks, logging.info)


### PR DESCRIPTION
Update the script to get disk names from command instead of the
cfg files. So we don't need to update it when the prefix of
disks changed.
