### PR TITLE
qemu.tests.cfg: Disable migrate.unix on RHEL5 host

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -21,6 +21,7 @@
             migration_protocol = "tcp"
         - unix:
             migration_protocol = "unix"
+            no Host_RHEL.5
         - exec:
             migration_protocol = "exec"
             variants:


### PR DESCRIPTION
migrate.unix protocol only support from RHEL6, so disable it on RHEL5 host.
