### PR TITLE
boot_time: Return result if no bound given

### DIFF
--- a/qemu/tests/boot_time.py
+++ b/qemu/tests/boot_time.py
@@ -43,6 +43,7 @@ def run(test, params, env):
         vm.verify_alive()
         session = vm.wait_for_serial_login(timeout=timeout)
         boot_time = time.time() - vm.start_time
+        test.write_test_keyval({'result': "%ss" % boot_time})
         expect_time = int(params.get("expect_bootup_time", "17"))
         logging.info("Boot up time: %ss" % boot_time)
 


### PR DESCRIPTION
Utilize the possibility to output a result in order to display the boot
time in the case where no bound is given. Add the old default value to
the .cfg file to make sure that the default output does not change.

This change is dependent on this pull request in virt-test: https://github.com/autotest/virt-test/pull/1574 and is currently an example of how the suggested functionality can be used.

Signed-off-by: Jonas Eriksson jonas.eriksson@enea.com
