### PR TITLE
qemu: Use new data_dir.get_deps_dir() to get cpu_flags in deps folder.

### DIFF
--- a/provider/cpuflags.py
+++ b/provider/cpuflags.py
@@ -16,8 +16,7 @@ def install_cpuflags_util_on_vm(test, vm, dst_dir, extra_flags=None):
     if not extra_flags:
         extra_flags = ""
 
-    cpuflags_src = os.path.join(data_dir.get_deps_dir("cpu_flags"),
-                                "cpu_flags")
+    cpuflags_src = data_dir.get_deps_dir("cpu_flags")
     cpuflags_dst = os.path.join(dst_dir, "cpu_flags")
     session = vm.wait_for_login()
     session.cmd("rm -rf %s" %

--- a/qemu/tests/cpuflags.py
+++ b/qemu/tests/cpuflags.py
@@ -8,7 +8,7 @@ import sys
 import traceback
 from xml.parsers import expat
 from autotest.client.shared import error, utils
-from virttest import qemu_vm, virt_vm
+from virttest import qemu_vm, virt_vm, data_dir
 from virttest import utils_misc, utils_test, aexpect
 from autotest.client.shared.syncdata import SyncData
 
@@ -24,8 +24,8 @@ def run(test, params, env):
     utils_misc.Flag.aliases = utils_misc.kvm_map_flags_aliases
     qemu_binary = utils_misc.get_qemu_binary(params)
 
-    cpuflags_src = os.path.join(test.virtdir, "deps", "cpu_flags", "src")
-    cpuflags_def = os.path.join(test.virtdir, "deps", "cpu_flags",
+    cpuflags_src = os.path.join(data_dir.get_deps_dir("cpu_flags"), "src")
+    cpuflags_def = os.path.join(data_dir.get_deps_dir("cpu_flags"),
                                 "cpu_map.xml")
     smp = int(params.get("smp", 1))
 


### PR DESCRIPTION
Signed-off-by: Feng Yang fyang@redhat.com
