### PR TITLE
qemu.tests: Add a test case for test invalid parameters in nic device

### DIFF
--- a/qemu/tests/cfg/invalid_parameter.cfg
+++ b/qemu/tests/cfg/invalid_parameter.cfg
@@ -1,0 +1,42 @@
+- invalid_parameter:
+    virt_test_type = qemu
+    type = invalid_parameter
+    start_vm = no
+    run_invalid_cmd = yes
+    queues = 4
+    failed_reason = "Device 'tap' could not be initialized"
+    vhost = on
+    variants:
+        - fd_vhostfds:
+            tapfds_len = 1
+        - fd_queues:
+            tapfds_len = 1
+            vhostfds_len = 0
+            add_queues = yes
+        - fd_fds:
+            add_tapfd = yes
+            vhostfds_len = 0
+        - fds_vhostfd:
+            vhostfds_len = 1
+        - fds_queues:
+            vhostfds_len = 0
+            add_queues = yes
+        - helper_fd:
+            tapfds_len = 1
+            vhostfds_len = 0
+            helper = /usr/libexec/qemu-bridge-helper
+        - helper_fds:
+            helper = /usr/libexec/qemu-bridge-helper
+            vhostfds_len = 0
+        - helper_vhostfds:
+            tapfds_len = 0
+            helper = /usr/libexec/qemu-bridge-helper
+        - helper_vhostfd:
+            tapfds_len = 0
+            vhostfds_len = 1
+            helper = /usr/libexec/qemu-bridge-helper
+        - helper_queues:
+            add_queues = yes
+            tapfds_len = 0
+            vhostfds_len = 0
+            helper = /usr/libexec/qemu-bridge-helper

--- a/qemu/tests/invalid_parameter.py
+++ b/qemu/tests/invalid_parameter.py
@@ -1,0 +1,31 @@
+import logging
+from autotest.client.shared import error
+from virttest import env_process
+from virttest import virt_vm
+
+
+@error.context_aware
+def run(test, params, env):
+    """
+    Qemu invalid parameter in qemu command line test:
+    1) Try boot up guest with invalid parameters
+    2) Catch the error message shows by qemu process
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    vm_name = params["main_vm"]
+    params['start_vm'] = "yes"
+    try:
+        error.context("Start guest with invalid parameters.")
+        env_process.preprocess_vm(test, params, env, vm_name)
+        vm = env.get_vm(vm_name)
+        vm.destroy()
+        raise error.TestFail("Guest start normally, didn't quit as expect.")
+    except Exception, emsg:
+        error.context("Check guest exit status.")
+        if "(core dumped)" in emsg.reason:
+            raise error.TestFail("Guest core dumped with invalid parameters.")
+        else:
+            logging.info("Guest quit as expect: %s" % emsg.reason)


### PR DESCRIPTION
This case is designed to test the qemu behavior when it get invcalid parameters.
Qemu should quit with some warning message but not core dump.
