### PR TITLE
tsc_sync change clocksource: Fix vsyscall check

### DIFF
--- a/qemu/tests/timerdevice_tscsync_change_host_clksource.py
+++ b/qemu/tests/timerdevice_tscsync_change_host_clksource.py
@@ -18,7 +18,7 @@ def run(test, params, env):
     5) Compile the time-warp-test.c.
     6) Switch host to hpet clocksource.
     6) Run time-warp-test.
-    7) Check the guest is using vsyscall.
+    7) Check the guest is not using vsyscall.
 
     :param test: QEMU test object.
     :param params: Dictionary with test parameters.


### PR DESCRIPTION
This is a breakout of the discussion around this patch in this pull request: https://github.com/autotest/tp-qemu/pull/63

According to the test spec in the beginning of the source, the test
should check both before and after that the test uses vsyscalls.
However, in the second if statement, the test checks that
clock_gettime|gettimeofday has been called which would indicate that the
guest has moved away from vsyscalls.

Signed-off-by: Jonas Eriksson jonas.eriksson@enea.com
