### PR TITLE
remote_build: clock_getres, tsc_sync, nx, pipetest

### DIFF
--- a/generic/deps/clock_getres/Makefile
+++ b/generic/deps/clock_getres/Makefile
@@ -5,6 +5,6 @@ LIBS = -lrt
 all: $(PROG)
 
 $(PROG):
-	$(CC) $(SRC) $(LIBS) -o $(PROG)
+	$(CC) $(SRC) $(CFLAGS) $(LIBS) -o $(PROG)
 clean:
 	rm -f $(PROG)

--- a/generic/tests/clock_getres.py
+++ b/generic/tests/clock_getres.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from autotest.client.shared import error
-from virttest import utils_test, data_dir
+from virttest import utils_test, data_dir, remote_build
 
 
 @error.context_aware
@@ -20,21 +20,17 @@ def run(test, params, env):
     timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=timeout)
 
-    getres_cmd = params.get("getres_cmd")
+    address = vm.get_address(0)
+    source_dir = data_dir.get_deps_dir("clock_getres")
+    build_dir = params.get("build_dir", None)
 
-    if not getres_cmd or session.cmd_status("test -x %s" % getres_cmd):
-        source_name = "clock_getres/clock_getres.c"
-        source_name = os.path.join(data_dir.get_deps_dir(), source_name)
-        getres_cmd = "/tmp/clock_getres"
-        dest_name = "/tmp/clock_getres.c"
+    builder = remote_build.Builder(params, address, source_dir,
+                                   build_dir=build_dir)
 
-        if not os.path.isfile(source_name):
-            raise error.TestError("Could not find %s" % source_name)
+    getres_cmd = os.path.join(builder.build(), "clock_getres")
 
-        vm.copy_files_to(source_name, dest_name)
-        session.cmd("gcc -lrt -o %s %s" % (getres_cmd, dest_name))
-
-    session.cmd(getres_cmd)
+    if not session.cmd_status(getres_cmd) == 0:
+        raise Exception("clock_getres failed")
     logging.info("PASS: Guest reported appropriate clock resolution")
     sub_test = params.get("sub_test")
     if sub_test:

--- a/qemu/deps/nx/Makefile
+++ b/qemu/deps/nx/Makefile
@@ -1,0 +1,9 @@
+CFLAGS+=-Wall
+
+.PHONY: clean
+
+nx_exploit: x64_sc_rdo.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	rm -f nx_exploit

--- a/qemu/deps/nx/x64_sc_rdo.c
+++ b/qemu/deps/nx/x64_sc_rdo.c
@@ -34,7 +34,7 @@ main(void)
     void (*p)();
     int fd;
 
-    printf("Length: %d\n", strlen(shellcode));
+    printf("Length: %zd\n", strlen(shellcode));
 
     fd = open("/tmp/. ", O_RDWR|O_CREAT, S_IRUSR|S_IWUSR);
     if (fd < 0)

--- a/qemu/deps/pipetest/Makefile
+++ b/qemu/deps/pipetest/Makefile
@@ -1,0 +1,8 @@
+CFLAGS+=-Wall
+
+.PHONY: clean
+
+pipetest: pipetest.c
+
+clean:
+	rm -f pipetest

--- a/qemu/deps/pipetest/pipetest.c
+++ b/qemu/deps/pipetest/pipetest.c
@@ -1,0 +1,52 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <linux/unistd.h>
+#define _GNU_SOURCE
+#define __USE_GNU
+#include <sched.h>
+#define TV_2_LONG(tv) (tv.tv_sec*1E6+tv.tv_usec)
+#define GET_TIME() \
+ ({ struct timeval __tv; gettimeofday(&__tv,NULL); TV_2_LONG(__tv); })
+#define LOOPS 10000
+int c0 = 0, c1 = 1;
+int main (int ac, char **av) {
+    unsigned long long t0, t1;
+    int fd1[2], fd2[2];
+    int m = 0, i;
+    cpu_set_t set;
+    if (ac == 3) {
+        c0 = atoi(av[1]);
+        c1 = atoi(av[2]);
+    }
+    CPU_ZERO(&set);
+    pipe(fd1);
+    pipe(fd2);
+    if (!fork()) {
+        CPU_SET(c0, &set);
+        sched_setaffinity(0, sizeof(set), &set);
+        for (;;) {
+            t0 = GET_TIME();
+            for (i = 0; i < LOOPS; i++) {
+                read(fd1[0], &m, sizeof(int));
+                m = 2;
+                write(fd2[1], &m, sizeof(int));
+            }
+            t1 = GET_TIME();
+            printf("%.2f usecs/loop.\n",
+            (double)(t1-t0)/(double)LOOPS);
+            fflush(stdout);
+        }
+    } else {
+        CPU_SET(c1, &set);
+        sched_setaffinity(0, sizeof(set), &set);
+        for (;;) {
+            m = 1;
+            write(fd1[1], &m, sizeof(int));
+            read(fd2[0], &m, sizeof(int));
+        }
+    }
+}

--- a/qemu/deps/tsc_sync/Makefile
+++ b/qemu/deps/tsc_sync/Makefile
@@ -1,0 +1,9 @@
+CFLAGS+=-Wall
+LDLIBS+=-lrt
+
+.PHONY: clean
+
+time-warp-test: time-warp-test.c
+
+clean:
+	rm -f time-warp-test

--- a/qemu/deps/tsc_sync/time-warp-test.c
+++ b/qemu/deps/tsc_sync/time-warp-test.c
@@ -25,7 +25,6 @@
 #include <time.h>
 #include <sys/mman.h>
 #include <dlfcn.h>
-#include <popt.h>
 #include <sys/socket.h>
 #include <ctype.h>
 #include <assert.h>

--- a/qemu/tests/cfg/ipi_x2apic.cfg
+++ b/qemu/tests/cfg/ipi_x2apic.cfg
@@ -4,7 +4,5 @@
     type = ipi_x2apic
     vms = ""
     check_x2apic_cmd = dmesg |grep x2apic
-    pipetest_cmd = "/tmp/pipetest"
-    build_pipetest_cmd = "cd /tmp/ && gcc -o pipetest pipetest.c"
     x2apic_check_string = Enabling x2apic, Enabled x2apic, Setting APIC routing to physical x2apic
     pre_command += " grep 'flags' /proc/cpuinfo|grep 'ept' && modprobe -r kvm_intel && modprobe kvm_intel ept=1 || echo ok;"

--- a/qemu/tests/timerdevice_tscsync_change_host_clksource.py
+++ b/qemu/tests/timerdevice_tscsync_change_host_clksource.py
@@ -3,7 +3,7 @@ import os
 import re
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import data_dir
+from virttest import data_dir, remote_build
 
 
 @error.context_aware
@@ -43,22 +43,19 @@ def run(test, params, env):
     if not '0' in output:
         raise error.TestFail("Failed to check vsyscall. Output: '%s'" % output)
 
-    error.context("Copy time-warp-test.c to guest", logging.info)
-    src_file_name = os.path.join(data_dir.get_deps_dir(), "tsc_sync",
-                                 "time-warp-test.c")
-    vm.copy_files_to(src_file_name, "/tmp")
+    address = vm.get_address(0)
+    source_dir = data_dir.get_deps_dir("tsc_sync")
+    build_dir = params.get("build_dir", None)
 
-    error.context("Compile the time-warp-test.c", logging.info)
-    cmd = "cd /tmp/;"
-    cmd += " yum install -y popt-devel;"
-    cmd += " rm -f time-warp-test;"
-    cmd += " gcc -Wall -o time-warp-test time-warp-test.c -lrt"
-    session.cmd(cmd)
+    builder = remote_build.Builder(params, address, source_dir,
+                                   build_dir=build_dir)
+
+    full_build_path = builder.build()
 
     error.context("Run time-warp-test", logging.info)
     test_run_timeout = int(params.get("test_run_timeout", 10))
     session.sendline("$(sleep %d; pkill time-warp-test) &" % test_run_timeout)
-    cmd = "/tmp/time-warp-test"
+    cmd = os.path.join(full_build_path, "time-warp-test")
     _, output = session.cmd_status_output(cmd, timeout=(test_run_timeout + 60))
 
     re_str = "fail:(\d+).*?fail:(\d+).*fail:(\d+)"
@@ -83,7 +80,7 @@ def run(test, params, env):
                       logging.info)
         cmd = "$(sleep %d; pkill time-warp-test) &"
         session.sendline(cmd % test_run_timeout)
-        cmd = "/tmp/time-warp-test"
+        cmd = os.path.join(full_build_path, "time-warp-test")
         _, output = session.cmd_status_output(cmd,
                                               timeout=(test_run_timeout + 60))
 


### PR DESCRIPTION
After an idea in https://github.com/autotest/tp-qemu/pull/70 , I added a pull request for a builder utility:
https://github.com/autotest/virt-test/pull/1594
This is an example of how to adapt a very tricky (cpuflags) and very simple (clock_getres) TC to use utils_build. clock_getres is tested, but cpuflags is not, so see this pull request as an example until it has been tested.