### PR TITLE
qemu.tests.drive_mirror: fix syntax when job status is empty

### DIFF
--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -79,7 +79,9 @@ class BlockCopy(object):
         """
         return block job info dict;
         """
-        return self.vm.get_job_status(self.device)
+        query_status = lambda: self.vm.get_job_status(self.device)
+        status = utils_misc.wait_for(query_status, timeout=120)
+        return status or {}
 
     def do_steps(self, tag=None):
         if not tag:

--- a/qemu/tests/drive_mirror.py
+++ b/qemu/tests/drive_mirror.py
@@ -106,7 +106,7 @@ class DriveMirror(block_copy.BlockCopy):
         """
         params = self.parser_test_args()
         info = self.get_status()
-        ret = (info["len"] == info["offset"])
+        ret = bool(info and info["len"] == info["offset"])
         if self.vm.monitor.protocol == "qmp":
             if params.get("check_event", "no") == "yes":
                 ret &= bool(self.vm.monitor.get_event("BLOCK_JOB_READY"))


### PR DESCRIPTION
Check block job status not empty to avoid 'KeyError: 'len' when qmp
monitor respone delay.

Signed-off-by: Xu Tian xutian@redhat.com
