### PR TITLE
generic.tests: Update the method get ncpu from server

### DIFF
--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -445,7 +445,7 @@ def launch_client(sessions, server, server_ctl, host, clients, l, nf_args,
         ssh_cmd(server_ctl, "pidof netserver || %s" % server_path)
         get_status_flag = True
         ncpu = ssh_cmd(server_ctl, "cat /proc/cpuinfo |grep processor |wc -l")
-        ncpu = re.findall(r"\d+", ncpu)[0]
+        ncpu = re.findall(r"\d+", ncpu)[-1]
 
     logging.info("Netserver start successfully")
 


### PR DESCRIPTION
Sometime the output from server include some unexpect letters include
some numbers. So the old method will failed to get the correct cpu
number.

The failed case logs from our test:
/netperf.py", line 426, in count_interrupt
    intr += int(stat.split()[cpu + 1])
ValueError: invalid literal for int() with base 10: 'PCI-MSI-edge'

The output of command try to get ncpu:
2014-02-07 22:03:18: cat /proc/cpuinfo |grep processor |w<tperf-2.6.0]# cat /proc/cpuinfo |grep processor |wc                          -l
2014-02-07 22:03:18: 1

The output of command that try to count interrupt:
2014-02-07 22:03:49:  45:        587   PCI-MSI-edge      virtio2-input.0
