### PR TITLE
qemu.tests: Fix the wrong balloon type in cfg

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -70,12 +70,12 @@
         - balloon_fix_value:
             no ppc64
             only balloon_base
-            test_tags = "evict_to_0.5 enlarge_to_0.75 enlarge_to_0.8"
-            balloon_type_evict_to_0.5 = evict
-            balloon_type = enlarge
+            test_tags = "evict_to_0.5 enlarge_to_0.75 evict_to_0.8"
+            balloon_type_enlarge_to_0.75 = enlarge
+            balloon_type = evict
             expect_memory_ratio_evict_to_0.5 = 0.5
             expect_memory_ratio_enlarge_to_0.75 = 0.75
-            expect_memory_ratio_enlarge_to_0.8 = 0.8
+            expect_memory_ratio_evict_to_0.8 = 0.8
             sub_test_after_balloon_evict_to_0.5 = guest_suspend
             sub_test_after_balloon_enlarge_to_0.75 =  guest_suspend
             run_sub_test_after_balloon_evict_to_0.5 = yes


### PR DESCRIPTION
After s4 step in balloon_fix_value, the guest memory is back to
original value. So the type for next balloon should be evict but not
enlarge.
