### PR TITLE
unattended_install.cfg: update multi_disk install image_size

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -80,6 +80,8 @@
             image_size_equal = 1G
             ahci:
                 images = "image1 stg stg2 stg3 stg4 stg5"
+            image_size = 512M
+            image_size_image1 = 20G
         - large_image:
             only unattended_install.cdrom
             only qcow2 qcow2v3


### PR DESCRIPTION
Define the image_size and image_size_image1 in unattended_install
cfg file.

Signed-off-by: Xiangmin Han xhan@redhat.com
