### PR TITLE
qemu.tests: Update cfg for stress_kernel_compile

### DIFF
--- a/qemu/tests/cfg/stress_kernel_compile.cfg
+++ b/qemu/tests/cfg/stress_kernel_compile.cfg
@@ -8,7 +8,5 @@
     download_url = "https://www.kernel.org/pub/linux/kernel/v2.6/linux-2.6.32.tar.bz2"
     test_cmd = "(tar xfj linux-2.6.32.tar.bz2 && cd linux-2.6.32 && make defconfig && make -j `grep processor /proc/cpuinfo | wc -l`) > /dev/null"
     variants:
-        - single_guest:
-            guest_number = 1
         - multi_guests:
             guest_number = 8


### PR DESCRIPTION
overcommit only support for booting multi guests,
so remove single_guest subtest.
