### PR TITLE
qemu.tests: Set restart_network to True when check guest network

### DIFF
--- a/qemu/tests/set_link.py
+++ b/qemu/tests/set_link.py
@@ -74,7 +74,7 @@ def run(test, params, env):
         Check whether guest network is connective by ping
         """
         if link_up:
-            vm.wait_for_login()
+            vm.wait_for_login(restart_network=True)
             guest_ip = vm.get_address()
         if change_queues:
             env["run_change_queues"] = False


### PR DESCRIPTION
As the link up and down in set_link may cause ip change in some enviroment.
We need add restart_network when we try to login guest after the operations.
