### PR TITLE
pxe_query_cpus: small fix of pxe_query_cpus

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -14,6 +14,7 @@
     pxe_timeout = 60
     image_verify_bootable = no
     kill_vm = yes
+    kill_vm_gracefully = no
     variants:
         - @default:
         - etherboot:


### PR DESCRIPTION
1. judge whether the bg thread is alive in every cpu info query.
2. add join() bg thread in the body.
3. set 'kill_vm_gracefully = no' in the cfg.

Signed-off-by: Cong Li coli@redhat.com
