### PR TITLE
generic.tests: Make the guest status collect configurable for netperf

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -56,6 +56,11 @@
     pkg_md5sum = 9654ffdfd4c4f2c93ce3733cd9ed9236
     setup_cmd = "cd /tmp && rm -rf netperf-2.6.0 && tar xvfj netperf-2.6.0.tar.bz2 && cd netperf-2.6.0 && ./configure --enable-burst --enable-demo=yes && make"
     log_hostinfo_script = scripts/rh_perf_log_hostinfo_script.sh
+    # Now the get status functions are implemented for RHEL and Fedora guests.
+    # Not test with other guests, please set this depends on your guest os
+    # environment.
+    RHEL, Fedora:
+        get_status_in_guest = yes
     #Linux:
     #    log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.sh
     #    log_guestinfo_exec = bash

--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -400,12 +400,12 @@ def launch_client(sessions, server, server_ctl, host, clients, l, nf_args,
     netperf_version = params.get("netperf_version", "2.6.0")
     client_path = "/tmp/netperf-%s/src/netperf" % netperf_version
     server_path = "/tmp/netperf-%s/src/netserver" % netperf_version
+    get_status_flag = params.get("get_status_in_guest", "no") == "yes"
     # Start netserver
     error.context("Start Netserver on guest", logging.info)
     if params.get("os_type") == "windows":
         timeout = float(params.get("timeout", "240"))
         cdrom_drv = utils_misc.get_winutils_vol(server_ctl)
-        get_status_flag = False
         if params.get("use_cygwin") == "yes":
             netserv_start_cmd = params.get("netserv_start_cmd")
             netperf_src = params.get("netperf_src") % cdrom_drv
@@ -443,7 +443,6 @@ def launch_client(sessions, server, server_ctl, host, clients, l, nf_args,
     else:
         logging.info("Netserver start cmd is '%s'" % server_path)
         ssh_cmd(server_ctl, "pidof netserver || %s" % server_path)
-        get_status_flag = True
         ncpu = ssh_cmd(server_ctl, "cat /proc/cpuinfo |grep processor |wc -l")
         ncpu = re.findall(r"\d+", ncpu)[0]
 


### PR DESCRIPTION
Now the guest statys collect functions are implemented and tested with
RHEL and Fedora guests. It may cause problem for other guests. So set
it default to no, only enable it for RHEL and Fedora guests.
