### PR TITLE
qemu.tests.cfg: Update some config for block_resize

### DIFF
--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -17,13 +17,15 @@
         block_size_cmd = wmic diskdrive get size, index
         block_size_pattern = "1\s+(\d+)"
         accept_ratio = 0.0005
-        guest_prepare_cmd_equal = "echo select disk 1 > cmd"
-        guest_prepare_cmd_equal += " && echo create partition primary >> cmd"
-        guest_prepare_cmd_equal += " && echo select partition 1 >> cmd"
-        guest_prepare_cmd_equal += " && echo format fs=ntfs quick >> cmd"
-        guest_prepare_cmd_equal += " && echo assign letter=E >> cmd"
-        guest_prepare_cmd_equal += " && echo exit >> cmd && diskpart /s cmd"
-        disk_update_cmd = "echo select disk 1 > cmd"
+        guest_prepare_cmd = "echo select disk 1 > cmd"
+        guest_prepare_cmd += " && echo online disk noerr >> cmd"
+        guest_prepare_cmd += " && echo attributes disk clear readonly noerr >> cmd"
+        guest_prepare_cmd += " && echo create partition primary >> cmd"
+        guest_prepare_cmd += " && echo format fs=ntfs label=local quick >> cmd"
+        guest_prepare_cmd += " && echo assign letter E >> cmd"
+        guest_prepare_cmd += " && echo exit >> cmd && diskpart /s cmd"
+        disk_update_cmd = "echo rescan > cmd"
+        disk_update_cmd += " && echo select disk 1 >> cmd"
         disk_update_cmd += " && echo select partition 1 >> cmd"
         disk_update_cmd += " && echo extend >> cmd"
         disk_update_cmd += " && echo exit >> cmd"
@@ -44,7 +46,8 @@
         need_reboot = no
     virtio_scsi:
         need_reboot = no
-        guest_prepare_cmd = "echo 1 > /sys/block/sda/device/rescan"
+        Linux:
+            guest_prepare_cmd = "echo 1 > /sys/block/sda/device/rescan"
     qcow2:
         disk_change_ratio = 1.5
     raw:


### PR DESCRIPTION
Since _equal suffix not support now, so change
guest_prepare_cmd_equal option to guest_prepare_cmd for windows guest.
