### PR TITLE
ping: modify the max ping packet size for windows guest

### DIFF
--- a/generic/tests/cfg/ping.cfg
+++ b/generic/tests/cfg/ping.cfg
@@ -3,6 +3,10 @@
     type = ping
     counts = 100
     flood_minutes = 10
+    Linux:
+        packet_size = "0 1 4 48 512 1440 1500 1505 4054 4055 4096 4192 8878 9000 32767 65507"
+    Windows:
+        packet_size = "0 1 4 48 512 1440 1500 1505 4054 4055 4096 4192 8878 9000 32767 65500"
     variants:
         - default_ping:
         - multi_nics:

--- a/generic/tests/ping.py
+++ b/generic/tests/ping.py
@@ -58,8 +58,7 @@ def run(test, params, env):
     counts = params.get("ping_counts", 100)
     flood_minutes = float(params.get("flood_minutes", 10))
 
-    packet_sizes = [0, 1, 4, 48, 512, 1440, 1500, 1505, 4054, 4055, 4096, 4192,
-                    8878, 9000, 32767, 65507]
+    packet_sizes = params.get("packet_size", "").split()
 
     for i, nic in enumerate(vm.virtnet):
         ip = vm.get_address(i)


### PR DESCRIPTION
Linux support the max ping packet size is 65507, but windows is 65500.
For windows systems, MSFT has limitation for the max size 65500.

Signed-off-by: Cong Li coli@redhat.com
