### PR TITLE
qemu.tests: Fix eject media failed for latest linux guest

### DIFF
--- a/qemu/tests/cfg/change_media.cfg
+++ b/qemu/tests/cfg/change_media.cfg
@@ -11,3 +11,11 @@
     cd_mount_cmd = mount %s /mnt
     cd_umount_cmd = umount /mnt
     cdrom_cd1 = /tmp/orig.iso
+    # systemd add new cdrom rules in udev to prevent eject media,
+    # so need to disable it before change media test to avoid test failed for some latest guest.
+    pre_cmd = "udev_cdrom=/lib/udev/rules.d/60-cdrom_id.rules; [ -f $udev_cdrom ] && "
+    pre_cmd += "sed -i 's/\(.*DISK_EJECT_REQUEST.*\)/#\1/g' $udev_cdrom && "
+    pre_cmd += "sed -i  's/\(.*lock-media.*\)/#\1/g' $udev_cdrom"
+    post_cmd = "udev_cdrom=/lib/udev/rules.d/60-cdrom_id.rules; [ -f $udev_cdrom ] && "
+    post_cmd += "sed -i 's/#\(.*DISK_EJECT_REQUEST.*\)/\1/g' $udev_cdrom  &&"
+    post_cmd += "sed -i 's/#\(.*lock-media.*\)/\1/g' $udev_cdrom"

--- a/qemu/tests/cfg/eject_media.cfg
+++ b/qemu/tests/cfg/eject_media.cfg
@@ -9,6 +9,15 @@
     post_command += "rm -rf /tmp/orig.iso /tmp/new.iso /tmp/orig /tmp/new;"
     new_img_name = /tmp/new.iso
     cdrom_cd1 = /tmp/orig.iso
+    # systemd add new cdrom rules in udev to prevent eject media,
+    # so need to disable it before eject media test to avoid test failed for some latest guest.
+    pre_cmd = "udev_cdrom=/lib/udev/rules.d/60-cdrom_id.rules; [ -f $udev_cdrom ] && "
+    pre_cmd += "sed -i 's/\(.*DISK_EJECT_REQUEST.*\)/#\1/g' $udev_cdrom && "
+    pre_cmd += "sed -i  's/\(.*lock-media.*\)/#\1/g' $udev_cdrom"
+    post_cmd = "udev_cdrom=/lib/udev/rules.d/60-cdrom_id.rules; [ -f $udev_cdrom ] && "
+    post_cmd += "sed -i 's/#\(.*DISK_EJECT_REQUEST.*\)/\1/g' $udev_cdrom  &&"
+    post_cmd += "sed -i 's/#\(.*lock-media.*\)/\1/g' $udev_cdrom"
+
     variants:
         - force_eject:
             force_eject = yes

--- a/qemu/tests/change_media.py
+++ b/qemu/tests/change_media.py
@@ -54,6 +54,11 @@ def run(test, params, env):
         monitor = vm.monitor
     session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
 
+    pre_cmd = params.get("pre_cmd")
+    if pre_cmd:
+        session.cmd(pre_cmd, timeout=60)
+        session = vm.reboot()
+
     logging.info("Wait until device is ready")
     time.sleep(10)
 
@@ -112,4 +117,9 @@ def run(test, params, env):
     umount_cmd = params.get("cd_umount_cmd")
     if umount_cmd:
         session.cmd(umount_cmd, timeout=360)
+
+    post_cmd = params.get("post_cmd")
+    if post_cmd:
+        session.cmd(post_cmd, timeout=60)
+
     session.close()

--- a/qemu/tests/eject_media.py
+++ b/qemu/tests/eject_media.py
@@ -29,6 +29,11 @@ def run(test, params, env):
     vm.verify_alive()
 
     session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
+    pre_cmd = params.get("pre_cmd")
+    if pre_cmd:
+        session.cmd(pre_cmd, timeout=60)
+        session = vm.reboot()
+
     logging.info("Wait until device is ready")
     time.sleep(10)
     blocks_info = vm.monitor.info("block")
@@ -103,5 +108,9 @@ def run(test, params, env):
     blocks_info = vm.monitor.info("block")
     if device_name not in str(blocks_info):
         raise error.TestFail("Could remove non-removable device!")
+
+    post_cmd = params.get("post_cmd")
+    if post_cmd:
+        session.cmd(post_cmd, timeout=60)
 
     session.close()


### PR DESCRIPTION
systemd add new cdrom rules in udev to prevent eject media, so need to disable it
before eject/change media test to avoid test failed for latest linux guest.
