### PR TITLE
qemu.test: Update the method for start vm in win_virtio_update

### DIFF
--- a/qemu/tests/cfg/win_virtio_update.cfg
+++ b/qemu/tests/cfg/win_virtio_update.cfg
@@ -2,7 +2,7 @@
     virt_test_type = qemu
     type = win_virtio_update
     only Windows
-    vms = ""
+    start_vm = no
     drivers_install = "balloon;block;nic"
     mount_point = "/tmp/mnt"
     driver_install_cmd_balloon = cmd /c WIN_UTILS:\\whql\virtio_driver_install_whql.exe WIN_VIRTIO:\\Balloon\\xp\\x86 balloon
@@ -49,7 +49,6 @@
         - check_info:
             type = win_virtio_update
             drivers_install = "balloon;block;nic;serial"
-            vms = ""
             check_info = yes
             drivers_check = "balloon;nic;block;serial"
             mount_point = "/tmp/mnt"

--- a/qemu/tests/win_virtio_update.py
+++ b/qemu/tests/win_virtio_update.py
@@ -154,10 +154,10 @@ def run(test, params, env):
                 check_cmds[driver][cmd_n] = cmd_c
 
     error.context("Boot up guest with setup parameters", logging.info)
-    vm = "vm1"
-    vm_params = params.copy()
-    env_process.preprocess_vm(test, vm_params, env, vm)
-    vm = env.get_vm(vm)
+    params["start_vm"] = "yes"
+    vm_name = params['main_vm']
+    env_process.preprocess_vm(test, params, env, vm_name)
+    vm = env.get_vm(vm_name)
     session = vm.wait_for_login(timeout=timeout)
 
     cdroms = params.get("cdroms")


### PR DESCRIPTION
The old code will cause problems in post process for images as the
vms is set to empty.
