### PR TITLE
qemu.tests: Small bug fix for ksm_base

### DIFF
--- a/qemu/tests/cfg/ksm_base.cfg
+++ b/qemu/tests/cfg/ksm_base.cfg
@@ -7,6 +7,7 @@
     shared_mem = 1024
     query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
     split = "yes"
+    guest_script_overhead = 20
     variants:
         - disable:
             test_type = "disable"

--- a/qemu/tests/ksm_base.py
+++ b/qemu/tests/ksm_base.py
@@ -79,7 +79,7 @@ def run(test, params, env):
                                     "shared/scripts/ksm_overcommit_guest.py")
     vm.copy_files_to(script_file_path, "/tmp")
     test_type = params.get("test_type")
-    shared_mem = params.get("shared_mem")
+    shared_mem = int(params["shared_mem"])
     get_free_mem_cmd = params.get("get_free_mem_cmd",
                                   "grep MemFree /proc/meminfo")
     free_mem = vm.get_memory_size(get_free_mem_cmd)


### PR DESCRIPTION
Correct the type of shared_mem in script. And enlarge the guest_script_overhead
in cfg file to ignore the memory leak lead in guest which will lead to the memory
allocate speed slow and make case failed in the memory allocate step.
