### PR TITLE
qemu.test: Remove remote params since it's set in base.cfg

### DIFF
--- a/generic/tests/cfg/ntpd.cfg
+++ b/generic/tests/cfg/ntpd.cfg
@@ -1,5 +1,7 @@
 - ntpd:
     no JeOS
+    # You must set remote parameters(ip and password) in base.cfg.
+    # The remote server must have ntp installed and port 123 opened
     virt_test_type = qemu libvirt
     only Linux
     requires_root = yes
@@ -10,11 +12,6 @@
     net_range = "NET.RANGE"
     mask = "NET.MASK"
     restrict_option = "nomodify notrap"
-    # server_* parameters must be set correctly.
-    # This server must have ntp installed and port 123 opened
-    remote_ip = "REMOTE.EXAMPLE.COM"
-    remote_pwd = "REMOTE.ROOT.PWD"
-    remote_user = "root"
     # Commonly we must wait at least 300 seconds for ntpd valid
     ntpdate_sleep = 300
     ntpd_sleep = 1200


### PR DESCRIPTION
Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
