### PR TITLE
qemu.tests.cfg: Update systemtap_tracing config

### DIFF
--- a/qemu/tests/cfg/systemtap_tracing.cfg
+++ b/qemu/tests/cfg/systemtap_tracing.cfg
@@ -53,6 +53,7 @@
                     probe_var_key = addr val
                     stap_script_file = cpu_out.stp
         - @qemu:
+            no Host_RHEL.7
             variants:
                 - qemu_free:
                     probe_var_key = ptr
@@ -132,15 +133,19 @@
                 - @ehci:
                     variants:
                         - usb_ehci_data:
+                            no Host_RHEL.7
                             probe_var_key = rw cpage offset addr len bufpos
                             stap_script_file = usb_echi_data.stp
                         - usb_ehci_mmio_change:
+                            no Host_RHEL.7
                             probe_var_key = addr str new old
                             stap_script_file = usb_ehci_mmio_change.stp
                         - usb_ehci_mmio_readl:
+                            no Host_RHEL.7
                             probe_var_key = addr str val
                             stap_script_file = usb_ehci_mmio_readl.stp
                         - usb_ehci_mmio_writel:
+                            no Host_RHEL.7
                             probe_var_key = addr str val
                             stap_script_file = usb_ehci_mmio_writel.stp
                         - usb_ehci_port_detach:
@@ -207,6 +212,7 @@
                             probe_var_key =  addr feature ret
                             stap_script_file = usb_set_device_feature.stp
         - @virtio_block:
+            only virtio_blk
             variants:
                 - virtio_blk_req_complete:
                     probe_var_key = req status


### PR DESCRIPTION
Disable some cases for rhel7 host, cause probe point not have in rhel7.

Signed-off-by: Shuping Cui scui@redhat.com
