### PR TITLE
qemu.tests.floppy: make mount tool auto-detect filesystem in floppy

### DIFF
--- a/qemu/tests/floppy.py
+++ b/qemu/tests/floppy.py
@@ -124,8 +124,8 @@ def run(test, params, env):
 
             if self.dest_dir:
                 error.context("Mounting floppy")
-                self.session.cmd("mount -t vfat %s %s" % (guest_floppy_path,
-                                                          self.dest_dir))
+                self.session.cmd("mount %s %s" % (guest_floppy_path,
+                                                  self.dest_dir))
             error.context("Testing floppy")
             self.session.cmd(params["test_floppy_cmd"])
 
@@ -243,8 +243,8 @@ def run(test, params, env):
 
                 error.context("Mount and copy data")
                 if self.mount_dir:
-                    session.cmd("mount -t vfat %s %s" % (guest_floppy_path,
-                                                         self.mount_dir),
+                    session.cmd("mount %s %s" % (guest_floppy_path,
+                                                 self.mount_dir),
                                 timeout=30)
 
                 error.context("File copying test")
@@ -356,8 +356,8 @@ def run(test, params, env):
 
                 error.context("Check floppy")
                 if self.mount_dir:   # If linux
-                    session.cmd("mount -t vfat %s %s" % (guest_floppy_path,
-                                                         self.mount_dir), timeout=30)
+                    session.cmd("mount %s %s" % (guest_floppy_path,
+                                                 self.mount_dir), timeout=30)
                     session.cmd("umount %s" % (self.mount_dir), timeout=30)
 
                 written = None
@@ -384,8 +384,8 @@ def run(test, params, env):
 
                 error.context("Mount and copy data")
                 if self.mount_dir:   # If linux
-                    session.cmd("mount -t vfat %s %s" % (guest_floppy_path,
-                                                         self.mount_dir), timeout=30)
+                    session.cmd("mount %s %s" % (guest_floppy_path,
+                                                 self.mount_dir), timeout=30)
 
                 if not second_floppy in vm.monitor.info("block"):
                     raise error.TestFail("Wrong floppy image is placed in vm.")


### PR DESCRIPTION
Not all floppy was be format to vfat filesystem, so remove it to make it
auto-detect by 'mount' tool.

Signed-off-by: Xu Tian xutian@redhat.com
