### PR TITLE
qemu.tests.cfg: Disable physical_resources_check for pci_assignable

### DIFF
--- a/qemu/tests/cfg/physical_resources_check.cfg
+++ b/qemu/tests/cfg/physical_resources_check.cfg
@@ -1,5 +1,6 @@
 - physical_resources_check: install setup image_copy unattended_install.cdrom
     only i386, x86_64
+    only no_pci_assignable
     type = physical_resources_check
     default_cpu_model = "qemu64"
     # The following config parameters are only for Linux guest, thay might


### PR DESCRIPTION
We don't need to test physical_resources_check for pci_assignable,
so diable it.

Signed-off-by: Shuping Cui scui@redhat.com
