### PR TITLE
qemu.tests.cfg: Small bug fix when booting vm with virtio_scsi

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -78,7 +78,10 @@
                     stg_params += "drive_unit:range(0,255,1,3) "
                     stg_params += "drive_port:range(0,16383,8191) "
                 - multi_bus_scsiid_lun:
-                    stg_params += "drive_bus:range(0,15,1,9) "
+                    ide, virtio_blk:
+                        stg_params += "drive_bus:range(0,15,1,9) "
+                    virtio_scsi:
+                        stg_params += "drive_bus:range(1,15,1,9) "
                     stg_params += "drive_unit:range(0,255,127,3) "
                     stg_params += "drive_port:range(0,16383,8191) "
         - debug_params:


### PR DESCRIPTION
The stg bus number will inflict with image1 as both of them are virtio_scsi
device, so change it, should be started from 1.

Signed-off-by: Shuping Cui scui@redhat.com
