### PR TITLE
qemu.tests.hdparm: disable virtio_blk scenario

### DIFF
--- a/qemu/tests/cfg/hdparm.cfg
+++ b/qemu/tests/cfg/hdparm.cfg
@@ -2,6 +2,7 @@
     only Linux
     no sd
     no virtio_scsi
+    no virtio_blk
     type = hdparm
     get_disk_cmd = \ls /dev/[vhs]da
     low_status_cmd = hdparm -a64 -d0 -u0 %s


### PR DESCRIPTION
As hdparm is used for IDE/AHCI device, disable virtio_blk scenario for this case.

Signed-off-by: Cong Li coli@redhat.com
