### PR TITLE
qemu.tests: Add a test case for collecting Windows guest information

### DIFF
--- a/qemu/tests/cfg/windows_info.cfg
+++ b/qemu/tests/cfg/windows_info.cfg
@@ -1,0 +1,3 @@
+- windows_info:
+    type = windows_info
+    only Windows

--- a/qemu/tests/windows_info.py
+++ b/qemu/tests/windows_info.py
@@ -1,0 +1,47 @@
+import logging
+import re
+from autotest.client.shared import error
+
+
+@error.context_aware
+def run(test, params, env):
+    """
+    KVM Windows version collect:
+    This case is used to collect windows guest informations using in test.
+    1) Get os version related informations
+    2) Get driver related informations
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    timeout = int(params.get("login_timeout", 360))
+    drivers_keywords = params.get("drivers_keywords", "VirtIO vio").split()
+    drivers_pattern = "|".join(drivers_keywords)
+    session = vm.wait_for_login(timeout=timeout)
+
+    error.context("Get OS version and name.", logging.info)
+    output = session.cmd("ver")
+    logging.info("Windows version: %s" % output.strip())
+    output = session.cmd("wmic os get Name")
+    output = output.strip().split()[-1]
+    logging.info("Windows name: %s" % output)
+
+    error.context("Get driver version information in guest.", logging.info)
+    system_drivers = session.cmd("wmic sysdriver get DisplayName,PathName")
+    logging.debug("Drivers exist in the system:\n %s" % system_drivers)
+    for i in system_drivers.splitlines():
+        if re.findall(drivers_pattern, i, re.I):
+            driver_info = i.strip().split()
+            driver_name = " ".join(driver_info[:-1])
+            path = driver_info[-1]
+            path = re.sub(r"\\", "\\\\\\\\", path)
+            driver_ver_cmd = "wmic datafile where name="
+            driver_ver_cmd += "'%s' get version" % path
+            output = session.cmd(driver_ver_cmd)
+            msg = "Driver %s" % driver_name
+            msg += " version is %s" % output.strip().split()[-1]
+            logging.info(msg)
+    session.close()


### PR DESCRIPTION
This case is used to collect guest information in test loop. This will
help the test runner have more information about guest os version and
dirver version informations(virtio drivers version etc.).
