### PR TITLE
generic.tests: Support ignore network break inside guest in autotest_con...

### DIFF
--- a/generic/tests/autotest_control.py
+++ b/generic/tests/autotest_control.py
@@ -23,10 +23,12 @@ def run(test, params, env):
     control_args = params.get("control_args")
     control_path = os.path.join(test.virtdir, "control",
                                 params.get("test_control_file"))
+    ignore_sess_terminated = params.get("ignore_session_terminated") == "yes"
     outputdir = test.outputdir
 
     utils_test.run_autotest(vm, session, control_path, timeout, outputdir,
-                            params, control_args=control_args)
+                            params, control_args=control_args,
+                            ignore_session_terminated=ignore_sess_terminated)
 
 
 def run_autotest_control_background(test, params, env,


### PR DESCRIPTION
...trol

based on this pullreqs

https://github.com/autotest/virt-test/pull/1771
