### PR TITLE
generic.tests.cfg: Small fix for multi_queues_test

### DIFF
--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -2,7 +2,9 @@
     virt_test_type = qemu libvirt
     no smp2
     only Linux
-    no RHEL.3, RHEL.4, RHEL.5, RHEL.6
+    no RHEL.3, RHEL.4, RHEL.5
+    no RHEL.6.0, RHEL.6.1, RHEL.6.2, RHEL.6.3, RHEL.6.4, RHEL.6.5
+    no Host_RHEL.5, Host_RHEL.6
     type = multi_queues_test
     queues = 4
     enable_msix_vectors = yes


### PR DESCRIPTION
(1) Host_RHEL.6 and Host_RHEL.5 not support MQ, disable it.
(2) RHEL.6.6 guest is ready to support MQ now, so add this guest back.
