### PR TITLE
qemu.tests: Update the method get qemu and qemu-img binary

### DIFF
--- a/qemu/tests/block_stream_drop_backingfile.py
+++ b/qemu/tests/block_stream_drop_backingfile.py
@@ -31,7 +31,7 @@ def run(test, params, env):
     alive_check_cmd = params.get("alive_check_cmd", "dir")
     image_file = storage.get_image_filename(params, data_dir.get_data_dir())
     image_dir = os.path.dirname(image_file)
-    qemu_img = params.get("qemu_img_binary", "qemu-img")
+    qemu_img = utils_misc.get_qemu_img_binary(params)
     speed = int(params.get("limited_speed", 0))
     wait_timeout = int(params.get("wait_timeout", 3600))
 

--- a/qemu/tests/enospc.py
+++ b/qemu/tests/enospc.py
@@ -20,9 +20,7 @@ class EnospcConfig(object):
         self.__dict__ = self.__shared_state
         root_dir = test.bindir
         self.tmpdir = test.tmpdir
-        self.qemu_img_binary = params['qemu_img_binary']
-        if not os.path.isfile(self.qemu_img_binary):
-            self.qemu_img_binary = utils_misc.get_qemu_img_binary(params)
+        self.qemu_img_binary = utils_misc.get_qemu_img_binary(self.params)
         self.raw_file_path = os.path.join(self.tmpdir, 'enospc.raw')
         # Here we're trying to choose fairly explanatory names so it's less
         # likely that we run in conflict with other devices in the system

--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -249,7 +249,7 @@ def run(test, params, env):
         session.cmd("modprobe %s" % module)
 
     # check monitor type
-    qemu_binary = params.get("qemu_binary", "/usr/libexec/qemu-kvm")
+    qemu_binary = utils_misc.get_qemu_binary(params)
     qemu_binary = utils_misc.get_path(test.bindir, qemu_binary)
     # Probe qemu to verify what is the supported syntax for PCI hotplug
     if vm.monitor.protocol == 'qmp':

--- a/qemu/tests/qemu_io.py
+++ b/qemu/tests/qemu_io.py
@@ -20,11 +20,7 @@ class QemuIOConfig(object):
         self.__dict__ = self.__shared_state
         root_dir = test.bindir
         self.tmpdir = test.tmpdir
-        self.qemu_img_binary = params.get('qemu_img_binary')
-        if not os.path.isfile(self.qemu_img_binary):
-            self.qemu_img_binary = utils_misc.get_path(os.path.join(root_dir,
-                                                                    params.get("vm_type")),
-                                                       self.qemu_img_binary)
+        self.qemu_img_binary = utils_misc.get_qemu_img_binary(params)
         self.raw_files = ["stg1.raw", "stg2.raw"]
         self.raw_files = map(lambda f: os.path.join(self.tmpdir, f),
                              self.raw_files)


### PR DESCRIPTION
Use the function from utils_misc to get the qemu and qemu-img binary.
