### PR TITLE
generic.tests.autotest_control: Support args parameters when running cli...

### DIFF
--- a/generic/tests/autotest_control.py
+++ b/generic/tests/autotest_control.py
@@ -20,12 +20,13 @@ def run(test, params, env):
 
     # Collect test parameters
     timeout = int(params.get("test_timeout", 300))
+    control_args = params.get("control_args")
     control_path = os.path.join(test.virtdir, "control",
                                 params.get("test_control_file"))
     outputdir = test.outputdir
 
     utils_test.run_autotest(vm, session, control_path, timeout, outputdir,
-                            params)
+                            params, control_args=control_args)
 
 
 def run_autotest_control_background(test, params, env,

--- a/generic/tests/cfg/autotest_control.cfg
+++ b/generic/tests/cfg/autotest_control.cfg
@@ -147,6 +147,7 @@
             no RHEL.3 RHEL.4
             test_timeout =1800
             test_control_file = fio.control
+            control_args = "-rw=randread -bs=8k -size 1G -numjobs=8 -runtime=600 -iodepth=32 -iodepth_batch=16"
         - unixbench5:
             no RHEL.3 RHEL.4
             test_timeout = 4200


### PR DESCRIPTION
...ent tests in guest.

run_autotest() support this feature by update the control file used in
guest.
We can add args by set control_args.
control_args = "-rw=randread -bs=8k -size 1G -numjobs=8 -runtime=600"

Signed-off-by: Feng Yang fyang@redhat.com
