### PR TITLE
generic.tests: Set test_timeout to 5400s for autotest.bonnie

### DIFF
--- a/generic/tests/cfg/autotest_control.cfg
+++ b/generic/tests/cfg/autotest_control.cfg
@@ -12,6 +12,7 @@
             test_control_file = dbench.control
         - bonnie:
             test_control_file = bonnie.control
+            test_timeout = 5400
         - ebizzy:
             test_control_file = ebizzy.control
         - ffsb:


### PR DESCRIPTION
Signed-off-by: Feng Yang fyang@redhat.com
