### PR TITLE
qemu.tests: Add check for qemu process after quit()

### DIFF
--- a/qemu/tests/cfg/valgrind_memalign.cfg
+++ b/qemu/tests/cfg/valgrind_memalign.cfg
@@ -7,6 +7,9 @@
     disable_kvm = yes
     enable-kvm = no
     start_vm = no
-    mem_equal = 1024
     Ubuntu:
         valgrind_install_cmd = "apt-get install -y valgrind"
+    images = ""
+    nics = ""
+    isa_serials = ""
+    usb_devices = ""

--- a/qemu/tests/valgrind_memalign.py
+++ b/qemu/tests/valgrind_memalign.py
@@ -30,14 +30,23 @@ def run(test, params, env):
             logging.info("Install valgrind successfully.")
 
     valgring_support_check_cmd = params.get("valgring_support_check_cmd")
+    error.context("Check valgrind installed in host", logging.info)
     try:
         utils.system(valgring_support_check_cmd, timeout=interval)
     except Exception:
         valgrind_intall()
 
+    params['mem'] = 384
     params["start_vm"] = "yes"
+    error.context("Start guest with specific parameters", logging.info)
     env_process.preprocess_vm(test, params, env, params.get("main_vm"))
     vm = env.get_vm(params["main_vm"])
 
     time.sleep(interval)
+    error.context("Verify guest status is running after cont", logging.info)
     vm.verify_status("running")
+
+    error.context("Quit guest and check the process quit normally",
+                  logging.info)
+    vm.destroy(gracefully=False)
+    vm.verify_userspace_crash()


### PR DESCRIPTION
We need check the qemu process can quit normally in the end of test.
Also fix the memory size inside script and remove the useless parameters.
