### PR TITLE
qemu.tests: Set up guest os runlevel for system_powerdown

### DIFF
--- a/qemu/tests/cfg/system_powerdown.cfg
+++ b/qemu/tests/cfg/system_powerdown.cfg
@@ -3,3 +3,5 @@
     shutdown_method = system_powerdown
     sleep_before_powerdown = 20
     kill_vm = yes
+    Linux:
+         setup_runlevel = yes


### PR DESCRIPTION
Setup the runlevel for system_powerdown case before test send the
monitor command.
