### PR TITLE
generic.tests: Update the migration related parameters for trans_hugepag...

### DIFF
--- a/generic/tests/cfg/trans_hugepage.cfg
+++ b/generic/tests/cfg/trans_hugepage.cfg
@@ -22,9 +22,9 @@
         - migration:
             type = migration
             migration_test_command = help
-            migration_bg_command = "mkdir -p /space; mount -t tmpfs none /space; while true; do dd if=/dev/zero of=/space/zero bs=4M count=1M;done"
-            migration_bg_check_command = "pidof dd"
-            migration_bg_kill_command = "killall dd"
+            migration_bg_command = "mkdir -p /space; mount -t tmpfs none /space; while true; do dd if=/dev/zero of=/space/zero bs=4M count=1M; sleep 1; done"
+            migration_bg_check_command = "pidof dd || pidof sleep"
+            migration_bg_kill_command = "killall dd || killall sleep"
         - memory_stress:
             type = trans_hugepage_memory_stress
             thp_memory_stress = autotest_control


### PR DESCRIPTION
...e

Add sleep in the background command to ignore the memory load too much to
failed the migrate.
