### PR TITLE
qemu.cfg.usb: Set max nest levels of hub device to 5.

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -44,6 +44,7 @@
                 - one_usb_dev:
                 - max_usb_dev:
                     only usb_boot, usb_reboot
+                    no usb_hub
                     usb_devices += " d1 d2 d3 d4 d5 d6 d7"
                     usb_port_d1 = "2.2"
                     usb_port_d2 = "2.3"
@@ -52,6 +53,13 @@
                     usb_port_d5 = "2.6"
                     usb_port_d6 = "2.7"
                     usb_port_d7 = "2.8"
+                - max_usb_hub_dev:
+                    only usb_boot, usb_reboot
+                    only usb_hub
+                    usb_devices += " hub2 hub3 hub4"
+                    usb_port_hub2 = "2.2"
+                    usb_port_hub3 = "2.3"
+                    usb_port_hub4 = "2.4"
 
     # usb devices
     variants:


### PR DESCRIPTION
Signed-off-by: Feng Yang fyang@redhat.com

ID: 1079874
