### PR TITLE
Timedrift adjust time fixes

### DIFF
--- a/qemu/tests/cfg/timedrift_adjust_time.cfg
+++ b/qemu/tests/cfg/timedrift_adjust_time.cfg
@@ -13,6 +13,7 @@
     nettype = user
     login_timeout = 360
     requires_root = yes
+    inactivity_treshold = 3600
     Linux:
         sys_time_command = "date +'%a, %d %b %Y %H:%M:%S %Z'"
         sys_time_filter_re = "(.*)"


### PR DESCRIPTION
Here's a couple of adjustments to the timedrift_adjust_time tests, that will reduce confusion and show to users properly that the test in question requires root.
