### PR TITLE
generic.test: update invalid_para_mq test

### DIFF
--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -56,7 +56,13 @@
         - invalid_queues_number:
             start_vm = no
             type = invalid_para_mq
-            queues = 9
+            variants:
+                - upper_border:
+                    queues = 9
+                    key_words = "Argument list too long"
+                - lower_border:
+                    queues = 0
+                    key_words = "(No such device|Cannot bring up TAP)"
         - multi_nics:
             check_vhost_threads = no
             mac_filter = "HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+)"

--- a/generic/tests/invalid_para_mq.py
+++ b/generic/tests/invalid_para_mq.py
@@ -1,6 +1,8 @@
+import re
 import logging
 from autotest.client.shared import error
-from virttest import utils_net, env_process
+from virttest import utils_net
+from virttest import env_process
 
 
 @error.context_aware
@@ -9,18 +11,41 @@ def run(test, params, env):
     Enable MULTI_QUEUE feature in guest
 
     1) Boot up VM with wrong queues number
-    2) check the qemu can report the error.
+    2) Check qemu not coredump
+    3) Check the qemu can report the error
 
     :param test: QEMU test object.
     :param params: Dictionary with the test parameters.
     :param env: Dictionary with test environment.
     """
+    vm_name = params["main_vm"]
     params["start_vm"] = "yes"
-    error.context("Boot the vm using queues %s'" % params.get("queues"), logging.info)
+    nic_queues = int(params["queues"])
     try:
-        env_process.preprocess_vm(test, params, env, params.get("main_vm"))
-        env.get_vm(params["main_vm"])
-    except utils_net.TAPCreationError, e:
-        logging.info("Error when open tap, error info is '%s'" % e)
-    else:
-        error.TestError("Params is wrong, the qemu should report that error")
+        error.context("Boot the vm using queues %s'" % nic_queues,
+                      logging.info)
+        env_process.preprocess_vm(test, params, env, vm_name)
+        vm = env.get_vm(vm_name)
+        vm.destroy()
+        raise error.TestError("Qemu start up normally, "
+                              "didn't quit as expect")
+    except utils_net.NetError, exp:
+        message = str(exp)
+        # clean up tap device when qemu coredump to ensure,
+        # to ensure next test has clean network envrioment
+        if (hasattr(exp, 'ifname') and exp.ifname
+                and exp.ifname in utils_net.get_host_iface()):
+            try:
+                bridge = params.get("netdst", "switch")
+                utils_net.del_from_bridge(exp.ifname, bridge)
+            except Exception as warning:
+                logging.warn("Error occurent when clean tap " +
+                             "device(%s)" % str(warning))
+        error.context("Check Qemu not coredump", logging.info)
+        if "(core dumped)" in message:
+            raise error.TestFail("Qemu core dumped when boot "
+                                 "with invalid parameters.")
+        error.context("Check Qemu quit with except message", logging.info)
+        if not re.search(params['key_words'], message, re.M | re.I):
+            logging.info("Error message: %s" % message)
+            raise error.TestFail("Can't detect expect error")


### PR DESCRIPTION
updates:
    1. fix pep8 issue
    2. update step to check both upper and lower border values.
    3. add step to check qemu process coredump.
    4. add step to remove tap device from swith in the end of test if
       netdst is openvswtich.

Signed-off-by: Xu Tian xutian@redhat.com
