### PR TITLE
spice tests: adding fixes for windows guest

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -50,14 +50,13 @@ only i440fx
 only hmp
 
 variants:
-    - qxl:
-
     - os:
         variants:
             - RHEL:
                 only Linux.RHEL.6.devel.x86_64
             - Windows:
-                only Win7.64.sp1
+                image_size = 30G
+                only Win7.x86_64.sp1
 
 variants:
     - vnc:
@@ -218,7 +217,7 @@ variants:
         only os.Windows
         # Subtest choice. You can modify that line to add more subtests
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only unattended_install.cdrom.default_install.aio_native
+        only unattended_install.cdrom.floppy_ks.default_install.aio_native
 
     - qemu_kvm_rhel6devel_install_guest:
         only os.RHEL


### PR DESCRIPTION
Increasing the image size to 30G for windows guests
and a couple of other minor fixes

Reviewed by: Swapna Krishnan skrishna@redhat.com
