### PR TITLE
qemu.tests: logout iscsi session in the end of test

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -77,6 +77,7 @@
                                    portal_ip = "192.168.1.2"
                                    initiator = "iqn.2010-07.test.org:kvmautotest"
                                    target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-test"
+                                   post_command = "iscsiadm --mode node --targetname ${target} --portal ${portal_ip}:3260 --logout"
                                    # End
                         - continuous_backup:
                            type = drive_mirror_continuous_backup
@@ -163,3 +164,4 @@
                    initiator = "iqn.2010-07.test.org:kvmautotest"
                    start_firewall_cmd = "iptables -A INPUT -p tcp -d ${portal_ip} --dport 3260 -j DROP"
                    target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-test"
+                   post_command += "; iscsiadm --mode node --targetname ${target} --portal ${portal_ip}:3260 --logout"


### PR DESCRIPTION
In the end of test, we cleanup target image after to save disk space,
but if target is a iscsi target, we just removed file under dev which
will make next test which  use iscsi target failed to detect dev file,
because iscsi still connect but leak dev file.

Signed-off-by: Xu Tian xutian@redhat.com
