### PR TITLE
Update the qemu_cpu.cfg to run autotest appropriately

### DIFF
--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -270,7 +270,46 @@
                     # If we are running on an AMD CPU, feature aliases will appear
                     # on CPUID, even if it was originally an Intel CPU model,
                     # so ignore the differences:
-                    (host_cpu_vendor = unknown), (host_cpu_vendor = amd)..cpu.intel, (host_cpu_vendor = intel)..cpu.amd:
+                    #(host_cpu_vendor = unknown), (host_cpu_vendor = amd)..cpu.intel, (host_cpu_vendor = intel)..cpu.amd:
+                    unknown:
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,0"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,2"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,3"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,4"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,5"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,6"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,7"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,8"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,9"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,12"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,13"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,14"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,15"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,16"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,17"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,23"
+                        ignore_cpuid_leaves += " 0x80000001,0x00,edx,24"
+                    amd:
+                        cpu.intel:
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,0"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,2"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,3"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,4"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,5"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,6"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,7"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,8"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,9"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,12"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,13"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,14"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,15"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,16"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,17"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,23"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,24"
+                    intel:
+                        cpu.amd:
                             ignore_cpuid_leaves += " 0x80000001,0x00,edx,0"
                             ignore_cpuid_leaves += " 0x80000001,0x00,edx,2"
                             ignore_cpuid_leaves += " 0x80000001,0x00,edx,3"


### PR DESCRIPTION
As the test fail of Invalid key: (host_cpu_vendor ，the " ( " can not be recognized succesfully.

Signed-off-by: Yang Xue <yaxue@redhat.com>