### PR TITLE
qemu.tests.cfg: Disable pre_cmd and post_cmd for RHEL3, 4, 5, 6 guest

### DIFF
--- a/qemu/tests/cfg/cdrom_test.cfg
+++ b/qemu/tests/cfg/cdrom_test.cfg
@@ -89,4 +89,7 @@
         post_cmd = "udev_cdrom=/lib/udev/rules.d/60-cdrom_id.rules; [ -f $udev_cdrom ] && "
         post_cmd += "sed -i 's/#\(.*DISK_EJECT_REQUEST.*\)/\1/g' $udev_cdrom  &&"
         post_cmd += "sed -i 's/#\(.*lock-media.*\)/\1/g' $udev_cdrom"
+        RHEL.3, RHEL.4, RHEL.5, RHEL.6:
+            pre_cmd = ""
+            post_cmd = ""
         md5sum_cmd = "md5sum %s"


### PR DESCRIPTION
There is no /usr/lib/udev/rules.d in these guest.
