### PR TITLE
fix bug in  block_copy releated cases

### DIFF
--- a/qemu/tests/blk_stream.py
+++ b/qemu/tests/blk_stream.py
@@ -79,12 +79,6 @@ class BlockStream(block_copy.BlockCopy):
             raise error.TestFail("Job not finished in %s seconds" % timeout)
         logging.info("Block stream job done.")
 
-    def action_before_start(self):
-        """
-        run steps before streaming start;
-        """
-        return self.do_steps("before_start")
-
     def action_when_streaming(self):
         """
         run steps when job in steaming;

--- a/qemu/tests/blk_stream.py
+++ b/qemu/tests/blk_stream.py
@@ -1,6 +1,5 @@
 import logging
-import time
-from virttest import utils_misc, data_dir
+from virttest import utils_misc
 from autotest.client.shared import error
 from qemu.tests import block_copy
 
@@ -15,9 +14,11 @@ class BlockStream(block_copy.BlockCopy):
         super(BlockStream, self).__init__(test, params, env, tag)
 
     def parser_test_args(self):
-        params = super(BlockStream, self).parser_test_args()
-        params["wait_finished"] = params.get("wait_finished", "yes").lower()
-        return params
+        default_params = {"wait_finished": "yes",
+                          "snapshot_format": "qcow2",
+                          "snapshot_chain": ""}
+        self.default_params.update(default_params)
+        return super(BlockStream, self).parser_test_args()
 
     @error.context_aware
     def start(self):
@@ -30,15 +31,11 @@ class BlockStream(block_copy.BlockCopy):
 
         error.context("start to stream block device", logging.info)
         self.vm.block_stream(self.device, default_speed, base_image)
-        time.sleep(0.5)
         status = self.get_status()
         if not status:
             raise error.TestFail("no active job found")
         msg = "block stream job running, "
-        if default_speed:
-            msg += "with limited speed %s B/s" % default_speed
-        else:
-            msg += "without limited speed"
+        msg += "with limited speed %s B/s" % default_speed
         logging.info(msg)
 
     @error.context_aware
@@ -47,26 +44,25 @@ class BlockStream(block_copy.BlockCopy):
         create live snapshot_chain, snapshots chain define in $snapshot_chain
         """
         params = self.parser_test_args()
-        snapshots = params.get("snapshot_chain").split()
-        format = params.get("snapshot_format", "qcow2")
+        image_format = params["snapshot_format"]
+        snapshots = params["snapshot_chain"].split()
         error.context("create live snapshots", logging.info)
-        for sn in snapshots:
-            sn = utils_misc.get_path(data_dir.get_data_dir(), sn)
+        for snapshot in snapshots:
+            snapshot = utils_misc.get_path(self.data_dir, snapshot)
             image_file = self.get_image_file()
-            device = self.vm.live_snapshot(image_file, sn, format)
+            device = self.vm.live_snapshot(image_file, snapshot, image_format)
             if device != self.device:
                 image_file = self.get_image_file()
-                logging.info("expect file: %s\n opening file: %s" % (sn,
-                                                                     image_file))
-                raise error.TestFail("create live snapshot %s fail" % sn)
-            self.trash.append(sn)
+                logging.info("expect file: %s" % snapshot +
+                             "opening file: %s" % image_file)
+                raise error.TestFail("create snapshot '%s' fail" % snapshot)
+            self.trash_files.append(snapshot)
 
     def job_finished(self):
         """
         check if streaming job finished;
         """
-        job_info = self.get_status()
-        if job_info:
+        if self.get_status():
             return False
         if self.vm.monitor.protocol == "qmp":
             return bool(self.vm.monitor.get_event("BLOCK_JOB_COMPLETED"))
@@ -78,11 +74,9 @@ class BlockStream(block_copy.BlockCopy):
         """
         params = self.parser_test_args()
         timeout = params.get("wait_timeout")
-        finished = utils_misc.wait_for(self.job_finished, step=1.0,
-                                       timeout=timeout,
-                                       text="wait job finshed in %ss" % timeout)
+        finished = utils_misc.wait_for(self.job_finished, timeout=timeout)
         if not finished:
-            raise error.TestFail("Wait job finished timeout in %s" % timeout)
+            raise error.TestFail("Job not finished in %s seconds" % timeout)
         logging.info("Block stream job done.")
 
     def action_before_start(self):
@@ -103,6 +97,6 @@ class BlockStream(block_copy.BlockCopy):
         """
         params = self.parser_test_args()
         # if block job cancelled, no need to wait it;
-        if params["wait_finished"].lower() == "yes":
+        if params["wait_finished"] == "yes":
             self.wait_for_finished()
         return self.do_steps("after_finished")

--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -244,6 +244,18 @@ class BlockCopy(object):
         except AttributeError:
             logging.warn("No backingfile found, cmd output: %s" % info)
 
+    def action_before_start(self):
+        """
+        run steps before job in steady status;
+        """
+        return self.do_steps("before_start")
+
+    def action_before_cleanup(self):
+        """
+        run steps before job in steady status;
+        """
+        return self.do_steps("before_cleanup")
+
     def clean(self):
         """
         close opening connections and clean trash files;

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -87,6 +87,13 @@
                            dd_cmd = "dd if=/dev/zero bs=1024 count=1024 of=tmp%s.file"
                            Windows:
                                clean_cmd = "del /F tmp*.file"
+                - negative_test:
+                    negative_test = yes
+                    variants:
+                        - readonly_target:
+                            create_mode = existing
+                            before_start = readonly_target
+                            before_cleanup = clear_readonly_bit
         - with_stress:
             type = drive_mirror_stress
             reopen_timeout = 600

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -20,14 +20,15 @@
     wait_timeout = 3600
     # wait_timeout: wait xx seconds for block mirror job go into steady status, aka offset equal image length
     source_images = "image1"
+    target_image_image1 = "target"
     # source_images: set which image will be mirroring to target, now only a image at one time;
     full_copy_image1 = "full"
     #for full image or top most
     default_speed_image1 = 0
     # default speed unit is B/s, for 10MB/s please set speed to '10M'
-    target_format_image1 = "qcow2"
-    create_mode_image1 = "absolute-paths"
-    target_image_image1 = "images/target1"
+    image_format_target = "qcow2"
+    create_mode_target = "absolute-paths"
+    image_name_target = "images/target1"
     check_event = no
     tmp_dir = "/tmp"
     variants:
@@ -59,9 +60,9 @@
                                    open_target_image = yes
                                    boot_target_image = no
                                - target_in_nfs:
-                                   target_image_type = nfs
+                                   image_type_target = nfs
                                    nfs_mount_dir = "/mnt/nfs"
-                                   target_image_image1 = "${nfs_mount_dir}/target1"
+                                   image_name_target = "${nfs_mount_dir}/target1"
                                    nfs_mount_options = "rw"
                                    export_dir = "/home/nfs"
                                    export_options = "rw,no_root_squash,async"
@@ -70,13 +71,15 @@
                                    open_target_image = no
                                - target_to_iscsi:
                                    # target_image will ingore, target_image will generate automatically
-                                   target_image_type = iscsi
+                                   image_type_target = iscsi
+                                   force_cleanup_target = yes
+                                   host_setup_flag_target = 2
                                    open_target_image = no
                                    boot_target_image = yes
                                    # Please replace below iscsi connection params before start your testing
-                                   portal_ip = "192.168.1.2"
-                                   initiator = "iqn.2010-07.test.org:kvmautotest"
-                                   target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-test"
+                                   portal_ip_target = "192.168.1.2"
+                                   initiator_target = "iqn.2010-07.test.org:kvmautotest"
+                                   target_target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-test"
                                    # End
                         - continuous_backup:
                            type = drive_mirror_continuous_backup
@@ -145,9 +148,9 @@
            post_command = "iptables -F"
            variants:
                - target_in_nfs:
-                   target_image_type = nfs
+                   image_type_target = nfs
                    nfs_mount_dir = "/mnt/nfs"
-                   target_image_image1 = "${nfs_mount_dir}/target1"
+                   image_name_target = "${nfs_mount_dir}/target1"
                    nfs_mount_options = "rw"
                    export_dir = "/home/nfs"
                    export_options = "rw,no_root_squash,async"
@@ -155,11 +158,13 @@
                    start_firewall_cmd = "iptables -A INPUT -p tcp -d 127.0.0.1 --dport 2049 -j DROP"
                - target_to_iscsi:
                    # target_image will ingore, target_image will generate automatically
-                   target_image_type = iscsi
+                   image_type_target = iscsi
                    open_target_image = no
                    boot_target_image = yes
+                   force_cleanup_target = yes
+                   host_setup_flag_target = 2
                    # Please replace below iscsi connection params before start your testing
-                   portal_ip = "192.168.1.2"
-                   initiator = "iqn.2010-07.test.org:kvmautotest"
-                   start_firewall_cmd = "iptables -A INPUT -p tcp -d ${portal_ip} --dport 3260 -j DROP"
-                   target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-test"
+                   portal_ip_target = "192.168.1.2"
+                   initiator_target = "iqn.2010-07.test.org:kvmautotest"
+                   target_target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-test"
+                   start_firewall_cmd = "iptables -A INPUT -p tcp -d ${portal_ip_target} --dport 3260 -j DROP"

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -70,6 +70,7 @@
                                    boot_target_image = yes
                                    open_target_image = no
                                - target_to_iscsi:
+                                   image_format_target = raw
                                    # target_image will ingore, target_image will generate automatically
                                    image_type_target = iscsi
                                    force_cleanup_target = yes
@@ -166,8 +167,6 @@
                - target_to_iscsi:
                    # target_image will ingore, target_image will generate automatically
                    image_type_target = iscsi
-                   open_target_image = no
-                   boot_target_image = yes
                    force_cleanup_target = yes
                    host_setup_flag_target = 2
                    # Please replace below iscsi connection params before start your testing

--- a/qemu/tests/drive_mirror.py
+++ b/qemu/tests/drive_mirror.py
@@ -133,12 +133,6 @@ class DriveMirror(block_copy.BlockCopy):
             raise error.TestFail("Wait mirroring job ready "
                                  "timeout in %ss" % timeout)
 
-    def action_before_start(self):
-        """
-        run steps before job in steady status;
-        """
-        return self.do_steps("before_start")
-
     def action_before_steady(self):
         """
         run steps before job in steady status;

--- a/qemu/tests/drive_mirror_complete.py
+++ b/qemu/tests/drive_mirror_complete.py
@@ -39,8 +39,9 @@ def run(test, params, env):
             device_id = mirror_test.vm.get_block({"file": target_image})
             if device_id != mirror_test.device:
                 raise error.TestError("Mirrored image not being used by guest")
-        error.context("Compare fully mirrored images", logging.info)
-        qemu_img.compare_images(source_image, target_image)
+        else:
+            error.context("Compare fully mirrored images", logging.info)
+            qemu_img.compare_images(source_image, target_image)
         mirror_test.vm.resume()
         mirror_test.vm.destroy()
         if params.get("boot_target_image", "no") == "yes":

--- a/qemu/tests/drive_mirror_complete.py
+++ b/qemu/tests/drive_mirror_complete.py
@@ -1,7 +1,10 @@
 import logging
 import time
 from autotest.client.shared import error
-from virttest import qemu_storage, data_dir, env_process
+from autotest.client.shared import utils
+from virttest import data_dir
+from virttest import env_process
+from virttest import qemu_storage
 from qemu.tests import drive_mirror
 
 
@@ -26,6 +29,9 @@ def run(test, params, env):
         target_image = mirror_test.get_target_image()
         mirror_test.start()
         mirror_test.wait_for_steady()
+        error.context("Flush host pagecache", logging.info)
+        # really useless when drive_cache = 'none'
+        utils.system("sync")
         mirror_test.vm.pause()
         time.sleep(5)
         if params.get("open_target_image", "no") == "yes":
@@ -39,12 +45,8 @@ def run(test, params, env):
         mirror_test.vm.destroy()
         if params.get("boot_target_image", "no") == "yes":
             params = params.object_params(tag)
-            if params.get("target_image_type") == "iscsi":
-                params["image_name"] = mirror_test.target_image
+            if params.get("image_type") == "iscsi":
                 params["image_raw_device"] = "yes"
-            else:
-                params["image_name"] = params["target_image"]
-                params["image_format"] = params["target_format"]
             env_process.preprocess_vm(test, params, env, params["main_vm"])
             vm = env.get_vm(params["main_vm"])
             timeout = int(params.get("login_timeout", 600))

--- a/qemu/tests/drive_mirror_powerdown.py
+++ b/qemu/tests/drive_mirror_powerdown.py
@@ -24,11 +24,9 @@ class DriveMirrorPowerdown(drive_mirror_stress.DriveMirrorStress):
         """
         params = self.parser_test_args()
         vm_name = params['main_vm']
-        self.params["image_name"] = params["target_image"]
-        self.params["image_format"] = params["target_format"]
         logging.info("Target image: %s" % self.target_image)
         error.context("powerup vm with target image", logging.info)
-        env_process.preprocess_vm(self.test, self.params, self.env, vm_name)
+        env_process.preprocess_vm(self.test, params, self.env, vm_name)
         vm = self.env.get_vm(vm_name)
         vm.verify_alive()
         self.vm = vm


### PR DESCRIPTION
1. update  parser_test_args in drive_mirror class to make test  use default naming conventions
2. update cleanup in drive_mirror to make it use right way to cleanup a iscsi target image
3. add step for flush page cache before compare image in  drive_mirrir_complete test
4. fix coding style issue.