### PR TITLE
qemu.tests.cfg: Disable virtio_scsi related cases for old rhel guest

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -45,6 +45,8 @@
                 Windows:
                     image_size_image1 = 30G
         - all_drive_format_types:
+            # virtio-scsi driver support from RHEL6.3
+            no RHEL.3 RHEL.4 RHEL.5 RHEL.6.0 RHEL.6.1 RHEL.6.2
             stg_image_size = 1M
             stg_params = "drive_format:ide,scsi,virtio,scsi-hd,usb2"
             Host_RHEL:
@@ -52,6 +54,8 @@
             usbs += " default-ehci"
             usb_type_default-ehci = usb-ehci
         - virtio_scsi_variants:
+            # virtio-scsi driver support from RHEL6.3
+            no RHEL.3 RHEL.4 RHEL.5 RHEL.6.0 RHEL.6.1 RHEL.6.2
             # Decrease length of the command
             stg_image_size = 1M
             stg_params = "drive_format:scsi-disk "


### PR DESCRIPTION
virtio-scsi driver support from RHEL6.3, so disable old rhel guest.
