### PR TITLE
qemu.tests: Update the tests use utils_netperf support compile_option

### DIFF
--- a/qemu/tests/cfg/flow_caches_stress_test.cfg
+++ b/qemu/tests/cfg/flow_caches_stress_test.cfg
@@ -13,6 +13,8 @@
     filesize = 4000
     transfer_timeout = 1000
     netperf_timeout = 600
+    compile_option_server = --enable-burst
+    compile_option_client = --enable-burst
     #test_protocol = TCP_STREAM
     variants:
         - vhost_on:

--- a/qemu/tests/flow_caches_stress_test.py
+++ b/qemu/tests/flow_caches_stress_test.py
@@ -78,6 +78,8 @@ def run(test, params, env):
     passwd = params.get("hostpasswd", "123456")
     client = params.get("shell_client", "ssh")
     port = params.get("shell_port", "22")
+    compile_option_client = params.get("compile_option_client", "")
+    compile_option_server = params.get("compile_option_server", "")
 
     if int(params.get("queues", 1)) > 1 and params.get("os_type") == "linux":
         error.context("Enable multi queues support in guest.", logging.info)
@@ -105,7 +107,7 @@ def run(test, params, env):
                                                  g_md5sum, g_client_link,
                                                  username=username,
                                                  password=password,
-                                                 compile_option="--enable-burst")
+                                                 compile_option=compile_option_client)
 
     netperf_server = utils_netperf.NetperfServer(netperf_server_ip,
                                                  server_path,
@@ -113,7 +115,7 @@ def run(test, params, env):
                                                  netperf_link,
                                                  client, port,
                                                  password=passwd,
-                                                 compile_option="--enable-burst")
+                                                 compile_option=compile_option_server)
     try:
         error.base_context("Run netperf test between host and guest.")
         error.context("Start netserver in host.", logging.info)

--- a/qemu/tests/migration_with_netperf.py
+++ b/qemu/tests/migration_with_netperf.py
@@ -53,6 +53,10 @@ def run(test, params, env):
     passwd = params.get("hostpasswd", "redhat")
     client = params.get("shell_client", "ssh")
     port = params.get("shell_port", "22")
+    compile_option_client_h = params.get("compile_option_client_h", "")
+    compile_option_server_h = params.get("compile_option_server_h", "")
+    compile_option_client_g = params.get("compile_option_client_g", "")
+    compile_option_server_g = params.get("compile_option_server_g", "")
     if params.get("os_type") == "linux":
         session.cmd("iptables -F", ignore_all_errors=True)
         g_client_link = netperf_link
@@ -78,16 +82,19 @@ def run(test, params, env):
                                                        port=port,
                                                        username=username,
                                                        password=password,
-                                                       install=g_client_install)
+                                                       install=g_client_install,
+                                                       compile_option=compile_option_client_g)
         netperf_server_h = utils_netperf.NetperfServer(remote_ip,
                                                        server_path,
                                                        server_md5sum,
                                                        netperf_link,
                                                        password=passwd,
-                                                       install=False)
+                                                       install=False,
+                                                       compile_option=compile_option_server_h)
         netperf_client_h = utils_netperf.NetperfClient(remote_ip, client_path,
                                                        md5sum, netperf_link,
-                                                       password=passwd)
+                                                       password=passwd,
+                                                       compile_option=compile_option_client_h)
         netperf_server_g = utils_netperf.NetperfServer(guest_address,
                                                        g_server_path,
                                                        server_md5sum,
@@ -95,7 +102,8 @@ def run(test, params, env):
                                                        client=client,
                                                        port=port,
                                                        username=username,
-                                                       password=password)
+                                                       password=password,
+                                                       compile_option=compile_option_server_g)
         error.base_context("Run netperf test between host and guest")
         error.context("Start netserver in guest.", logging.info)
         netperf_server_g.start()

--- a/qemu/tests/multi_nics_stress.py
+++ b/qemu/tests/multi_nics_stress.py
@@ -59,6 +59,8 @@ def run(test, params, env):
     os_type = params.get("os_type")
     host_ip = utils_net.get_host_ip_address(params)
     ping_count = int(params.get("ping_count", 10))
+    compile_option_client = params.get("compile_option_client", "")
+    compile_option_server = params.get("compile_option_server", "")
 
     vms = params.get("vms")
     server_infos = []
@@ -169,7 +171,8 @@ def run(test, params, env):
                                                client=c_info["shell_client"],
                                                port=c_info["shell_port"],
                                                username=c_info["username"],
-                                               password=c_info["password"])
+                                               password=c_info["password"],
+                                               compile_option=compile_option_client)
         netperf_clients.append(n_client)
     error.context("Setup netperf server.", logging.info)
     for s_info in server_infos:
@@ -186,7 +189,8 @@ def run(test, params, env):
                                                client=s_info["shell_client"],
                                                port=s_info["shell_port"],
                                                username=s_info["username"],
-                                               password=s_info["password"])
+                                               password=s_info["password"],
+                                               compile_option=compile_option_server)
         netperf_servers.append(n_server)
 
     try:

--- a/qemu/tests/netperf_stress.py
+++ b/qemu/tests/netperf_stress.py
@@ -30,6 +30,8 @@ def run(test, params, env):
     shell_client = params.get("shell_client")
     shell_port = params.get("shell_port")
     os_type = params.get("os_type")
+    compile_option_client = params.get("compile_option_client", "")
+    compile_option_server = params.get("compile_option_server", "")
     host_ip = utils_net.get_host_ip_address(params)
 
     vms = params.get("vms")
@@ -141,7 +143,8 @@ def run(test, params, env):
                                                client=c_info["shell_client"],
                                                port=c_info["shell_port"],
                                                username=c_info["username"],
-                                               password=c_info["password"])
+                                               password=c_info["password"],
+                                               compile_option=compile_option_client)
         netperf_clients.append(n_client)
 
     for s_info in server_infos:
@@ -157,7 +160,8 @@ def run(test, params, env):
                                                client=s_info["shell_client"],
                                                port=s_info["shell_port"],
                                                username=s_info["username"],
-                                               password=s_info["password"])
+                                               password=s_info["password"],
+                                               compile_option=compile_option_server)
         netperf_servers.append(n_server)
 
     # Get range of message size.

--- a/qemu/tests/netperf_udp.py
+++ b/qemu/tests/netperf_udp.py
@@ -63,6 +63,8 @@ def run(test, params, env):
     host_password = params.get("hostpassword")
     client = params.get("shell_client")
     port = params.get("shell_port")
+    compile_option_client = params.get("compile_option_client", "")
+    compile_option_server = params.get("compile_option_server", "")
 
     if dsthost in params.get("vms", "vm1 vm2"):
         server_vm = env.get_vm(dsthost)
@@ -112,7 +114,8 @@ def run(test, params, env):
                                                  c_md5sum, c_link,
                                                  client, port,
                                                  username=guest_username,
-                                                 password=guest_password)
+                                                 password=guest_password,
+                                                 compile_option=compile_option_client)
 
     netperf_server = utils_netperf.NetperfServer(netserver_ip,
                                                  s_path,
@@ -120,7 +123,8 @@ def run(test, params, env):
                                                  s_link,
                                                  s_client, s_port,
                                                  username=s_username,
-                                                 password=s_password)
+                                                 password=s_password,
+                                                 compile_option=compile_option_server)
 
     # Get range of message size.
     message_size = params.get("message_size_range", "580 590 1").split()

--- a/qemu/tests/ovs_qos.py
+++ b/qemu/tests/ovs_qos.py
@@ -161,6 +161,9 @@ def run(test, params, env):
         client_path_linux = params.get("client_path", "/var/tmp")
         server_path_win = params.get("server_path_win", "c:\\")
         client_path_win = params.get("client_path_win", "c:\\")
+        compile_option_client = params.get("compile_option_client", "")
+        compile_option_server = params.get("compile_option_server", "")
+
         netperf_servers, netperf_clients = [], []
         for idx, (vm, info) in enumerate(__get_vminfo()):
             if idx % 2 == 0:
@@ -177,7 +180,8 @@ def run(test, params, env):
                                                      port=info[-2],
                                                      client=info[-3],
                                                      password=info[-4],
-                                                     username=info[-5])
+                                                     username=info[-5],
+                                                     compile_option=compile_option_server)
                 netperf_servers.append((server, vm))
                 continue
             else:
@@ -194,7 +198,8 @@ def run(test, params, env):
                                                      port=info[-2],
                                                      client=info[-3],
                                                      password=info[-4],
-                                                     username=info[-5])
+                                                     username=info[-5],
+                                                     compile_option=compile_option_client)
                 netperf_clients.append((client, vm))
                 continue
         return netperf_clients, netperf_servers


### PR DESCRIPTION
We need add different comile_option for utils_netperf to compile the code in different
platform. So add this support for related test cases.
