### PR TITLE
qemu.tests.cfg: Remove vhost variants form pktgen

### DIFF
--- a/qemu/tests/cfg/pktgen.cfg
+++ b/qemu/tests/cfg/pktgen.cfg
@@ -9,11 +9,6 @@
     #set pktgen threads
     pktgen_threads =  4
     variants:
-        - vhost_on:
-            netdev_extra_params = ",vhost=on"
-        - vhost_off:
-            netdev_extra_params = ",vhost=off"
-    variants:
         - guest_guest:
             only Linux
             pktgen_server = vm2


### PR DESCRIPTION
No need to add vhost variants,remove it from qemu/tests/cfg/pktgen.cfg

Signed-off-by: Xiaoling Gao <xiagao@redhat.com>