### PR TITLE
qemu.tests: Rename mac_ip_filter to interface_mac_ip_filter in multi_vms...

### DIFF
--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -70,9 +70,9 @@
             flood_minutes = 1
             transfer_timeout = 1000
             ping_counts = 10
-            mac_ip_filter = "(eth\d+).*?HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+).*?inet addr:(.\d+.\d+.\d+.\d+)"
-            Fedora.18:
-                mac_ip_filter = "(em\d+).*inet (.\d+.\d+.\d+.\d+).*?ether (.\w+:\w+:\w+:\w+:\w+:\w+)"
+            interface_mac_ip_filter = "(eth\d+).*?HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+).*?inet addr:(.\d+.\d+.\d+.\d+)"
+            Fedora.18, RHEL7:
+                interface_mac_ip_filter = (\w+):.*inet (.\d+.\d+.\d+.\d+).*?ether (.\w+:\w+:\w+:\w+:\w+:\w+)
             file_create_cmd = "dd if=/dev/urandom of=/tmp/1 bs=100M count=1"
             # We can test multi nics in multi vms by setting nics.
             nics += " nic2"

--- a/qemu/tests/cfg/multi_vms_nic.cfg
+++ b/qemu/tests/cfg/multi_vms_nic.cfg
@@ -11,9 +11,9 @@
     transfer_timeout = 1000
     type = multi_vms_nics
     ping_counts = 10
-    mac_ip_filter = "(eth\d+).*?HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+).*?inet addr:(.\d+.\d+.\d+.\d+)"
-    Fedora.18:
-        mac_ip_filter = "(em\d+).*inet (.\d+.\d+.\d+.\d+).*?ether (.\w+:\w+:\w+:\w+:\w+:\w+)"
+    interface_mac_ip_filter = "(eth\d+).*?HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+).*?inet addr:(.\d+.\d+.\d+.\d+)"
+    Fedora.18, RHEL.7:
+        interface_mac_ip_filter = "(\w+):.*inet (.\d+.\d+.\d+.\d+).*?ether (.\w+:\w+:\w+:\w+:\w+:\w+)"
     file_create_cmd = "dd if=/dev/urandom of=/tmp/1 bs=100M count=1"
     # We can test multi nics in multi vms by setting nics.
     #nics += " nic2"

--- a/qemu/tests/multi_vms_nics.py
+++ b/qemu/tests/multi_vms_nics.py
@@ -114,7 +114,7 @@ def run(test, params, env):
     session_list = []
     vms = params["vms"].split()
     timeout = float(params.get("login_timeout", 360))
-    mac_ip_filter = params["mac_ip_filter"]
+    int_mac_ip_filter = params["interface_mac_ip_filter"]
     strict_check = params.get("strick_check", "no")
     host_ip = utils_net.get_ip_address_by_interface(params.get("netdst"))
     host_ip = params.get("srchost", host_ip)
@@ -138,7 +138,7 @@ def run(test, params, env):
                 err_msg = "Can not get ip from guest."
                 err_msg += " Cmd '%s' fail with output: %s" % (cmd, output)
                 logging.error(err_msg)
-            ips = re.findall(mac_ip_filter, output, re.S)
+            ips = re.findall(int_mac_ip_filter, output, re.S)
             if count_nics == len(ips):
                 break
             time.sleep(2)


### PR DESCRIPTION
....nics.py

mac_ip_filter already used to save RE string to filter mac and ip.
But in multi_vms_nics.py, we need RE string to filter interface, mac and ip.
So create a new paramter interface_mac_ip_filter.

Signed-off-by: Feng Yang fyang@redhat.com
