### PR TITLE
qemu.tests.cfg: Remove 11 from error number list

### DIFF
--- a/qemu/tests/cfg/qemu_io_blkdebug.cfg
+++ b/qemu/tests/cfg/qemu_io_blkdebug.cfg
@@ -10,7 +10,7 @@
     image_cluster_size = 512
     err_command = "write 0 1G"
     err_event = "refblock_alloc"
-    errn_list = "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28"
+    errn_list = "1 2 3 4 5 6 7 8 9 10 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28"
     re_std_msg = "error\s+code\s+\d+:\s+([a-zA-Z\/\-\s]+)$"
     test_timeout = 2000
     blkdebug_default = blkdebug/qemu_io_default.conf


### PR DESCRIPTION
As error 11 means EAGAIN in Linux will cause qemu_io process keep
re-try the operatoin. This makes the test will timeout instead of
raise an error. So remove it from the list.