### PR TITLE
generic.tests: Add wait_for when check guest run level

### DIFF
--- a/generic/tests/shutdown.py
+++ b/generic/tests/shutdown.py
@@ -34,14 +34,19 @@ def run(test, params, env):
         if params.get("setup_runlevel") == "yes":
             error.context("Setup the runlevel for guest", logging.info)
             expect_runlevel = params.get("expect_runlevel", "3")
+            cmd = "runlevel"
 
-            ori_runlevel = session.cmd("runlevel")
+            if utils_misc.wait_for(lambda: session.cmd_status(cmd) == 0, 15):
+                ori_runlevel = session.cmd(cmd)
+            else:
+                ori_runlevel = "0"
+
             ori_runlevel = re.findall("\d+", ori_runlevel)[-1]
             if ori_runlevel == expect_runlevel:
                 logging.info("Guest runlevel is the same as expect.")
             else:
                 session.cmd("init %s" % expect_runlevel)
-                tmp_runlevel = session.cmd("runlevel")
+                tmp_runlevel = session.cmd(cmd)
                 tmp_runlevel = re.findall("\d+", tmp_runlevel)[-1]
                 if tmp_runlevel != expect_runlevel:
                     logging.warn("Failed to setup runlevel for guest")


### PR DESCRIPTION
Sometimes we login into guest in a very short time before all services are
fully start in guest os. This will cause runlevel command return a non-zero
status. Add wait_for there to check the runlevel until we get it.