### PR TITLE
qemu.tests: Add sleep after set_link

### DIFF
--- a/qemu/tests/set_link.py
+++ b/qemu/tests/set_link.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from autotest.client import utils
 from autotest.client.shared import error
 from virttest import remote, aexpect
@@ -154,6 +155,7 @@ def run(test, params, env):
 
         """
         vm.set_link(linkid, up=link_up)
+        time.sleep(1)
         error.context("Check guest interface operstate", logging.info)
         if operstate_always_up:
             if expect_status == "down":


### PR DESCRIPTION
The guest OS need some time to update the status. So add sleep after
we set set_link from monitor.