### PR TITLE
remove vhost variants from cfg

### DIFF
--- a/generic/tests/cfg/file_transfer.cfg
+++ b/generic/tests/cfg/file_transfer.cfg
@@ -11,7 +11,7 @@
         - vhost_force:
             only virtio_net
             nettype = bridge
-            vhost = "vhost=on"
+            vhost_fix = "vhost=on"
             variants:
                 - @force_default:
                     #vhost=on only has effect for virtio guests which use MSIX
@@ -19,7 +19,7 @@
                 - vhostforce_on:
                     #For non-MSIX guests or guest disable pci msi,
                     #using vhostforce=on, force enable vhost.
-                    vhostforce = on
+                    vhostforce_fix = on
                     variants:
                         - @default_msi_setting:
                             only Windows

--- a/generic/tests/cfg/macvtap_mac_change.cfg
+++ b/generic/tests/cfg/macvtap_mac_change.cfg
@@ -5,11 +5,6 @@
     nettype = macvtap
     no Win2003, WinXP, Win2000, WinVista
     variants:
-        - vhost_on_option:
-            vhost = on
-        - vhost_off_option:
-            vhost = off
-    variants:
         - ctrl_mac_addr_on_option:
             ctrl_mac_addr = on
         - ctrl_mac_addr_off_option:
@@ -21,4 +16,3 @@
         ctrl_mac_addr =
     virtio_net:
         no RHEL.5, RHEL.6.0, RHEL.6.1, RHEL.6.2, RHEL.6.3
-

--- a/qemu/tests/cfg/flow_caches_stress_test.cfg
+++ b/qemu/tests/cfg/flow_caches_stress_test.cfg
@@ -17,11 +17,6 @@
     compile_option_client = --enable-burst
     #test_protocols = TCP_STREAM
     variants:
-        - vhost_on:
-            vhost=on
-        - vhost_off:
-            vhost=off
-    variants:
         - multi_queues:
             no Windows
             queues = 4

--- a/qemu/tests/cfg/remove_interface_from_host.cfg
+++ b/qemu/tests/cfg/remove_interface_from_host.cfg
@@ -2,9 +2,3 @@
     type = remove_interface_from_host
     #rtl8139 or e1000, do not test vhost=on
     #for virtio-net, test both vhost=on and off
-    variants:
-        - vhost_on:
-            no rtl8139, e1000
-            vhost = "vhost=on"
-        - vhost_off:
-            vhost = "vhost=off"


### PR DESCRIPTION
vhost is 'on' or 'off' should be a parts of matrix, should be convert in
test plan or in special test, so remove it from case cfg.

Signed-off-by: Xu Tian <xutian@redhat.com>