### PR TITLE
Change the variants with_file_copy.prepare_op in stop_continue.cfg

### DIFF
--- a/generic/tests/cfg/stop_continue.cfg
+++ b/generic/tests/cfg/stop_continue.cfg
@@ -6,7 +6,7 @@
         - stop_cont_only:
 
         - with_file_copy:
-            prepare_op = "dd if=/dev/urandom of=/tmp/origin bs=1M count=1024"
+            prepare_op = "dd if=/dev/zero of=/tmp/origin bs=1M count=1024"
             prepare_op_timeout = 240
             start_bg_process = yes
             bg_cmd = "rm -rf /tmp/new; cp /tmp/origin /tmp/new"


### PR DESCRIPTION
Just modify the variants "with_file_copy.prepare_op" from "dd if=/dev/urandom of=/tmp/origin bs=1M  count=1024" to "dd if=/dev/zero of=/tmp/origin bs=1M count=1024"