### PR TITLE
qemu.cfg.spice: Use virt-tests-vm1 as first VM name.

### DIFF
--- a/qemu/tests/cfg/spice.cfg
+++ b/qemu/tests/cfg/spice.cfg
@@ -1,15 +1,15 @@
 - rv:
     no JeOS
-    vms = vm1 vm2
-    guest_vm = vm1
+    vms += " vm2"
+    guest_vm = virt-tests-vm1
     client_vm = vm2
     display_vm2 = vnc
     vga_vm2 = cirrus
     full_screen = no
-    virtio_ports_vm1 = "vdagent"
-    virtio_port_type_vm1 = "serialport"
-    virtio_port_chardev_vm1 = "spicevmc"
-    virtio_port_name_prefix_vm1 = "com.redhat.spice."
+    virtio_ports_virt-tests-vm1 = "vdagent"
+    virtio_port_type_virt-tests-vm1 = "serialport"
+    virtio_port_chardev_virt-tests-vm1 = "spicevmc"
+    virtio_port_name_prefix_virt-tests-vm1 = "com.redhat.spice."
   
     variants:
         -RHEL.6.3.x86_64:
@@ -38,7 +38,7 @@
             destination_video_file_path = /tmp/test.ogv
         - rv_migrate:
             type = migration
-            main_vm = vm1
+            main_vm = virt-tests-vm1
             migrate_background = yes
             migration_test_command = help
             #migration_bg_command = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"


### PR DESCRIPTION
Now we will append migrate_vms to vms if it not vms.
migrate_vms set to virt-tests-vm1, so we'd better use virt-tests-vm1 in vms. Or one more VM named virt-tests-vm1 will be created.


Signed-off-by: Feng Yang <fyang@redhat.com>