### PR TITLE
qemu.test: Update the ioeventfd cfg file

### DIFF
--- a/qemu/tests/cfg/ioeventfd.cfg
+++ b/qemu/tests/cfg/ioeventfd.cfg
@@ -19,11 +19,11 @@
     variants:
         - ioeventfd_on:
             virtio_blk:
-                blk_extra_params = "ioeventfd=on"
+                blk_extra_params_image1 = "ioeventfd=on"
             virtio_scsi:
-                bus_extra_params = "ioeventfd=on"
+                bus_extra_params_image1 = "ioeventfd=on"
         - ioeventfd_off:
             virtio_blk:
-                blk_extra_params = "ioeventfd=off"
+                blk_extra_params_image1 = "ioeventfd=off"
             virtio_scsi:
-                bus_extra_params = "ioeventfd=on"
+                bus_extra_params_image1 = "ioeventfd=off"


### PR DESCRIPTION
Update the cfg file to set up ioeventfd only for image1 and correct the parameter
set up mistakes.
