### PR TITLE
qemu.cfg: Do not test netperf TCP_SENDFILE test in windows guest.

### DIFF
--- a/qemu/tests/cfg/ext_host_netperf_stress.cfg
+++ b/qemu/tests/cfg/ext_host_netperf_stress.cfg
@@ -18,5 +18,6 @@
         netperf_client_link_win = "netperf.exe"
         server_path_win = "c:\\"
         client_path_win = "c:\\"
+        test_protocols = TCP_RR TCP_CRR UDP_RR TCP_STREAM TCP_MAERTS UDP_STREAM
     RHEL.4:
         netperf_link = netperf-2.4.5.tar.bz2

--- a/qemu/tests/cfg/multi_nics_stress.cfg
+++ b/qemu/tests/cfg/multi_nics_stress.cfg
@@ -22,4 +22,4 @@
         netperf_client_link_win = "netperf.exe"
         server_path_win = "c:\\"
         client_path_win = "c:\\"
-
+        test_protocols = "TCP_STREAM TCP_MAERTS UDP_STREAM TCP_RR TCP_CRR UDP_RR"

--- a/qemu/tests/cfg/netperf_stress_test.cfg
+++ b/qemu/tests/cfg/netperf_stress_test.cfg
@@ -37,6 +37,7 @@
             test_protocols = TCP_MAERTS
         - TCP_SENDFILE:
             test_protocols = TCP_SENDFILE
+            no Windows
         - UDP_STREAM:
             test_protocols = UDP_STREAM
         - UDP_RR:


### PR DESCRIPTION
Signed-off-by: Feng Yang <fyang@redhat.com>

ID : 1190989