### PR TITLE
qemu.test.live_snapshot: Add the default value for reboot_timeout

### DIFF
--- a/qemu/tests/live_snapshot.py
+++ b/qemu/tests/live_snapshot.py
@@ -73,7 +73,7 @@ def run(test, params, env):
 
     def reboot_test():
         try:
-            reboot_timeout = int(params.get("reboot_timeout"))
+            reboot_timeout = int(params.get("reboot_timeout", 900))
             bg = utils_test.BackgroundTest(vm.reboot, (session, "shell", 0,
                                                        reboot_timeout, False,))
             logging.info("Rebooting guest ...")


### PR DESCRIPTION
To avoid to raise exception TypeError if not set it.

ID: 1088129