### PR TITLE
qemu.tests: instead utils.wait_for with utils_misc.wait_for

### DIFF
--- a/qemu/tests/balloon_stress.py
+++ b/qemu/tests/balloon_stress.py
@@ -2,7 +2,7 @@ import re
 import time
 import logging
 from autotest.client.shared import error
-from autotest.client.shared import utils
+from virttest import utils_misc
 
 
 @error.context_aware
@@ -58,8 +58,8 @@ def run(test, params, env):
     # need to wait for wmplayer loading remote video
     time.sleep(float(params.get("loading_timeout", 60)))
     check_playing_cmd = params["check_playing_cmd"]
-    running = utils.wait_for(lambda: session.cmd_status(check_playing_cmd) == 0,
-                             first=5.0, timeout=600)
+    running = utils_misc.wait_for(lambda: session.cmd_status(
+        check_playing_cmd) == 0, first=5.0, timeout=600)
     if not running:
         raise error.TestError("Video do not playing")
 

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -873,7 +873,7 @@ def run(test, params, env):
                     else:
                         cmd = "ps -p %s" % pid
                     return session.cmd_status(cmd) != 0
-                if utils.wait_for(is_copy_done, timeout=copy_timeout) is None:
+                if utils_misc.wait_for(is_copy_done, timeout=copy_timeout) is None:
                     raise error.TestFail("Wait for file copy finish timeout")
 
                 error.context("Compare file on disk and on cdrom")

--- a/qemu/tests/nic_hotplug.py
+++ b/qemu/tests/nic_hotplug.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from autotest.client.shared import error, utils
-from virttest import utils_test, utils_net, virt_vm
+from virttest import utils_test, utils_net, virt_vm, utils_misc
 
 
 @error.context_aware
@@ -58,7 +58,7 @@ def run(test, params, env):
                 renew_ip_address(session, nic["mac"], is_linux_guest)
             return
 
-        nic_ip = utils.wait_for(__get_address, timeout=360)
+        nic_ip = utils_misc.wait_for(__get_address, timeout=360)
         if nic_ip:
             return nic_ip
         cached_ip = vm.address_cache.get(nic["mac"])

--- a/qemu/tests/win_heavyload.py
+++ b/qemu/tests/win_heavyload.py
@@ -118,7 +118,8 @@ def run(test, params, env):
             raise error.TestError("heavyload process is not started")
 
         error.context("Verify vm is alive", logging.info)
-        utils.wait_for(vm.verify_alive, timeout=test_timeout, step=steping)
+        utils_misc.wait_for(vm.verify_alive,
+                            timeout=test_timeout, step=steping)
     finally:
         error.context("Stop load and clean tmp files", logging.info)
         if not installed and download_url:


### PR DESCRIPTION
Most  of our test case use wait_for function in utils_misc module and only a little use same function in under autotest.client.shared.utils module.  this fix unify all case in tp-qemu repo to use wait_for function in virttest.utils_misc module.

Signed-off-by: Xu Tian <xutian@redhat.com>