### PR TITLE
spice.build_install: Add RHEL7 support for building spice pkgs

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -364,6 +364,7 @@ variants:
         vm_name = client
         dst_dir = /tmp
         spice_gtk_devel_url = path_to_spice_gtk_devel_rpm
+        spice_gtk3_devel_url = path_to_spice_gtk3_devel_rpm
         spice_protocol_url = path_to_spice_protocol_rpm
         spice_glib_devel_url = path_to_spice_glib_devel_rpm
         celt051_devel_url = path_to_celt051_rpm
@@ -382,6 +383,8 @@ variants:
         celt051_devel_url = path_to_celt051_rpm
         libogg_devel_url = path_to_libogg_rpm
         libcacard_devel_url = path_to_libcacard_rpm
+        source_highlight_url = path_to_source_highlight_rpm
+        gtk_doc_url = path_to_gtk_doc_rpm
         only remote_viewer_rhel6devel_build_install
     - negative_qemu_spice_launch_badport:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.bad_port.no_password.dcp_off.1monitor.default_sc

--- a/qemu/deps/spice/build_install.py
+++ b/qemu/deps/spice/build_install.py
@@ -6,6 +6,7 @@ Script to build and install packages from git in VMs
 
 import os
 import sys
+import re
 import optparse
 import subprocess
 
@@ -22,10 +23,10 @@ git_repo["xf86-video-qxl"] = "git://anongit.freedesktop.org/xorg/driver/xf86-vid
 git_repo["virt-viewer"] = "https://git.fedorahosted.org/git/virt-viewer.git"
 
 # options to pass
-autogen_options["spice-gtk"] = "--with-gtk=2.0 --disable-gtk-doc --disable-werror --disable-vala --disable-controller"
+autogen_options["spice-gtk"] = "--disable-gtk-doc --disable-werror --disable-vala --disable-controller"
 autogen_options["spice-vd-agent"] = "--libdir=/usr/lib64 --sysconfdir=/etc"
 autogen_options["xf86-video-qxl"] = "--libdir=\"/usr/lib64\" --disable-kms"
-autogen_options["virt-viewer"] = "--with-gtk=2.0 --with-spice-gtk --disable-update-mimedb"
+autogen_options["virt-viewer"] = "--with-spice-gtk --disable-update-mimedb"
 prefix_defaults["spice-protocol"] = "/usr/local"
 prefix_defaults["spice-vd-agent"] = "/usr"
 
@@ -77,6 +78,13 @@ if options.buildOptions:
     autogen_options[pkgName] = options.buildOptions
 if options.gitRepo:
     git_repo[pkgName] = options.gitRepo
+
+f = open("/etc/redhat-release", "r")
+rhelVersion = f.read()
+print "OS: %s" % rhelVersion
+if re.findall("release 6", rhelVersion):
+    if pkgName in ("spice-gtk", "virt-viewer"):
+        autogen_options[pkgName] += " --with-gtk=2.0"
 
 ret = os.system("which git")
 if ret != 0:

--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -96,13 +96,18 @@ def build_install_virtviewer(vm_root_session, vm_script_path, params):
         logging.error("Could not kill remote-viewer " + err.output)
 
     try:
-        output = vm_root_session.cmd("yum -y remove virt-viewer")
+        output = vm_root_session.cmd("yum -y remove virt-viewer", timeout=120)
         logging.info(output)
     except ShellCmdError, err:
         logging.error("virt-viewer package couldn't be removed! " + err.output)
 
-    pkgsRequired = ["spice-protocol", "libogg-devel", "celt051-devel",
-                    "spice-glib-devel", "spice-gtk-devel"]
+    if "release 7" in vm_root_session.cmd("cat /etc/redhat-release"):
+        pkgsRequired = ["spice-protocol", "libogg-devel", "celt051-devel",
+                        "spice-glib-devel", "spice-gtk3-devel"]
+    else:
+        pkgsRequired = ["spice-protocol", "libogg-devel", "celt051-devel",
+                        "spice-glib-devel", "spice-gtk-devel"]
+
     install_req_pkgs(pkgsRequired, vm_root_session, params)
 
     output = vm_root_session.cmd("%s -p virt-viewer" % (vm_script_path),
@@ -142,7 +147,12 @@ def build_install_spicegtk(vm_root_session, vm_script_path, params):
     except ShellCmdError:
         logging.error(output)
 
-    pkgsRequired = ["libogg-devel", "celt051-devel", "libcacard-devel"]
+    if "release 7" in vm_root_session.cmd("cat /etc/redhat-release"):
+        pkgsRequired = ["libogg-devel", "celt051-devel", "libcacard-devel",
+                        "source-highlight", "gtk-doc"]
+    else:
+        pkgsRequired = ["libogg-devel", "celt051-devel", "libcacard-devel"]
+
     install_req_pkgs(pkgsRequired, vm_root_session, params)
 
     utils_spice.deploy_epel_repo(vm_root_session, params)


### PR DESCRIPTION
Building spice-gtk and virt-viewer on RHEL7 requires
extra packages and different build options.

Reviewed By: Swapna Krishnan <skrishna@redhat.com>