### PR TITLE
qemu.tests: Add new function to get the disk index for windows guest

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -58,17 +58,18 @@
             usbs += " default-ehci"
             usb_type_default-ehci = usb-ehci
         - virtio_scsi_variants:
+            only virtio_scsi
             # virtio-scsi driver support from RHEL6.3
             no RHEL.3 RHEL.4 RHEL.5 RHEL.6.0 RHEL.6.1 RHEL.6.2
             # Decrease length of the command
-            stg_image_size = 1M
+            stg_image_size = 40M
             stg_params = "drive_format:scsi-disk "
             variants:
                 - @passthrough:
                     # We need to unload scsi_debug modules used by VM
                     kill_vm = yes
                     force_create_image = no
-                    pre_command = "modprobe -r scsi_debug; modprobe sg; modprobe scsi_debug add_host=9"
+                    pre_command = "modprobe -r scsi_debug; modprobe sg; modprobe scsi_debug add_host=9 dev_size_mb=40"
                     post_command = "rmmod scsi_debug"
                     stg_params += "image_raw_device:yes "
                     stg_params += "image_format:raw "
@@ -81,11 +82,14 @@
                             stg_params += "drive_format:scsi-generic "
                             stg_params += "image_name:/dev/sg* "
                 - multi_lun:
+                    only Linux
                     stg_params += "drive_port:range(0,16383,63) "
                 - multi_scsiid_lun:
+                    only Linux
                     stg_params += "drive_unit:range(0,255,1,3) "
                     stg_params += "drive_port:range(0,16383,8191) "
                 - multi_bus_scsiid_lun:
+                    only Linux
                     ide, virtio_blk:
                         stg_params += "drive_bus:range(0,15,1,9) "
                     virtio_scsi:

--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -7,6 +7,7 @@
     cmd_timeout = 1000
     black_list = C:
     start_vm = no
+    kill_vm = yes
     stg_image_name = "images/%s"
     check_guest_proc_scsi = no
     virtio_scsi:
@@ -26,8 +27,8 @@
                 # 3 + boot disk = 4 disks
                 image_extra_params = ""
                 stg_image_num = 3
-                stg_params  = "image_size:1G,10G,5G "
-                stg_params += "image_format:qcow2,qcow2,raw "
+                stg_image_size = 1G
+                stg_params = "image_format:qcow2,qcow2,raw "
             virtio_blk, virtio_scsi:
                 usbs = ""
                 usb_devices = ""
@@ -47,7 +48,8 @@
         - all_drive_format_types:
             # virtio-scsi driver support from RHEL6.3
             no RHEL.3 RHEL.4 RHEL.5 RHEL.6.0 RHEL.6.1 RHEL.6.2
-            stg_image_size = 1M
+            stg_image_num = 4
+            stg_image_size = 100M
             stg_params = "drive_format:ide,scsi,virtio,scsi-hd,usb2"
             Host_RHEL:
                 stg_params = "drive_format:ide,virtio,scsi-hd,usb2"

--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -247,11 +247,21 @@
             only ehci
             type = multi_disk
             cmd_timeout = 1000
-            black_list = C: D:
+            black_list = "C: D:"
             start_vm = no
             kill_vm = yes
             create_image = yes
             image_boot_image1 = yes
+            force_create_image = yes
+            force_create_image_image1 = no
+            remove_image = yes
+            remove_image_image1 = no
+            cmd_timeout = 1000
+            stg_image_size = 1G
+            stg_image_boot = no
+            stg_image_format = qcow2
+            stg_assign_index = yes
+            stg_drive_format = usb2
             usbs = usb1
             # Override global config for the usb1.
             usb_type_usb1 = usb-ehci
@@ -261,27 +271,8 @@
             usb_devices = ""
             variants:
                 - one_disk_repeat:
-                    images += " stg"
-                    image_format_stg = qcow2
-                    image_name_stg = images/storage
-                    image_size_stg = 1G
-                    drive_format_stg = usb2
-                    drive_index_stg = 1
-                    image_boot_stg = no
-                    force_create_image_stg = yes
-                    remove_image_stg = yes
+                    stg_image_num = 1
                     n_repeat = 10
                 - max_disk:
-                    start_vm = no
-                    restart_vm = no
                     usbs += " usb2 usb3 usb4"
                     stg_image_num = 24
-                    stg_image_size = 1G
-                    stg_image_boot = no
-                    stg_drive_format = usb2
-                    stg_assign_index = yes
-                    force_create_image = yes
-                    force_create_image_image1 = no
-                    remove_image = yes
-                    remove_image_image1 = no
-                    cmd_timeout = 1000


### PR DESCRIPTION
1. Add new function to get the disk index for windows guest.
2. Update the related config.
    
Signed-off-by: Shuping Cui <scui@redhat.com>