### PR TITLE
generic.tests.cfg: Small fix for kdump_with_stress

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -45,7 +45,7 @@
             variants:
                 - netperf_stress:
                     stress_type = netperf
-                    #netperf server is guest, the netperf client is host
+                    # Run netperf server in host, the netperf client in guest
                     wait_bg_time = 60
                     run_bgstress = netperf_stress
                     hostpassword = redhat
@@ -57,7 +57,7 @@
                     netperf_test_duration = 360
                     netperf_para_sessions = 2
                     test_protocols = TCP_STREAM
-                    check_cmd = "pidof netserver"
+                    check_cmd = "ps -C netperf"
                     RHEL.4:
                         netperf_link = netperf-2.4.5.tar.bz2
                 - io_stress:


### PR DESCRIPTION
Update the check_cmd config because running netperf client in guest.

Signed-off-by: Shuping Cui <scui@redhat.com>