### PR TITLE
tp-qemu: disable multi queue test on RHEL.6 host.

### DIFF
--- a/qemu/tests/cfg/boot_with_different_vectors.cfg
+++ b/qemu/tests/cfg/boot_with_different_vectors.cfg
@@ -2,6 +2,7 @@
     only Linux
     only virtio_net
     no RHEL.3 RHEL.4 RHEL.5 RHEL.6
+    no Host_RHEL.5, Host_RHEL.6
     queues = 4
     vectors_list = 0 1 2 3 4 5 6 7 8 9 10 11 -1
     type = boot_with_different_vectors

--- a/qemu/tests/cfg/flow_caches_stress_test.cfg
+++ b/qemu/tests/cfg/flow_caches_stress_test.cfg
@@ -18,6 +18,7 @@
     #test_protocols = TCP_STREAM
     variants:
         - multi_queues:
+            no Host_RHEL.5, Host_RHEL.6
             no Windows
             queues = 4
         - no_multi_queues:

--- a/qemu/tests/cfg/invalid_parameter.cfg
+++ b/qemu/tests/cfg/invalid_parameter.cfg
@@ -4,6 +4,7 @@
     start_vm = no
     run_invalid_cmd = yes
     queues = 4
+    no Host_RHEL.5, Host_RHEL.6
     failed_reason = "Device 'tap' could not be initialized"
     vhost = on
     run_invalid_cmd_nic = yes

--- a/qemu/tests/cfg/mq_change_qnum.cfg
+++ b/qemu/tests/cfg/mq_change_qnum.cfg
@@ -1,6 +1,7 @@
 - mq_change_qnum:
     only Linux
     queues = 4
+    no Host_RHEL.5, Host_RHEL.6
     # Here vectors should be queues * 2 + 2
     vectors = 10
     virt_test_type = qemu

--- a/qemu/tests/cfg/pktgen.cfg
+++ b/qemu/tests/cfg/pktgen.cfg
@@ -1,11 +1,12 @@
 - pktgen: install setup image_copy unattended_install.cdrom
     no JeOS
     no Windows
+    no Host_RHEL.5, Host_RHEL.6
     virt_test_type = qemu
     type = pktgen
     kill_vm = yes
     pktgen_test_timeout = 120
-    queues =  4
+    queues = 4
     #set pktgen threads
     pktgen_threads =  4
     external_host = 'www.redhat.com'


### PR DESCRIPTION
as RHEL.6 host does not support multi queue.

Signed-off-by: Cong Li <coli@redhat.com>