### PR TITLE
qemu.tests.cgroup: Increase the check command timeout

### DIFF
--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -614,7 +614,7 @@ def run(test, params, env):
             err += _test("read", blkio)
             # verify sessions between tests
             for session in sessions:
-                session.cmd("true", timeout=360)
+                session.cmd("true", timeout=600)
             error.context("Write test")
             err += _test("write", blkio)
 
@@ -632,7 +632,7 @@ def run(test, params, env):
 
             for session in sessions:
                 # try whether all sessions are clean
-                session.cmd("true", timeout=360)
+                session.cmd("true", timeout=600)
                 session.close()
 
             for i in range(len(vms)):


### PR DESCRIPTION
In blkio_throttle* tests the command "dd" often finishes after > 360s
with latest kernel. This patch changes the deadline to 600s which
usually works fine (the long deadline is fine as we use very slow
speeds - 1024B/s - for testing).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>