### PR TITLE
qemu.tests: Remove the nic device in down status from the host ifaces li...

### DIFF
--- a/qemu/tests/nic_bonding_host.py
+++ b/qemu/tests/nic_bonding_host.py
@@ -58,7 +58,8 @@ def run(test, params, env):
     host_ph_iface_pre = params.get("host_ph_iface_prefix", "en")
     host_iface_bonding = int(params.get("host_iface_bonding", 2))
 
-    host_ph_ifaces = [_ for _ in host_ifaces if re.match(host_ph_iface_pre, _)]
+    ph_ifaces = [_ for _ in host_ifaces if re.match(host_ph_iface_pre, _)]
+    host_ph_ifaces = [_ for _ in ph_ifaces if utils_net.Interface(_).is_up()]
 
     ifaces_in_use = host_bridges.list_iface()
     host_ph_ifaces_un = list(set(host_ph_ifaces) - set(ifaces_in_use))


### PR DESCRIPTION
...st

The nic_bonding_host test need devices is in up status in host to make sure
the interfaces can be used in the test.