### PR TITLE
generic.tests: Add some debug information for kdump

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -18,14 +18,14 @@
         kdump_config = core_collector makedumpfile -c -d 31
     RHEL.6:
         kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args=crashkernel=128M@16M"
-        kdump_enable_cmd = "chkconfig kdump on && service kdump start"
+        kdump_enable_cmd = "chkconfig kdump on && service kdump restart"
         kdump_propagate_cmd = "service kdump propagate"
         kdump_restart_cmd = "service kdump restart"
     RHEL.7:
         kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args=crashkernel=auto"
-        kdump_enable_cmd = "chkconfig kdump on && kdumpctl start"
+        kdump_enable_cmd = "chkconfig kdump on && systemctl restart kdump.service"
         kdump_propagate_cmd = "kdumpctl propagate"
-        kdump_restart_cmd = "kdumpctl restart"
+        kdump_restart_cmd = "systemctl restart kdump.service"
 
     variants:
         - @default:


### PR DESCRIPTION
We met some test failed without enough debug information for kdump.
So will store the kdump.cfg to debug dir and record the kdump service
status before we run this case. Also update the command to use the
suitable commands for different version of guests.
