### PR TITLE
qemu.tests: catch except in negative test

### DIFF
--- a/qemu/tests/boot_with_different_vectors.py
+++ b/qemu/tests/boot_with_different_vectors.py
@@ -28,7 +28,7 @@ def run(test, params, env):
         params["start_vm"] = "yes"
         try:
             env_process.preprocess_vm(test, params, env, params.get("main_vm"))
-        except virt_vm.VMStartError, err:
+        except virt_vm.VMError, err:
             if int(vectors) < 0:
                 txt = "Parameter 'vectors' expects uint32_t"
                 if re.findall(txt, str(err)):


### PR DESCRIPTION
qemu abort with error is expect when vm boot with a non-uint32
values, catch VMError and check exception message it reasonable.

Signed-off-by: Xu Tian <xutian@redhat.com>