### PR TITLE
qemu.cfg.host-kernel: Update host_rhel name

### DIFF
--- a/generic/tests/cfg/boot_savevm.cfg
+++ b/generic/tests/cfg/boot_savevm.cfg
@@ -14,7 +14,7 @@
         - default_savevm:
 
         - with_floppy:
-            no Host_RHEL.7
+            no Host_RHEL.m7
             virt_test_type = qemu
             save_method = save_to_tag
             with_floppy = yes

--- a/generic/tests/cfg/guest_suspend.cfg
+++ b/generic/tests/cfg/guest_suspend.cfg
@@ -8,26 +8,26 @@
         - @default:
             # New guests which support acpi on old hosts.
             only RHEL.6.3, RHEL.6.4
-            only Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            only Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
         - no_virtio:
             # Old guests which can't do s3/s4 with virtio device.
             no virtio_net
             no virtio_blk
             only RHEL.5, RHEL.6.0, RHEL.6.1, RHEL.6.2
-            only Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            only Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
         - global_disable_s3:
             only guest_s3
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             negative_test = yes
             extra_params += " -global PIIX4_PM.disable_s3=1"
         - global_enable_s3:
             only guest_s3
             no RHEL.4, RHEL.5, RHEL.6.0, RHEL.6.1, RHEL.6.2
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             extra_params += " -global PIIX4_PM.disable_s3=0"
         - global_disable_s4:
             only guest_s4
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             # The iasl package isn't available on RHEL5 i386 platform.
             no RHEL.5.i386
             negative_test = yes
@@ -35,7 +35,7 @@
         - global_enable_s4:
             only guest_s4
             no RHEL.4, RHEL.5, RHEL.6.0, RHEL.6.1, RHEL.6.2
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             extra_params += " -global PIIX4_PM.disable_s4=0"
     variants:
         - @default:

--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -5,7 +5,7 @@
     only virtio_net
     no RHEL.3, RHEL.4, RHEL.5
     no RHEL.6.0, RHEL.6.1, RHEL.6.2, RHEL.6.3, RHEL.6.4, RHEL.6.5
-    no Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m5, Host_RHEL.m6
     type = multi_queues_test
     queues = 4
     enable_msix_vectors = yes

--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -23,17 +23,17 @@
         - @default:
         - etherboot:
             # etherboot pkg only in RHEL.5 Host
-            only Host_RHEL.5
+            only Host_RHEL.m5
             pre_command = "alternatives --display qemu-pxe-roms |grep -q etherboot && alternatives --set 'qemu-pxe-roms' /usr/share/etherboot || true"
         - gpxe:
-            only Host_RHEL.6
+            only Host_RHEL.m6
             pre_command = "alternatives --display qemu-pxe-roms |grep -q gpxe || alternatives --install /usr/share/qemu-pxe-roms qemu-pxe-roms /usr/share/gpxe 1; alternatives --set 'qemu-pxe-roms' /usr/share/gpxe"
         - ipxe:
-            only Host_RHEL.7
+            only Host_RHEL.m7
             pre_command = "alternatives --display qemu-pxe-roms |grep -q ipxe || alternatives --install /usr/share/qemu-pxe-roms qemu-pxe-roms /usr/share/ipxe 1; alternatives --set 'qemu-pxe-roms' /usr/share/ipxe"
         - with_query_cpus:
             # EPT/NPT not support by kvm module in RHEL.5 Host
-            no Host_RHEL.5
+            no Host_RHEL.m5
             type = pxe_query_cpus
             start_vm = no
             restart_vm = no

--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -89,13 +89,13 @@
             image_size_image1 = 128G
             image_cluster_size = 512
             install_timeout = 60000
-            no Host_RHEL.5
+            no Host_RHEL.m5
             only qcow2 qcow2v3
         - with_migration:
             migrate_background = yes
         - setting_cluster_size:
             # qemu-kvm bug 812705
-            no Host_RHEL.5
+            no Host_RHEL.m5
             image_cluster_size = 4096
             install_timeout = 7200
             only qcow2 qcow2v3

--- a/qemu/cfg/host-kernel/Host_RHEL/5.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/5.cfg
@@ -1,4 +1,4 @@
-- 5:
+- m5:
     no qcow2v3
     host_kernel_ver_str += ".5"
     monitor_type = human

--- a/qemu/cfg/host-kernel/Host_RHEL/5/10.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/5/10.cfg
@@ -1,3 +1,3 @@
-- 10:
+- u10:
     host_kernel_ver_str += ".10"
     requires_kernel = [">= 2.6.18-349", "<  2.6.18-372"]

--- a/qemu/cfg/host-kernel/Host_RHEL/5/11.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/5/11.cfg
@@ -1,3 +1,3 @@
-- 11:
+- u11:
     host_kernel_ver_str += ".11"
     requires_kernel = [">= 2.6.18-372", "<  2.6.19"]

--- a/qemu/cfg/host-kernel/Host_RHEL/5/7.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/5/7.cfg
@@ -1,3 +1,3 @@
-- 7:
+- u7:
     host_kernel_ver_str += ".7"
     requires_kernel = [">= 2.6.18-274", "<  2.6.18-308"]

--- a/qemu/cfg/host-kernel/Host_RHEL/5/8.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/5/8.cfg
@@ -1,3 +1,3 @@
-- 8:
+- u8:
       host_kernel_ver_str += ".8"
       requires_kernel = [">= 2.6.18-308", "<  2.6.18-348"]

--- a/qemu/cfg/host-kernel/Host_RHEL/5/9.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/5/9.cfg
@@ -1,3 +1,3 @@
-- 9:
+- u9:
     host_kernel_ver_str += ".9"
     requires_kernel = [">= 2.6.18-348", "<  2.6.19"]

--- a/qemu/cfg/host-kernel/Host_RHEL/6.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6.cfg
@@ -1,4 +1,4 @@
-- 6:
+- m6:
     no qcow2v3
     # RHEL-6 pointer
     host_kernel_ver_str += ".6"

--- a/qemu/cfg/host-kernel/Host_RHEL/6/1.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/1.cfg
@@ -1,4 +1,4 @@
-- 1:
+- u1:
     host_kernel_ver_str += ".1"
     requires_kernel = [">= 2.6.32-131", "<  2.6.32-220"]
     usbs = ""

--- a/qemu/cfg/host-kernel/Host_RHEL/6/2.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/2.cfg
@@ -1,3 +1,3 @@
-- 2:
+- u2:
     host_kernel_ver_str += ".2"
     requires_kernel = [">= 2.6.32-220", "<  2.6.32-279"]

--- a/qemu/cfg/host-kernel/Host_RHEL/6/3.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/3.cfg
@@ -1,4 +1,4 @@
-- 3:
+- u3:
     host_kernel_ver_str += ".3"
     requires_kernel = [">= 2.6.32-279", "<  2.6.32-280"]
     bios_path = "/usr/share/seabios/bios-pm.bin"

--- a/qemu/cfg/host-kernel/Host_RHEL/6/4.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/4.cfg
@@ -1,4 +1,4 @@
-- 4:
+- u4:
     host_kernel_ver_str += ".4"
     requires_kernel = [">= 2.6.32-280", "<  2.6.32-359"]
     i386:

--- a/qemu/cfg/host-kernel/Host_RHEL/6/5.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/5.cfg
@@ -1,4 +1,4 @@
-- 5:
+- u5:
     host_kernel_ver_str += ".5"
     requires_kernel = [">= 2.6.32-359", "<  2.6.33-432"]
     i386:

--- a/qemu/cfg/host-kernel/Host_RHEL/6/6.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/6.cfg
@@ -1,4 +1,4 @@
-- 6:
+- u6:
     host_kernel_ver_str += ".6"
     requires_kernel = [">= 2.6.32-432", "<  2.6.32-505"]
     machine_type = "rhel6.6.0"

--- a/qemu/cfg/host-kernel/Host_RHEL/7.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/7.cfg
@@ -1,4 +1,4 @@
-- 7:
+- m7:
     # RHEL-7 pointer
     host_kernel_ver_str += ".7"
     netdev_peer_re = "\s{2,}(.*?):.*?peer=(.*?)\n"

--- a/qemu/cfg/host-kernel/Host_RHEL/7/0.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/7/0.cfg
@@ -1,3 +1,3 @@
-- 0:
+- u0:
     host_kernel_ver_str += ".0"
     requires_kernel = [">= 3.2.1-0.8", "< 3.10.0-124"]

--- a/qemu/cfg/host-kernel/Host_RHEL/7/1.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/7/1.cfg
@@ -1,3 +1,3 @@
-- 1:
+- u1:
     host_kernel_ver_str += ".1"
     requires_kernel = [">= 3.10.0-124", "< 3.10.0-230"]

--- a/qemu/cfg/host-kernel/host-kernel-check.cfg
+++ b/qemu/cfg/host-kernel/host-kernel-check.cfg
@@ -19,54 +19,54 @@ variants:
         pre_check_cmd = "grep 'Red Hat Enterprise Linux' /etc/redhat-release"
         host_kernel_ver_str = Host_RHEL
         variants:
-            - 5:
+            - m5:
                 host_kernel_ver_str += ".5"
                 variants:
-                    - 7:
+                    - u7:
                         host_kernel_ver_str += ".7"
                         requires_kernel = [">= 2.6.18-274", "<  2.6.18-308"]
-                    - 8:
+                    - u8:
                         host_kernel_ver_str += ".8"
                         requires_kernel = [">= 2.6.18-308", "<  2.6.18-348"]
-                    - 9:
+                    - u9:
                         host_kernel_ver_str += ".9"
                         requires_kernel = [">= 2.6.18-348", "<  2.6.18-349"]
-                    - 10:
+                    - u10:
                         host_kernel_ver_str += ".10"
                         requires_kernel = [">= 2.6.18-349", "<  2.6.18-372"]
-                    - 11:
+                    - u11:
                         host_kernel_ver_str += ".11"
                         requires_kernel = [">= 2.6.18-372", "<  2.6.19"]
-            - 6:
+            - m6:
                 host_kernel_ver_str += ".6"
                 variants:
-                    - 1:
+                    - u1:
                         host_kernel_ver_str += ".1"
                         requires_kernel = [">= 2.6.32-131", "<  2.6.32-220"]
-                    - 2:
+                    - u2:
                         host_kernel_ver_str += ".2"
                         requires_kernel = [">= 2.6.32-220", "<  2.6.32-279"]
-                    - 3:
+                    - u3:
                         host_kernel_ver_str += ".3"
                         requires_kernel = [">= 2.6.32-279", "<  2.6.32-280"]
-                    - 4:
+                    - u4:
                         host_kernel_ver_str += ".4"
                         requires_kernel = [">= 2.6.32-280", "<  2.6.32-359"]
-                    - 5:
+                    - u5:
                         host_kernel_ver_str += ".5"
                         requires_kernel = [">= 2.6.32-359", "<  2.6.32-432"]
-                    - 6:
+                    - u6:
                         host_kernel_ver_str += ".6"
                         requires_kernel = [">= 2.6.32-432", "<  2.6.32-505"]
-                    - 7:
+                    - u7:
                         host_kernel_ver_str += ".7"
                         requires_kernel = [">= 2.6.32-505", "<  2.6.32-574"]
-            - 7:
+            - m7:
                 host_kernel_ver_str += ".7"
                 variants:
-                    - 0:
+                    - u0:
                         host_kernel_ver_str += ".0"
                         requires_kernel = [">= 3.2.1-0.8", "< 3.10.0-124"]
-                    - 1:
+                    - u1:
                         host_kernel_ver_str += ".1"
                         requires_kernel = [">= 3.10.0-124", "< 3.10.0-230"]

--- a/qemu/tests/cfg/block_discard.cfg
+++ b/qemu/tests/cfg/block_discard.cfg
@@ -1,5 +1,5 @@
 - block_discard:
-    no Host_RHEL.4, Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m4, Host_RHEL.m5, Host_RHEL.m6
     no virtio_blk
     only Linux
     type = block_discard

--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -1,5 +1,5 @@
 - boot_from_device:
-    no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+    no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
     type = boot_from_device
     boot_menu = on
     enable_sga = yes

--- a/qemu/tests/cfg/boot_with_different_vectors.cfg
+++ b/qemu/tests/cfg/boot_with_different_vectors.cfg
@@ -2,7 +2,7 @@
     only Linux
     only virtio_net
     no RHEL.3 RHEL.4 RHEL.5 RHEL.6
-    no Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m5, Host_RHEL.m6
     queues = 4
     vectors_list = 0 1 2 3 4 5 6 7 8 9 10 11 -1
     type = boot_with_different_vectors

--- a/qemu/tests/cfg/cdrom_test.cfg
+++ b/qemu/tests/cfg/cdrom_test.cfg
@@ -21,10 +21,10 @@
             # test whether cdrom is unlocked <300s after boot
             cdrom_test_autounlock = yes
             cdrom_test_locked = yes
-            Host_RHEL.5:
+            Host_RHEL.m5:
                 cdrom_test_locked = no
         - cdrom_not_insert:
-            no Host_RHEL.5
+            no Host_RHEL.m5
             no RHEL.3, RHEL.4, RHEL.5
             not_insert_at_start = yes
             cdrom_without_file = yes
@@ -80,7 +80,7 @@
         eject_cdrom_cmd = "eject %s"
         close_cdrom_cmd = "eject -t %s"
         mount_cdrom_cmd = "mount %s %s"
-        HOST_RHEL.5:
+        Host_RHEL.m5:
             mount_cdrom_cmd = "mount %s %s -ro"
         umount_cdrom_cmd = "umount %s"
         show_mount_cmd = "cat /etc/mtab"

--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -1,7 +1,7 @@
 - check_block_size:
     only Linux
     only virtio_blk
-    no Host_RHEL.5
+    no Host_RHEL.m5
     no RHEL.3 RHEL.4 RHEL.5
     type = check_block_size
     virt_test_type = qemu

--- a/qemu/tests/cfg/check_roms.cfg
+++ b/qemu/tests/cfg/check_roms.cfg
@@ -1,12 +1,12 @@
 - check_roms:
-    no Host_RHEL.5
+    no Host_RHEL.m5
     type = check_roms
     enable-kvm = yes
     fw_filter = "^fw.*name="(.*?)""
     addr_filter = "^addr.*name="(.*?)""
-    # used default roms, under /usr/share/qemu-kvm in Host_RHEL.6,
-    # or /usr/share/qemu in Host_RHEL.7
-    Host_RHEL.6:
+    # used default roms, under /usr/share/qemu-kvm in Host_RHEL.m6,
+    # or /usr/share/qemu in Host_RHEL.m7
+    Host_RHEL.m6:
         option_roms = "pxe-e1000.bin pxe-rtl8139.bin vgabios-qxl.bin"
-    Host_RHEL.7:
+    Host_RHEL.m7:
         option_roms = "pxe-e1000.rom pxe-rtl8139.rom vgabios-qxl.bin"

--- a/qemu/tests/cfg/cluster_size_check.cfg
+++ b/qemu/tests/cfg/cluster_size_check.cfg
@@ -1,5 +1,5 @@
 - cluster_size_check:
-    no Host_RHEL.5
+    no Host_RHEL.m5
     only qcow2
     type = cluster_size_check
     virt_test_type = qemu

--- a/qemu/tests/cfg/cpu_add.cfg
+++ b/qemu/tests/cfg/cpu_add.cfg
@@ -9,7 +9,7 @@
     vcpu_maxcpus = 255
     vcpu_need_hotplug = 1
     #In RHEL6 host, if your monitor type is qmp, need config vcpu_add_cmd.
-    Host_RHEL.6:
+    Host_RHEL.m6:
         vcpu_add_cmd = "human-monitor-command command-line=cpu_set %s online"
     Host_Fedora:
         monitor_type = qmp
@@ -42,14 +42,14 @@
         - add_after_stop:
             stop_before_hotplug = yes
         - guest_s3:
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             run_sub_test = yes
             extra_params += " -global PIIX4_PM.disable_s3=0"
             sub_test_name = "guest_suspend"
             guest_suspend_type = "mem"
             services_up_timeout = 30
         - guest_s4:
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             run_sub_test = yes
             extra_params += " -global PIIX4_PM.disable_s4=0"
             sub_test_name = "guest_suspend"

--- a/qemu/tests/cfg/cpuinfo_query.cfg
+++ b/qemu/tests/cfg/cpuinfo_query.cfg
@@ -3,18 +3,18 @@
     vms = ''
     variants:
         - qcpu_id:
-            no Host_RHEL.5
+            no Host_RHEL.m5
             query_cmd = " -cpu ?cpuid"
             cpu_info = "f_edx,f_ecx,extf_edx,extf_ecx"
         - qmachine_type:
-            only Host_RHEL.6.4
+            only Host_RHEL.m6.u4
             query_cmd = " -M ?"
             cpu_info = "pc,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
         - qcpu_dump:
-            no Host_RHEL.5
+            no Host_RHEL.m5
             query_cmd = " -cpu ?dump"
             cpu_info = "Opteron_G4,Opteron_G3,Opteron_G2,Opteron_G1,SandyBridge,Westmere,Nehalem,Penryn,Conroe"
         - qcpu_model:
-            no Host_RHEL.5
+            no Host_RHEL.m5
             query_cmd = " -cpu ?model"
             cpu_info = "Opteron_G4,Opteron_G3,Opteron_G2,Opteron_G1,SandyBridge,Westmere,Nehalem,Penryn,Conroe"

--- a/qemu/tests/cfg/device_assignment.cfg
+++ b/qemu/tests/cfg/device_assignment.cfg
@@ -50,7 +50,7 @@
             unplug_pci_num = 2
             kill_vm = yes
             pci_model = kvm-pci-assign
-            Host_RHEL.6:
+            Host_RHEL.m6:
                 pci_model = pci-assign
         - emulation_nic_pf_hot_unplug:
             type = pci_hotunplug
@@ -64,7 +64,7 @@
             login_timeout = 240
             reboot_count = 1
             pci_model = kvm-pci-assign
-            Host_RHEL.6:
+            Host_RHEL.m6:
                 pci_model = pci-assign
         - pf_hotplug:
             type = sr_iov_hotplug
@@ -99,6 +99,6 @@
         - vfio-pci:
             device_driver = vfio-pci
             pci_model = vfio-pci
-            no  Host_RHEL.5, Host_RHEL.6
+            no  Host_RHEL.m5, Host_RHEL.m6
         - pci-assign:
             device_driver = pci-assign

--- a/qemu/tests/cfg/device_assignment_netperf_test.cfg
+++ b/qemu/tests/cfg/device_assignment_netperf_test.cfg
@@ -23,7 +23,7 @@
     variants:
         - vfio-pci:
             device_driver = vfio-pci
-            no  Host_RHEL.5, Host_RHEL.6
+            no  Host_RHEL.m5, Host_RHEL.m6
         - pci-assign:
             device_driver = pci-assign
-            no Host_RHEL.7
+            no Host_RHEL.m7

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -1,7 +1,7 @@
 - drive_mirror:
-    no Host_RHEL.5
-    no Host_RHEL.6.1
-    no Host_RHEL.6.2
+    no Host_RHEL.m5
+    no Host_RHEL.m6.u1
+    no Host_RHEL.m6.u2
     no raw qed vmdk
     type = drive_mirror
     monitor_type = qmp

--- a/qemu/tests/cfg/enforce_quit.cfg
+++ b/qemu/tests/cfg/enforce_quit.cfg
@@ -1,12 +1,12 @@
 - enforce_quit:
     type = enforce_quit
     start_vm = "no"
-    no Host_RHEL.5
+    no Host_RHEL.m5
     cpu_model_flags = ",enforce"
-    Host_RHEL.6:
+    Host_RHEL.m6:
         msg_unavailable = "flag restricted to guest:lacks requested flag"
         msg_unknow = "not found"
-    Host_RHEL.7:
+    Host_RHEL.m7:
         msg_unavailable = "host doesn't support requested feature"
         msg_unknow = "not found"
     variants:

--- a/qemu/tests/cfg/flow_caches_stress_test.cfg
+++ b/qemu/tests/cfg/flow_caches_stress_test.cfg
@@ -18,7 +18,7 @@
     #test_protocols = TCP_STREAM
     variants:
         - multi_queues:
-            no Host_RHEL.5, Host_RHEL.6
+            no Host_RHEL.m5, Host_RHEL.m6
             no Windows
             queues = 4
         - no_multi_queues:

--- a/qemu/tests/cfg/invalid_parameter.cfg
+++ b/qemu/tests/cfg/invalid_parameter.cfg
@@ -4,7 +4,7 @@
     start_vm = no
     run_invalid_cmd = yes
     queues = 4
-    no Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m5, Host_RHEL.m6
     failed_reason = "Device 'tap' could not be initialized"
     vhost = on
     run_invalid_cmd_nic = yes

--- a/qemu/tests/cfg/ipi_x2apic.cfg
+++ b/qemu/tests/cfg/ipi_x2apic.cfg
@@ -1,5 +1,5 @@
 - ipi_x2apic:
-    no Host_RHEL.5
+    no Host_RHEL.m5
     only RHEL.6
     type = ipi_x2apic
     vms = ""

--- a/qemu/tests/cfg/ksm_base.cfg
+++ b/qemu/tests/cfg/ksm_base.cfg
@@ -14,10 +14,10 @@
             split = "no"
             variants:
                 - other_host:
-                    no Host_RHEL.5, Host_RHEL.6
+                    no Host_RHEL.m5, Host_RHEL.m6
                     extra_params += " -machine mem-merge=off"
                 - rhel_host:
-                    only Host_RHEL.6
+                    only Host_RHEL.m6
                     extra_params += " -redhat-disable-KSM"
         - base:
             test_type = "base"

--- a/qemu/tests/cfg/macvtap_event_notification.cfg
+++ b/qemu/tests/cfg/macvtap_event_notification.cfg
@@ -1,5 +1,5 @@
 - macvtap_event_notification:
-    no Host_RHEL.5
+    no Host_RHEL.m5
     no RHEL.3
     type = macvtap_event_notification
     start_vm = no

--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -21,7 +21,7 @@
             migration_protocol = "tcp"
         - unix:
             migration_protocol = "unix"
-            no Host_RHEL.5
+            no Host_RHEL.m5
         - exec:
             migration_protocol = "exec"
             variants:
@@ -153,8 +153,8 @@
                     test_type = "stress_memory_heavy"
         - between_vhost_novhost:
             no JeOS
-            only Host_RHEL.6
-            no Host_RHEL.6.1
+            only Host_RHEL.m6
+            no Host_RHEL.m6.u1
             migrate_between_vhost_novhost = "yes"
             type = migration_with_file_transfer
         - with_netperf:

--- a/qemu/tests/cfg/monitor_cmds_check.cfg
+++ b/qemu/tests/cfg/monitor_cmds_check.cfg
@@ -4,7 +4,7 @@
 
 - monitor_cmds_check:
     type = monitor_cmds_check
-    only Host_RHEL.6, Host_RHEL.7
+    only Host_RHEL.m6, Host_RHEL.m7
     start_vm = yes
     verify_disk_image_bootable = no
     monitors = "human1 qmp1"

--- a/qemu/tests/cfg/mq_change_qnum.cfg
+++ b/qemu/tests/cfg/mq_change_qnum.cfg
@@ -1,7 +1,7 @@
 - mq_change_qnum:
     only Linux
     queues = 4
-    no Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m5, Host_RHEL.m6
     # Here vectors should be queues * 2 + 2
     vectors = 10
     virt_test_type = qemu

--- a/qemu/tests/cfg/mq_max_queues.cfg
+++ b/qemu/tests/cfg/mq_max_queues.cfg
@@ -3,7 +3,7 @@
     only Linux
     virt_test_type = qemu
     type = mq_change_qnum
-    no Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m5, Host_RHEL.m6
     #In this test need set snapshot for our test will chang guest msi support
     image_snapshot = yes
     #set repeat_counts for chang queues number

--- a/qemu/tests/cfg/multi_nics_hotplug.cfg
+++ b/qemu/tests/cfg/multi_nics_hotplug.cfg
@@ -1,6 +1,6 @@
 - multi_nics_hotplug: install setup image_copy unattended_install.cdrom
     no RHEL.3
-    no Host_RHEL.5
+    no Host_RHEL.m5
     virt_test_type = qemu
     type = nic_hotplug
     run_dhclient = yes
@@ -16,7 +16,7 @@
         - nic_virtio:
             pci_model = virtio-net-pci
             match_string = "Virtio network device"
-            Host_RHEL.5:
+            Host_RHEL.m5:
                 pci_model = virtio
             nics = ""
             extra_params += "-net none"

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -16,7 +16,7 @@
             #TODO: Confirm this works with libvirt
             pci_model = virtio-net-pci
             match_string = "Virtio network device"
-            Host_RHEL.5:
+            Host_RHEL.m5:
                 pci_model = virtio
         - nic_e1000:
             no ppc64 ppc64le
@@ -30,7 +30,7 @@
             pci_num = 2
             repeat_times = 1
         - additional:
-            no Host_RHEL.5
+            no Host_RHEL.m5
             run_dhclient = yes
             type = nic_hotplug
             nics = ""
@@ -40,14 +40,14 @@
         - migration:
             # For now, migration + networking only works
             # with bridge (no usermode)
-            no Host_RHEL.5
+            no Host_RHEL.m5
             requires_root = yes
             type = migration_after_nichotplug
             kill_vm = yes
             nics = ""
             extra_params += "-net none"
         - vhost_nic:
-            no Host_RHEL.5
+            no Host_RHEL.m5
             only nic_virtio
             nic_hotplug_count = 1
             netdev_extra_params_hotplug_nic1 = ",vhost=on"

--- a/qemu/tests/cfg/pci_hotplug.cfg
+++ b/qemu/tests/cfg/pci_hotplug.cfg
@@ -18,7 +18,7 @@
         - with_suspend:
             no RHEL.3, RHEL.4
             only Host_RHEL
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             services_up_timeout = 30
             reboot_vm = yes
             variants:

--- a/qemu/tests/cfg/pktgen.cfg
+++ b/qemu/tests/cfg/pktgen.cfg
@@ -1,7 +1,7 @@
 - pktgen: install setup image_copy unattended_install.cdrom
     no JeOS
     no Windows
-    no Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m5, Host_RHEL.m6
     virt_test_type = qemu
     type = pktgen
     kill_vm = yes

--- a/qemu/tests/cfg/qcow2perf.cfg
+++ b/qemu/tests/cfg/qcow2perf.cfg
@@ -26,18 +26,18 @@
             opcmd = "time strace -c qemu-img convert -f qcow2 %s -O qcow2 -t %s %s"
             variants:
                 - default_test:
-                    only Host_RHEL.5   
+                    only Host_RHEL.m5   
                 - cache_none:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = none
                 - cache_unsafe:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = unsafe
                 - cache_writeback:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = writeback
                 - cache_writethrough:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = writethrough
         - rebase:
             op_type = rebase
@@ -55,18 +55,18 @@
             opcmd = "time strace -c qemu-img rebase -F qcow2 -b %s -f qcow2 -t %s %s"
             variants:
                 - default_test:
-                    only Host_RHEL.5
+                    only Host_RHEL.m5
                 - cache_none:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = none
                 - cache_unsafe:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = unsafe
                 - cache_writeback:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = writeback
                 - cache_writethrough:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = writethrough
         - commit:
             op_type = commit
@@ -77,18 +77,18 @@
             opcmd = "time strace -c qemu-img commit -f qcow2 -t %s %s"
             variants:
                 - default_test:
-                    only Host_RHEL.5
+                    only Host_RHEL.m5
                 - cache_none:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = none
                 - cache_unsafe:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = unsafe
                 - cache_writeback:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = writeback
                 - cache_writethrough:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     cache_mode = writethrough
        - summary_qcow2perf:
             start_vm = yes

--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -23,7 +23,7 @@
         - qemu_flavor_rhel:
             variants:
                 - 6:
-                    only Host_RHEL.6
+                    only Host_RHEL.m6
                     variants:
                         - 6_0:
                         - 6_1:
@@ -31,7 +31,7 @@
                         - 6_3:
                         - 6_4:
                 - 7:
-                    only Host_RHEL.7
+                    only Host_RHEL.m7
                     variants:
                         - 7_0:
                         - 7_1:
@@ -75,7 +75,7 @@
                 - core2duo:
                     cpu_model = "core2duo"
                 - kvm32:
-                    no Host_RHEL.6
+                    no Host_RHEL.m6
                     cpu_model = "kvm32"
                 - kvm64:
                     cpu_model = "kvm64"
@@ -142,7 +142,7 @@
 
         #KNOWN BUG: RHEL-7.0 qemu-kvm doesn't show the -no-kvm option on -help,
         # so virt-test doesn't use the option and disable_kvm=yes doesn't work
-        no Host_RHEL.7
+        no Host_RHEL.m7
 
     variants:
         - check_models:
@@ -372,7 +372,7 @@
                     machine_type_rhel.rhel6:
                         cpu_model_amd.qemu64:
                             # RHEL-7 doesn't keep the ABI for rhel6.* + qemu64
-                            no Host_RHEL.7
+                            no Host_RHEL.m7
                             no qemu_flavor_unknown
 
                     # SEP bit depended on host kernel on 6.3 and older:
@@ -459,26 +459,26 @@
                         - KVM:
                             signature = "KVMKVMKVM\x00\x00\x00"
                         - hv_relaxed:
-                            no Host_RHEL.3 Host_RHEL.4 Host_RHEL.5
-                            no Host_RHEL.6.0 Host_RHEL.6.1 Host_RHEL.6.2 Host_RHEL.6.3
+                            no Host_RHEL.m3 Host_RHEL.m4 Host_RHEL.m5
+                            no Host_RHEL.m6.u0 Host_RHEL.m6.u1 Host_RHEL.m6.u2 Host_RHEL.m6.u3
                             signature = "Microsoft Hv"
                             flags = "hv_relaxed"
                         - hv_vapic:
-                            no Host_RHEL.3 Host_RHEL.4 Host_RHEL.5 Host_RHEL.6
+                            no Host_RHEL.m3 Host_RHEL.m4 Host_RHEL.m5 Host_RHEL.m6
                             signature = "Microsoft Hv"
                             flags = "hv_vapic"
                         - hv_spinlocks:
-                            no Host_RHEL.3 Host_RHEL.4 Host_RHEL.5 Host_RHEL.6
+                            no Host_RHEL.m3 Host_RHEL.m4 Host_RHEL.m5 Host_RHEL.m6
                             signature = "Microsoft Hv"
                             flags = "hv_spinlocks=4095"
                         - 0x40000001:
-                            no Host_RHEL.3 Host_RHEL.4 Host_RHEL.5
+                            no Host_RHEL.m3 Host_RHEL.m4 Host_RHEL.m5
                             signature = "Hv#1"
                             leaf = "0x40000001"
                             flags = "hv_relaxed"
                             regs = "eax"
                 - hyperv:
-                    no Host_RHEL.3 Host_RHEL.4 Host_RHEL.5 Host_RHEL.6
+                    no Host_RHEL.m3 Host_RHEL.m4 Host_RHEL.m5 Host_RHEL.m6
                     only kvm
                     only cpu_model_unset
                     test_type = "cpuid_bit_test"

--- a/qemu/tests/cfg/qemu_img.cfg
+++ b/qemu/tests/cfg/qemu_img.cfg
@@ -13,7 +13,7 @@
             create_image_cmd = "dd if=/dev/zero of=%s bs=1G count=1"
             # Test the conversion from 'dd_image_name' to specified format
             supported_image_formats = qcow2 raw qed
-            Host_RHEL.5:
+            Host_RHEL.m5:
                 supported_image_formats = qcow2 raw
         - create:
             subcommand = create
@@ -25,7 +25,7 @@
             variants:
                 - @cluster_size_default:
                 - cluster_size:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     variants:
                         - cluster_512:
                             image_cluster_size = 512
@@ -42,7 +42,7 @@
                     no raw
                     preallocated = off
                 - preallocated:
-                    no Host_RHEL.5
+                    no Host_RHEL.m5
                     no raw
                     preallocated = metadata
         - convert:
@@ -63,7 +63,7 @@
                             qemu_img_options = cluster_size
                             #cluster_size set cluster size used in qemu-img -o cluster_size=, default is 64k.
                             cluster_size = 2048
-                            no Host_RHEL.5
+                            no Host_RHEL.m5
                 - to_raw:
                     dest_image_format = raw
                 - to_qed:

--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -1,5 +1,5 @@
 - qmp_command:
-    no Host_RHEL.5
+    no Host_RHEL.m5
     no RHEL.3 RHEL.4
     type = qmp_command
     virt_test_type = qemu
@@ -19,7 +19,7 @@
             post_cmd = "info mice"
             cmd_result_check = contain
             cmd_return_value = "u'name': u'QEMU PS/2 Mouse';u'name': u'QEMU HID Tablet'"
-            Host_RHEL.6:
+            Host_RHEL.m6:
                 cmd_return_value = "u'name': u'QEMU PS/2 Mouse';u'name': u'QEMU USB Tablet'"
         - qmp_query-status:
             pre_cmd = stop
@@ -106,7 +106,7 @@
             cmd_return_value = "{u'status': u'paused', u'singlestep': False, u'running': False}"
         - qmp_redhat_device_add:
             no ide
-            only Host_RHEL.6
+            only Host_RHEL.m6
             pre_command += "qemu-img create -f qcow2 /tmp/device_add01.qcow2 100M"
             event_cmd_type = qmp_cmd
             pre_cmd = "__com.redhat_drive_add file=/tmp/device_add01.qcow2,format=qcow2,id=device_add01"
@@ -117,7 +117,7 @@
             post_command += " rm -rf /tmp/device_add01.qcow2;"
         - qmp_device_del:
             no ide
-            only Host_RHEL.6
+            only Host_RHEL.m6
             pre_command += "qemu-img create -f qcow2 /tmp/device_del01.qcow2 100M"
             event_cmd_type = qmp_cmd
             pre_cmd = "__com.redhat_drive_add file=/tmp/device_del01.qcow2, format=qcow2, id=device_del01"
@@ -147,7 +147,7 @@
             post_cmd = info kvm
             cmd_result_check = m_in_q
         - qmp__com.redhat.drive_del:
-            only Host_RHEL.6
+            only Host_RHEL.m6
             pre_command += "qemu-img create -f qcow2 /tmp/__com.redhat.drive_del01.qcow2 100M"
             event_cmd_type = qmp_cmd
             pre_cmd = "__com.redhat_drive_add file=/tmp/__com.redhat.drive_del01.qcow2, format=qcow2, id=com.redhat.drive_del01;query-block"

--- a/qemu/tests/cfg/qmp_event_notification.cfg
+++ b/qemu/tests/cfg/qmp_event_notification.cfg
@@ -1,5 +1,5 @@
 - qmp_event_notification:
-    no Host_RHEL.5
+    no Host_RHEL.m5
     no RHEL.3
     type = qmp_event_notification
     virt_test_type = qemu

--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -1,5 +1,5 @@
 - seabios: install setup image_copy unattended_install.cdrom
-    no Host_RHEL.5
+    no Host_RHEL.m5
     type = seabios
     start_vm = no
     restart_vm = no
@@ -11,7 +11,7 @@
     boot_menu_hint = "Press .*F12 for boot menu"
     # Specify the boot device name which you want to test here.
     boot_device = "iPXE"
-    Host_RHEL.6:
+    Host_RHEL.m6:
         boot_device = "gPXE"
     # SGA Bios info message, using sep as ";"
     # Please update this message to suit for your own system.

--- a/qemu/tests/cfg/set_link.cfg
+++ b/qemu/tests/cfg/set_link.cfg
@@ -9,7 +9,7 @@
     #queues = 4
     # In newest version of qemu guest can get the state
     # So please set operstate_always_up to yes for old version of qemu
-    Host_RHEL.5, Host_RHEL.6:
+    Host_RHEL.m5, Host_RHEL.m6:
         operstate_always_up = yes
     variants:
         - @default:

--- a/qemu/tests/cfg/sr_iov.cfg
+++ b/qemu/tests/cfg/sr_iov.cfg
@@ -57,7 +57,7 @@
             repeat_times = 500
             test_timeout = 10000
         - vf_guest_suspend:
-            no Host_RHEL.6
+            no Host_RHEL.m6
             variants:
                 - vf_assigned:
                     type = guest_suspend
@@ -96,7 +96,7 @@
                     iommu = off
                     type = sr_iov_boot_negative
                 - no-kvm:
-                    no Host_RHEL.7
+                    no Host_RHEL.m7
                     pci_assignable = vf
                     disable_kvm = yes
                     enable_kvm = no
@@ -109,7 +109,7 @@
                     modprobe_cmd = modprobe -r %s
                     pci_invaild_addr = abc
                     negative_msg = "Property 'pci-assign.addr' doesn't take value 'abc'"
-                    Host_RHEL.7:
+                    Host_RHEL.m7:
                         negative_msg = "Property 'kvm-pci-assign.addr' doesn't take value 'abc'"
                 - hotplug_iommu_off:
                     no vfio-pci
@@ -132,7 +132,7 @@
     variants:
         - vfio-pci:
             device_driver = vfio-pci
-            no  Host_RHEL.5, Host_RHEL.6
+            no  Host_RHEL.m5, Host_RHEL.m6
         - pci-assign:
             device_driver = pci-assign
-            no Host_RHEL.7
+            no Host_RHEL.m7

--- a/qemu/tests/cfg/sr_iov_file_transfer.cfg
+++ b/qemu/tests/cfg/sr_iov_file_transfer.cfg
@@ -21,6 +21,6 @@
         - vfio-pci:
             device_driver = vfio-pci
             only vf
-            no  Host_RHEL.5  Host_RHEL.6
+            no  Host_RHEL.m5  Host_RHEL.m6
         - pci-assign:
             device_driver = pci-assign

--- a/qemu/tests/cfg/sr_iov_irqbalance.cfg
+++ b/qemu/tests/cfg/sr_iov_irqbalance.cfg
@@ -14,6 +14,6 @@
     variants:
         - vfio-pci:
             device_driver = vfio-pci
-            no  Host_RHEL.5, Host_RHEL.6
+            no  Host_RHEL.m5, Host_RHEL.m6
         - pci-assign:
             device_driver = pci-assign

--- a/qemu/tests/cfg/sr_iov_netperf_test.cfg
+++ b/qemu/tests/cfg/sr_iov_netperf_test.cfg
@@ -24,7 +24,7 @@
     variants:
         - vfio-pci:
             device_driver = vfio-pci
-            no  Host_RHEL.5, Host_RHEL.6
+            no  Host_RHEL.m5, Host_RHEL.m6
         - pci-assign:
             device_driver = pci-assign
-            no Host_RHEL.7
+            no Host_RHEL.m7

--- a/qemu/tests/cfg/sr_iov_sanity.cfg
+++ b/qemu/tests/cfg/sr_iov_sanity.cfg
@@ -11,6 +11,6 @@
     variants:
         - vfio-pci:
             device_driver = vfio-pci
-            no Host_RHEL.5, Host_RHEL.6
+            no Host_RHEL.m5, Host_RHEL.m6
         - pci-assign:
             device_driver = pci-assign

--- a/qemu/tests/cfg/suspend_under_netperf.cfg
+++ b/qemu/tests/cfg/suspend_under_netperf.cfg
@@ -24,7 +24,7 @@
         client_path_win = "c:\\"
     variants:
         - guest_s3:
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             run_sub_test = yes
             sub_test_name = "guest_suspend"
             extra_params += " -global PIIX4_PM.disable_s3=0"
@@ -35,7 +35,7 @@
             # s3_start_cmd and services_up_timeout are set in guest-os.cfg
         - guest_s4:
             #When do guest S4 make sure turn off image snapshot
-            no Host_RHEL.5, Host_RHEL.6.0, Host_RHEL.6.1, Host_RHEL.6.2
+            no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
             run_sub_test = yes
             extra_params += " -global PIIX4_PM.disable_s4=0"
             sub_test_name = "guest_suspend"

--- a/qemu/tests/cfg/systemtap_tracing.cfg
+++ b/qemu/tests/cfg/systemtap_tracing.cfg
@@ -54,7 +54,7 @@
                     probe_var_key = addr val
                     stap_script_file = cpu_out.stp
         - @qemu:
-            no Host_RHEL.7
+            no Host_RHEL.m7
             variants:
                 - qemu_free:
                     probe_var_key = ptr
@@ -134,19 +134,19 @@
                 - @ehci:
                     variants:
                         - usb_ehci_data:
-                            no Host_RHEL.7
+                            no Host_RHEL.m7
                             probe_var_key = rw cpage offset addr len bufpos
                             stap_script_file = usb_echi_data.stp
                         - usb_ehci_mmio_change:
-                            no Host_RHEL.7
+                            no Host_RHEL.m7
                             probe_var_key = addr str new old
                             stap_script_file = usb_ehci_mmio_change.stp
                         - usb_ehci_mmio_readl:
-                            no Host_RHEL.7
+                            no Host_RHEL.m7
                             probe_var_key = addr str val
                             stap_script_file = usb_ehci_mmio_readl.stp
                         - usb_ehci_mmio_writel:
-                            no Host_RHEL.7
+                            no Host_RHEL.m7
                             probe_var_key = addr str val
                             stap_script_file = usb_ehci_mmio_writel.stp
                         - usb_ehci_port_detach:

--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -1,5 +1,5 @@
 - timerdevice:
-    no Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m5, Host_RHEL.m6
     restart_vm = yes
     variants:
         - tscwrite:
@@ -90,7 +90,7 @@
                             vcpu_socket = 2
         - newer_msrs_support_check:
             only Linux
-            no Host_RHEL.3,4,5 Host_RHEL.6.0
+            no Host_RHEL.m3,m4,m5 Host_RHEL.m6.u0
             no RHEL.3,4,5 RHEL.6.0,1,2,3
             type = timerdevice_kvmclock_newer_msrs_support
             rtc_base = utc

--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -1,7 +1,7 @@
 - usb:
     virt_test_type = qemu
-    no Host_RHEL.5
-    no Host_RHEL.6.1
+    no Host_RHEL.m5
+    no Host_RHEL.m6.u1
     restart_vm = yes
     kill_vm_on_error = yes
     usbs += " usbtest"
@@ -38,7 +38,7 @@
             no RHEL.3
             no RHEL.4
             no RHEL.5
-            no Host_RHEL.6
+            no Host_RHEL.m6
             usb_type_usbtest = nec-usb-xhci
             usb_controller = xhci
             usb_max_port_usbtest = 4
@@ -113,8 +113,8 @@
             vendor = "Gemplus"
             product = "QEMU USB CCID"
         - usb_audio:
-            no Host_RHEL.6
-            no Host_RHEL.7
+            no Host_RHEL.m6
+            no Host_RHEL.m7
             only usb_boot, usb_reboot, usb_hotplug
             usb_type = usb-audio
             info_usb_name = "QEMU USB Audio"
@@ -240,10 +240,10 @@
                 - usb_negative_test:
                     usb_negative_test = "yes"
                     usb_reply_msg = "Property 'usb-host.productid' doesn't take value"
-                    Host_RHEL.6:
-                        # Now no output from monitor for negative test on Host_RHEL.6
+                    Host_RHEL.m6:
+                        # Now no output from monitor for negative test on Host_RHEL.m6
                         usb_reply_msg = ""
-                    Host_RHEL.7:
+                    Host_RHEL.m7:
                         usb_reply_msg = "Parameter 'productid' expects an int64 value or range;"
                         usb_reply_msg += "Parameter 'vendorid' expects an int64 value or range;"
                         usb_reply_msg += "productid out of range;"

--- a/qemu/tests/cfg/virtio_scsi_mq.cfg
+++ b/qemu/tests/cfg/virtio_scsi_mq.cfg
@@ -3,7 +3,7 @@
     only virtio_scsi
     only RHEL
     no RHEL.3 RHEL.4 RHEL.5 RHEL.6
-    no Host_RHEL.5 Host_RHEL.6
+    no Host_RHEL.m5 Host_RHEL.m6
     kill_vm_on_error = yes
     login_timeout = 240
     start_vm = no

--- a/qemu/tests/cfg/vnc.cfg
+++ b/qemu/tests/cfg/vnc.cfg
@@ -1,5 +1,5 @@
 - vnc_test:
-    no Host_RHEL.5
+    no Host_RHEL.m5
     type = vnc
     vnc_password = 'yes'
     rfb_version = 3.3 3.7 3.8

--- a/qemu/tests/cfg/zero_copy.cfg
+++ b/qemu/tests/cfg/zero_copy.cfg
@@ -1,5 +1,5 @@
 - zero_copy:
-    no Host_RHEL.5, Host_RHEL.6
+    no Host_RHEL.m5, Host_RHEL.m6
     only virtio_net
     type = zero_copy
     start_vm = no


### PR DESCRIPTION
Currently, When install Win8..1 guest on RHEL.7.1 host, will
create the incorrect case list and install Win8..0 and Win8..1
guest now, cause RHEL.7.1 conflicts with Win8.1 configs,
so this is a workaround, using 7.u1 to fix it.