### PR TITLE
qemu.tests: Removing debugging commands from rv_video.py

### DIFF
--- a/qemu/tests/rv_video.py
+++ b/qemu/tests/rv_video.py
@@ -52,11 +52,7 @@ def launch_totem(guest_session, params):
         cmd += " true"
     else:
         cmd += " false"
-
     guest_session.cmd(cmd)
-
-    cmd = "gsettings get org.gnome.totem repeat"
-    logging.info(guest_session.cmd(cmd))
 
     cmd = "export DISPLAY=:0.0"
     guest_session.cmd(cmd)


### PR DESCRIPTION
Removing some leftover debugging commands to verify
that the repeat totem value was set.

Reviewed by: Swapna Krishnan <skrishna@redhat.com>