### PR TITLE
generic.tests: Fix a typo in shutdown

### DIFF
--- a/generic/tests/shutdown.py
+++ b/generic/tests/shutdown.py
@@ -72,7 +72,7 @@ def run(test, params, env):
             check_failed = False
             vm_status = vm.monitor.get_status()
             if vm.monitor.protocol == "qmp":
-                if not vm_status['status'] != "shutdown":
+                if vm_status['status'] != "shutdown":
                     check_failed = True
             else:
                 if not re.findall("paused\s+\(shutdown\)", vm_status):


### PR DESCRIPTION
Fix a typo when last patch is made. It will lead to a wrong result
for monitor status check.