### PR TITLE
qemu.tests.rv_logging: Changing the amount of log to grep

### DIFF
--- a/qemu/tests/rv_logging.py
+++ b/qemu/tests/rv_logging.py
@@ -90,13 +90,13 @@ def run(test, params, env):
 
         # Testing the log after starting spice-vdagentd
         utils_spice.start_vdagent(guest_root_session, test_timeout=15)
-        cmd = spice_vdagent_loginfo_cmd + "| tail -n 6 | grep \"opening vdagent virtio channel\""
+        cmd = spice_vdagent_loginfo_cmd + "| tail -n 7 | grep \"opening vdagent virtio channel\""
         output = guest_root_session.cmd(cmd)
         logging.debug(output)
 
         # Testing the log after restart spice-vdagentd
         utils_spice.restart_vdagent(guest_root_session, test_timeout=10)
-        cmd = spice_vdagent_loginfo_cmd + "| tail -n 6 | grep 'opening vdagent virtio channel'"
+        cmd = spice_vdagent_loginfo_cmd + "| tail -n 7 | grep 'opening vdagent virtio channel'"
         output = guest_root_session.cmd(cmd)
         logging.debug(output)
 


### PR DESCRIPTION
Due to additional logging statements coming from spice-vdagent, the
number of lines which are being searched needs to be updated.

Reviewed-By: Swapna Krishnan <skrishna@redhat.com>