### PR TITLE
qemu.tests: Update the monitor_dir in softlockup

### DIFF
--- a/qemu/tests/softlockup.py
+++ b/qemu/tests/softlockup.py
@@ -38,7 +38,8 @@ def run(test, params, env):
     login_timeout = int(params.get("login_timeout", 360))
     auto_dir = os.environ.get("AUTODIR", os.environ.get("AUTOTEST_PATH"))
     stress_dir = os.path.join(auto_dir, "tests", "stress")
-    monitor_dir = params.get("monitor_dir", os.path.join(test.virtdir, 'deps'))
+    monitor_dir = params.get("monitor_dir",
+                             data_dir.get_deps_dir("softlockup"))
 
     def _kill_guest_programs(session, kill_stress_cmd, kill_monitor_cmd):
         logging.info("Kill stress and monitor on guest")


### PR DESCRIPTION
Autotest test structure already changed, so update the code to fit it.