### PR TITLE
tp-qemu: fix mount-point not exist issue

### DIFF
--- a/qemu/tests/cfg/format_disk.cfg
+++ b/qemu/tests/cfg/format_disk.cfg
@@ -13,7 +13,7 @@
     format_cmd = "cd /dev && for i in `ls | egrep [shv]db`;do yes |mkfs.ext3 $i; done"
     list_disk_cmd = ""
     set_online_cmd = ""
-    mount_cmd =  "cd /dev && ls | egrep [shv]db | xargs -I dev mount -t ext3 dev /media"
+    mount_cmd =  "mkdir -p /media && cd /dev && ls | egrep [shv]db | xargs -I dev mount -t ext3 dev /media"
     umount_cmd = "mount | grep -Eo '/dev/[shv]db' | xargs umount"
     testfile_name = "/media/format_disk-test.txt"
     writefile_cmd = "echo %s > %s"


### PR DESCRIPTION
/media dir not exist in some mini install os(eg, SLES), so
create /media before mount disk to it;

ID: 1176735

Signed-off-by: Xu Tian <xutian@redhat.com>