### PR TITLE
qemu.tests: make migrate..with_netperf case more reasonable

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -161,7 +161,7 @@
             no JeOS
             iterations = 1
             type = migration_with_netperf
-            client_num = 100
+            client_num = 4
             netperf_timeout = 1000
             hostpassword = redhat
             mig_timeout = 1500


### PR DESCRIPTION
Response test owner's request to update netperf clinets numbers
to make test more reasonable.

ID: 993578

Signed-off-by: Xu Tian <xutian@redhat.com>