### PR TITLE
qemu.tests.cfg: Disable the old host for win_virtio_update

### DIFF
--- a/qemu/tests/cfg/win_virtio_update.cfg
+++ b/qemu/tests/cfg/win_virtio_update.cfg
@@ -2,6 +2,8 @@
     virt_test_type = qemu
     type = win_virtio_update
     only Windows
+    # virtio-scsi driver support from RHEL6.3, so disalbe the old host
+    no Host_RHEL.3,4,5 Host_RHEL.6.0 Host_RHEL.6.1 Host_RHEL.6.2
     start_vm = no
     drivers_install = "balloon;block;nic"
     mount_point = "/tmp/mnt"


### PR DESCRIPTION
virtio-scsi driver support from RHEL6.3, so disable the old host.
