### PR TITLE
qemu.tests.cfg: Fix systemtap_tracing config

### DIFF
--- a/qemu/tests/cfg/systemtap_tracing.cfg
+++ b/qemu/tests/cfg/systemtap_tracing.cfg
@@ -222,6 +222,7 @@
                     stap_script_file = virtio_blk_rw_complete.stp
                     cmds_exec = dd if=/dev/zero of=/tmp/testvirt bs=1k count=1000
         - @virtio_queue:
+            only virtio_blk
             variants:
                 - virtio_notify:
                     probe_var_key = vdev vq


### PR DESCRIPTION
Some testcase need to boot virtio_blk disk, so update
related config.

Signed-off-by: Shuping Cui <scui@redhat.com>