### PR TITLE
qemu.tests.virtio_console: Avoid hang on exception

### DIFF
--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -1993,6 +1993,7 @@ def run(test, params, env):
             fce = locals()[_fce]
             return fce()
         except Exception, details:
+            EXIT_EVENT.set()    # Avoid hangs
             exc_type, exc_value, exc_traceback = sys.exc_info()
             logging.error("Original traceback:\n" +
                           "".join(traceback.format_exception(


### PR DESCRIPTION
When qemu_virtio_port is waiting for reconnection and exception occurs
we need to set the EXIT_EVENT otherwise the test hangs for infinity.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>