### PR TITLE
qemu.tests: Adjust tests to ppc64le

### DIFF
--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -106,7 +106,7 @@ def run(test, params, env):
         if pci_model == "scsi" or pci_model == "scsi-hd":
             if pci_model == "scsi":
                 pci_model = "scsi-disk"
-                if arch.ARCH == 'ppc64':
+                if arch.ARCH in ('ppc64', 'ppc64le'):
                     controller_model = "spapr-vscsi"
                 else:
                     controller_model = "lsi53c895a"

--- a/qemu/tests/pci_hotplug_check.py
+++ b/qemu/tests/pci_hotplug_check.py
@@ -135,7 +135,7 @@ def run(test, params, env):
 
         if pci_model == "scsi":
             pci_model = "scsi-disk"
-            if arch.ARCH == 'ppc64':
+            if arch.ARCH in ('ppc64', 'ppc64le'):
                 controller_model = "spapr-vscsi"
             else:
                 controller_model = "lsi53c895a"


### PR DESCRIPTION
this patch only replaces 'ppc64' checks for 'ppc64' and 'ppc64le' checks.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>