### PR TITLE
qemu.tests: correct balloon values for qmp command

### DIFF
--- a/qemu/tests/cfg/systemtap_tracing.cfg
+++ b/qemu/tests/cfg/systemtap_tracing.cfg
@@ -17,7 +17,8 @@
             extra_params = -device virtio-balloon-pci,id=ballooning
             probe_var_key = opaque addr
             stap_script_file = balloon_event.stp
-            cmds_exec = monitor:balloon value=2048
+            cmds_exec = monitor:balloon value=2097152
+            cmds_exec_human = monitor:balloon value=2048
         - memalign:
             probe_var_key = alignment size ptr
             stap_script_file = memalign.stp

--- a/qemu/tests/systemtap_tracing.py
+++ b/qemu/tests/systemtap_tracing.py
@@ -55,9 +55,9 @@ def run(test, params, env):
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
-
-    if params.get("cmds_exec"):
-        for cmd in params.get("cmds_exec").split(","):
+    _params = params.object_params(vm.monitor.protocol)
+    if _params.get("cmds_exec"):
+        for cmd in _params.get("cmds_exec").split(","):
             if re.findall(":", cmd):
                 cmd_type = cmd.split(":")[0]
                 exec_cmds = cmd.split(":")[1]
@@ -65,8 +65,8 @@ def run(test, params, env):
                 cmd_type = "bash"
                 exec_cmds = cmd
             for cmd_exec in exec_cmds.split(";"):
-                error.context("Execute %s cmd '%s'" %
-                              (cmd_type, cmd_exec), logging.info)
+                msg = "Execute %s cmd '%s'" % (cmd_type, cmd_exec)
+                error.context(msg, logging.info)
                 if cmd_type == "monitor":
                     vm.monitor.send_args_cmd(cmd_exec)
                 elif cmd_type == "bash":


### PR DESCRIPTION
default unit of qmp monitor for balloon value is byte, so
update value to avoid guest reboot when balloon memory to
a incorrect vaule.

Signed-off-by: Xu Tian <xutian@redhat.com>