### PR TITLE
tp-qemu: lvm.lvm_fill: update some config.

### DIFF
--- a/generic/tests/cfg/lvm.cfg
+++ b/generic/tests/cfg/lvm.cfg
@@ -27,6 +27,9 @@
             fillup_timeout = 120
             fillup_size = 20
             fillup_cmd = "dd if=/dev/zero of=%s/fillup.%d bs=%dM count=1 oflag=direct"
+            clean_cmd = "killall -9 dd;"
+            clean_cmd += "rm -f /%s/fillup.*"
+            show_fillup_dir_cmd = "ls %s"
         - lvm_ioquit: lvm_create
             type = ioquit
             force_create_image_stg1 = no


### PR DESCRIPTION
case 'lvm.lvm_fill' needs case 'fillup_disk' as a subcase,
need add the config from fillup_disk.cfg to lvm.cfg.

Signed-off-by: Cong Li <coli@redhat.com>