### PR TITLE
qemu.spice: Add smartcard option while building and add dependencies

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -365,6 +365,7 @@ variants:
         spice_gtk3_devel_url = path_to_spice_gtk3_devel_rpm
         spice_protocol_url = path_to_spice_protocol_rpm
         spice_glib_devel_url = path_to_spice_glib_devel_rpm
+        libcacard_devel_url = path_to_libcacard_rpm
         celt051_devel_url = path_to_celt051_rpm
         libogg_devel_url = path_to_libogg_rpm
         only remote_viewer_rhel6devel_build_install

--- a/qemu/deps/spice/build_install.py
+++ b/qemu/deps/spice/build_install.py
@@ -23,7 +23,7 @@ git_repo["xf86-video-qxl"] = "git://anongit.freedesktop.org/xorg/driver/xf86-vid
 git_repo["virt-viewer"] = "https://git.fedorahosted.org/git/virt-viewer.git"
 
 # options to pass
-autogen_options["spice-gtk"] = "--disable-gtk-doc --disable-werror --disable-vala --disable-controller"
+autogen_options["spice-gtk"] = "--disable-gtk-doc --disable-werror --disable-vala --disable-controller --enable-smartcard"
 autogen_options["spice-vd-agent"] = "--libdir=/usr/lib64 --sysconfdir=/etc"
 autogen_options["xf86-video-qxl"] = "--libdir=\"/usr/lib64\" --disable-kms"
 autogen_options["virt-viewer"] = "--with-spice-gtk --disable-update-mimedb"


### PR DESCRIPTION
While building virt-viewer, enable smartcard option to be able to run
smartcard tests. Also, building smartcard functionality requires
libcacard-devel package. Adding path to libcacard-devel rpm to
config file.