### PR TITLE
tp-qemu: mq_max_queues: RHEL.6 host does not support multi host.

### DIFF
--- a/qemu/tests/cfg/mq_max_queues.cfg
+++ b/qemu/tests/cfg/mq_max_queues.cfg
@@ -3,6 +3,7 @@
     only Linux
     virt_test_type = qemu
     type = mq_change_qnum
+    no Host_RHEL.5, Host_RHEL.6
     #In this test need set snapshot for our test will chang guest msi support
     image_snapshot = yes
     #set repeat_counts for chang queues number


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>