### PR TITLE
qemu.tests.virtio_console: Mostly config tweaks

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -78,6 +78,8 @@
                             only Linux
                             virtio_console_test = rmmod
                         - migration:
+                            # Arm doesn't support migration
+                            no aarch64
                             virtio_console_no_migrations = 5
                             virtio_console_no_ports = 2
                             virtio_console_blocklen = 4096
@@ -223,6 +225,8 @@
                             virtio_port_type_vs1 = serialport
                             virtio_port_params_vs1 = "nr=1"
                         - boot_too_much_ports:
+                            # arm doesn't use pci bus
+                            no aarch64
                             extra_params = " -device virtio-serial-pci,max_ports=32"
                             start_vm = no
                             virtio_console_test = failed_boot

--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -38,9 +38,13 @@
                         - close:
                             virtio_console_test = close
                         - polling:
+                            # Works with virtconsole, but is not the comon usage, don't test by default
+                            no virtconsole
                             only Linux
                             virtio_console_test = polling
                         - sigio:
+                            # Works with virtconsole, but is not the comon usage, don't test by default
+                            no virtconsole
                             only Linux
                             virtio_console_test = sigio
                         - lseek:
@@ -66,6 +70,8 @@
                         - basic_loopback:
                             virtio_console_test = basic_loopback
                 - @with_vm:
+                    # Works with virtconsole, but is not the comon usage, don't test by default
+                    no virtconsole
                     variants:
                        # Destructive tests
                         - rmmod:
@@ -132,6 +138,8 @@
                                     virtio_console_interruption = s4
                 # Tests which creates own VMs
                 - @without_vm:
+                    # Works with virtconsole, but is not the comon usage, don't test by default
+                    no virtconsole
                     vms = ""
                     variants:
                         - hotplug:
@@ -171,18 +179,19 @@
                                     virtio_console_params = "serialport@4:serialport@2:serialport@4:serialport@8:8"
                                 - serialport_big:
                                     virtio_console_params = "serialport@16384:serialport@2048:serialport@4096:serialport@8192:8192"
-                        - virtconsole:
-                            variants:
-                                - console_small:
-                                    virtio_console_params = "console@4:console@2:console@4:console@8:8"
-                                - console_big:
-                                    virtio_console_params = "console@16384:console@2048:console@4096:console@8192:8192"
-                        - virtmixed:
-                            variants:
-                                - mixed_small:
-                                    virtio_console_params = "serialport@4:console@2:serialport@5:console@6:8"
-                                - mixed_big:
-                                    virtio_console_params = "console@16384:serialport@2048:console@4096:serialport@8192:8192"
+                        # Works with virtconsole, but is not the comon usage, don't test by default
+                        #- virtconsole:
+                        #    variants:
+                        #        - console_small:
+                        #            virtio_console_params = "console@4:console@2:console@4:console@8:8"
+                        #        - console_big:
+                        #            virtio_console_params = "console@16384:console@2048:console@4096:console@8192:8192"
+                        #- virtmixed:
+                        #    variants:
+                        #        - mixed_small:
+                        #            virtio_console_params = "serialport@4:console@2:serialport@5:console@6:8"
+                        #        - mixed_big:
+                        #            virtio_console_params = "console@16384:serialport@2048:console@4096:serialport@8192:8192"
                 - performance:
                     virtio_console_test = perf
                     virtio_console_params = "serialport;serialport@1000000"

--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -855,7 +855,7 @@ def run(test, params, env):
             threads[1].port = ports[1]
             threads[0].migrate_event.set()  # Wake up sender thread immediately
             threads[1].migrate_event.set()
-            guest_worker.reconnect(vm, 30)
+            guest_worker.reconnect(vm, 360)
             logging.debug("S4: watch 1s for initial data loss stabilization.")
             for _ in xrange(10):
                 time.sleep(0.1)


### PR DESCRIPTION
Hello guys,

this pull request adjusts the default configuration. First patch disables some of the virtconsole subtest variants as they don't reflect real-world usage and related issues might never be fixed. The second and third patch adjusts the configuration to work on aarch64 out of the box.

Regards,
Lukáš