### PR TITLE
generic.tests.cfg: Disable up_change sub case for SLES guest

### DIFF
--- a/generic/tests/cfg/mac_change.cfg
+++ b/generic/tests/cfg/mac_change.cfg
@@ -11,6 +11,7 @@
         - @up_change:
             virtio_net:
                 no RHEL.5, RHEL.6.0, RHEL.6.1, RHEL.6.2, RHEL.6.3
+                no SLES
             shutdown_int = no
             reboot_vm_after_mac_changed = yes
     variants:


### PR DESCRIPTION
mac_change..up_change sub case is not suitable for SLES guest,
should be down the ethernet then change the mac.

Signed-off-by: Shuping Cui <scui@redhat.com>