### PR TITLE
tp-qemu: netstress_kill_guest.driver: disable windows test.

### DIFF
--- a/generic/tests/cfg/netstress_kill_guest.cfg
+++ b/generic/tests/cfg/netstress_kill_guest.cfg
@@ -9,6 +9,10 @@
     # There should be enough vms for build topology.
     variants:
         -driver:
+            # Have not implemented the windows support yet,
+            # disable the test for windows.
+            # Will make windows support in the future.
+            no Windows
             mode = driver
         -load:
             mode = load


### PR DESCRIPTION
We have not implemented the windows support yet, disable the
test for windows, will make windows support in the future.

Signed-off-by: Cong Li <coli@redhat.com>