### PR TITLE
qemu.tests.cfg: Update the boot_menu_hint config

### DIFF
--- a/qemu/tests/boot_from_device.py
+++ b/qemu/tests/boot_from_device.py
@@ -139,7 +139,8 @@ def run(test, params, env):
         if not match:
             cleanup(dev_name)
             raise error.TestFail("Could not get boot menu message. "
-                                 "Excepted Result: '%s'" % boot_menu_hint)
+                                 "Excepted Result: '%s', Actual result: '%s'"
+                                 % (boot_menu_hint, console_str))
 
         # Send boot menu key in monitor.
         vm.send_key(boot_menu_key)

--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -6,7 +6,7 @@
     image_boot = no
     virt_test_type = qemu
     boot_menu_key = "f12"
-    boot_menu_hint = "Press F12 for boot menu"
+    boot_menu_hint = "Press .*F12 for boot menu"
     boot_fail_info = "Booting from Hard Disk...;"
     boot_fail_info += "Boot failed: not a bootable disk"
     variants:


### PR DESCRIPTION
For RHEL6 host, boot menu hint message changed.

ID: 1224039