### PR TITLE
tp-qemu: device_bit_check.block_device: only set the specific params to the image

### DIFF
--- a/qemu/tests/cfg/device_bit_check.cfg
+++ b/qemu/tests/cfg/device_bit_check.cfg
@@ -22,13 +22,13 @@
         - block_device:
             only virtio_blk virtio_scsi
             virtio_blk:
-                dev_param_name = blk_extra_params
-                blk_extra_params = ""
+                dev_param_name = blk_extra_params_image1
+                blk_extra_params_image1 = ""
                 pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio block device"
                 dev_type = virtio-blk-pci
             virtio_scsi:
-                dev_param_name = bus_extra_params
-                bus_extra_params = ""
+                dev_param_name = bus_extra_params_image1
+                bus_extra_params_image1 = ""
                 pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio SCSI"
                 dev_type = virtio-scsi-pci
         - nic_device:

--- a/qemu/tests/device_bit_check.py
+++ b/qemu/tests/device_bit_check.py
@@ -26,7 +26,7 @@ def run(test, params, env):
     test_loop = params.get("test_loop", "default").split(";")
     timeout = float(params.get("login_timeout", 240))
     dev_type = params.get("dev_type", "virtio-blk-pci")
-    dev_param_name = params.get("dev_param_name", "blk_extra_params")
+    dev_param_name = params.get("dev_param_name", "blk_extra_params_image1")
     dev_pattern = params.get("dev_pattern", "(dev: %s.*?)dev:" % dev_type)
     pci_id_pattern = params.get("pci_id_pattern")
     convert_dict = {"1": ["on", "true"], "0": ["off", "false"]}


### PR DESCRIPTION
only set the specific params to the image instead of to every block device, 
especially for some non virtio devices (e.g. ide).

e.g.
    -drive id=drive_image1,if=none,cache=none,snapshot=off,aio=native,file=/home/autotest/autotest-devel/client/tests/virt/shared/data/images/win8-64.1-virtio.raw \
    -device virtio-blk-pci,id=image1,drive=drive_image1,bootindex=0,indirect_desc=off,bus=pci.0,addr=05 \
    -drive id=drive_cd1,if=none,snapshot=off,aio=native,media=cdrom,file=/home/autotest/autotest-devel/client/tests/virt/shared/data/isos/windows/winutils.iso \
    -device ide-drive,id=cd1,drive=drive_cd1,bootindex=1,indirect_desc=off,bus=ide.0,unit=0 \

Signed-off-by: Cong Li <coli@redhat.com>