### PR TITLE
qemu.tests: Add rescan after hot unplug and timeout for commands runn…

### DIFF
--- a/qemu/tests/cfg/pci_hotplug.cfg
+++ b/qemu/tests/cfg/pci_hotplug.cfg
@@ -132,6 +132,10 @@
             only hotplug_block
             pci_model = scsi-hd
             match_string = "SCSI"
+            Windows:
+                cmd_after_unplug_dev = "echo rescan > rescan_cmd &&"
+                cmd_after_unplug_dev += "echo exit >> rescan_cmd &&"
+                cmd_after_unplug_dev += "diskpart /s rescan_cmd"
     variants:
         - hotplug_block:
             pci_type = block

--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -223,7 +223,7 @@ def run(test, params, env):
                 if params.get("pci_test_cmd"):
                     test_cmd = re.sub("PCI_NUM", "%s" % (pci_num + 1),
                                       params.get("pci_test_cmd"))
-                    session.cmd(test_cmd)
+                    session.cmd(test_cmd, timeout=disk_op_timeout)
             except aexpect.ShellError, e:
                 raise error.TestFail("Check for %s device failed after PCI "
                                      "hotplug. Output: %r" % (pci_type, e.output))
@@ -251,6 +251,10 @@ def run(test, params, env):
             else:
                 cmd = "device_del id=%s" % pci_info[pci_num][1]
             vm.monitor.send_args_cmd(cmd, convert=False)
+            if params.get("cmd_after_unplug_dev"):
+                cmd = re.sub("PCI_NUM", "%s" % (pci_num + 1),
+                             params.get("cmd_after_unplug_dev"))
+                session.cmd(cmd, timeout=disk_op_timeout)
             blk_removed.append(pci_info[pci_num][1])
             pci_model = params.get("pci_model")
             if pci_model == "scsi" or pci_model == "scsi-hd":
@@ -280,6 +284,7 @@ def run(test, params, env):
     session = vm.wait_for_login(timeout=timeout)
 
     test_timeout = int(params.get("hotplug_timeout", 360))
+    disk_op_timeout = int(params.get("disk_op_timeout", 360))
     reference_cmd = params["reference_cmd"]
     # Test if it is nic or block
     pci_type = params["pci_type"]


### PR DESCRIPTION
…ing in guest

As some device need manually rescan disk inside guest after hot unplug, so add the step
to the script.
Also add timeout for the disk operations in the test as sometime the commands need more
time to finish.