### PR TITLE
tp-qemu: pxe_boot: disable pxe_boot for macvtap.

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -15,6 +15,10 @@
     image_verify_bootable = no
     kill_vm = yes
     kill_vm_gracefully = no
+    # pxe_boot does not work for macvtap backend, as pxe can't
+    # capture the packet from the macvtap tap port, disable it
+    # for macvtap temporarily, will fix it in the furture.
+    no macvtap
     variants:
         - @default:
         - etherboot:


### PR DESCRIPTION
pxe_boot does not work for macvtap backend, as pxe can't
capture the packet from the macvtap tap port, disable it
for macvtap temporarily, will fix it in the furture.

Signed-off-by: Cong Li <coli@redhat.com>