### PR TITLE
qemu.spice: Removing some options not required for spice testing

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -46,6 +46,9 @@ only no_pci_assignable
 only smallpages
 # Only i440fx pc type
 only i440fx
+no rng_random
+no rng_egd
+no ovmf
 
 variants:
     - os:


### PR DESCRIPTION
Removing some options not required for spice testing. ovmf,
rng_randomn, rng_egd are not required.

Reviewed By: Swapna Krishnan <skrishna@redhat.com>