### PR TITLE
qemu.spice: Removing options not needed for spice testing

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -49,6 +49,7 @@ only i440fx
 no rng_random
 no rng_egd
 no ovmf
+only bridge
 
 variants:
     - os:


### PR DESCRIPTION
Only bridge option is required for spice testing. Removing user, network and macvtap options.

Reviewed-By: Swapna Krishnan <skrishna@redhat.com>