### PR TITLE
tp-qemu: fillup_disk: ignore the errors in post processing.

### DIFF
--- a/generic/tests/cfg/fillup_disk.cfg
+++ b/generic/tests/cfg/fillup_disk.cfg
@@ -3,6 +3,8 @@
     only Linux
     only qcow2
     type = fillup_disk
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
     fillup_timeout = 320
     fillup_size = 200
     fillup_cmd = "dd if=/dev/zero of=/%s/fillup.%d bs=%dM count=1 oflag=direct"

--- a/generic/tests/fillup_disk.py
+++ b/generic/tests/fillup_disk.py
@@ -46,17 +46,10 @@ def run(test, params, env):
         error.context("Cleaning the temporary files...", logging.info)
         try:
             clean_cmd = params.get("clean_cmd") % fill_dir
-            status, output = session2.cmd_status_output(clean_cmd)
-            if status != 0:
-                raise error.TestWarn("Cleaning the temporary files failed ! \n"
-                                     "Guest may be unresponsive or "
-                                     "command timeout. \n"
-                                     "The error info is: %s \n" % output)
-            else:
-                logging.debug(output)
+            session2.cmd(clean_cmd, ignore_all_errors=True)
         finally:
             show_fillup_dir_cmd = params.get("show_fillup_dir_cmd") % fill_dir
-            output = session2.cmd_output_safe(show_fillup_dir_cmd)
+            output = session2.cmd(show_fillup_dir_cmd, ignore_all_errors=True)
             logging.debug("The fill_up dir shows:\n %s", output)
             if session:
                 session.close()


### PR DESCRIPTION
1. backup image before testing and restore image after testing.
2. ignore the errors in post processing, which will cover the
       main error reason.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1172016