### PR TITLE
tp-qemu: mac_change: Init the serial again after guest reboot and set "image_snapshot=yes".

### DIFF
--- a/generic/tests/cfg/mac_change.cfg
+++ b/generic/tests/cfg/mac_change.cfg
@@ -2,6 +2,7 @@
     virt_test_type = qemu libvirt
     type = mac_change
     kill_vm = yes
+    image_snapshot = yes
     variants:
         - down_change:
             only Linux

--- a/generic/tests/mac_change.py
+++ b/generic/tests/mac_change.py
@@ -142,7 +142,7 @@ def run(test, params, env):
                     vm.virtnet.update_db()
                     mac_check = old_mac
 
-                session = vm.reboot(session)
+                session_serial = vm.reboot(session_serial, serial=True)
                 check_guest_mac(mac_check, vm)
             if params.get("file_transfer", "no") == "yes":
                 error.context("File transfer between host and guest.",


### PR DESCRIPTION
1. Register has been changed after mac change, and delete
    the register may fail, then set "image_snapshot=yes" to
    save the original image. 
2. Init the serial again after guest reboot.

Signed-off-by: Cong Li <coli@redhat.com>