### PR TITLE
tp-qemu: disable hyperv and hv_relaxed for host os older than rhel7

### DIFF
--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -452,6 +452,7 @@
                         - KVM:
                             signature = "KVMKVMKVM\x00\x00\x00"
                         - hv_relaxed:
+                            no Host_RHEL.3 Host_RHEL.4 Host_RHEL.5 Host_RHEL.6
                             signature = "Microsoft Hv"
                             flags = "hv_relaxed"
                         - hv_vapic:
@@ -466,6 +467,7 @@
                             flags = "hv_relaxed"
                             regs = "eax"
                 - hyperv:
+                    no Host_RHEL.3 Host_RHEL.4 Host_RHEL.5 Host_RHEL.6
                     only kvm
                     only cpu.unset
                     test_type = "cpuid_bit_test"


### PR DESCRIPTION
ID: 1110644