### PR TITLE
nic_bonding does not work for macvtap backend, disable it

### DIFF
--- a/qemu/tests/cfg/nic_bonding.cfg
+++ b/qemu/tests/cfg/nic_bonding.cfg
@@ -1,6 +1,7 @@
 - nic_bonding: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu
     only Linux
+    no macvtap
     type = nic_bonding
     nics += ' nic2 nic3 nic4'
     image_snapshot = yes


### PR DESCRIPTION
for macvtap temporarily, will fix it in the furture.

id: 1241390

Signed-off-by: Mike Cao <bcao@redhat.com>