### PR TITLE
qemu.tests.pktgen: Small fix for log format

### DIFF
--- a/qemu/tests/pktgen.py
+++ b/qemu/tests/pktgen.py
@@ -117,7 +117,7 @@ def run(test, params, env):
             loss_ratio == -1):
         logging.debug("Ping %s output: %s" % (external_host, output))
         raise error.TestFail("Guest network connction unusable," +
-                             "packet lost ratio is '%%%d'" % loss_ratio)
+                             "packet lost ratio is '%d%%'" % loss_ratio)
     if server_session:
         server_session.close()
     if session:


### PR DESCRIPTION
Change log "packet lost ratio is '%100'" to '100%'.

Signed-off-by: Shuping Cui <scui@redhat.com>