### PR TITLE
tp-qemu: no need to umount cdrom for windows

### DIFF
--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -343,8 +343,8 @@ def run(test, params, env):
         """
         if params["os_type"] == "windows":
             winutil_drive = utils_misc.get_winutils_vol(session)
-            winutils_drive = "%s:" % winutils_drive
-            cdrom_dev_list.remove(winutils_drive)
+            winutil_drive = "%s:" % winutil_drive
+            cdrom_dev_list.remove(winutil_drive)
         try:
             testing_cdrom_device = cdrom_dev_list[-1]
         except IndexError:

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -343,11 +343,12 @@ def run(test, params, env):
         """
         if params["os_type"] == "windows":
             winutil_drive = utils_misc.get_winutils_vol(session)
-            cdrom_dev_list.remove(str(winutil_drive) + ":")
+            winutils_drive = "%s:" % winutils_drive 
+            cdrom_dev_list.remove(winutils_drive)
         try:
             testing_cdrom_device = cdrom_dev_list[-1]
         except IndexError:
-            raise error.TestFail("Could not find a valid testingcdrom device")
+            raise error.TestFail("Could not find the testing cdrom device")
 
         return testing_cdrom_device
 

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -343,7 +343,7 @@ def run(test, params, env):
         """
         if params["os_type"] == "windows":
             winutil_drive = utils_misc.get_winutils_vol(session)
-            winutils_drive = "%s:" % winutils_drive 
+            winutils_drive = "%s:" % winutils_drive
             cdrom_dev_list.remove(winutils_drive)
         try:
             testing_cdrom_device = cdrom_dev_list[-1]

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -612,8 +612,8 @@ def run(test, params, env):
             error.context("Detecting the existence of a cdrom (qemu side)",
                           logging.info)
             qemu_cdrom_device = get_device(vm, iso_image)
-
-            self.session.get_command_output("umount %s" % guest_cdrom_device)
+            if params["os_type"] != "windows":
+                self.session.get_command_output("umount %s" % guest_cdrom_device)
             if params.get('cdrom_test_autounlock') == 'yes':
                 error.context("Trying to unlock the cdrom", logging.info)
                 if not utils_misc.wait_for(lambda: not

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -335,6 +335,22 @@ def run(test, params, env):
                 raise error.TestFail("Could not find a valid cdrom device")
         return device
 
+    def get_testing_cdrom_device(session, cdrom_dev_list):
+        """
+        Get the testing cdrom used for eject
+        :param session: VM session
+        :param cdrom_dev_list: cdrom_dev_list
+        """
+        if params["os_type"] == "windows":
+            winutil_drive = utils_misc.get_winutils_vol(session)
+            cdrom_dev_list.remove(str(winutil_drive) + ":")
+        try:
+            testing_cdrom_device = cdrom_dev_list[-1]
+        except IndexError:
+            raise error.TestFail("Could not find a valid testingcdrom device")
+
+        return testing_cdrom_device
+
     def disk_copy(vm, src_path, dst_path, copy_timeout=None, dsize=None):
         """
         Start disk load. Cyclic copy from src_path to dst_path.
@@ -351,7 +367,7 @@ def run(test, params, env):
         copy_file_cmd = (
             "nohup cp %s %s 2> /dev/null &" % (src_path, dst_path))
         get_pid_cmd = "echo $!"
-        if params["os_type"] == "windwos":
+        if params["os_type"] == "windows":
             copy_file_cmd = "start cmd /c copy /y %s %s" % (src_path, dst_path)
             get_pid_cmd = "wmic process where name='cmd.exe' get ProcessID"
         session.cmd(copy_file_cmd, timeout=copy_timeout)
@@ -579,7 +595,7 @@ def run(test, params, env):
                 # XXX: The device got from monitor might not match with the guest
                 # defice if there are multiple cdrom devices.
                 qemu_cdrom_device = get_empty_cdrom_device(vm)
-                guest_cdrom_device = cdrom_dev_list[-1]
+                guest_cdrom_device = get_testing_cdrom_device(self.session, cdrom_dev_list)
                 if vm.check_block_locked(qemu_cdrom_device):
                     raise error.TestFail("Device should not be locked just"
                                          " after booting up")
@@ -592,11 +608,7 @@ def run(test, params, env):
             error.context("Detecting the existence of a cdrom (guest OS side)",
                           logging.info)
             cdrom_dev_list = list_guest_cdroms(self.session)
-            try:
-                guest_cdrom_device = cdrom_dev_list[-1]
-            except IndexError:
-                raise error.TestFail("Could not find a valid cdrom device")
-
+            guest_cdrom_device = get_testing_cdrom_device(self.session, cdrom_dev_list)
             error.context("Detecting the existence of a cdrom (qemu side)",
                           logging.info)
             qemu_cdrom_device = get_device(vm, iso_image)
@@ -718,7 +730,7 @@ def run(test, params, env):
                 vm = env.get_vm(self.vms[0])
                 session = vm.wait_for_login(timeout=login_timeout)
                 cdrom_dev_list = list_guest_cdroms(session)
-                guest_cdrom_device = cdrom_dev_list[-1]
+                guest_cdrom_device = get_testing_cdrom_device(session, cdrom_dev_list)
                 logging.debug("cdrom_dev_list: %s", cdrom_dev_list)
                 device = get_device(vm, self.cdrom_orig)
 
@@ -753,7 +765,7 @@ def run(test, params, env):
             error.context("Unlock cdrom from VM.")
             if not self.is_src:  # Starts in dest
                 cdrom_dev_list = list_guest_cdroms(session)
-                guest_cdrom_device = cdrom_dev_list[-1]
+                guest_cdrom_device = get_testing_cdrom_device(session, cdrom_dev_list)
                 session.cmd(params["unlock_cdrom_cmd"] % guest_cdrom_device)
                 locked = check_cdrom_lock(vm, device)
                 if not locked:
@@ -792,7 +804,7 @@ def run(test, params, env):
                 cdrom_dev_list = list_guest_cdroms(session)
                 logging.debug("cdrom_dev_list: %s", cdrom_dev_list)
                 device = get_device(vm, self.cdrom_orig)
-                cdrom = cdrom_dev_list[-1]
+                cdrom = get_testing_cdrom_device(session, cdrom_dev_list)
 
                 error.context("Eject cdrom.")
                 session.cmd(params["eject_cdrom_cmd"] % cdrom)
@@ -839,7 +851,7 @@ def run(test, params, env):
                 session = vm.wait_for_login(timeout=login_timeout)
                 cdrom_dev_list = list_guest_cdroms(session)
                 logging.debug("cdrom_dev_list: %s", cdrom_dev_list)
-                cdrom = cdrom_dev_list[-1]
+                cdrom = get_testing_cdrom_device(session, cdrom_dev_list)
                 mount_point = get_cdrom_mount_point(session, cdrom, params)
                 mount_cmd = params["mount_cdrom_cmd"] % (cdrom, mount_point)
                 src_file = params["src_file"] % (mount_point, filename)

--- a/qemu/tests/cfg/cdrom_test.cfg
+++ b/qemu/tests/cfg/cdrom_test.cfg
@@ -56,15 +56,15 @@
         remove_file_cmd = "del /f /q ${tmp_dir}%s"
         copy_file_cmd = "copy /y %s\%s ${tmp_dir}\"
         tray_check_cmd = "c:\python27\python.exe ${tray_check_src} %s"
-        lock_cdrom_cmd = "D:\eject.exe -i on %s"
-        unlock_cdrom_cmd = "D:\eject.exe -i off %s"
-        eject_cdrom_cmd = "D:\eject.exe %s"
-        close_cdrom_cmd = "D:\eject.exe -t %s"
+        lock_cdrom_cmd = "eject.exe -i on %s"
+        unlock_cdrom_cmd = "eject.exe -i off %s"
+        eject_cdrom_cmd = "eject.exe %s"
+        close_cdrom_cmd = "eject.exe -t %s"
         readonly_test_cmd = "format /FS:ntfs /Q %s"
         mount_cdrom_cmd = "mountvol %s %s"
         umount_cdrom_cmd = "mountvol %s /d"
         show_mount_cmd = "wmic volume list brief"
-        md5sum_cmd = "D:\md5sums.exe %s"
+        md5sum_cmd = "md5sum.exe %s"
     Linux:
         cdroms = cd1
         cdrom_cd1 = images/orig.iso


### PR DESCRIPTION
    tp-qemu: do no use fixed cdrom letter for windows
    
    this patch fixed 2 things:
    1. not using fixed cdrom letter for windows
    2. if the letter of winutil is bigger than the letter of testing
    cdrom ,testing will fail ,this patch is changing to make sure not
    using winutil cdrom for testing
ID: 1240903

Signed-off-by: Mike Cao \<bcao@redhat.com\>