### PR TITLE
qemu/cfg/host-kernel: Update the max queues number

### DIFF
--- a/qemu/cfg/host-kernel/Host_RHEL/7.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/7.cfg
@@ -21,3 +21,7 @@
         black_cmds = "block-stream block-job-cancel block-job-set-speed drive-mirror block-job-complete block-job-pause block-job-resume"
     monitor_cmds_check.human:
         black_cmds = "block_stream block_job_cancel block_job_set_speed drive_mirror block_job_complete block_job_pause block_job_resume"
+    multi_queues_test.with_netperf.max_queues:
+        queues = 256
+    multi_queues_test.invalid_queues_number.upper_border:
+        queues = 257


### PR DESCRIPTION
qemu-kvm support up to 256 queues now.

Signed-off-by: Shuping Cui <scui@redhat.com>