### PR TITLE
qemu.tests: Install the kernel dependencies packages

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -31,6 +31,9 @@
     verify_virtio = no
     virtio_drivers_list = "virtio virtio_ring virtio_pci"
     upgrade_pkgs = glibc
+    kernel_deps_pkgs = dracut
+    RHEL.6:
+        arch_dracut = noarch
     ignore_deps = yes
     install_debuginfo = no
     install_pkg_timeout = 600


### PR DESCRIPTION
For installing the latest rhel kernel package, failed with
dracut dependencies, so add "--nodeps" to skip it.

Signed-off-by: Shuping Cui <scui@redhat.com>