### PR TITLE
tp-qemu: fixed mem for nmi crashdump case

### DIFF
--- a/qemu/tests/cfg/nmi_bsod_catch.cfg
+++ b/qemu/tests/cfg/nmi_bsod_catch.cfg
@@ -1,6 +1,7 @@
 - nmi_bsod_catch:
     type = nmi_bsod_catch
     only Windows
+    mem_fixed = 2048
     config_cmds = config_cmd1, config_cmd2, config_cmd3, config_cmd4, config_cmd5, config_cmd6
     # enable AutoReboot, guest will reboot after finishing create dump file.
     config_cmd1 = reg add HKLM\System\CurrentControlSet\Control\CrashControl /v AutoReboot /d 1 /t REG_DWORD /f


### PR DESCRIPTION
The default setting of mem page file is 4096
According to https://support.microsoft.com/en-us/kb/889654
the traditional model of the page file should be
at least the size of physical ram plus 1 MB, or 1.5 times
So test will fail  if the mem in qemu-kvm larger than 4096
This patch is to use fixed mem size for this case

id: 1165933
Signed-off-by: Mike Cao <bcao@redhat.com>