### PR TITLE
disable nic_hotplug/unplug for spapr-vlan bus

### DIFF
--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -1,5 +1,6 @@
 - nic_hotplug: install setup image_copy unattended_install.cdrom
-    no RHEL.3
+    no RHEL.3 
+    no spapr-vlan
     pci_type = nic
     type = pci_hotplug
     reference_cmd = lspci

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -1,5 +1,5 @@
 - nic_hotplug: install setup image_copy unattended_install.cdrom
-    no RHEL.3 
+    no RHEL.3
     pci_type = nic
     type = pci_hotplug
     reference_cmd = lspci

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -1,6 +1,5 @@
 - nic_hotplug: install setup image_copy unattended_install.cdrom
     no RHEL.3 
-    no spapr-vlan
     pci_type = nic
     type = pci_hotplug
     reference_cmd = lspci
@@ -10,6 +9,7 @@
     run_dhclient = no
     variants:
         - nic_8139:
+            no ppc64 ppc64le 
             pci_model = rtl8139
             match_string = "8139"
         - nic_virtio:
@@ -19,6 +19,7 @@
             Host_RHEL.5:
                 pci_model = virtio
         - nic_e1000:
+            no ppc64 ppc64le
             pci_model = e1000
             match_string = "Gigabit Ethernet Controller"
     variants:


### PR DESCRIPTION
Currently, spapr-vio bus doesn't support hot pluging.
So variant spapr-vlan shouldn't be added to this case
This patch is to remove it

ID: 1214221

Signed-off-by: Mike Cao <bcao@redhat.com>