### PR TITLE
tp-qemu:Get driver installation log from windows guest

### DIFF
--- a/qemu/tests/cfg/win_virtio_update.cfg
+++ b/qemu/tests/cfg/win_virtio_update.cfg
@@ -18,6 +18,7 @@
     force_create_image_stg = yes
     nics += " nic2"
     nic_model_nic2 = virtio
+    driver_debug_file = %systemroot%\\DPINST.log, %systemroot%\\inf\\setupapi.dev.log
     cdroms += " virtio"
     cdrom_virtio = isos/windows/virtio-win.iso
     kill_rundll = no

--- a/qemu/tests/win_virtio_update.py
+++ b/qemu/tests/win_virtio_update.py
@@ -210,7 +210,7 @@ def run(test, params, env):
             f_flag_tmp, log_tmp = virtio_driver_install(session, cmd, driver)
             if f_flag_tmp:
                 fail_flag = True
-                fail_logs += log_tmp
+                fail_log += log_tmp
             session = vm.reboot(nic_index=nic_index)
     driver_debug_file = params_driver.get("driver_debug_file").split(',')
     error.context("Get Driver installation log", logging.info)

--- a/qemu/tests/win_virtio_update.py
+++ b/qemu/tests/win_virtio_update.py
@@ -44,7 +44,7 @@ def run(test, params, env):
             session.cmd(cmd, timeout=driver_install_timeout)
         except Exception, msg:
             fail_flag = True
-            fail_logs += "driver %s install failed,msg %s" % (driver, msg)
+            fail_logs += "driver %s install failed. Msg %s" % (driver, msg)
             error.context("Install drivers %s failed " % driver, logging.info)
         return (fail_flag, fail_logs)
     if params.get("case_type") == "driver_install":
@@ -218,10 +218,10 @@ def run(test, params, env):
         s, o = session.cmd_status_output("dir %s" % _file)
         if not s:
             output = session.cmd("type %s" % _file)
-            _file_host = _file.split("\\")[-1].strip()
-            _debug_log = open("%s/%s" % (test.resultsdir, _file_host), "w")
-            _debug_log.write("%s\n" % output)
-            _debug_log.close()
+            g_file_host = _file.split("\\")[-1].strip()
+            g_debug_log = open("%s/%s" % (test.resultsdir, g_file_host), "w")
+            g_debug_log.write("%s\n" % output)
+            g_debug_log.close()
 
     if params.get("check_info") == "yes":
         fail_log += "Details check failed in guest."


### PR DESCRIPTION
When guest failed to install driver, autotest will raise a Exception
and we will not know why driver installtion failed. This patch is to
make sure guest can get DPINST.log and SETUPAPI.DEV.log from windows
guest no matter the installation results .

The log file is putting under /runname/results.
It will help us to debug driver installation issue.

patch2  has two enhancement for win_virtio_driver update.
1.remove the default rtl8139 nic
2.use serial login guest to execute comment
3.enhance failed_to_install_error reports

ID: 1233526

Signed-off-by: Mike Cao <bcao@redhat.com>