### PR TITLE
qemu/tests/pci_hotplug_check: fix wrong check condition

### DIFF
--- a/qemu/tests/pci_hotplug_check.py
+++ b/qemu/tests/pci_hotplug_check.py
@@ -299,7 +299,7 @@ def run(test, params, env):
 
     cmd_type = utils_misc.find_substring(str(cmd_output), "device_add",
                                          "pci_add")
-    if not cmd_output:
+    if not cmd_type:
         raise error.TestError("Could find a suitable method for hotplugging"
                               " device in this version of qemu")
 


### PR DESCRIPTION
The return of utils_misc.find_substring() should be checked,
not the output of monitor.info() or monitor.human_monitor_cmd().