### PR TITLE
qemu.cfg.rh_kernel_update: correct regex for ppc64

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -51,8 +51,8 @@
         kernel_re = .*kernel-%s.el.*.i686.*
         knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.i686.*
     ppc64:
-        kernel_re = .*kernel-%s.el.*.ppc64.*
-        knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.ppc64.*
+        kernel_re = .*kernel-%s.el.*.ppc64\..*
+        knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.ppc64\..*
     ppc64le:
         kernel_re = .*kernel-%s.el.*.ppc64le.*
         knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.ppc64le.*


### PR DESCRIPTION
Because of the wrong regex, it will fetch a ppc64le kernel for ppc64
guest. Now have corrected it.