### PR TITLE
tp-qemu: New test cases for windows disk smoke test

### DIFF
--- a/qemu/tests/cfg/windows_disk_smoke_test.cfg
+++ b/qemu/tests/cfg/windows_disk_smoke_test.cfg
@@ -1,7 +1,7 @@
 - windows_disk_smoke_test:
     type = windows_disk_smoke_test
     only Windows
-    start_vm = no
+    start_vm = yes
     kill_vm_on_error = yes
     clear_verifier = "verifier.exe /reset"
     images += " stg"

--- a/qemu/tests/cfg/windows_disk_smoke_test.cfg
+++ b/qemu/tests/cfg/windows_disk_smoke_test.cfg
@@ -1,0 +1,48 @@
+- windows_disk_smoke_test:
+    type = windows_disk_smoke_test
+    only Windows
+    start_vm = no
+    kill_vm_on_error = yes
+    clear_verifier = "verifier.exe /reset"
+    images += " stg"
+    image_name_stg = "images/storage"
+    image_size_stg = 4G
+    force_create_image_stg = yes
+    iozone_cli = "%s:\\Iozone\\iozone.exe -az -b %s:\\output.xlsx -g 2g -y 32k -i 0 -i 1 -f %s:\\testing.out"
+    disk_format = "%s:\\diskpart_cmd.py --disk_id=%s --op=mount_disk"
+    iozone_start_timeout = 600
+    variants:
+        #all support types:
+        - with_virtio_blk:
+            drive_format_stg = virtio
+            verifier_cli = verifier.exe /standard /driver viostor.sys
+            verifier_query = verifier.exe /querysettings | find "viostor.sys"
+        - with_virtio_scsi:
+            drive_format_stg = scsi-hd
+            verifier_cli = verifier.exe /standard /driver vioscsi.sys
+            verifier_query = verifier.exe /querysettings | find "vioscsi.sys"
+        - with_ide:
+            drive_format_stg = ide
+
+    variants:
+        - with_stop_continue:
+            suppress_exception = no
+            virt_subtest = stop_continue
+            iozone_timeout = 1800
+        - with_shutdown:
+            suppress_exception = yes
+            shutdown_method = shell
+            virt_subtest = shutdown
+            iozone_timeout = 600
+        - with_system_reset:
+            virt_subtest = boot
+            reboot_count = 1
+            suppress_exception = yes
+            reboot_method = system_reset
+            iozone_timeout = 600
+        - with_reboot:
+            virt_subtest = boot
+            reboot_count = 1
+            suppress_exception = yes
+            reboot_method = shell
+            iozone_timeout = 600

--- a/qemu/tests/windows_disk_smoke_test.py
+++ b/qemu/tests/windows_disk_smoke_test.py
@@ -1,0 +1,143 @@
+import time
+import sys
+import re
+import logging
+import os
+
+from autotest.client.shared import error, utils
+from virttest import utils_test
+from virttest import utils_misc
+from virttest import data_dir
+from virttest import env_process
+
+
+@error.context_aware
+def run(test, params, env):
+    """
+    Guest reboot/shutdown/system_reset/stop while iozone running
+    1) Boot up guest with specified CLI
+    2) Enable verifier for specified driver except for ide driver
+    3) Online the 2nd testing image
+    4) Running iozone command in the guest
+    5) During iozone running ,do reboot/shutdown/system_reset/stop
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def iozone_run(session, iozone_cli, timeout):
+        try:
+            env["iozone_status"] = 1
+            s, o = session.cmd_status_output(iozone_cli, timeout)
+        finally:
+            env["iozone_status"] = 2
+
+    def get_disk_id(session):
+        cmd = "wmic diskdrive where Partitions=0 Get deviceid"
+        output = session.cmd(cmd, timeout=120)
+        disk_id = re.search(r'[0-9]+', output, re.M)
+        if not disk_id:
+            return ""
+        else:
+            return disk_id.group(0)[-1]
+
+    def verifier_cleanup(vm, session, clear_verifier):
+        error.context("clear driver verifier: %s"
+                      % clear_verifier, logging.info)
+        try:
+            s, o = session.cmd_status_output(clear_verifier, timeout=120)
+        finally:
+            session = vm.reboot()
+            if session:
+                session.close()
+
+    error.context("Generating qemu-kvm commandline", logging.info)
+    params["start_vm"] = "yes"
+    vm_name = params['main_vm']
+    env_process.preprocess_vm(test, params, env, vm_name)
+    vm = env.get_vm(vm_name)
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=1200)
+    env["iozone_status"] = 0
+    verifier_cli = params.get("verifier_cli")
+    verifier_query = params.get("verifier_query")
+    iozone_cli = params.get("iozone_cli")
+    disk_format = params.get("disk_format")
+    iozone_timeout = int(params.get("iozone_timeout", 1800))
+    virt_subtest = params.get("virt_subtest")
+    testtag = params.get("testtag")
+    image_size_stg = params.get("image_size_stg")
+    iozone_start_timeout = int(params.get("iozone_start_timeout", 600))
+    clear_verifier = params.get("clear_verifier", "verifier /reset")
+
+    if params["os_type"] == "windows":
+        winutil_drive = utils_misc.get_winutils_vol(session)
+    if verifier_cli:
+        error.context("Enable driver verifier and reboot guest", logging.info)
+        session.cmd(verifier_cli)
+        session = vm.reboot()
+        error.context("Check driver verifier whether enabled", logging.info)
+        status, output = session.cmd_status_output(verifier_query)
+        if status:
+            raise error.TestFail("Execute %s Failed "
+                                 "Failed to enable driver verifier"
+                                 % verifier_query)
+            verifier_cleanup(vm, session, clear_verifier)
+
+    error.context("Get disk_ID for testing", logging.info)
+    pre_volumes = utils_misc.get_windows_drive_letters(session)
+    disk_id = get_disk_id(session)
+    if not disk_id:
+        raise error.TestFail("Failed to find the testing disks ,aborting")
+        verifier_cleanup(vm, session, clear_verifier)
+
+    error.context("Formatting data disks for testing", logging.info)
+    status, output = session.cmd_status_output(disk_format
+                                               % (winutil_drive, disk_id))
+    if status:
+        raise error.TestFail("Failed to exec diskpart"
+                             "logs %s" % output)
+        verifier_cleanup(vm, session, clear_verifier)
+    post_volumes = utils_misc.get_windows_drive_letters(session)
+    for item in pre_volumes:
+        post_volumes.remove(item)
+    if not len(post_volumes):
+        raise error.TestFail("Failed to assign letters")
+        verifier_cleanup(vm, session, clear_verifier)
+    else:
+        testing_letter = post_volumes[-1]
+
+    target = iozone_run
+    iozone_cli = iozone_cli % (winutil_drive, testing_letter, testing_letter)
+    args = (session, iozone_cli, iozone_timeout)
+    kwargs = {}
+    iozone_thread = utils.InterruptedThread(target, args, kwargs)
+    error.context("Iozone commands starting", logging.info)
+    iozone_thread.start()
+    start = time.time()
+    while time.time() < start + iozone_start_timeout:
+        if env["iozone_status"] == 1:
+            break
+        time.sleep(0.5)
+
+    if (not env["iozone_status"]) or env["iozone_status"] == 0:
+        raise error.TestError("Waiting for iozone start timeout in %s"
+                              % iozone_start_timeout)
+        verifier_cleanup(vm, session, clear_verifier)
+    elif env["iozone_status"] == 2:
+        raise error.TestError("Iozone finished before subtest start")
+    if virt_subtest:
+        suppress_exception = params.get("suppress_exception")
+        error.context("Running subtests : %s " % virt_subtest, logging.info)
+        utils_test.run_virt_sub_test(test, params, env, virt_subtest, testtag)
+    iozone_thread.join(timeout=iozone_timeout,
+                       suppress_exception=suppress_exception)
+
+    if iozone_thread.is_alive():
+        raise error.TestFail("Waiting for iozone finished in %s"
+                             % iozone_timeout)
+    error.context("clear driver verifier at last", logging.info)
+    if vm.is_dead():
+        vm.create(params=params)
+    session = vm.wait_for_login(timeout=1200)
+    verifier_cleanup(vm, session, clear_verifier)

--- a/qemu/tests/windows_disk_smoke_test.py
+++ b/qemu/tests/windows_disk_smoke_test.py
@@ -52,7 +52,6 @@ def run(test, params, env):
                 session.close()
 
     error.context("Generating qemu-kvm commandline", logging.info)
-    params["start_vm"] = "yes"
     vm_name = params['main_vm']
     env_process.preprocess_vm(test, params, env, vm_name)
     vm = env.get_vm(vm_name)


### PR DESCRIPTION
This patch Add following scenarios:
1.reboot guest when iozone is running on scsi/blk/ide disk
2.shutdown guest when iozone is running on scsi/blk/ide disk
3.system_reset when iozone is running on scsi/blk/ide disk
4.stop_cont when iozone is running on scsi/blk/ide disk

ID: 1231021, 1231005, 1230684, 1231022, 1231008, 1230683

Signed-off-by: Mike Cao \<bcao@redhat.com\>