### PR TITLE
spice: Modifying fullscreen test to change resolution of client

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -297,7 +297,7 @@ variants:
         clear_interface = no
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.password.dcp_off.1monitor.default_sc
-        only rv.rr.fullscreen_setup.RHEL.6.devel.x86_64, rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_fullscreen.RHEL.6.devel.x86_64
+        only rv.rr.fullscreen_setup.RHEL.6.devel.x86_64, rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_fullscreen.RHEL.6.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @rv_smartcard_rhel6devel:
         spice_port = 3060


### PR DESCRIPTION
Changing resolution of guest in RHEL7 causes some weird behavior. So
changing the resolution of the client instead to see if fullscreen
remote-viewer causes the guest resolution to change to match client.

Also, shutdown both client and guest after test to reset to previous
configurations and to go to clean slate

Reviewed By: Swapna Krishnan <skrishna@redhat.com>