### PR TITLE
Fix skip message for TestFail()

### DIFF
--- a/qemu/tests/multi_disk_random_hotplug.py
+++ b/qemu/tests/multi_disk_random_hotplug.py
@@ -222,7 +222,7 @@ def run(test, params, env):
             logging.error("%sHotplug status:\nverified %s\nunverified %s\n"
                           "failed %s", prefix, passed, unverif, failed)
             logging.error("qtree:\n%s", monitor.info("qtree", debug=False))
-            raise error.TestFail("%sHotplug of some devices failed.", prefix)
+            raise error.TestFail("%sHotplug of some devices failed." % prefix)
 
     def hotplug_serial(new_devices, monitor):
         _hotplug(new_devices[0], monitor)
@@ -308,7 +308,7 @@ def run(test, params, env):
             logging.error("%sUnplug status:\nverified %s\nunverified %s\n"
                           "failed %s", prefix, passed, unverif, failed)
             logging.error("qtree:\n%s", monitor.info("qtree", debug=False))
-            raise error.TestFail("%sUnplug of some devices failed.", prefix)
+            raise error.TestFail("%sUnplug of some devices failed." % prefix)
 
     def unplug_serial(new_devices, qdev, monitor):
         _unplug(new_devices[0], qdev, monitor)

--- a/qemu/tests/rv_copyandpaste.py
+++ b/qemu/tests/rv_copyandpaste.py
@@ -70,7 +70,7 @@ def place_img_in_clipboard(session_to_copy_from, interpreter, script_call,
         if "The image has been placed into the clipboard." in output:
             logging.info("Copying of the image was successful")
         else:
-            raise error.TestFail("Copying to the clipboard failed", output)
+            raise error.TestFail("Copying to the clipboard failed. %s" % output)
     except aexpect.ShellCmdError:
         raise error.TestFail("Copying to the clipboard failed")
 
@@ -100,7 +100,7 @@ def verify_img_paste(session_to_copy_from, interpreter, script_call,
         if "Cb Image stored and saved to:" in output:
             logging.info("Copying of the image was successful")
         else:
-            raise error.TestFail("Copying to the clipboard failed", output)
+            raise error.TestFail("Copying to the clipboard failed. %s" % output)
     except aexpect.ShellCmdError:
         raise error.TestFail("Copying to the clipboard failed")
 
@@ -147,7 +147,7 @@ def verify_img_paste_success(session_to_copy_from, interpreter, script_call,
         if "Cb Image stored and saved to:" in output:
             logging.info("Copying of the image was successful")
         else:
-            raise error.TestFail("Copying to the clipboard failed", output)
+            raise error.TestFail("Copying to the clipboard failed. %s" % output)
     finally:
         logging.info("------------ End of script output of the Pasting"
                      " Session ------------")
@@ -225,7 +225,7 @@ def verify_text_copy(session_to_copy_from, interpreter, script_call,
         if "The string has also been placed in the clipboard" in output:
             logging.info("Copying of the large text file was successful")
         else:
-            raise error.TestFail("Copying to the clipboard failed", output)
+            raise error.TestFail("Copying to the clipboard failed. %s" % output)
     except aexpect.ShellCmdError:
         raise error.TestFail("Copying to the clipboard failed")
 
@@ -271,7 +271,7 @@ def verify_txt_paste_success(session_to_paste_to, interpreter,
         if "Writing of the clipboard text is complete" in output:
             logging.info("Copying of the large text file was successful")
         else:
-            raise error.TestFail("Copying to the clipboard failed", output)
+            raise error.TestFail("Copying to the clipboard failed. %s" % output)
     finally:
         logging.info("------------ End of script output of the Pasting"
                      " Session ------------")
@@ -315,7 +315,7 @@ def place_text_in_clipboard(session_to_copy_from, interpreter, script_call,
         if "The text has been placed into the clipboard." in output:
             logging.info("Copying of text was successful")
         else:
-            raise error.TestFail("Copying to the clipboard failed", output)
+            raise error.TestFail("Copying to the clipboard failed. %s" % output)
     except aexpect.ShellCmdError:
         raise error.TestFail("Copying to the clipboard failed")
 
@@ -332,7 +332,7 @@ def place_text_in_clipboard(session_to_copy_from, interpreter, script_call,
         if testing_text in output:
             logging.info("Text was successfully copied to the clipboard")
         else:
-            raise error.TestFail("Copying to the clipboard Failed ", output)
+            raise error.TestFail("Copying to the clipboard Failed. %s" % output)
     except aexpect.ShellCmdError:
         raise error.TestFail("Copying to the clipboard failed")
 

--- a/qemu/tests/rv_logging.py
+++ b/qemu/tests/rv_logging.py
@@ -112,8 +112,7 @@ def run(test, params, env):
             if "The text has been placed into the clipboard." in output:
                 logging.info("Copying of text was successful")
             else:
-                raise error.TestFail("Copying to the clipboard failed ELSE",
-                                     output)
+                raise error.TestFail("Copying to the clipboard failed. %s" % output)
         except:
             raise error.TestFail("Copying to the clipboard failed try" +
                                  " block failed")

--- a/qemu/tests/transfer_file_over_ipv6.py
+++ b/qemu/tests/transfer_file_over_ipv6.py
@@ -135,8 +135,7 @@ def run(test, params, env):
                           logging.info)
             dst_md5 = (utils.hash_file(host_path, method="md5"))
             if dst_md5 != src_md5:
-                raise error.TestFail("File changed after transfer",
-                                     "Files md5sum mismatch!")
+                raise error.TestFail("File changed after transfer (md5sum mismatch)")
             utils.system_output("rm -rf %s" % host_path, timeout=timeout)
 
     finally:


### PR DESCRIPTION
In order to display message to users correctly,
The exception message has to use interpolation.
This PR refers to the commit beacb9d.

Signed-off-by: Wei,Jiangang <weijg.fnst@cn.fujitsu.com>