### PR TITLE
tp-qemu: Add some subtests when netkvm driver in use.

### DIFF
--- a/qemu/tests/cfg/netkvm_in_use.cfg
+++ b/qemu/tests/cfg/netkvm_in_use.cfg
@@ -1,0 +1,65 @@
+- netkvm_in_use:
+    type = driver_in_use
+    only Windows
+    only virtio_net
+    hostpassword = redhat
+    login_timeout = 800
+    start_vm = yes
+    kill_vm_on_error = yes
+    check_guest_bsod = yes
+    driver_name = "netkvm"
+    run_bgstress = netperf_stress
+    bg_stress_run_flag = netperf_run
+    netperf_link = netperf-2.6.0.tar.bz2
+    server_path = /var/tmp/
+    client_path = /var/tmp/
+    test_protocols = TCP_STREAM
+    netperf_client = ${vms}
+    netperf_server = localhost
+    netperf_test_duration = 200
+    wait_before_subtest = 100
+    ping_ext_host = "yes"
+    ext_host_get_cmd = "ip route | awk '/default/ { print $3 }'"
+    shell_client = "nc"
+    variants:
+        - before_bg_test:
+            run_bg_flag = "before_bg_test"
+        - during_bg_test:
+            run_bg_flag = "during_bg_test"
+        - after_bg_test:
+            run_bg_flag = "after_bg_test"
+    variants:
+        - with_stop_continue:
+            sub_test = stop_continue
+            suppress_exception = False
+        - with_shutdown:
+            sub_test = shutdown
+            suppress_exception = True
+            shutdown_method = shell
+        - with_reboot:
+            sub_test = boot
+            suppress_exception = True
+            reboot_count = 1
+            reboot_method = shell
+        - with_system_reset:
+            sub_test = boot
+            suppress_exception = True
+            reboot_method = system_reset
+            sleep_before_reset = 20
+        - with_live_migration:
+            sub_test = migration
+            suppress_exception = False
+            migration_test_command = ver && vol
+        - with_hotplug:
+            sub_test = pci_hotplug
+            suppress_exception = False
+            pci_type = nic
+            pci_model = virtio-net-pci
+            match_string = "Virtio network device"
+            reference_cmd = wmic nic list
+            find_pci_cmd = wmic nic list
+            # Do nothing in Windows guest.
+            pci_test_cmd = echo PCI_NUM
+            run_dhclient = no
+            pci_num = 1
+            repeat_times = 100


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>

id: 1231015, 1230674, 1231007

Based on: autotest/tp-qemu#463