### PR TITLE
spice: Updating to install pyparsing as part of spice-protocol build

### DIFF
--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -64,6 +64,19 @@ def build_install_spiceprotocol(vm_root_session, vm_script_path, params):
     :param params: Dictionary with test parameters.
     """
 
+    utils_spice.deploy_epel_repo(vm_root_session, params)
+
+    # In RHEL6, pyparsing is in EPEL but in RHEL7, it's part of
+    # the main product repo
+    if "release 6" in vm_root_session.cmd("cat /etc/redhat-release"):
+        try:
+            cmd = "yum --disablerepo=\"*\" " + \
+                  "--enablerepo=\"epel\" -y install pyparsing"
+            output = vm_root_session.cmd(cmd, timeout=300)
+            logging.info(output)
+        except ShellCmdError:
+            logging.error("Not able to install pyparsing!")
+
     output = vm_root_session.cmd("%s -p spice-protocol" % (vm_script_path))
     logging.info(output)
     if re.search("Return code", output):
@@ -168,15 +181,9 @@ def build_install_spicegtk(vm_root_session, vm_script_path, params):
 
     install_req_pkgs(pkgsRequired, vm_root_session, params)
 
-    utils_spice.deploy_epel_repo(vm_root_session, params)
-
     try:
         cmd = "yum --disablerepo=\"*\" " + \
               "--enablerepo=\"epel\" -y install perl-Text-CSV"
-        # In RHEL6, pyparsing is in EPEL but in RHEL7, it's part of
-        # the main product repo
-        if "release 6" in vm_root_session.cmd("cat /etc/redhat-release"):
-            cmd += " pyparsing"
         output = vm_root_session.cmd(cmd, timeout=300)
         logging.info(output)
     except ShellCmdError:


### PR DESCRIPTION
pyparsing is now required for building spice-protocol. Hence moving
epel creation and pyparsing install to build_install_spiceprotocol

Reviewed-By: Swapna Krishnan <skrishna@redhat.com>