### PR TITLE
tp-qemu: cdrom.py: update the way to get the cdrom in guest.

### DIFF
--- a/qemu/tests/cfg/cdrom_test.cfg
+++ b/qemu/tests/cfg/cdrom_test.cfg
@@ -25,6 +25,7 @@
                 cdrom_test_locked = no
         - cdrom_not_insert:
             no Host_RHEL.5
+            no RHEL.3, RHEL.4, RHEL.5
             not_insert_at_start = yes
             cdrom_without_file = yes
         - guest_s3:
@@ -79,6 +80,8 @@
         eject_cdrom_cmd = "eject %s"
         close_cdrom_cmd = "eject -t %s"
         mount_cdrom_cmd = "mount %s %s"
+        HOST_RHEL.5:
+            mount_cdrom_cmd = "mount %s %s -ro"
         umount_cdrom_cmd = "umount %s"
         show_mount_cmd = "cat /etc/mtab"
         remove_file_cmd = "rm -f ${tmp_dir}/%s"


### PR DESCRIPTION
1. The way in cdrom.py (cdrom_dev_list[-1]) to get cdrom is not
suitable, especially for multiple cdrom, update the way to
get the cdrom in guest according to the serial number.

2. The guest <= RHEl.5 does not support subcase "cdrom_not_insert",
    then disable it.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1209727 1185789