### PR TITLE
tp-qemu: usb: test the usb bus alone.

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -4,7 +4,7 @@
     no Host_RHEL.6.1
     restart_vm = yes
     kill_vm_on_error = yes
-    usbs += " usbtest"
+    usbs = " usbtest"
     usb_bus = "usbtest.0"
 
     # usb controllers


### PR DESCRIPTION
There is the default bus which is added in base.cfg,
for usb test only, not add the default bus for testing.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1183906