### PR TITLE
spice: Building qxl has new dependencies, adding dependencies

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -360,6 +360,8 @@ variants:
         libpciaccess_devel_url = path_to_libpciaccess_rpm
         xorg_x11_server_devel_url = path_to_xorgx11server_rpm
         xorg_x11_util_macros_url = path_to_xorgx11utilmacros_rpm
+        libfontenc_devel_url = path_to_libfontenc_devel_rpm
+        libXfont_devel_url = path_to_libXfont_devel_rpm
         only remote_viewer_rhel6devel_build_install
     - build_install_virtviewer:
         build_install_pkg = virt-viewer

--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -94,7 +94,8 @@ def build_install_qxl(vm_root_session, vm_script_path, params):
 
     # Checking to see if required packages exist and if not, install them
     pkgsRequired = ["libpciaccess-devel", "xorg-x11-util-macros",
-                    "xorg-x11-server-devel"]
+                    "xorg-x11-server-devel", "libfontenc-devel",
+                    "libXfont-devel"]
     install_req_pkgs(pkgsRequired, vm_root_session, params)
 
     output = vm_root_session.cmd("%s -p xf86-video-qxl" % (vm_script_path),


### PR DESCRIPTION
Building qxl from upstream has new dependecies on packages
"libfontenc-devel" and "libXfont-devel". Adding these packages
to the list of packages to be installed before building qxl.

Reviewed-By: Swapna Krishnan <skrishna@redhat.com>