### PR TITLE
tp-qemu: Modify disable/enable test cases for windows

### DIFF
--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -2,35 +2,133 @@
     type = driver_load
     kill_vm_on_error = yes
     login_timeout = 240
-    driver_load_cmd = modprobe DRIVER_ID
-    driver_unload_cmd = modprobe -r DRIVER_ID
     repeats = 1
     variants:
-        - nic_device:
+        - with_nic:
             no e1000
             nics += " nic2"
-            nic_model_nic2 = e1000
-            driver_id_cmd = lsmod |grep virtio_net
-            driver_id_pattern = virtio_net
-            test_after_load = file_transfer
-            filesize = 100
-            transfer_timeout = 1000
+            nic_model_nic2 = rtl8139
+            nic_model_nic1 = virtio
+            Linux:
+                driver_load_cmd = modprobe DRIVER_ID
+                driver_unload_cmd = modprobe -r DRIVER_ID
+                driver_id_cmd = lsmod |grep virtio_net
+                driver_id_pattern = virtio_net
+                test_after_load = file_transfer
+                filesize = 100
+                transfer_timeout = 1000
             Windows:
                 # The DevCon utility is a command-line utility that acts as an
                 # alternative to Device Manager. Please set up your windows guest
                 # following: http://support.microsoft.com/kb/311272/en-us
                 driver_id_cmd = C:\devcon.exe find * | find "VirtIO Ethernet Adapter"
                 driver_id_pattern = "(.*?):"
-                driver_load_cmd = C:\devcon.exe enable DRIVER_ID
-                driver_unload_cmd = C:\devcon.exe disable DRIVER_ID
-        - balloon_device:
+                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
+                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
+                x86_64:
+                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
+                i386:
+                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
+
+        - with_balloon:
             balloon = balloon0
             balloon_dev_devid = balloon0
             balloon_dev_add_bus = yes
-            driver_id_cmd = lsmod |grep virtio_balloon
-            driver_id_pattern = virtio_balloon
+            Linux:
+                driver_load_cmd = modprobe DRIVER_ID
+                driver_unload_cmd = modprobe -r DRIVER_ID
+                driver_id_cmd = lsmod |grep virtio_balloon
+                driver_id_pattern = virtio_balloon
             Windows:
                 driver_id_cmd = C:\devcon.exe find * | find "VirtIO Balloon Driver"
                 driver_id_pattern = "(.*?):"
-                driver_load_cmd = C:\devcon.exe enable DRIVER_ID
-                driver_unload_cmd = C:\devcon.exe disable DRIVER_ID
+                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
+                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
+                x86_64:
+                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
+                i386:
+                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
+
+        - with_viorng:
+            no_virtio_rng:
+                virtio_rngs += " rng0"
+                backend_rng0 = rng-random
+                backend_type = passthrough
+                filename_passthrough = /dev/urandom
+            Linux:
+                driver_load_cmd = modprobe DRIVER_ID
+                driver_unload_cmd = modprobe -r DRIVER_ID
+                driver_id_cmd = lsmod |grep virtio_rng
+                driver_id_pattern = virtio_rng
+            Windows:
+                driver_id_cmd = C:\devcon.exe find * | find "VirtIO RNG Device"
+                driver_id_pattern = "(.*?):"
+                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
+                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
+                x86_64:
+                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
+                i386:
+                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
+
+        - with_block:
+            drive_format_image1 = ide
+            images += " stg"
+            image_name_stg = "images/storage"
+            image_size_stg = 4G
+            drive_format_stg = virtio
+            Linux:
+                driver_load_cmd = modprobe DRIVER_ID
+                driver_unload_cmd = modprobe -r DRIVER_ID
+                driver_id_cmd = lsmod |grep virtio_blk
+                driver_id_pattern = virtio_blk
+            Windows:
+                driver_id_cmd = C:\devcon.exe find * | find "VirtIO SCSI Disk Device"
+                driver_id_pattern = "(.*?):"
+                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
+                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
+                x86_64:
+                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
+                i386:
+                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
+
+        -with_vioscsi:
+            cd_format_fixed =ide
+            drive_format_image1 = ide
+            images += " stg"
+            image_name_stg = "images/storage"
+            image_size_stg = 4G
+            drive_format_stg = scsi-hd
+            Linux:
+                driver_load_cmd = modprobe DRIVER_ID
+                driver_unload_cmd = modprobe -r DRIVER_ID
+                driver_id_cmd = lsmod |grep virtio_scsi
+                driver_id_pattern = virtio_scsi
+            Windows:
+                driver_id_cmd = C:\devcon.exe find * | find "VirtIO SCSI pass-through controller"
+                driver_id_pattern = "(.*?):"
+                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
+                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
+                x86_64:
+                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
+                i386:
+                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
+
+        -with_vioserial: 
+            driver_name = vioser
+            virtio_ports = "vs"
+            virtio_port_type = serialport
+            Linux:
+                driver_load_cmd = modprobe DRIVER_ID
+                driver_unload_cmd = modprobe -r DRIVER_ID
+                driver_id_cmd = lsmod |grep virtio_console
+                driver_id_pattern = virtio_console
+            Windows:
+                driver_id_cmd = C:\devcon.exe find * | find "VirtIO-Serial Driver"
+                driver_id_pattern = "(.*?):"
+                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
+                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
+                x86_64:
+                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
+                i386:
+                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
+

--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -76,6 +76,7 @@
             image_name_stg = "images/storage"
             image_size_stg = 4G
             drive_format_stg = virtio
+            force_create_image_stg = yes
             Linux:
                 driver_load_cmd = modprobe DRIVER_ID
                 driver_unload_cmd = modprobe -r DRIVER_ID
@@ -98,6 +99,7 @@
             image_name_stg = "images/storage"
             image_size_stg = 4G
             drive_format_stg = scsi-hd
+            force_create_image_stg = yes
             Linux:
                 driver_load_cmd = modprobe DRIVER_ID
                 driver_unload_cmd = modprobe -r DRIVER_ID

--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -9,38 +9,26 @@
             nics += " nic2"
             nic_model_nic2 = rtl8139
             nic_model_nic1 = virtio
-            Linux:
-                driver_id_pattern = virtio_net
-                test_after_load = file_transfer
-                filesize = 100
-                transfer_timeout = 1000
-            Windows:
-                # The DevCon utility is a command-line utility that acts as an
-                # alternative to Device Manager. Please set up your windows guest
-                # following: http://support.microsoft.com/kb/311272/en-us
-                driver_id_cmd = C:\devcon.exe find * | find "VirtIO Ethernet Adapter"
+            driver_id_pattern = virtio_net
+            test_after_load = file_transfer
+            filesize = 100
+            transfer_timeout = 1000
 
         - with_balloon:
             balloon = balloon0
             balloon_dev_devid = balloon0
             balloon_dev_add_bus = yes
-            Linux:
-                driver_id_cmd = lsmod |grep virtio_balloon
-                driver_id_pattern = virtio_balloon
-            Windows:
-                driver_id_cmd = C:\devcon.exe find * | find "VirtIO Balloon Driver"
+            driver_id_cmd = lsmod |grep virtio_balloon
+            driver_id_pattern = virtio_balloon
 
         - with_viorng:
             no_virtio_rng:
-                virtio_rngs += " rng0"
+            virtio_rngs += " rng0"
                 backend_rng0 = rng-random
                 backend_type = passthrough
                 filename_passthrough = /dev/urandom
-            Linux:
-                driver_id_cmd = lsmod |grep virtio_rng
-                driver_id_pattern = virtio_rng
-            Windows:
-                driver_id_cmd = C:\devcon.exe find * | find "VirtIO RNG Device"
+            driver_id_cmd = lsmod |grep virtio_rng
+            driver_id_pattern = virtio_rng
 
         - with_block:
             drive_format_image1 = ide
@@ -49,11 +37,8 @@
             image_size_stg = 4G
             drive_format_stg = virtio
             force_create_image_stg = yes
-            Linux:
-                driver_id_cmd = lsmod |grep virtio_blk
-                driver_id_pattern = virtio_blk
-            Windows:
-                driver_id_cmd = C:\devcon.exe find * | find "VirtIO SCSI Disk Device"
+            driver_id_cmd = lsmod |grep virtio_blk
+            driver_id_pattern = virtio_blk
 
         -with_vioscsi:
             cd_format_fixed =ide
@@ -63,19 +48,12 @@
             image_size_stg = 4G
             drive_format_stg = scsi-hd
             force_create_image_stg = yes
-            Linux:
-                driver_id_cmd = lsmod |grep virtio_scsi
-                driver_id_pattern = virtio_scsi
-            Windows:
-                driver_id_cmd = C:\devcon.exe find * | find "VirtIO SCSI pass-through controller"
+            driver_id_cmd = lsmod |grep virtio_scsi
+            driver_id_pattern = virtio_scsi
 
         -with_vioserial: 
             driver_name = vioser
             virtio_ports = "vs"
             virtio_port_type = serialport
-            Linux:
-                driver_id_cmd = lsmod |grep virtio_console
-                driver_id_pattern = virtio_console
-            Windows:
-                driver_id_cmd = C:\devcon.exe find * | find "VirtIO-Serial Driver"
-
+            driver_id_cmd = lsmod |grep virtio_console
+            driver_id_pattern = virtio_console

--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -10,9 +10,6 @@
             nic_model_nic2 = rtl8139
             nic_model_nic1 = virtio
             Linux:
-                driver_load_cmd = modprobe DRIVER_ID
-                driver_unload_cmd = modprobe -r DRIVER_ID
-                driver_id_cmd = lsmod |grep virtio_net
                 driver_id_pattern = virtio_net
                 test_after_load = file_transfer
                 filesize = 100
@@ -22,32 +19,16 @@
                 # alternative to Device Manager. Please set up your windows guest
                 # following: http://support.microsoft.com/kb/311272/en-us
                 driver_id_cmd = C:\devcon.exe find * | find "VirtIO Ethernet Adapter"
-                driver_id_pattern = "(.*?):"
-                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
-                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
-                x86_64:
-                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
-                i386:
-                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
 
         - with_balloon:
             balloon = balloon0
             balloon_dev_devid = balloon0
             balloon_dev_add_bus = yes
             Linux:
-                driver_load_cmd = modprobe DRIVER_ID
-                driver_unload_cmd = modprobe -r DRIVER_ID
                 driver_id_cmd = lsmod |grep virtio_balloon
                 driver_id_pattern = virtio_balloon
             Windows:
                 driver_id_cmd = C:\devcon.exe find * | find "VirtIO Balloon Driver"
-                driver_id_pattern = "(.*?):"
-                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
-                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
-                x86_64:
-                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
-                i386:
-                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
 
         - with_viorng:
             no_virtio_rng:
@@ -56,19 +37,10 @@
                 backend_type = passthrough
                 filename_passthrough = /dev/urandom
             Linux:
-                driver_load_cmd = modprobe DRIVER_ID
-                driver_unload_cmd = modprobe -r DRIVER_ID
                 driver_id_cmd = lsmod |grep virtio_rng
                 driver_id_pattern = virtio_rng
             Windows:
                 driver_id_cmd = C:\devcon.exe find * | find "VirtIO RNG Device"
-                driver_id_pattern = "(.*?):"
-                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
-                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
-                x86_64:
-                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
-                i386:
-                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
 
         - with_block:
             drive_format_image1 = ide
@@ -78,19 +50,10 @@
             drive_format_stg = virtio
             force_create_image_stg = yes
             Linux:
-                driver_load_cmd = modprobe DRIVER_ID
-                driver_unload_cmd = modprobe -r DRIVER_ID
                 driver_id_cmd = lsmod |grep virtio_blk
                 driver_id_pattern = virtio_blk
             Windows:
                 driver_id_cmd = C:\devcon.exe find * | find "VirtIO SCSI Disk Device"
-                driver_id_pattern = "(.*?):"
-                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
-                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
-                x86_64:
-                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
-                i386:
-                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
 
         -with_vioscsi:
             cd_format_fixed =ide
@@ -101,36 +64,18 @@
             drive_format_stg = scsi-hd
             force_create_image_stg = yes
             Linux:
-                driver_load_cmd = modprobe DRIVER_ID
-                driver_unload_cmd = modprobe -r DRIVER_ID
                 driver_id_cmd = lsmod |grep virtio_scsi
                 driver_id_pattern = virtio_scsi
             Windows:
                 driver_id_cmd = C:\devcon.exe find * | find "VirtIO SCSI pass-through controller"
-                driver_id_pattern = "(.*?):"
-                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
-                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
-                x86_64:
-                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
-                i386:
-                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
 
         -with_vioserial: 
             driver_name = vioser
             virtio_ports = "vs"
             virtio_port_type = serialport
             Linux:
-                driver_load_cmd = modprobe DRIVER_ID
-                driver_unload_cmd = modprobe -r DRIVER_ID
                 driver_id_cmd = lsmod |grep virtio_console
                 driver_id_pattern = virtio_console
             Windows:
                 driver_id_cmd = C:\devcon.exe find * | find "VirtIO-Serial Driver"
-                driver_id_pattern = "(.*?):"
-                driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
-                driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
-                x86_64:
-                    devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
-                i386:
-                    devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
 

--- a/qemu/tests/driver_load.py
+++ b/qemu/tests/driver_load.py
@@ -57,13 +57,13 @@ def run(test, params, env):
         error.context("unload CLI %s" % driver_unload_cmd,
                       logging.info)
         status, output = session.cmd_status_output(driver_unload_cmd)
-        if params["os_type"] == "windows" and not "device(s) disabled" in output:
+        if params["os_type"] == "windows" and "device(s) disabled" not in output:
             raise error.TestError("failed to unload driver %s" % output)
         error.context("status %s unload output %s"
                       % (status, output), logging.info)
         time.sleep(5)
         status, output = session.cmd_status_output(driver_load_cmd)
-        if params["os_type"] == "windows" and not "device(s) are enabled" in output:
+        if params["os_type"] == "windows" and "device(s) are enabled" not in output:
             raise error.TestError("failed to unload driver %s" % output)
         error.context("status %s load output %s"
                       % (status, output), logging.info)

--- a/qemu/tests/driver_load.py
+++ b/qemu/tests/driver_load.py
@@ -59,14 +59,14 @@ def run(test, params, env):
         status, output = session.cmd_status_output(driver_unload_cmd)
         if params["os_type"] == "windows" and "device(s) disabled" not in output:
             raise error.TestError("failed to unload driver %s" % output)
-        error.context("status %s unload output %s"
-                      % (status, output), logging.info)
+        logging.info("status %s unload output %s"
+                     % (status, output))
         time.sleep(5)
         status, output = session.cmd_status_output(driver_load_cmd)
         if params["os_type"] == "windows" and "device(s) are enabled" not in output:
             raise error.TestError("failed to unload driver %s" % output)
-        error.context("status %s load output %s"
-                      % (status, output), logging.info)
+        logging.info("status %s load output %s"
+                     % (status, output))
         time.sleep(5)
         if params.get("test_after_load"):
             test_after_load = params.get("test_after_load")

--- a/qemu/tests/driver_load.py
+++ b/qemu/tests/driver_load.py
@@ -58,13 +58,13 @@ def run(test, params, env):
                       logging.info)
         status, output = session.cmd_status_output(driver_unload_cmd)
         if params["os_type"] == "windows" and "device(s) disabled" not in output:
-            raise error.TestError("failed to unload driver %s" % output)
+            raise error.TestError("failed to unload driver, %s" % output)
         logging.info("status %s unload output %s"
                      % (status, output))
         time.sleep(5)
         status, output = session.cmd_status_output(driver_load_cmd)
         if params["os_type"] == "windows" and "device(s) are enabled" not in output:
-            raise error.TestError("failed to load driver %s" % output)
+            raise error.TestError("failed to load driver, %s" % output)
         logging.info("status %s load output %s"
                      % (status, output))
         time.sleep(5)

--- a/qemu/tests/driver_load.py
+++ b/qemu/tests/driver_load.py
@@ -64,7 +64,7 @@ def run(test, params, env):
         time.sleep(5)
         status, output = session.cmd_status_output(driver_load_cmd)
         if params["os_type"] == "windows" and "device(s) are enabled" not in output:
-            raise error.TestError("failed to unload driver %s" % output)
+            raise error.TestError("failed to load driver %s" % output)
         logging.info("status %s load output %s"
                      % (status, output))
         time.sleep(5)


### PR DESCRIPTION
modify disable/enable test cases for different devices

This patch can be used for disable/enable driver during reboot/shutdown/system_reset in the future.
Signed-off-by: Mike Cao <bcao@redhat.com>