### PR TITLE
tp-qemu: fix cfg for cpuinfo_query

### DIFF
--- a/qemu/tests/cfg/cpuinfo_query.cfg
+++ b/qemu/tests/cfg/cpuinfo_query.cfg
@@ -3,7 +3,7 @@
     vms = ''
     variants:
         - qcpu_id:
-            no Host_RHEL.m5
+            only Host_RHEL.m6
             query_cmd = " -cpu ?cpuid"
             cpu_info = "f_edx,f_ecx,extf_edx,extf_ecx"
         - qmachine_type:
@@ -11,10 +11,14 @@
             query_cmd = " -M ?"
             cpu_info = "pc,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
         - qcpu_dump:
-            no Host_RHEL.m5
+            only Host_RHEL.m6
             query_cmd = " -cpu ?dump"
             cpu_info = "Opteron_G4,Opteron_G3,Opteron_G2,Opteron_G1,SandyBridge,Westmere,Nehalem,Penryn,Conroe"
         - qcpu_model:
-            no Host_RHEL.m5
+            only Host_RHEL.m6
             query_cmd = " -cpu ?model"
+            cpu_info = "Opteron_G4,Opteron_G3,Opteron_G2,Opteron_G1,SandyBridge,Westmere,Nehalem,Penryn,Conroe"
+        - qcpu_info:
+            only Host_RHEL.m7
+            query_cmd = " -cpu ?"
             cpu_info = "Opteron_G4,Opteron_G3,Opteron_G2,Opteron_G1,SandyBridge,Westmere,Nehalem,Penryn,Conroe"


### PR DESCRIPTION
Some commands it not supported on RHLL7 host ,this patch is to delete
them and add some new config on RHEL7
As qemu-kvm ?dump is not supported in RHEL7 ,
modify config file to make it RHEL6 only.
Add new test case in cfg for RHEL7 cpuinfo query

ID: 1044928

Signed-off-by: Mike Cao <bcao@redhat.com>