### PR TITLE
Import fixes and cleanups

### DIFF
--- a/generic/tests/autotest_control.py
+++ b/generic/tests/autotest_control.py
@@ -1,7 +1,9 @@
 import os
 import logging
 import sys
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/generic/tests/autotest_distro_detect.py
+++ b/generic/tests/autotest_distro_detect.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import string
+
 from virttest import utils_test
 
 

--- a/generic/tests/autotest_regression.py
+++ b/generic/tests/autotest_regression.py
@@ -1,6 +1,10 @@
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect, utils_misc
+
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/generic/tests/boot.py
+++ b/generic/tests/boot.py
@@ -1,6 +1,8 @@
 import time
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/generic/tests/boot_savevm.py
+++ b/generic/tests/boot_savevm.py
@@ -2,8 +2,12 @@ import logging
 import time
 import tempfile
 import os
+
 from autotest.client.shared import error
-from virttest import qemu_storage, data_dir, utils_misc
+
+from virttest import qemu_storage
+from virttest import data_dir
+from virttest import utils_misc
 
 
 def run(test, params, env):

--- a/generic/tests/build.py
+++ b/generic/tests/build.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import installer
 
 

--- a/generic/tests/clock_getres.py
+++ b/generic/tests/clock_getres.py
@@ -1,7 +1,10 @@
 import logging
 import os
+
 from autotest.client.shared import error
-from virttest import utils_test, data_dir
+
+from virttest import utils_test
+from virttest import data_dir
 
 
 @error.context_aware

--- a/generic/tests/dd_test.py
+++ b/generic/tests/dd_test.py
@@ -4,8 +4,10 @@ Configurable on-guest dd test.
 :copyright: 2012 Red Hat, Inc.
 """
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
 
 
 @error.context_aware

--- a/generic/tests/dropin.py
+++ b/generic/tests/dropin.py
@@ -1,6 +1,8 @@
 import os
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import data_dir
 
 

--- a/generic/tests/ethtool.py
+++ b/generic/tests/ethtool.py
@@ -6,7 +6,9 @@ import aexpect
 from autotest.client.shared import error
 from autotest.client import utils
 
-from virttest import utils_net, utils_misc, remote
+from virttest import utils_net
+from virttest import utils_misc
+from virttest import remote
 
 
 @error.context_aware

--- a/generic/tests/ethtool.py
+++ b/generic/tests/ethtool.py
@@ -1,9 +1,12 @@
 import logging
 import re
-import time
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_net, utils_misc, remote, aexpect
+
+from virttest import utils_net, utils_misc, remote
 
 
 @error.context_aware

--- a/generic/tests/fillup_disk.py
+++ b/generic/tests/fillup_disk.py
@@ -1,4 +1,5 @@
 import logging
+
 from autotest.client.shared import error
 
 

--- a/generic/tests/guest_suspend.py
+++ b/generic/tests/guest_suspend.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/generic/tests/guest_test.py
+++ b/generic/tests/guest_test.py
@@ -1,7 +1,9 @@
 import os
 import logging
 import sys
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/generic/tests/invalid_para_mq.py
+++ b/generic/tests/invalid_para_mq.py
@@ -1,6 +1,8 @@
 import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_net
 from virttest import env_process
 

--- a/generic/tests/iofuzz.py
+++ b/generic/tests/iofuzz.py
@@ -6,8 +6,11 @@ import aexpect
 
 from autotest.client.shared import error
 
-from virttest import qemu_vm, virt_vm
-from virttest import data_dir, storage, qemu_storage
+from virttest import data_dir
+from virttest import qemu_storage
+from virttest import qemu_vm
+from virttest import storage
+from virttest import virt_vm
 
 
 def run(test, params, env):

--- a/generic/tests/iofuzz.py
+++ b/generic/tests/iofuzz.py
@@ -1,8 +1,12 @@
 import logging
 import re
 import random
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect, qemu_vm, virt_vm
+
+from virttest import qemu_vm, virt_vm
 from virttest import data_dir, storage, qemu_storage
 
 

--- a/generic/tests/iometer_windows.py
+++ b/generic/tests/iometer_windows.py
@@ -6,8 +6,12 @@ import logging
 import time
 import re
 import os
+
 from autotest.client.shared import error
-from virttest import utils_test, utils_misc, data_dir
+
+from virttest import data_dir
+from virttest import utils_misc
+from virttest import utils_test
 
 
 @error.context_aware

--- a/generic/tests/ioquit.py
+++ b/generic/tests/ioquit.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import random
+
 from autotest.client.shared import error
 
 

--- a/generic/tests/iozone_windows.py
+++ b/generic/tests/iozone_windows.py
@@ -1,6 +1,8 @@
 import logging
 import os
+
 from autotest.client import utils
+
 from virttest import postprocess_iozone
 from virttest import utils_misc
 

--- a/generic/tests/jumbo.py
+++ b/generic/tests/jumbo.py
@@ -1,9 +1,13 @@
 import logging
 import commands
 import random
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_misc, utils_test, utils_net
+
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import utils_net
 
 
 @error.context_aware

--- a/generic/tests/kdump.py
+++ b/generic/tests/kdump.py
@@ -1,8 +1,12 @@
 import logging
 import os
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_misc, utils_net, utils_conn
+
+from virttest import utils_conn
+from virttest import utils_misc
+from virttest import utils_net
 
 
 @error.context_aware

--- a/generic/tests/ksm_services.py
+++ b/generic/tests/ksm_services.py
@@ -2,7 +2,9 @@ import re
 import os
 import logging
 import shutil
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/generic/tests/lvm.py
+++ b/generic/tests/lvm.py
@@ -1,5 +1,6 @@
 import os
 import logging
+
 from autotest.client.shared import error
 
 

--- a/generic/tests/mac_change.py
+++ b/generic/tests/mac_change.py
@@ -1,7 +1,11 @@
 import re
 import logging
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_net, utils_test
+
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import utils_test
 
 
 def check_guest_mac(mac, vm, device_id=None):

--- a/generic/tests/module_probe.py
+++ b/generic/tests/module_probe.py
@@ -1,7 +1,9 @@
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import base_installer, utils_misc
+
+from virttest import base_installer
 
 
 def run(test, params, env):

--- a/generic/tests/multi_queues_test.py
+++ b/generic/tests/multi_queues_test.py
@@ -1,9 +1,13 @@
 import logging
 import re
 import time
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_net, utils_misc, utils_test
+
+from virttest import utils_net
+from virttest import utils_misc
+from virttest import utils_test
 
 
 @error.context_aware

--- a/generic/tests/multicast.py
+++ b/generic/tests/multicast.py
@@ -1,9 +1,13 @@
 import logging
 import os
 import re
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test, aexpect
+
+from virttest import utils_test
 
 
 def run(test, params, env):

--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -4,9 +4,15 @@ import commands
 import threading
 import re
 import time
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_test, utils_misc, utils_net, remote, data_dir
+
+from virttest import utils_test
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import remote
+from virttest import data_dir
 
 
 _netserver_started = False

--- a/generic/tests/netstress_kill_guest.py
+++ b/generic/tests/netstress_kill_guest.py
@@ -1,12 +1,13 @@
 import logging
 import os
-import signal
-import re
 import time
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_misc, data_dir, utils_net
-from virttest import utils_test, env_process
+
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import env_process
 
 
 @error.context_aware

--- a/generic/tests/nfs_corrupt.py
+++ b/generic/tests/nfs_corrupt.py
@@ -1,9 +1,11 @@
 import os
 import re
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
 from autotest.client import os_dep
+
 from virttest import utils_misc
 from virttest import utils_net
 from virttest import env_process

--- a/generic/tests/nic_promisc.py
+++ b/generic/tests/nic_promisc.py
@@ -3,7 +3,9 @@ import os
 
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_test, utils_net
+
+from virttest import utils_test
+from virttest import utils_net
 
 
 @error.context_aware

--- a/generic/tests/nic_promisc.py
+++ b/generic/tests/nic_promisc.py
@@ -1,9 +1,9 @@
 import logging
 import os
-import time
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_test, utils_net, aexpect
+from virttest import utils_test, utils_net
 
 
 @error.context_aware

--- a/generic/tests/nicdriver_unload.py
+++ b/generic/tests/nicdriver_unload.py
@@ -2,9 +2,13 @@ import logging
 import os
 import time
 import random
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_misc, utils_net, data_dir
+
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import data_dir
 
 
 @error.context_aware

--- a/generic/tests/ntpd.py
+++ b/generic/tests/ntpd.py
@@ -3,9 +3,11 @@ import time
 
 import aexpect
 
-from autotest.client.shared import utils, error
+from autotest.client.shared import utils
+from autotest.client.shared import error
 
-from virttest import remote, utils_test
+from virttest import remote
+from virttest import utils_test
 from virttest.staging import service
 
 

--- a/generic/tests/ntpd.py
+++ b/generic/tests/ntpd.py
@@ -1,7 +1,11 @@
 import logging
 import time
+
+import aexpect
+
 from autotest.client.shared import utils, error
-from virttest import remote, utils_test, aexpect
+
+from virttest import remote, utils_test
 from virttest.staging import service
 
 

--- a/generic/tests/ntttcp.py
+++ b/generic/tests/ntttcp.py
@@ -8,7 +8,10 @@ import aexpect
 
 from autotest.client.shared import error
 from autotest.client.shared import utils
-from virttest import utils_misc, utils_test, remote
+
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import remote
 
 _receiver_ready = False
 

--- a/generic/tests/ntttcp.py
+++ b/generic/tests/ntttcp.py
@@ -3,10 +3,12 @@ import os
 import glob
 import re
 import commands
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
 from virttest import utils_misc, utils_test, remote
-from virttest import aexpect
 
 _receiver_ready = False
 

--- a/generic/tests/ping.py
+++ b/generic/tests/ping.py
@@ -1,7 +1,10 @@
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test, utils_net
+
+from virttest import utils_test
+from virttest import utils_net
 
 
 @error.context_aware

--- a/generic/tests/pxe_boot.py
+++ b/generic/tests/pxe_boot.py
@@ -1,6 +1,8 @@
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
 
 
 @error.context_aware

--- a/generic/tests/shutdown.py
+++ b/generic/tests/shutdown.py
@@ -1,8 +1,10 @@
 import time
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import utils_misc, env_process
+from virttest import utils_misc
+from virttest import env_process
 
 
 @error.context_aware

--- a/generic/tests/stress_boot.py
+++ b/generic/tests/stress_boot.py
@@ -1,4 +1,5 @@
 import logging
+
 from autotest.client.shared import error
 from virttest import env_process
 

--- a/generic/tests/trans_hugepage.py
+++ b/generic/tests/trans_hugepage.py
@@ -1,9 +1,11 @@
 import logging
 import os
 import re
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
-from virttest import utils_test, funcatexit
+
+from virttest import funcatexit
 
 
 def cleanup(debugfs_path, session):

--- a/generic/tests/trans_hugepage_defrag.py
+++ b/generic/tests/trans_hugepage_defrag.py
@@ -2,9 +2,11 @@ import logging
 import time
 import os
 import re
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test, test_setup
+
+from virttest import test_setup
 
 
 @error.context_aware

--- a/generic/tests/trans_hugepage_memory_stress.py
+++ b/generic/tests/trans_hugepage_memory_stress.py
@@ -1,13 +1,11 @@
 import logging
 import os
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test
 
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from virttest import utils_test
+from virttest.staging import utils_memory
 
 
 @error.context_aware

--- a/generic/tests/trans_hugepage_relocated.py
+++ b/generic/tests/trans_hugepage_relocated.py
@@ -3,13 +3,11 @@ import time
 import commands
 import os
 import re
-from autotest.client.shared import error
-from virttest import utils_test
 
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from autotest.client.shared import error
+
+from virttest import utils_test
+from virttest.staging import utils_memory
 
 
 def run(test, params, env):

--- a/generic/tests/trans_hugepage_swapping.py
+++ b/generic/tests/trans_hugepage_swapping.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import re
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import env_process
 
 

--- a/generic/tests/vlan.py
+++ b/generic/tests/vlan.py
@@ -1,8 +1,12 @@
 import logging
 import time
 import re
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_test, aexpect, utils_net
+
+from virttest import utils_misc, utils_test, utils_net
 
 
 @error.context_aware

--- a/generic/tests/vlan.py
+++ b/generic/tests/vlan.py
@@ -6,7 +6,9 @@ import aexpect
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, utils_test, utils_net
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import utils_net
 
 
 @error.context_aware

--- a/generic/tests/whql_client_install.py
+++ b/generic/tests/whql_client_install.py
@@ -1,9 +1,14 @@
 import logging
 import time
 import os
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_test, remote
-from virttest import rss_client, data_dir
+
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import remote
+from virttest import rss_client
+from virttest import data_dir
 
 
 def run(test, params, env):

--- a/generic/tests/whql_env_setup.py
+++ b/generic/tests/whql_env_setup.py
@@ -2,12 +2,14 @@ import time
 import os
 import re
 import logging
+
 from autotest.client.shared import error
+from autotest.client import utils
+
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import env_process
 from virttest import data_dir
-from autotest.client import utils
 
 
 @error.context_aware

--- a/generic/tests/whql_hck_client_install.py
+++ b/generic/tests/whql_hck_client_install.py
@@ -1,9 +1,8 @@
 import logging
-import time
-import os
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_test, remote
-from virttest import rss_client
+
+from virttest import remote
 
 
 @error.context_aware

--- a/generic/tests/whql_submission.py
+++ b/generic/tests/whql_submission.py
@@ -1,8 +1,11 @@
 import logging
 import os
 import re
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect, utils_misc, remote, rss_client
+from virttest import utils_misc, remote, rss_client
 
 
 def run(test, params, env):

--- a/generic/tests/whql_submission.py
+++ b/generic/tests/whql_submission.py
@@ -5,7 +5,10 @@ import re
 import aexpect
 
 from autotest.client.shared import error
-from virttest import utils_misc, remote, rss_client
+
+from virttest import utils_misc
+from virttest import remote
+from virttest import rss_client
 
 
 def run(test, params, env):

--- a/openvswitch/tests/load_module.py
+++ b/openvswitch/tests/load_module.py
@@ -1,10 +1,12 @@
 import sys
 import traceback
 import logging
-from virttest import openvswitch
-from virttest import versionable_class
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
+from virttest import openvswitch
+from virttest import versionable_class
 
 
 @error.context_aware

--- a/openvswitch/tests/ovs_basic.py
+++ b/openvswitch/tests/ovs_basic.py
@@ -4,9 +4,14 @@ import os
 
 import aexpect
 
-from virttest import utils_misc, utils_net, openvswitch, ovs_utils
-from virttest import versionable_class, data_dir
 from autotest.client.shared import error
+
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import openvswitch
+from virttest import ovs_utils
+from virttest import versionable_class
+from virttest import data_dir
 
 
 def allow_iperf_firewall(machine):

--- a/openvswitch/tests/ovs_basic.py
+++ b/openvswitch/tests/ovs_basic.py
@@ -1,7 +1,10 @@
 import logging
 import time
 import os
-from virttest import utils_misc, aexpect, utils_net, openvswitch, ovs_utils
+
+import aexpect
+
+from virttest import utils_misc, utils_net, openvswitch, ovs_utils
 from virttest import versionable_class, data_dir
 from autotest.client.shared import error
 

--- a/provider/cpuflags.py
+++ b/provider/cpuflags.py
@@ -2,6 +2,7 @@
 Shared code for tests that make use of cpuflags
 """
 import os
+
 from virttest import data_dir
 
 

--- a/qemu/tests/9p.py
+++ b/qemu/tests/9p.py
@@ -1,6 +1,8 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -1,8 +1,12 @@
 import re
 import logging
 import random
+
 from autotest.client.shared import error
-from virttest import qemu_monitor, utils_test, utils_misc
+
+from virttest import qemu_monitor
+from virttest import utils_test
+from virttest import utils_misc
 
 
 class BallooningTest(object):

--- a/qemu/tests/balloon_disable.py
+++ b/qemu/tests/balloon_disable.py
@@ -1,7 +1,5 @@
-import logging
-import time
-import string
 from autotest.client.shared import error
+
 from virttest import qemu_monitor
 
 

--- a/qemu/tests/balloon_stress.py
+++ b/qemu/tests/balloon_stress.py
@@ -1,6 +1,7 @@
 import re
 import time
 import logging
+
 from autotest.client.shared import error
 from virttest import utils_misc
 

--- a/qemu/tests/blk_stream.py
+++ b/qemu/tests/blk_stream.py
@@ -1,6 +1,9 @@
 import logging
-from virttest import utils_misc
+
 from autotest.client.shared import error
+
+from virttest import utils_misc
+
 from qemu.tests import block_copy
 
 

--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -2,8 +2,10 @@ import re
 import time
 import random
 import logging
+
 from autotest.client.shared import utils
 from autotest.client.shared import error
+
 from virttest import data_dir
 from virttest import storage
 from virttest import utils_misc

--- a/qemu/tests/block_discard.py
+++ b/qemu/tests/block_discard.py
@@ -1,9 +1,11 @@
 import os
 import re
 import logging
+
 from autotest.client import os_dep
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import env_process
 
 

--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -1,7 +1,11 @@
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import qemu_monitor, utils_misc, storage, data_dir
+
+from virttest import utils_misc
+from virttest import storage
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/block_stream.py
+++ b/qemu/tests/block_stream.py
@@ -1,7 +1,10 @@
 import re
 import logging
+
 from autotest.client.shared import error, utils
+
 from virttest import env_process, utils_misc
+
 from qemu.tests import blk_stream
 
 

--- a/qemu/tests/block_stream_check_backingfile.py
+++ b/qemu/tests/block_stream_check_backingfile.py
@@ -1,6 +1,8 @@
 import logging
+
 from autotest.client.shared import error
 from virttest import utils_misc
+
 from qemu.tests import blk_stream
 
 

--- a/qemu/tests/block_stream_drop_backingfile.py
+++ b/qemu/tests/block_stream_drop_backingfile.py
@@ -1,10 +1,13 @@
 import os
 import re
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import storage
-from virttest import utils_misc, data_dir
+from virttest import utils_misc
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/block_stream_stress.py
+++ b/qemu/tests/block_stream_stress.py
@@ -1,8 +1,11 @@
 import time
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import utils_misc
+
 from qemu.tests import blk_stream
 
 

--- a/qemu/tests/boot_cpu_model.py
+++ b/qemu/tests/boot_cpu_model.py
@@ -1,6 +1,10 @@
 import logging
-from autotest.client.shared import error, utils
-from virttest import env_process, utils_misc, utils_test
+
+from autotest.client.shared import error
+
+from virttest import env_process
+from virttest import utils_misc
+from virttest import utils_test
 
 
 @error.context_aware

--- a/qemu/tests/boot_from_device.py
+++ b/qemu/tests/boot_from_device.py
@@ -2,12 +2,14 @@ import os
 import re
 import time
 import logging
+
 from autotest.client import utils
+from autotest.client.shared import error
+
 from virttest import utils_misc
 from virttest import data_dir
 from virttest import qemu_storage
 from virttest import env_process
-from autotest.client.shared import error
 
 
 @error.context_aware

--- a/qemu/tests/boot_order_check.py
+++ b/qemu/tests/boot_order_check.py
@@ -1,8 +1,10 @@
 import logging
 import re
+
 from autotest.client import utils
-from virttest import utils_misc
 from autotest.client.shared import error
+
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/boot_time.py
+++ b/qemu/tests/boot_time.py
@@ -1,14 +1,10 @@
 import logging
-import time
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
-
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
-
 from virttest import env_process
+from virttest.staging import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/boot_with_different_vectors.py
+++ b/qemu/tests/boot_with_different_vectors.py
@@ -1,8 +1,12 @@
 import logging
 import re
-from autotest.client import utils
+
 from autotest.client.shared import error
-from virttest import utils_net, utils_test, utils_misc, env_process, virt_vm
+
+from virttest import utils_net
+from virttest import utils_test
+from virttest import env_process
+from virttest import virt_vm
 
 
 @error.context_aware

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -13,10 +13,13 @@ import os
 import sys
 import tempfile
 import random
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
 from autotest.client.shared.syncdata import SyncData
-from virttest import utils_misc, aexpect, gluster
+from virttest import utils_misc, gluster
 from virttest import env_process, data_dir, utils_test
 
 

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -19,8 +19,12 @@ import aexpect
 from autotest.client.shared import error
 from autotest.client import utils
 from autotest.client.shared.syncdata import SyncData
-from virttest import utils_misc, gluster
-from virttest import env_process, data_dir, utils_test
+
+from virttest import utils_misc
+from virttest import gluster
+from virttest import env_process
+from virttest import data_dir
+from virttest import utils_test
 
 
 @error.context_aware

--- a/qemu/tests/cdrom_block_size_check.py
+++ b/qemu/tests/cdrom_block_size_check.py
@@ -1,10 +1,13 @@
 import re
 import logging
-import time
-import os.path
+import os
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import env_process, utils_disk, utils_misc, data_dir
+
+from virttest import env_process
+from virttest import utils_misc
+from virttest import data_dir
 
 
 # This decorator makes the test function aware of context strings

--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -7,13 +7,15 @@ import logging
 import os
 import re
 import time
+
+from aexpect import ExpectTimeoutError
+from aexpect import ExpectProcessTerminatedError
+from aexpect import ShellTimeoutError
+
 from autotest.client.shared import error
 from autotest.client import utils
 from virttest.env_process import preprocess
 from virttest import qemu_monitor
-from virttest.aexpect import ExpectTimeoutError
-from virttest.aexpect import ExpectProcessTerminatedError
-from virttest.aexpect import ShellTimeoutError
 try:
     from virttest.staging.utils_cgroup import Cgroup
     from virttest.staging.utils_cgroup import CgroupModules

--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -8,28 +8,20 @@ import os
 import re
 import time
 
+from autotest.client.shared import error
+from autotest.client import utils
+
 from aexpect import ExpectTimeoutError
 from aexpect import ExpectProcessTerminatedError
 from aexpect import ShellTimeoutError
 
-from autotest.client.shared import error
-from autotest.client import utils
 from virttest.env_process import preprocess
 from virttest import qemu_monitor
-try:
-    from virttest.staging.utils_cgroup import Cgroup
-    from virttest.staging.utils_cgroup import CgroupModules
-    from virttest.staging.utils_cgroup import get_load_per_cpu
-except ImportError:
-    # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
-    from autotest.client.shared.utils_cgroup import Cgroup
-    from autotest.client.shared.utils_cgroup import CgroupModules
-    from autotest.client.shared.utils_cgroup import get_load_per_cpu
 
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from virttest.staging import utils_memory
+from virttest.staging.utils_cgroup import Cgroup
+from virttest.staging.utils_cgroup import CgroupModules
+from virttest.staging.utils_cgroup import get_load_per_cpu
 
 
 # Serial ID of the attached disk
@@ -1883,7 +1875,7 @@ def run(test, params, env):
                 except ExpectTimeoutError:
                     # 0.1s passed, lets begin the next round
                     pass
-                except ShellTimeoutError, detail:
+                except ShellTimeoutError, details:
                     if memsw and not vm.is_alive():
                         # VM was killed, finish the test
                         break

--- a/qemu/tests/change_media.py
+++ b/qemu/tests/change_media.py
@@ -1,6 +1,8 @@
 import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import data_dir

--- a/qemu/tests/change_media.py
+++ b/qemu/tests/change_media.py
@@ -1,5 +1,4 @@
 import re
-import time
 import logging
 from autotest.client.shared import error
 from virttest import utils_misc
@@ -69,7 +68,7 @@ def run(test, params, env):
     logging.info("Wait until device is ready")
     exists = utils_misc.wait_for(lambda: (orig_img_name in
                                           str(monitor.info("block"))
-                                          ), timeout=10,  first=3)
+                                          ), timeout=10, first=3)
     if not exists:
         msg = "Fail to insert device %s to guest" % orig_img_name
         raise error.TestFail(msg)
@@ -80,8 +79,8 @@ def run(test, params, env):
     if params.get("os_type") != "windows":
         error.context("mount cdrom to make status to locked", logging.info)
         cdroms = utils_misc.wait_for(lambda: (utils_test.get_readable_cdroms(
-                                                  params, session)),
-                                     timeout=10)
+            params, session)),
+            timeout=10)
         if not cdroms:
             raise error.TestFail("Not readable cdrom found in your guest")
         cdrom = cdroms[0]

--- a/qemu/tests/check_block_size.py
+++ b/qemu/tests/check_block_size.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/check_coredump.py
+++ b/qemu/tests/check_coredump.py
@@ -6,8 +6,10 @@ import os
 import glob
 import logging
 import time
+
 from autotest.client import os_dep
 from autotest.client.shared import error
+
 from virttest import data_dir
 from virttest import utils_misc
 import virttest.utils_libguestfs as lgf

--- a/qemu/tests/client_guest_shutdown.py
+++ b/qemu/tests/client_guest_shutdown.py
@@ -1,5 +1,7 @@
 import time
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/cluster_size_check.py
+++ b/qemu/tests/cluster_size_check.py
@@ -2,7 +2,9 @@ import re
 import logging
 
 from autotest.client.shared import error
-from virttest import qemu_storage, data_dir
+
+from virttest import qemu_storage
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/cpu_add.py
+++ b/qemu/tests/cpu_add.py
@@ -1,8 +1,11 @@
 import logging
 import re
 import time
+
 from autotest.client.shared import error
-from virttest import utils_test, utils_misc
+
+from virttest import utils_test
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/cpu_hotplug.py
+++ b/qemu/tests/cpu_hotplug.py
@@ -1,8 +1,11 @@
 import os
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import utils_test, utils_misc
+
+from virttest import utils_test
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/cpuflags.py
+++ b/qemu/tests/cpuflags.py
@@ -10,11 +10,14 @@ from xml.parsers import expat
 
 import aexpect
 
-from virttest import qemu_vm, virt_vm, data_dir
-from virttest import utils_misc, utils_test
-
 from autotest.client.shared import error, utils
 from autotest.client.shared.syncdata import SyncData
+
+from virttest import qemu_vm
+from virttest import virt_vm
+from virttest import data_dir
+from virttest import utils_misc
+from virttest import utils_test
 
 
 def run(test, params, env):

--- a/qemu/tests/cpuflags.py
+++ b/qemu/tests/cpuflags.py
@@ -7,9 +7,13 @@ import pickle
 import sys
 import traceback
 from xml.parsers import expat
-from autotest.client.shared import error, utils
+
+import aexpect
+
 from virttest import qemu_vm, virt_vm, data_dir
-from virttest import utils_misc, utils_test, aexpect
+from virttest import utils_misc, utils_test
+
+from autotest.client.shared import error, utils
 from autotest.client.shared.syncdata import SyncData
 
 

--- a/qemu/tests/cpuid.py
+++ b/qemu/tests/cpuid.py
@@ -2,14 +2,18 @@
 Group of cpuid tests for X86 CPU
 """
 import re
-import sys
 import os
 import string
-from autotest.client.shared import error, utils
-from autotest.client.shared import test as test_module
-from virttest import utils_misc, env_process, virt_vm, data_dir
-
 import logging
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import utils_misc
+from virttest import env_process
+from virttest import virt_vm
+from virttest import data_dir
+
 logger = logging.getLogger(__name__)
 dbg = logger.debug
 info = logger.info

--- a/qemu/tests/cpuinfo_query.py
+++ b/qemu/tests/cpuinfo_query.py
@@ -1,6 +1,5 @@
-import logging
-import os
 from autotest.client.shared import error, utils
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/create_macvtap_device.py
+++ b/qemu/tests/create_macvtap_device.py
@@ -1,8 +1,11 @@
 import re
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_net, utils_test
+
+from virttest import utils_net
+from virttest import utils_test
 
 
 def get_macvtap_device_on_ifname(ifname):

--- a/qemu/tests/cyginstall.py
+++ b/qemu/tests/cyginstall.py
@@ -1,7 +1,6 @@
-import logging
 import re
+
 from autotest.client.shared import error
-from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/device_bit_check.py
+++ b/qemu/tests/device_bit_check.py
@@ -1,6 +1,8 @@
 import logging
 import re
+
 from autotest.client.shared import error
+
 from virttest import env_process
 
 

--- a/qemu/tests/device_option_check.py
+++ b/qemu/tests/device_option_check.py
@@ -1,6 +1,8 @@
 import logging
 import re
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 from virttest import env_process
 from virttest import qemu_qtree

--- a/qemu/tests/drive_mirror.py
+++ b/qemu/tests/drive_mirror.py
@@ -1,7 +1,13 @@
 import os
 import logging
+
 from autotest.client.shared import error, utils
-from virttest import utils_misc, storage, qemu_storage, nfs
+
+from virttest import utils_misc
+from virttest import storage
+from virttest import qemu_storage
+from virttest import nfs
+
 from qemu.tests import block_copy
 
 

--- a/qemu/tests/drive_mirror_complete.py
+++ b/qemu/tests/drive_mirror_complete.py
@@ -1,10 +1,13 @@
 import logging
 import time
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import data_dir
 from virttest import env_process
 from virttest import qemu_storage
+
 from qemu.tests import drive_mirror
 
 

--- a/qemu/tests/drive_mirror_continuous_backup.py
+++ b/qemu/tests/drive_mirror_continuous_backup.py
@@ -1,8 +1,12 @@
 import logging
 import time
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
-from virttest import qemu_storage, data_dir
+
+from virttest import qemu_storage
+from virttest import data_dir
+
 from qemu.tests import drive_mirror
 
 

--- a/qemu/tests/drive_mirror_powerdown.py
+++ b/qemu/tests/drive_mirror_powerdown.py
@@ -1,6 +1,9 @@
 import logging
-from virttest import env_process
+
 from autotest.client.shared import error
+
+from virttest import env_process
+
 from qemu.tests import drive_mirror_stress
 
 

--- a/qemu/tests/drive_mirror_stress.py
+++ b/qemu/tests/drive_mirror_stress.py
@@ -1,8 +1,11 @@
 import time
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import utils_misc
+
 from qemu.tests import drive_mirror
 
 

--- a/qemu/tests/driver_load.py
+++ b/qemu/tests/driver_load.py
@@ -1,7 +1,9 @@
 import logging
 import re
 import time
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/eject_media.py
+++ b/qemu/tests/eject_media.py
@@ -1,6 +1,8 @@
 import logging
 import time
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/enforce_quit.py
+++ b/qemu/tests/enforce_quit.py
@@ -1,7 +1,10 @@
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import env_process, utils_misc
+
+from virttest import env_process
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/enospc.py
+++ b/qemu/tests/enospc.py
@@ -2,9 +2,14 @@ import logging
 import time
 import re
 import os
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import virt_vm, utils_misc, qemu_storage, data_dir
+
+from virttest import virt_vm
+from virttest import utils_misc
+from virttest import qemu_storage
+from virttest import data_dir
 
 
 class EnospcConfig(object):

--- a/qemu/tests/file_copy_stress.py
+++ b/qemu/tests/file_copy_stress.py
@@ -1,9 +1,10 @@
-import os
 import time
 import logging
+
 from autotest.client.shared import error
-from autotest.client import utils
-from virttest import data_dir, utils_misc, utils_test
+
+from virttest import utils_misc
+from virttest import utils_test
 
 
 @error.context_aware

--- a/qemu/tests/flag_check.py
+++ b/qemu/tests/flag_check.py
@@ -1,8 +1,11 @@
 import re
 import logging
 import os.path
-from virttest import utils_misc, data_dir
+
 from autotest.client.shared import utils, error
+
+from virttest import utils_misc
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/floppy.py
+++ b/qemu/tests/floppy.py
@@ -10,7 +10,9 @@ from autotest.client import utils
 from autotest.client.shared import error
 from autotest.client.shared.syncdata import SyncData
 
-from virttest import data_dir, env_process, utils_test
+from virttest import data_dir
+from virttest import env_process
+from virttest import utils_test
 
 
 @error.context_aware

--- a/qemu/tests/floppy.py
+++ b/qemu/tests/floppy.py
@@ -3,10 +3,14 @@ import time
 import os
 import sys
 import re
-from autotest.client.shared import error
+
+import aexpect
+
 from autotest.client import utils
+from autotest.client.shared import error
 from autotest.client.shared.syncdata import SyncData
-from virttest import data_dir, env_process, utils_test, aexpect
+
+from virttest import data_dir, env_process, utils_test
 
 
 @error.context_aware

--- a/qemu/tests/flow_caches_stress_test.py
+++ b/qemu/tests/flow_caches_stress_test.py
@@ -1,9 +1,14 @@
 import logging
-import time
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_netperf, utils_net, env_process, utils_misc
-from virttest import data_dir, utils_test
+
+from virttest import utils_netperf
+from virttest import utils_net
+from virttest import env_process
+from virttest import utils_misc
+from virttest import data_dir
+from virttest import utils_test
 
 
 # This decorator makes the test function aware of context strings

--- a/qemu/tests/format_disk.py
+++ b/qemu/tests/format_disk.py
@@ -1,7 +1,11 @@
 import logging
 import re
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import utils_misc, aexpect
+
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/fullscreen_setup.py
+++ b/qemu/tests/fullscreen_setup.py
@@ -7,7 +7,9 @@ the same setup will result in them having the same resolution.
 
 """
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_spice
 
 

--- a/qemu/tests/gluster_boot_snap_boot.py
+++ b/qemu/tests/gluster_boot_snap_boot.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import env_process
 from virttest import qemu_storage
 from virttest import data_dir

--- a/qemu/tests/gluster_create_images.py
+++ b/qemu/tests/gluster_create_images.py
@@ -1,5 +1,5 @@
-import logging
 from autotest.client.shared import error
+
 from virttest import env_process
 
 

--- a/qemu/tests/guest_memory_dump_analysis.py
+++ b/qemu/tests/guest_memory_dump_analysis.py
@@ -9,12 +9,14 @@ Related RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=990118
 """
 
 import logging
-from virttest.aexpect import ShellCmdError
-from autotest.client.shared import error
 import string
 import os
 import gzip
 import threading
+
+from aexpect import ShellCmdError
+
+from autotest.client.shared import error
 
 REQ_GUEST_MEM = 4096        # exact size of guest RAM required
 REQ_GUEST_ARCH = "x86_64"    # the only supported guest arch

--- a/qemu/tests/hdparm.py
+++ b/qemu/tests/hdparm.py
@@ -1,7 +1,9 @@
 import re
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
 
 
 @error.context_aware

--- a/qemu/tests/invalid_parameter.py
+++ b/qemu/tests/invalid_parameter.py
@@ -1,7 +1,8 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import env_process
-from virttest import virt_vm
 
 
 @error.context_aware

--- a/qemu/tests/ipi_x2apic.py
+++ b/qemu/tests/ipi_x2apic.py
@@ -1,8 +1,12 @@
 import logging
 import os
 import re
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import env_process, aexpect
+
+from virttest import env_process
 
 
 def get_re_average(opt, re_str):

--- a/qemu/tests/kdump_with_stress.py
+++ b/qemu/tests/kdump_with_stress.py
@@ -1,7 +1,11 @@
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test, utils_misc
+
+from virttest import utils_test
+from virttest import utils_misc
+
 from generic.tests import kdump
 
 

--- a/qemu/tests/kernbench.py
+++ b/qemu/tests/kernbench.py
@@ -2,8 +2,10 @@ import logging
 import commands
 import os
 import re
-from autotest.client import test, utils, job
+
+from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import env_process
 
 

--- a/qemu/tests/kernel_install.py
+++ b/qemu/tests/kernel_install.py
@@ -1,8 +1,11 @@
 import logging
 import os
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test, data_dir
+
+from virttest import utils_test
+from virttest import data_dir
 
 CLIENT_TEST = "kernelinstall"
 

--- a/qemu/tests/kexec.py
+++ b/qemu/tests/kexec.py
@@ -1,7 +1,6 @@
 import logging
-import os
+
 from autotest.client.shared import error
-from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/ksm_base.py
+++ b/qemu/tests/ksm_base.py
@@ -4,8 +4,12 @@ import random
 import os
 import commands
 import re
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect, utils_test, utils_misc, data_dir
+
+from virttest import utils_test, utils_misc, data_dir
 
 
 TMPFS_OVERHEAD = 0.0022

--- a/qemu/tests/ksm_base.py
+++ b/qemu/tests/ksm_base.py
@@ -9,8 +9,7 @@ import aexpect
 
 from autotest.client.shared import error
 
-from virttest import utils_test, utils_misc, data_dir
-
+from virttest import utils_misc, data_dir
 
 TMPFS_OVERHEAD = 0.0022
 

--- a/qemu/tests/ksm_overcommit.py
+++ b/qemu/tests/ksm_overcommit.py
@@ -10,11 +10,7 @@ from autotest.client.shared import error
 from autotest.client.shared import utils
 
 from virttest import utils_misc, utils_test, env_process, data_dir
-
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from virttest.staging import utils_memory
 
 
 def run(test, params, env):

--- a/qemu/tests/ksm_overcommit.py
+++ b/qemu/tests/ksm_overcommit.py
@@ -3,10 +3,13 @@ import time
 import random
 import math
 import os
-from autotest.client.shared import error
-from virttest import utils_misc, utils_test, aexpect, env_process, data_dir
 
+import aexpect
+
+from autotest.client.shared import error
 from autotest.client.shared import utils
+
+from virttest import utils_misc, utils_test, env_process, data_dir
 
 try:
     from virttest.staging import utils_memory

--- a/qemu/tests/live_snapshot.py
+++ b/qemu/tests/live_snapshot.py
@@ -1,6 +1,8 @@
 import time
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/live_snapshot_base.py
+++ b/qemu/tests/live_snapshot_base.py
@@ -1,7 +1,11 @@
 import logging
+
 from autotest.client import utils
-from virttest import utils_misc, storage, data_dir
 from autotest.client.shared import error
+
+from virttest import utils_misc
+from virttest import storage
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/live_snapshot_chain.py
+++ b/qemu/tests/live_snapshot_chain.py
@@ -1,10 +1,12 @@
-from virttest import storage
-from virttest import qemu_storage
-from virttest import data_dir
-from autotest.client.shared import error
 import re
 import logging
 import time
+
+from autotest.client.shared import error
+
+from virttest import storage
+from virttest import qemu_storage
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/macvtap_event_notification.py
+++ b/qemu/tests/macvtap_event_notification.py
@@ -1,7 +1,11 @@
 import logging
 import time
+
 from autotest.client.shared import error, utils
-from virttest import utils_misc, utils_net, env_process
+
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import env_process
 
 
 @error.context_aware

--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -7,7 +7,8 @@ import aexpect
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, utils_test
+from virttest import utils_misc
+from virttest import utils_test
 
 
 @error.context_aware

--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -2,8 +2,12 @@ import logging
 import time
 import types
 import re
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_test, aexpect
+
+from virttest import utils_misc, utils_test
 
 
 @error.context_aware

--- a/qemu/tests/migration_after_nichotplug.py
+++ b/qemu/tests/migration_after_nichotplug.py
@@ -1,7 +1,11 @@
 import logging
 import time
+
 from autotest.client.shared import error
-from virttest import utils_test, virt_vm, utils_net
+
+from virttest import utils_test
+from virttest import virt_vm
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/migration_multi_host.py
+++ b/qemu/tests/migration_multi_host.py
@@ -1,6 +1,8 @@
 import logging
 import time
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/migration_multi_host_cancel.py
+++ b/qemu/tests/migration_multi_host_cancel.py
@@ -1,9 +1,12 @@
 import logging
 import os
+
 from autotest.client.shared import error
+
 from virttest import remote
 from virttest import utils_test
 from virttest import virt_vm
+
 from provider import cpuflags
 
 

--- a/qemu/tests/migration_multi_host_downtime_and_speed.py
+++ b/qemu/tests/migration_multi_host_downtime_and_speed.py
@@ -1,9 +1,15 @@
 import logging
 import os
 import time
+
 from autotest.client.shared import error
-from virttest import utils_test, remote, virt_vm, utils_misc
 from autotest.client.shared import utils
+
+from virttest import utils_test
+from virttest import remote
+from virttest import virt_vm
+from virttest import utils_misc
+
 from provider import cpuflags
 
 

--- a/qemu/tests/migration_multi_host_firewall_block.py
+++ b/qemu/tests/migration_multi_host_firewall_block.py
@@ -1,9 +1,15 @@
 import logging
 import os
 import time
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test, remote, virt_vm, utils_misc, qemu_monitor
+
+from virttest import utils_test
+from virttest import virt_vm
+from virttest import utils_misc
+from virttest import qemu_monitor
+
 from provider import cpuflags
 
 

--- a/qemu/tests/migration_multi_host_firewall_block.py
+++ b/qemu/tests/migration_multi_host_firewall_block.py
@@ -210,7 +210,7 @@ def run(test, params, env):
                 test, params, env)
 
         def migrate_vms_src(self, mig_data):
-            super(TestMultihostMigrationLongWait,
+            super(TestMultihostMigrationShortInterrupt,
                   self).migrate_vms_src(mig_data)
             self._hosts_barrier(self.hosts, mig_data.mig_id, 'mig_started',
                                 self.mig_timeout)
@@ -256,7 +256,7 @@ def run(test, params, env):
 
             :param mig_data: object with migration data.
             """
-            super(TestMultihostMigrationLongWait, self).check_vms_dst(mig_data)
+            super(TestMultihostMigrationShortInterrupt, self).check_vms_dst(mig_data)
 
         def check_vms_src(self, mig_data):
             """
@@ -264,7 +264,7 @@ def run(test, params, env):
 
             :param mig_data: object with migration data.
             """
-            super(TestMultihostMigrationLongWait, self).check_vms_src(mig_data)
+            super(TestMultihostMigrationShortInterrupt, self).check_vms_src(mig_data)
 
     mig = None
     if sub_type == "long_wait":

--- a/qemu/tests/migration_multi_host_helper_tests.py
+++ b/qemu/tests/migration_multi_host_helper_tests.py
@@ -1,10 +1,7 @@
 import re
 import time
+
 from autotest.client.shared import error
-from virttest import utils_test
-from virttest import remote
-from virttest import virt_vm
-from virttest import utils_misc
 
 
 class MiniSubtest(object):

--- a/qemu/tests/migration_multi_host_ping_pong.py
+++ b/qemu/tests/migration_multi_host_ping_pong.py
@@ -1,9 +1,13 @@
 import logging
 import os
+
 from autotest.client.shared import error
-from autotest.client import utils
-from virttest import env_process, utils_test, remote, virt_vm, utils_misc
 from autotest.client.shared.syncdata import SyncData
+
+from virttest import env_process
+from virttest import utils_test
+from virttest import utils_misc
+
 from provider import cpuflags
 
 

--- a/qemu/tests/migration_multi_host_timedrift.py
+++ b/qemu/tests/migration_multi_host_timedrift.py
@@ -1,8 +1,10 @@
 import logging
 import time
+
 from autotest.client.shared import error, utils
-from virttest import utils_test
 from autotest.client.shared.syncdata import SyncData
+
+from virttest import utils_test
 
 
 @error.context_aware

--- a/qemu/tests/migration_multi_host_with_file_transfer.py
+++ b/qemu/tests/migration_multi_host_with_file_transfer.py
@@ -1,9 +1,14 @@
 import logging
 import threading
+
 from autotest.client import utils as client_utils
-from autotest.client.shared import utils, error
+from autotest.client.shared import utils
+from autotest.client.shared import error
 from autotest.client.shared.syncdata import SyncData
-from virttest import env_process, utils_test, remote
+
+from virttest import env_process
+from virttest import utils_test
+from virttest import remote
 from virttest import utils_misc
 
 

--- a/qemu/tests/migration_multi_host_with_speed_measurement.py
+++ b/qemu/tests/migration_multi_host_with_speed_measurement.py
@@ -3,10 +3,14 @@ import re
 import logging
 import time
 import socket
+
 from autotest.client.shared import error, utils
 from autotest.client.shared.barrier import listen_server
 from autotest.client.shared.syncdata import SyncData
-from virttest import utils_test, utils_misc
+
+from virttest import utils_test
+from virttest import utils_misc
+
 from provider import cpuflags
 
 

--- a/qemu/tests/migration_with_dst_problem.py
+++ b/qemu/tests/migration_with_dst_problem.py
@@ -3,9 +3,12 @@ import os
 import time
 import re
 import sys
+
+import aexpect
+
 from autotest.client.shared import utils, error
-from autotest.client import utils as client_utils
-from virttest import aexpect, env_process, utils_misc, qemu_storage
+
+from virttest import env_process, utils_misc, qemu_storage
 
 
 @error.context_aware

--- a/qemu/tests/migration_with_dst_problem.py
+++ b/qemu/tests/migration_with_dst_problem.py
@@ -8,7 +8,9 @@ import aexpect
 
 from autotest.client.shared import utils, error
 
-from virttest import env_process, utils_misc, qemu_storage
+from virttest import env_process
+from virttest import utils_misc
+from virttest import qemu_storage
 
 
 @error.context_aware

--- a/qemu/tests/migration_with_file_transfer.py
+++ b/qemu/tests/migration_with_file_transfer.py
@@ -1,7 +1,10 @@
 import logging
 import os
-from autotest.client.shared import utils, error
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
 from autotest.client import utils as client_utils
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/migration_with_netperf.py
+++ b/qemu/tests/migration_with_netperf.py
@@ -1,7 +1,11 @@
 import logging
-from autotest.client import utils
+
 from autotest.client.shared import error
-from virttest import utils_netperf, utils_misc, data_dir, utils_net
+
+from virttest import utils_netperf
+from virttest import utils_misc
+from virttest import data_dir
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -2,8 +2,10 @@ import os
 import re
 import logging
 import time
-from virttest import utils_misc
-from autotest.client.shared import error, utils
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from provider import cpuflags
 
 

--- a/qemu/tests/monitor_cmds_check.py
+++ b/qemu/tests/monitor_cmds_check.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import qemu_monitor
 
 

--- a/qemu/tests/mq_change_qnum.py
+++ b/qemu/tests/mq_change_qnum.py
@@ -1,11 +1,14 @@
 import logging
 import re
+
+import aexpect
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import utils_net
 from virttest import utils_test
 from virttest import utils_misc
-from virttest import aexpect
 
 
 @error.context_aware

--- a/qemu/tests/multi_disk.py
+++ b/qemu/tests/multi_disk.py
@@ -7,8 +7,13 @@ import logging
 import re
 import random
 import string
-from autotest.client.shared import error, utils
-from virttest import qemu_qtree, env_process, utils_misc
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import qemu_qtree
+from virttest import env_process
+from virttest import utils_misc
 
 _RE_RANGE1 = re.compile(r'range\([ ]*([-]?\d+|n).*\)')
 _RE_RANGE2 = re.compile(r',[ ]*([-]?\d+|n)')

--- a/qemu/tests/multi_disk_random_hotplug.py
+++ b/qemu/tests/multi_disk_random_hotplug.py
@@ -7,9 +7,14 @@ import logging
 import random
 import time
 import threading
+
 from autotest.client.shared import error
-from virttest import funcatexit, data_dir
-from virttest import qemu_qtree, utils_test, env_process
+
+from virttest import funcatexit
+from virttest import data_dir
+from virttest import qemu_qtree
+from virttest import utils_test
+from virttest import env_process
 from virttest.qemu_devices import utils
 from virttest.remote import LoginTimeoutError
 

--- a/qemu/tests/multi_macvtap_devices.py
+++ b/qemu/tests/multi_macvtap_devices.py
@@ -6,7 +6,8 @@ import aexpect
 from autotest.client import utils
 from autotest.client.shared import error
 
-from virttest import utils_net, env_process
+from virttest import utils_net
+from virttest import env_process
 
 
 def guest_ping(session, dst_ip, count=None, os_type="linux",

--- a/qemu/tests/multi_macvtap_devices.py
+++ b/qemu/tests/multi_macvtap_devices.py
@@ -1,9 +1,12 @@
 import logging
 import time
-import random
+
+import aexpect
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_net, env_process, aexpect
+
+from virttest import utils_net, env_process
 
 
 def guest_ping(session, dst_ip, count=None, os_type="linux",

--- a/qemu/tests/multi_nics_stress.py
+++ b/qemu/tests/multi_nics_stress.py
@@ -1,9 +1,14 @@
-import re
 import os
 import logging
 import time
+
 from autotest.client.shared import error
-from virttest import utils_net, utils_netperf, utils_misc, data_dir, utils_test
+
+from virttest import utils_net
+from virttest import utils_netperf
+from virttest import utils_misc
+from virttest import data_dir
+from virttest import utils_test
 
 
 def launch_netperf_client(server_ips, netperf_clients, test_option,

--- a/qemu/tests/multi_nics_verify.py
+++ b/qemu/tests/multi_nics_verify.py
@@ -1,7 +1,9 @@
 import os
 import logging
+
 from autotest.client.shared import error
-from virttest import utils_test, utils_net
+
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/multi_vms_file_transfer.py
+++ b/qemu/tests/multi_vms_file_transfer.py
@@ -1,9 +1,13 @@
 import time
 import os
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import remote, utils_misc, data_dir
+
+from virttest import remote
+from virttest import utils_misc
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/multi_vms_nics.py
+++ b/qemu/tests/multi_vms_nics.py
@@ -1,8 +1,12 @@
 import logging
 import time
 import re
+
 from autotest.client.shared import error
-from virttest import utils_test, remote, utils_net
+
+from virttest import utils_test
+from virttest import remote
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/negative_create.py
+++ b/qemu/tests/negative_create.py
@@ -1,5 +1,7 @@
 import logging
-from virttest import virt_vm, utils_misc, utils_net
+
+from virttest import virt_vm
+from virttest import utils_net
 from virttest import env_process
 
 

--- a/qemu/tests/netperf_stress.py
+++ b/qemu/tests/netperf_stress.py
@@ -1,9 +1,13 @@
-import re
 import os
 import logging
 import time
+
 from autotest.client.shared import error
-from virttest import utils_net, utils_netperf, utils_misc, data_dir
+
+from virttest import utils_net
+from virttest import utils_netperf
+from virttest import utils_misc
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/netperf_udp.py
+++ b/qemu/tests/netperf_udp.py
@@ -1,9 +1,12 @@
 import logging
 import os
 import re
-from autotest.client import utils
+
 from autotest.client.shared import error
-from virttest import utils_net, utils_netperf, utils_misc, data_dir
+
+from virttest import utils_net
+from virttest import utils_netperf
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/nfs_perf.py
+++ b/qemu/tests/nfs_perf.py
@@ -1,8 +1,10 @@
 import logging
 import re
 import os
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import utils_misc
 
 STEP_1, STEP_2, STEP_3, STEP_4, STEP_5, STEP_6 = range(6)

--- a/qemu/tests/nic_bonding.py
+++ b/qemu/tests/nic_bonding.py
@@ -1,8 +1,12 @@
 import logging
 import time
 import random
-from virttest import utils_test, aexpect, utils_net
+
+import aexpect
+
 from autotest.client.shared import error, utils
+
+from virttest import utils_test, utils_net
 
 
 def run(test, params, env):

--- a/qemu/tests/nic_bonding.py
+++ b/qemu/tests/nic_bonding.py
@@ -4,9 +4,11 @@ import random
 
 import aexpect
 
-from autotest.client.shared import error, utils
+from autotest.client.shared import error
+from autotest.client.shared import utils
 
-from virttest import utils_test, utils_net
+from virttest import utils_test
+from virttest import utils_net
 
 
 def run(test, params, env):

--- a/qemu/tests/nic_bonding_host.py
+++ b/qemu/tests/nic_bonding_host.py
@@ -1,8 +1,10 @@
 import time
 import logging
 import re
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import env_process

--- a/qemu/tests/nic_hotplug.py
+++ b/qemu/tests/nic_hotplug.py
@@ -1,7 +1,13 @@
 import logging
 import random
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_net, virt_vm, utils_misc
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import utils_test
+from virttest import utils_net
+from virttest import virt_vm
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/nic_teaming.py
+++ b/qemu/tests/nic_teaming.py
@@ -2,8 +2,12 @@ import time
 import re
 import random
 import logging
-from virttest import utils_test, utils_net
-from autotest.client.shared import error, utils
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import utils_test
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/nonexist_vcpu_hotplug.py
+++ b/qemu/tests/nonexist_vcpu_hotplug.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/numa_basic.py
+++ b/qemu/tests/numa_basic.py
@@ -1,11 +1,11 @@
 import logging
-from autotest.client.shared import error
-from virttest import env_process, utils_misc, utils_test
 
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from autotest.client.shared import error
+
+from virttest import env_process
+from virttest import utils_misc
+from virttest import utils_test
+from virttest.staging import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/numa_consistency.py
+++ b/qemu/tests/numa_consistency.py
@@ -1,13 +1,12 @@
 import logging
-from autotest.client.shared import error
 
-from virttest import env_process, utils_misc, utils_test
+from autotest.client.shared import error
 from autotest.client.shared import utils
 
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from virttest import env_process
+from virttest import utils_misc
+from virttest import utils_test
+from virttest.staging import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/numa_opts.py
+++ b/qemu/tests/numa_opts.py
@@ -1,7 +1,7 @@
-from autotest.client.shared import error
-from virttest import qemu_vm
-
 import logging
+
+from autotest.client.shared import error
+
 logger = logging.getLogger(__name__)
 dbg = logger.debug
 

--- a/qemu/tests/numa_stress.py
+++ b/qemu/tests/numa_stress.py
@@ -1,14 +1,16 @@
 import logging
 import os
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_misc, funcatexit, utils_test, data_dir
-from generic.tests import autotest_control
 
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from virttest import utils_misc
+from virttest import funcatexit
+from virttest import utils_test
+from virttest import data_dir
+from virttest.staging import utils_memory
+
+from generic.tests import autotest_control
 
 
 def max_mem_map_node(host_numa_node, qemu_pid):

--- a/qemu/tests/nx.py
+++ b/qemu/tests/nx.py
@@ -1,6 +1,8 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import data_dir
 
 

--- a/qemu/tests/openflow_acl_test.py
+++ b/qemu/tests/openflow_acl_test.py
@@ -7,7 +7,7 @@ import aexpect
 from autotest.client.shared import error
 from autotest.client.shared import utils
 
-from virttest import utils_net, utils_test, utils_misc
+from virttest import utils_net
 from virttest import remote
 from virttest import data_dir
 

--- a/qemu/tests/openflow_acl_test.py
+++ b/qemu/tests/openflow_acl_test.py
@@ -1,10 +1,13 @@
 import logging
 import re
 import os
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import utils_net, utils_test, utils_misc
-from virttest import aexpect
 from virttest import remote
 from virttest import data_dir
 

--- a/qemu/tests/openflow_test.py
+++ b/qemu/tests/openflow_test.py
@@ -1,8 +1,12 @@
 import logging
 import re
 import time
+
 from autotest.client.shared import error
-from virttest import utils_net, utils_test, utils_misc
+
+from virttest import utils_net
+from virttest import utils_test
+from virttest import utils_misc
 from virttest import remote
 
 

--- a/qemu/tests/ovs_mirror.py
+++ b/qemu/tests/ovs_mirror.py
@@ -4,8 +4,11 @@ import glob
 import shutil
 import time
 import logging
+
 from autotest.client import os_dep
-from autotest.client.shared import error, utils
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from virttest import utils_net
 from virttest import env_process
 

--- a/qemu/tests/ovs_qos.py
+++ b/qemu/tests/ovs_qos.py
@@ -4,9 +4,13 @@ import time
 import glob
 import shutil
 import logging
+
 from autotest.client import os_dep
-from autotest.client.shared import error, utils
-from virttest import utils_netperf, data_dir
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import utils_netperf
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/ovs_quit.py
+++ b/qemu/tests/ovs_quit.py
@@ -1,6 +1,11 @@
 from autotest.client import os_dep
-from autotest.client.shared import error, utils
-from virttest import data_dir, env_process, virt_vm, utils_misc
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import data_dir
+from virttest import env_process
+from virttest import virt_vm
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/pci_devices.py
+++ b/qemu/tests/pci_devices.py
@@ -5,13 +5,15 @@ This is a autotest/virt-test test for testing PCI devices in various PCI setups
 :author: Lukas Doktor <ldoktor@redhat.com>
 :copyright: 2013 Red Hat, Inc.
 """
-from autotest.client.shared import error
-from virttest import env_process
-from virttest import qemu_qtree
 import logging
 import random
 import re
 import time
+
+from autotest.client.shared import error
+
+from virttest import env_process
+from virttest import qemu_qtree
 
 
 class PCIBusInfo:

--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -6,7 +6,11 @@ import aexpect
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, storage, utils_test, data_dir, arch
+from virttest import utils_misc
+from virttest import storage
+from virttest import utils_test
+from virttest import data_dir
+from virttest import arch
 
 
 @error.context_aware

--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -1,8 +1,12 @@
 import re
 import logging
 import string
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import utils_misc, aexpect, storage, utils_test, data_dir, arch
+
+from virttest import utils_misc, storage, utils_test, data_dir, arch
 
 
 @error.context_aware

--- a/qemu/tests/pci_hotplug_check.py
+++ b/qemu/tests/pci_hotplug_check.py
@@ -3,10 +3,13 @@ import logging
 import time
 import random
 import string
+
+import aexpect
+
 from autotest.client.shared import error
+
 from virttest import data_dir
 from virttest import utils_misc
-from virttest import aexpect
 from virttest import storage
 from virttest import arch
 from virttest import env_process

--- a/qemu/tests/pci_hotunplug.py
+++ b/qemu/tests/pci_hotunplug.py
@@ -1,7 +1,10 @@
 import re
 import logging
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_test
+
+from virttest import utils_misc
+from virttest import utils_test
 
 
 @error.context_aware

--- a/qemu/tests/performance.py
+++ b/qemu/tests/performance.py
@@ -1,14 +1,17 @@
 import os
 import re
 import commands
-import glob
 import shutil
 import shelve
 import threading
 from Queue import Queue
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test, utils_misc, data_dir
+
+from virttest import utils_test
+from virttest import utils_misc
+from virttest import data_dir
 
 
 def cmd_runner_monitor(vm, monitor_cmd, test_cmd, guest_path, timeout=300):

--- a/qemu/tests/physical_resources_check.py
+++ b/qemu/tests/physical_resources_check.py
@@ -2,8 +2,15 @@ import re
 import string
 import logging
 import random
-from autotest.client.shared import error, utils
-from virttest import qemu_monitor, storage, utils_misc, env_process, data_dir
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import qemu_monitor
+from virttest import storage
+from virttest import utils_misc
+from virttest import env_process
+from virttest import data_dir
 from virttest import qemu_qtree
 
 

--- a/qemu/tests/ping_kill_test.py
+++ b/qemu/tests/ping_kill_test.py
@@ -1,9 +1,12 @@
 import logging
 import time
-import re
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
-from virttest import aexpect, utils_net
+
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/pktgen.py
+++ b/qemu/tests/pktgen.py
@@ -2,12 +2,15 @@ import logging
 import re
 import time
 import os
+
+import aexpect
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import remote
 from virttest import data_dir
 from virttest import utils_net
-from virttest import aexpect
 from virttest import utils_test
 from virttest import utils_misc
 

--- a/qemu/tests/pxe_query_cpus.py
+++ b/qemu/tests/pxe_query_cpus.py
@@ -1,9 +1,14 @@
 import os
 import time
 import logging
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_misc
-from virttest import qemu_monitor, env_process
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import utils_test
+from virttest import utils_misc
+from virttest import qemu_monitor
+from virttest import env_process
 
 
 @error.context_aware

--- a/qemu/tests/qcow2perf.py
+++ b/qemu/tests/qcow2perf.py
@@ -1,10 +1,11 @@
 import re
 import logging
-import time
+
 from autotest.client.shared import error
-from virttest import qemu_io, data_dir
-from virttest.qemu_storage import QemuImg
 from autotest.client import utils
+
+from virttest import data_dir
+from virttest.qemu_storage import QemuImg
 
 
 @error.context_aware

--- a/qemu/tests/qemu_disk_img.py
+++ b/qemu/tests/qemu_disk_img.py
@@ -1,10 +1,14 @@
 import os
 import re
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import data_dir, env_process
-from virttest import storage, qemu_storage
+
+from virttest import data_dir
+from virttest import env_process
+from virttest import storage
+from virttest import qemu_storage
 
 
 class QemuImgTest(qemu_storage.QemuImg):

--- a/qemu/tests/qemu_disk_img_convert.py
+++ b/qemu/tests/qemu_disk_img_convert.py
@@ -1,7 +1,10 @@
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import storage
+
 from qemu.tests import qemu_disk_img
 
 

--- a/qemu/tests/qemu_disk_img_info.py
+++ b/qemu/tests/qemu_disk_img_info.py
@@ -1,10 +1,11 @@
 import re
-import copy
-import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from qemu.tests import qemu_disk_img
+
 from virttest import storage
+
+from qemu.tests import qemu_disk_img
 
 
 class InfoTest(qemu_disk_img.QemuImgTest):

--- a/qemu/tests/qemu_disk_img_rebase.py
+++ b/qemu/tests/qemu_disk_img_rebase.py
@@ -1,10 +1,13 @@
 import re
 import copy
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from qemu.tests import qemu_disk_img
+
 from virttest import storage
+
+from qemu.tests import qemu_disk_img
 
 
 class RebaseTest(qemu_disk_img.QemuImgTest):

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -1,11 +1,14 @@
 import logging
 import time
 import os
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import guest_agent
 from virttest import utils_misc
-from virttest import aexpect
 
 
 class BaseVirtTest(object):

--- a/qemu/tests/qemu_guest_agent_snapshot.py
+++ b/qemu/tests/qemu_guest_agent_snapshot.py
@@ -1,6 +1,9 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import storage, data_dir
+
+from virttest import storage
+from virttest import data_dir
 
 from qemu.tests.qemu_guest_agent import QemuGuestAgentBasicCheck
 

--- a/qemu/tests/qemu_guest_agent_suspend.py
+++ b/qemu/tests/qemu_guest_agent_suspend.py
@@ -1,6 +1,9 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import guest_agent
+
 from generic.tests.guest_suspend import GuestSuspendBaseTest
 from qemu.tests.qemu_guest_agent import QemuGuestAgentTest
 

--- a/qemu/tests/qemu_img.py
+++ b/qemu/tests/qemu_img.py
@@ -4,8 +4,10 @@ import logging
 import commands
 import shutil
 import tempfile
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import utils_misc
 from virttest import env_process
 from virttest import storage

--- a/qemu/tests/qemu_io.py
+++ b/qemu/tests/qemu_io.py
@@ -2,9 +2,13 @@ import os
 import re
 import logging
 import time
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import aexpect, utils_misc, data_dir
+
+from virttest import utils_misc, data_dir
 
 
 class QemuIOConfig(object):

--- a/qemu/tests/qemu_io.py
+++ b/qemu/tests/qemu_io.py
@@ -8,7 +8,8 @@ import aexpect
 from autotest.client.shared import error
 from autotest.client import utils
 
-from virttest import utils_misc, data_dir
+from virttest import utils_misc
+from virttest import data_dir
 
 
 class QemuIOConfig(object):

--- a/qemu/tests/qemu_io_blkdebug.py
+++ b/qemu/tests/qemu_io_blkdebug.py
@@ -1,11 +1,14 @@
 import re
 import logging
 import ConfigParser
+
 from autotest.client.shared import error
-from virttest import qemu_io, data_dir
+from autotest.client import utils
+
+from virttest import qemu_io
+from virttest import data_dir
 from virttest import utils_misc
 from virttest.qemu_storage import QemuImg
-from autotest.client import utils
 
 
 @error.context_aware

--- a/qemu/tests/qemu_iotests.py
+++ b/qemu/tests/qemu_iotests.py
@@ -1,6 +1,9 @@
 import os
-from autotest.client.shared import git, error
+
+from autotest.client.shared import git
+from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/qemu_killer_report.py
+++ b/qemu/tests/qemu_killer_report.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+
 from autotest.client.shared import error
 from virttest import utils_misc
 

--- a/qemu/tests/qemu_no_shutdown.py
+++ b/qemu/tests/qemu_no_shutdown.py
@@ -1,5 +1,5 @@
 import logging
-import time
+
 from autotest.client.shared import error
 from virttest import utils_misc
 

--- a/qemu/tests/qemu_nobody.py
+++ b/qemu/tests/qemu_nobody.py
@@ -1,6 +1,9 @@
 import logging
 import re
-from autotest.client.shared import utils, error
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
 from virttest import env_process
 
 

--- a/qemu/tests/qemu_option_check.py
+++ b/qemu/tests/qemu_option_check.py
@@ -1,7 +1,9 @@
 import re
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/qmp_basic.py
+++ b/qemu/tests/qmp_basic.py
@@ -1,5 +1,4 @@
 from autotest.client.shared import error
-from virttest import qemu_monitor
 
 
 def run(test, params, env):

--- a/qemu/tests/qmp_basic_rhel6.py
+++ b/qemu/tests/qmp_basic_rhel6.py
@@ -1,6 +1,6 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import qemu_monitor
 
 
 def run(test, params, env):

--- a/qemu/tests/qmp_command.py
+++ b/qemu/tests/qmp_command.py
@@ -1,7 +1,11 @@
 import logging
 import re
-from autotest.client.shared import utils, error
-from virttest import utils_misc, qemu_monitor
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
+from virttest import utils_misc
+from virttest import qemu_monitor
 
 
 @error.context_aware

--- a/qemu/tests/qmp_event_notification.py
+++ b/qemu/tests/qmp_event_notification.py
@@ -1,7 +1,9 @@
 import logging
 import time
 import commands
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/readonly_disk.py
+++ b/qemu/tests/readonly_disk.py
@@ -1,6 +1,9 @@
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
+
 from virttest import utils_misc
 from virttest import env_process
 

--- a/qemu/tests/reboot_time.py
+++ b/qemu/tests/reboot_time.py
@@ -1,14 +1,10 @@
 import logging
-import time
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
-
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
-
 from virttest import env_process
+from virttest.staging import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/remove_interface_from_host.py
+++ b/qemu/tests/remove_interface_from_host.py
@@ -3,8 +3,9 @@ Remove tap/interface in host while guest is using it.
 """
 import logging
 import time
+
 from autotest.client.shared import error
-from autotest.client.shared import utils
+
 from virttest import utils_net
 from virttest import utils_misc
 from virttest import utils_test

--- a/qemu/tests/rh_kernel_update.py
+++ b/qemu/tests/rh_kernel_update.py
@@ -2,7 +2,10 @@ import os
 import re
 import time
 import logging
-from autotest.client.shared import error, utils
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/rng_bat.py
+++ b/qemu/tests/rng_bat.py
@@ -1,7 +1,9 @@
 import re
 import logging
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -14,7 +14,8 @@ from aexpect import ShellCmdError
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, utils_spice, data_dir
+from virttest import utils_spice
+from virttest import data_dir
 
 
 def connect_to_vm(vm_name, env, params):

--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -9,8 +9,11 @@ import logging
 import os
 import time
 import re
+
+from aexpect import ShellCmdError
+
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
+
 from virttest import utils_misc, utils_spice, data_dir
 
 

--- a/qemu/tests/rv_connect.py
+++ b/qemu/tests/rv_connect.py
@@ -14,7 +14,10 @@ from aexpect import ShellProcessTerminatedError
 
 from autotest.client.shared import error
 
-from virttest import utils_net, utils_spice, remote, utils_misc
+from virttest import utils_net
+from virttest import utils_spice
+from virttest import remote
+from virttest import utils_misc
 
 
 def str_input(client_vm, ticket):

--- a/qemu/tests/rv_connect.py
+++ b/qemu/tests/rv_connect.py
@@ -7,11 +7,14 @@ Requires: binaries remote-viewer, Xorg, netstat
 """
 import logging
 import socket
-from virttest.aexpect import ShellStatusError
-from virttest.aexpect import ShellCmdError
-from virttest.aexpect import ShellProcessTerminatedError
-from virttest import utils_net, utils_spice, remote, utils_misc
+
+from aexpect import ShellStatusError
+from aexpect import ShellCmdError
+from aexpect import ShellProcessTerminatedError
+
 from autotest.client.shared import error
+
+from virttest import utils_net, utils_spice, remote, utils_misc
 
 
 def str_input(client_vm, ticket):

--- a/qemu/tests/rv_copyandpaste.py
+++ b/qemu/tests/rv_copyandpaste.py
@@ -13,7 +13,9 @@ import aexpect
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, utils_spice, data_dir
+from virttest import utils_misc
+from virttest import utils_spice
+from virttest import data_dir
 
 
 def wait_timeout(timeout=10):

--- a/qemu/tests/rv_copyandpaste.py
+++ b/qemu/tests/rv_copyandpaste.py
@@ -8,8 +8,12 @@ Requires: connected binaries remote-viewer, Xorg, gnome session
 import logging
 import os
 import time
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_spice, aexpect, data_dir
+
+from virttest import utils_misc, utils_spice, data_dir
 
 
 def wait_timeout(timeout=10):

--- a/qemu/tests/rv_fullscreen.py
+++ b/qemu/tests/rv_fullscreen.py
@@ -8,8 +8,10 @@ Requires: connected binaries remote-viewer, Xorg, gnome session
 
 """
 import logging
+
+from aexpect import ShellCmdError
+
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
 
 
 def run(test, params, env):

--- a/qemu/tests/rv_input.py
+++ b/qemu/tests/rv_input.py
@@ -10,9 +10,12 @@ Requires: Two VMs - client and guest and remote-viewer session
 
 import logging
 import os
+
+from aexpect import ShellCmdError
+
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
-from virttest import utils_misc, utils_spice, aexpect, data_dir
+
+from virttest import utils_misc, utils_spice, data_dir
 
 
 def install_pygtk(guest_session, params):
@@ -283,7 +286,7 @@ def run(test, params, env):
     # Verify that gnome is now running on the guest
     try:
         guest_session.cmd("ps aux | grep -v grep | grep gnome-session")
-    except aexpect.ShellCmdError:
+    except ShellCmdError:
         raise error.TestWarn("gnome-session was probably not corretly started")
 
     guest_session.cmd("export DISPLAY=:0.0")

--- a/qemu/tests/rv_input.py
+++ b/qemu/tests/rv_input.py
@@ -15,7 +15,8 @@ from aexpect import ShellCmdError
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, utils_spice, data_dir
+from virttest import utils_spice
+from virttest import data_dir
 
 
 def install_pygtk(guest_session, params):

--- a/qemu/tests/rv_logging.py
+++ b/qemu/tests/rv_logging.py
@@ -8,8 +8,11 @@ Requires: connected binaries remote-viewer, Xorg, gnome session
 """
 import logging
 import os
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_spice
+
+from virttest import utils_misc
+from virttest import utils_spice
 
 
 def run(test, params, env):

--- a/qemu/tests/rv_smartcard.py
+++ b/qemu/tests/rv_smartcard.py
@@ -8,7 +8,9 @@ options to handle smartcards.
 
 """
 import logging
-from virttest import aexpect
+
+import aexpect
+
 from autotest.client.shared import error
 
 

--- a/qemu/tests/rv_vdagent.py
+++ b/qemu/tests/rv_vdagent.py
@@ -6,6 +6,7 @@ Requires: connected binaries remote-viewer, Xorg, gnome session
 
 """
 from autotest.client.shared import error
+
 from virttest import utils_spice
 
 

--- a/qemu/tests/rv_video.py
+++ b/qemu/tests/rv_video.py
@@ -11,8 +11,10 @@ import logging
 import os
 import time
 import re
+
 from autotest.client.shared import error
-from virttest import utils_misc, remote
+from virttest import utils_misc
+from virttest import remote
 
 
 def launch_totem(guest_session, params):

--- a/qemu/tests/rv_vmshutdown.py
+++ b/qemu/tests/rv_vmshutdown.py
@@ -5,9 +5,12 @@ Requires: connected binaries remote-viewer, Xorg, gnome session
 
 """
 import logging
-from virttest.virt_vm import VMDeadError
+
+from aexpect import ShellCmdError
+
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
+
+from virttest.virt_vm import VMDeadError
 from virttest import utils_spice
 from virttest import utils_misc
 from virttest import utils_net

--- a/qemu/tests/save_restore_vm.py
+++ b/qemu/tests/save_restore_vm.py
@@ -1,15 +1,11 @@
 import logging
 import time
-from autotest.client.shared import error
-from virttest import utils_misc
 import os
 
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from autotest.client.shared import error
 
-from virttest import env_process
+from virttest import utils_misc
+from virttest.staging import utils_memory
 
 
 @error.context_aware

--- a/qemu/tests/seabios.py
+++ b/qemu/tests/seabios.py
@@ -1,6 +1,8 @@
 import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/set_link.py
+++ b/qemu/tests/set_link.py
@@ -7,7 +7,10 @@ from autotest.client import utils
 from autotest.client.shared import error
 
 from virttest import remote
-from virttest import utils_test, utils_net, utils_misc, virt_vm
+from virttest import utils_test
+from virttest import utils_net
+from virttest import utils_misc
+from virttest import virt_vm
 
 
 @error.context_aware

--- a/qemu/tests/set_link.py
+++ b/qemu/tests/set_link.py
@@ -1,8 +1,12 @@
 import logging
 import time
+
+import aexpect
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import remote, aexpect
+
+from virttest import remote
 from virttest import utils_test, utils_net, utils_misc, virt_vm
 
 

--- a/qemu/tests/smartcard_setup.py
+++ b/qemu/tests/smartcard_setup.py
@@ -9,8 +9,10 @@ to be generated.
 
 """
 import logging
-from virttest import utils_misc, utils_spice, aexpect
+
 from autotest.client.shared import error
+
+from virttest import utils_misc, utils_spice
 
 
 def run(test, params, env):

--- a/qemu/tests/smartcard_setup.py
+++ b/qemu/tests/smartcard_setup.py
@@ -12,7 +12,8 @@ import logging
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, utils_spice
+from virttest import utils_misc
+from virttest import utils_spice
 
 
 def run(test, params, env):

--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -1,6 +1,10 @@
 import logging
-from autotest.client.shared import utils, error
-from virttest import env_process, utils_misc
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
+from virttest import env_process
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/softlockup.py
+++ b/qemu/tests/softlockup.py
@@ -2,8 +2,10 @@ import logging
 import os
 import socket
 import time
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import data_dir
 
 

--- a/qemu/tests/sr_iov_boot_negative.py
+++ b/qemu/tests/sr_iov_boot_negative.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import env_process
 
 

--- a/qemu/tests/sr_iov_hotplug.py
+++ b/qemu/tests/sr_iov_hotplug.py
@@ -1,7 +1,11 @@
 import re
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import utils_misc, aexpect, utils_test, utils_net, test_setup
+
+from virttest import utils_misc, utils_test, utils_net, test_setup
 
 
 @error.context_aware

--- a/qemu/tests/sr_iov_hotplug.py
+++ b/qemu/tests/sr_iov_hotplug.py
@@ -5,7 +5,10 @@ import aexpect
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, utils_test, utils_net, test_setup
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import utils_net
+from virttest import test_setup
 
 
 @error.context_aware

--- a/qemu/tests/sr_iov_hotplug_negative.py
+++ b/qemu/tests/sr_iov_hotplug_negative.py
@@ -1,8 +1,10 @@
 import logging
-import os
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import utils_test, utils_misc, utils_net
+
+from virttest import utils_misc
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/sr_iov_irqbalance.py
+++ b/qemu/tests/sr_iov_irqbalance.py
@@ -1,8 +1,13 @@
 import re
 import time
 import logging
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_net
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import utils_test
+from virttest import utils_net
+
 # The backports module will take care of using the builtin if available
 from virttest.staging.backports import bin
 

--- a/qemu/tests/sr_iov_sanity.py
+++ b/qemu/tests/sr_iov_sanity.py
@@ -3,8 +3,14 @@ import re
 import time
 import random
 import logging
-from autotest.client.shared import error, utils
-from virttest import test_setup, utils_net, utils_misc, env_process
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import test_setup
+from virttest import utils_net
+from virttest import utils_misc
+from virttest import env_process
 
 
 def check_network_interface_ip(interface, ipv6="no"):

--- a/qemu/tests/stepmaker.py
+++ b/qemu/tests/stepmaker.py
@@ -7,15 +7,20 @@ Step file creator/editor.
 @version: "20090401"
 """
 
-import pygtk
-import gtk
-import gobject
 import time
 import os
 import commands
 import logging
-from virttest import utils_misc, ppm_utils, step_editor
+
+import pygtk
+import gtk
+import gobject
+
+from virttest import utils_misc
+from virttest import ppm_utils
+from virttest import step_editor
 from virttest import qemu_monitor
+
 pygtk.require('2.0')
 
 

--- a/qemu/tests/steps.py
+++ b/qemu/tests/steps.py
@@ -8,8 +8,12 @@ import os
 import time
 import shutil
 import logging
+
 from autotest.client.shared import error
-from virttest import utils_misc, ppm_utils, qemu_monitor
+
+from virttest import utils_misc
+from virttest import ppm_utils
+from virttest import qemu_monitor
 
 try:
     import PIL.Image

--- a/qemu/tests/stop_continue.py
+++ b/qemu/tests/stop_continue.py
@@ -1,5 +1,7 @@
 import logging
-from autotest.client.shared import error, utils
+
+from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/stress_kernel_compile.py
+++ b/qemu/tests/stress_kernel_compile.py
@@ -1,12 +1,9 @@
 import logging
-import os
-from autotest.client.shared import error
-from virttest import utils_test, utils_misc, env_process
 
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from autotest.client.shared import error
+
+from virttest import utils_test, env_process
+from virttest.staging import utils_memory
 
 
 def run(test, params, env):

--- a/qemu/tests/suspend_under_stress.py
+++ b/qemu/tests/suspend_under_stress.py
@@ -1,7 +1,11 @@
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_test, utils_misc
+
+from virttest import utils_test
+from virttest import utils_misc
+
 from generic.tests import guest_suspend
 
 

--- a/qemu/tests/sysprep.py
+++ b/qemu/tests/sysprep.py
@@ -1,7 +1,10 @@
 import logging
 import os
 import re
-from virttest import utils_misc, env_process
+
+from virttest import utils_misc
+from virttest import env_process
+
 from autotest.client.shared import error
 
 

--- a/qemu/tests/system_reset_bootable.py
+++ b/qemu/tests/system_reset_bootable.py
@@ -1,7 +1,9 @@
 import logging
 import time
 import random
+
 from autotest.client.shared import error
+
 from virttest import env_process
 
 

--- a/qemu/tests/systemtap_tracing.py
+++ b/qemu/tests/systemtap_tracing.py
@@ -2,9 +2,13 @@ import logging
 import re
 import os
 import time
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_misc, env_process, data_dir
+
+from virttest import utils_misc
+from virttest import env_process
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/time_manage.py
+++ b/qemu/tests/time_manage.py
@@ -1,7 +1,11 @@
 import logging
 import time
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import utils_test, aexpect
+
+from virttest import utils_test
 from virttest import env_process
 
 

--- a/qemu/tests/timedrift.py
+++ b/qemu/tests/timedrift.py
@@ -1,8 +1,12 @@
 import logging
 import time
 import commands
+
+import aexpect
+
+from virttest import utils_test
+
 from autotest.client.shared import error
-from virttest import utils_test, aexpect
 
 
 def run(test, params, env):

--- a/qemu/tests/timedrift_adjust_time.py
+++ b/qemu/tests/timedrift_adjust_time.py
@@ -1,10 +1,13 @@
 import re
 import time
 import logging
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import env_process
 from virttest import test_setup
+
 from generic.tests.guest_suspend import GuestSuspendBaseTest
 
 

--- a/qemu/tests/timedrift_check_with_syscall.py
+++ b/qemu/tests/timedrift_check_with_syscall.py
@@ -1,7 +1,10 @@
 import os
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
+
 from virttest import data_dir
 
 

--- a/qemu/tests/timedrift_monotonicity.py
+++ b/qemu/tests/timedrift_monotonicity.py
@@ -3,7 +3,10 @@ import os
 import time
 import re
 import shutil
-from autotest.client.shared import error, utils
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from virttest import utils_test
 
 

--- a/qemu/tests/timedrift_no_net.py
+++ b/qemu/tests/timedrift_no_net.py
@@ -1,9 +1,12 @@
 import logging
 import time
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import utils_test
 from virttest import utils_misc
+
 from generic.tests.guest_suspend import GuestSuspendBaseTest
 
 

--- a/qemu/tests/timedrift_no_net_win.py
+++ b/qemu/tests/timedrift_no_net_win.py
@@ -1,9 +1,12 @@
 import logging
 import time
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import utils_test
 from virttest import utils_misc
+
 from generic.tests.guest_suspend import GuestSuspendBaseTest
 
 

--- a/qemu/tests/timedrift_with_cpu_offline.py
+++ b/qemu/tests/timedrift_with_cpu_offline.py
@@ -1,6 +1,8 @@
 import logging
 import time
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/timedrift_with_migration.py
+++ b/qemu/tests/timedrift_with_migration.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/timedrift_with_reboot.py
+++ b/qemu/tests/timedrift_with_reboot.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/timedrift_with_stop.py
+++ b/qemu/tests/timedrift_with_stop.py
@@ -2,7 +2,9 @@ import logging
 import time
 import os
 import signal
+
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/qemu/tests/timerdevice_boot.py
+++ b/qemu/tests/timerdevice_boot.py
@@ -1,9 +1,15 @@
 import logging
 import re
 import time
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import data_dir, storage, utils_disk, utils_test, env_process
+
+from virttest import data_dir
+from virttest import storage
+from virttest import utils_disk
+from virttest import utils_test
+from virttest import env_process
 from virttest import funcatexit
 
 

--- a/qemu/tests/timerdevice_change_guest_clksource.py
+++ b/qemu/tests/timerdevice_change_guest_clksource.py
@@ -1,7 +1,12 @@
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import data_dir, storage, utils_disk, env_process
+
+from virttest import data_dir
+from virttest import storage
+from virttest import utils_disk
+from virttest import env_process
 
 
 @error.context_aware

--- a/qemu/tests/timerdevice_clock_drift_with_ntp.py
+++ b/qemu/tests/timerdevice_clock_drift_with_ntp.py
@@ -1,8 +1,12 @@
 import logging
 import os
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import data_dir, utils_misc, aexpect
+
+from virttest import data_dir, utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/timerdevice_clock_drift_with_ntp.py
+++ b/qemu/tests/timerdevice_clock_drift_with_ntp.py
@@ -6,7 +6,8 @@ import aexpect
 from autotest.client.shared import error
 from autotest.client import utils
 
-from virttest import data_dir, utils_misc
+from virttest import data_dir
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/timerdevice_clock_drift_with_sleep.py
+++ b/qemu/tests/timerdevice_clock_drift_with_sleep.py
@@ -1,8 +1,13 @@
 import logging
 import re
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import data_dir, storage, utils_disk, env_process
+
+from virttest import data_dir
+from virttest import storage
+from virttest import utils_disk
+from virttest import env_process
 
 
 @error.context_aware

--- a/qemu/tests/timerdevice_tscsync_change_host_clksource.py
+++ b/qemu/tests/timerdevice_tscsync_change_host_clksource.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import re
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import data_dir
 
 

--- a/qemu/tests/timerdevice_tscsync_longtime.py
+++ b/qemu/tests/timerdevice_tscsync_longtime.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import re
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import data_dir
 
 

--- a/qemu/tests/trace_cmd_boot.py
+++ b/qemu/tests/trace_cmd_boot.py
@@ -1,11 +1,12 @@
 import re
 import os
-import time
 import signal
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_test, utils_misc
+
+from virttest import utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/transfer_file_over_ipv6.py
+++ b/qemu/tests/transfer_file_over_ipv6.py
@@ -1,9 +1,13 @@
 import logging
 import os
 import re
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import remote, utils_misc, utils_net
+
+from virttest import remote
+from virttest import utils_misc
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/tsc_drift.py
+++ b/qemu/tests/tsc_drift.py
@@ -3,8 +3,10 @@ import os
 import logging
 import commands
 import re
+
 from autotest.client.shared import error
 from autotest.client import local_host
+
 from virttest import data_dir
 
 

--- a/qemu/tests/unittest.py
+++ b/qemu/tests/unittest.py
@@ -3,8 +3,11 @@ import os
 import shutil
 import glob
 import ConfigParser
+
 from autotest.client.shared import error
-from virttest import utils_misc, env_process
+
+from virttest import utils_misc
+from virttest import env_process
 
 
 def run(test, params, env):

--- a/qemu/tests/usb_basic_check.py
+++ b/qemu/tests/usb_basic_check.py
@@ -1,8 +1,11 @@
 import time
 import re
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/usb_storage.py
+++ b/qemu/tests/usb_storage.py
@@ -1,8 +1,12 @@
 import logging
 import re
 import uuid
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import utils_test, aexpect, utils_misc
+
+from virttest import utils_test, utils_misc
 
 
 @error.context_aware

--- a/qemu/tests/valgrind_memalign.py
+++ b/qemu/tests/valgrind_memalign.py
@@ -1,6 +1,9 @@
 import logging
 import time
-from autotest.client.shared import error, utils
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from virttest import env_process
 
 

--- a/qemu/tests/virt_subtest_combine.py
+++ b/qemu/tests/virt_subtest_combine.py
@@ -1,7 +1,9 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import utils_test
 from autotest.client import utils
+
+from virttest import utils_test
 
 
 @error.context_aware

--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -15,12 +15,16 @@ import threading
 import traceback
 import time
 from subprocess import Popen
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import qemu_virtio_port, env_process, utils_test, utils_misc
+
+from virttest import qemu_virtio_port
+from virttest import env_process
+from virttest import utils_test
+from virttest import utils_misc
 from virttest import funcatexit
 from virttest.qemu_devices import qdevices
-
 
 EXIT_EVENT = threading.Event()
 

--- a/qemu/tests/virtio_driver_sign_check.py
+++ b/qemu/tests/virtio_driver_sign_check.py
@@ -2,7 +2,9 @@ import logging
 import os
 import re
 import time
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 
 

--- a/qemu/tests/virtio_port_login.py
+++ b/qemu/tests/virtio_port_login.py
@@ -9,7 +9,8 @@ import aexpect
 
 from autotest.client.shared import error
 
-from virttest import utils_misc, remote
+from virttest import utils_misc
+from virttest import remote
 from virttest import utils_virtio_port
 
 

--- a/qemu/tests/virtio_port_login.py
+++ b/qemu/tests/virtio_port_login.py
@@ -4,8 +4,12 @@ Collection of virtio_console and virtio_serialport tests.
 :copyright: 2010-2012 Red Hat Inc.
 """
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect, utils_misc, remote
+
+from virttest import utils_misc, remote
 from virttest import utils_virtio_port
 
 

--- a/qemu/tests/virtio_scsi_mq.py
+++ b/qemu/tests/virtio_scsi_mq.py
@@ -1,7 +1,9 @@
 import logging
 import re
+
 from autotest.client.shared import error
 from autotest.client import local_host
+
 from virttest import utils_misc
 from virttest import env_process
 from virttest import qemu_qtree

--- a/qemu/tests/virtual_nic_private.py
+++ b/qemu/tests/virtual_nic_private.py
@@ -6,7 +6,9 @@ from aexpect import ShellCmdError
 from autotest.client import utils
 from autotest.client.shared import error
 
-from virttest import remote, utils_misc, utils_net
+from virttest import remote
+from virttest import utils_misc
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/virtual_nic_private.py
+++ b/qemu/tests/virtual_nic_private.py
@@ -1,9 +1,12 @@
 import logging
 import re
+
+from aexpect import ShellCmdError
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import remote, utils_misc, utils_net
-from virttest.aexpect import ShellCmdError
 
 
 @error.context_aware

--- a/qemu/tests/virtual_nic_send_buffer.py
+++ b/qemu/tests/virtual_nic_send_buffer.py
@@ -1,7 +1,12 @@
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import remote, utils_misc, utils_test, utils_net
+
+from virttest import remote
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import utils_net
 
 
 @error.context_aware

--- a/qemu/tests/vnc.py
+++ b/qemu/tests/vnc.py
@@ -3,7 +3,9 @@ import time
 import socket
 import struct
 import random
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 from virttest.RFBDes import Des
 

--- a/qemu/tests/watchdog.py
+++ b/qemu/tests/watchdog.py
@@ -1,9 +1,11 @@
-import os
 import re
 import time
 import logging
-from autotest.client.shared import error, utils
-from virttest import utils_misc, env_process
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+from virttest import utils_misc
+from virttest import env_process
 
 
 @error.context_aware

--- a/qemu/tests/win_heavyload.py
+++ b/qemu/tests/win_heavyload.py
@@ -4,9 +4,10 @@ import logging
 import aexpect
 
 from autotest.client.shared import error
-from autotest.client.shared import data_dir
 from autotest.client import utils
+
 from virttest import utils_misc
+from virttest import data_dir
 
 
 @error.context_aware

--- a/qemu/tests/win_heavyload.py
+++ b/qemu/tests/win_heavyload.py
@@ -1,10 +1,12 @@
 import re
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client.shared import data_dir
 from autotest.client import utils
 from virttest import utils_misc
-from virttest import aexpect
 
 
 @error.context_aware

--- a/qemu/tests/win_virtio_serial_data_transfer_reboot.py
+++ b/qemu/tests/win_virtio_serial_data_transfer_reboot.py
@@ -1,9 +1,11 @@
 import os
-import time
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import data_dir, qemu_virtio_port
+
+from virttest import data_dir
+from virttest import qemu_virtio_port
 
 
 # This decorator makes the test function aware of context strings

--- a/qemu/tests/win_virtio_update.py
+++ b/qemu/tests/win_virtio_update.py
@@ -1,10 +1,11 @@
 import time
-import sys
 import re
 import logging
 import os
 
-from autotest.client.shared import error, utils
+from autotest.client.shared import error
+from autotest.client.shaed import utils
+
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import data_dir

--- a/qemu/tests/yonit_bitmap.py
+++ b/qemu/tests/yonit_bitmap.py
@@ -1,7 +1,10 @@
 import logging
 import signal
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
+
 from generic.tests import guest_test
 
 

--- a/qemu/tests/zero_copy.py
+++ b/qemu/tests/zero_copy.py
@@ -1,7 +1,10 @@
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import env_process, utils_test
+
+from virttest import env_process
+from virttest import utils_test
 
 
 @error.context_aware


### PR DESCRIPTION
This PR accomplishes some goals:

* Reflect the fact that `virttest.aexpect` no longer exists in avocado-vt, the new runner for the tp-qemu tests.
* Clean up imports according to a set of rules. This cleanup ultimately aims to pave the way for a future PR that replaces the use of autotest libraries with avocado ones.