### PR TITLE
	qemu/tests/cgroup.py:Fix wrong argument passed to cgroup.set_propert…

### DIFF
--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -1270,10 +1270,10 @@ def run(test, params, env):
         cgroup.set_property('cpuset.cpus', cpus.str_slice(), 0)
         cgroup.set_property('cpuset.mems', 0, 0)
         cgroup.mk_cgroup()  # O___
-        cgroup.set_property('cpuset.cpus', 0, cpus[0])
+        cgroup.set_property('cpuset.cpus', cpus[0], 1)
         cgroup.set_property('cpuset.mems', 0, 1)
         cgroup.mk_cgroup()  # _OO_
-        cgroup.set_property('cpuset.cpus', cpus.str_slice(1), 2)
+        cgroup.set_property('cpuset.cpus', cpus.str_slice(1, 3), 2)
         cgroup.set_property('cpuset.mems', 0, 2)
         assign_vm_into_cgroup(vm, cgroup, 0)
 


### PR DESCRIPTION
    I run type_specific.io-github-autotest-qemu.cgroup.cpuset_cpus_switching (requires root) an error has occurred.

    The ERROR is TestError: cg.set_cgroup(): Setting 6523 pid into /sys/fs/cgroup/cpuset/cgroup-hzd6zC/ cgroup failed

    I found that the problem is one of cgroups didn`t set cpuset.cpus.So,Tracking code and I found that the problem happened in cpuset_cpus_switching()