### PR TITLE
tp-qemu: combile output of query block to one line

### DIFF
--- a/qemu/tests/qmp_command.py
+++ b/qemu/tests/qmp_command.py
@@ -77,7 +77,20 @@ def run(test, params, env):
             else:
                 len_o = len(qmp_o)
             if len(res) != len_o:
-                raise error.TestFail(msg)
+                if res[0].startswith(' '):
+                    raise error.TestFail("Human command starts with ' ', "
+                                         "there is probably some garbage in "
+                                         "the output.\n" + msg)
+                res_tmp = []
+                #(qemu)info block in RHEL7 divided into 3 lines
+                for line in res:
+                    if not line.startswith(' '):
+                        res_tmp.append(line)
+                    else:
+                        res_tmp[-1] += line
+                res = res_tmp
+                if len(res) != len_o:
+                    raise error.TestFail(msg)
             re_str = r'([^ \t\n\r\f\v=]*)=([^ \t\n\r\f\v=]*)'
             for i in range(len(res)):
                 if qmp_cmd == "query-version":


### PR DESCRIPTION
In RHEL7 ,(qemu)info block will reply 2 or 3 lines for one block device
This patch combile all the lines to single line

ID: 1263527
Signed-off-by: Mike Cao <bcao@redhat.com>