### PR TITLE
qemu.spice: Changing spice-gtk tar pkg to latest

### DIFF
--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -197,7 +197,7 @@ def build_install_spicegtk(vm_root_session, vm_script_path, params):
     # spice-gtk needs to built from tarball before building virt-viewer on RHEL6
     pkgName = params.get("build_install_pkg")
     if pkgName != "spice-gtk":
-        tarballLocation = "http://www.spice-space.org/download/gtk/spice-gtk-0.29.tar.bz2"
+        tarballLocation = "http://www.spice-space.org/download/gtk/spice-gtk-LATEST.tar.bz2"
         cmd = "%s -p spice-gtk --tarball %s" % (vm_script_path, tarballLocation)
         output = vm_root_session.cmd(cmd, timeout=600)
         logging.info(output)


### PR DESCRIPTION
Changing the spice-gtk tar package to be the latest upstream 
release from 0.29. 

Reviewed By: Swapna Krishnan <skrishna@redhat.com>