### PR TITLE
tp-qemu: device_bit_check.cfg: Update the dev_type.

### DIFF
--- a/qemu/tests/cfg/device_bit_check.cfg
+++ b/qemu/tests/cfg/device_bit_check.cfg
@@ -25,15 +25,15 @@
                 dev_param_name = blk_extra_params
                 blk_extra_params = ""
                 pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio block device"
-                dev_type = virtio-blk-pci
+                dev_type = "virtio-blk-.*"
             virtio_scsi:
                 dev_param_name = bus_extra_params
                 bus_extra_params = ""
                 pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio SCSI"
-                dev_type = virtio-scsi-pci
+                dev_type = "virtio-scsi-.*"
         - nic_device:
             only virtio_net
             nic_extra_params = ""
             pci_id_pattern = "(\d+:\d+\.\d+)\s+Ethernet controller:.*?Virtio network device"
-            dev_type = virtio-net-pci
+            dev_type = "virtio-net-.*"
             dev_param_name = nic_extra_params


### PR DESCRIPTION
The latest RHEL.7 has updated the qtree info, the
properties "event_idx" and "indirect_desc" is under
"virtio-blk-device" instead of "virtio-blk-pci".

Signed-off-by: Cong Li <coli@redhat.com>

id: 1265888