### PR TITLE
qemu/tests/cfg/: Update boot_menu_hint for seabios log

### DIFF
--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -6,7 +6,9 @@
     image_boot = no
     virt_test_type = qemu
     boot_menu_key = "f12"
-    boot_menu_hint = "Press .*F12 for boot menu"
+    Host_RHEL.m7:
+        boot_menu_key = "esc"
+    boot_menu_hint = "Press .*(F12|ESC) for boot menu"
     boot_fail_info = "Booting from Hard Disk...;"
     boot_fail_info += "Boot failed: not a bootable disk"
     variants:

--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -8,7 +8,9 @@
     enable_sga = yes
     image_verify_bootable = no
     boot_menu_key = "f12"
-    boot_menu_hint = "Press .*F12 for boot menu"
+    Host_RHEL.m7:
+        boot_menu_key = "esc"
+    boot_menu_hint = "Press .*(F12|ESC) for boot menu"
     # Specify the boot device name which you want to test here.
     boot_device = "iPXE"
     Host_RHEL.m6:


### PR DESCRIPTION
For latest RHEL.7, boot_menu_hint changed from "F12" to
"ESC".

Signed-off-by: Shuping Cui <scui@redhat.com>

ID: 1224039