### PR TITLE
tp-qemu: qemu_disk_img.convert: disable option "compat" for RHEL5 and RHEL6 host.

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -49,6 +49,7 @@
                                 - cluster_size_2M:
                                     cluster_size = 2M
                         - compat:
+                            no Host_RHEL.m5, Host_RHEL.m6
                             variants:
                                 - compat_0.10:
                                     compat = 0.10


### PR DESCRIPTION
RHEL5 and RHEL6 host do not support option "compat"
for qemu_disk_img.convert.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1270632