### PR TITLE
tp-qemu: fix typo

### DIFF
--- a/qemu/tests/win_virtio_update.py
+++ b/qemu/tests/win_virtio_update.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 from autotest.client.shared import error
-from autotest.client.shaed import utils
+from autotest.client.shared import utils
 
 from virttest import utils_test
 from virttest import utils_misc


### PR DESCRIPTION
It is introduced in 288ce897
module autotest.client.shaed is typo
change back to shared

 
Signed-off-by: Mike Cao <bcao@redhat.com>