### PR TITLE
tp-qemu: balloon_stress: some updates for balloon_stress.

### DIFF
--- a/qemu/tests/cfg/balloon_stress.cfg
+++ b/qemu/tests/cfg/balloon_stress.cfg
@@ -18,10 +18,9 @@
         pre_cmd += " & reg add HKCU\Software\Microsoft\MediaPlayer\Preferences /v ModeLoop /t REG_DWORD /d 1 /f"
         play_video_cmd  = taskkill /IM wmplayer.exe /F & "${program_files}\Windows Media Player\wmplayer.exe"  "${video_url}"  /play /fullscreen
         check_playing_cmd = "tasklist|findstr /I wmplayer"
-        enable_driver_verifier_cmd = "verifier.exe /standard /driver balloon.sys"
-        driver_verifier_cmd = "verifier.exe /querysettings"
         driver_name = "balloon.sys"
-        need_reboot = yes
+        need_enable_verifier = yes
+        need_clear_verifier = yes
         stop_player_cmd = "taskkill /IM wmplayer.exe /F"
         # reset media player play mode
         post_cmd += "reg add HKCU\Software\Microsoft\MediaPlayer\Preferences /v ModeLoop /t REG_DWORD /d 0 /f"


### PR DESCRIPTION
1. using the existing func() to enable and clear driver
   verifier for windows guest.
2. set flag to enable and clear driver verifier, which can makes
   the case more flexible, and the case can be a background case.
3. add a flag env["balloon_test"], which makes the case balloon_stress
     be a background case.


Signed-off-by: Cong Li <coli@redhat.com>

id: 1274571