### PR TITLE
sr_iov_irqbalance: remove unused pattern string

### DIFF
--- a/qemu/tests/sr_iov_irqbalance.py
+++ b/qemu/tests/sr_iov_irqbalance.py
@@ -53,7 +53,6 @@ def get_guest_service_status(session, service):
     """
     cmd = "service %s status" % service
     output = session.cmd_output(cmd)
-    service_status_filter = "running|active"
     if re.search("running|active", output, re.I):
         status = "active"
     elif re.search("stopped|inactive", output, re.I):


### PR DESCRIPTION
Maybe the variable 'service_status_filter is intended to
be the pattern param for re.search(),
But re.search() adopts character string directly.
So It becomes meaningless.