### PR TITLE
Remove ib700 wdt(watchdog timer) test for power guest as it is not su…

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -10,6 +10,7 @@
             dmesg_info = "i6300ESB.*init"
         -ib700:
             no RHEL.5
+            no ppc64 ppc64le
             watchdog_device_type = ib700
             dmesg_info = "ib700wdt.*init"
     variants:


### PR DESCRIPTION
Remove ib700 wdt(watchdog timer) test for power guest as it is not supported.

ID: 1245141