### PR TITLE
tp-qemu: job.resultsdir return to null ,use logdir instead

### DIFF
--- a/qemu/tests/win_virtio_update.py
+++ b/qemu/tests/win_virtio_update.py
@@ -202,7 +202,8 @@ def run(test, params, env):
         fail_log += " Please check the error_log. "
     else:
         fail_log = "Failed to install:"
-    error_log = open("%s/error_log" % test.resultsdir, "w")
+    logdir = test.resultsdir or test.logdir
+    error_log = open("%s/error_log" % logdir, "w")
     fail_flag = False
     error.context("Check driver available in guest", logging.info)
     if setup_ps:


### PR DESCRIPTION
When running jobs on avocado , job.resultsdir will
return zero. this patch is using to fix it .
ID:1277031
Signed-off-by: Mike Cao <bcao@redhat.com>