### PR TITLE
CPUID QOM path lookup fix + small CPUID whitelist update

### DIFF
--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -375,7 +375,7 @@
                     #KNOWN BUG: QEMU 2.1.0 broke the ABI by changing
                     # CPUID[0x40000000].EAX without any compat code
                     kvm:
-                        pc_1_0, pc_1_1, pc_1_2, pc_1_3, pc_q35_1_4, pc_i440fx_1_4, pc_q35_1_5, pc_i440fx_1_5, machine_type_rhel:
+                        pc_1_0, pc_1_1, pc_1_2, pc_1_3, pc_q35_1_4, pc_i440fx_1_4, pc_q35_1_5, pc_i440fx_1_5, pc_q35_2_0, pc_i440fx_2_0, machine_type_rhel:
                             # Ignore only bits 30 and 0. that means 0x400000001 and 0 are equivalent, but
                             # other bits can't change
                             ignore_cpuid_leaves += " 0x40000000,0,eax,0 0x40000000,0,eax,30"

--- a/qemu/tests/cpuid.py
+++ b/qemu/tests/cpuid.py
@@ -457,11 +457,10 @@ def run(test, params, env):
             raise error.TestFail("Test was expected to fail, but it didn't")
 
     def cpuid_regs_to_string(cpuid_dump, leaf, idx, regs):
-        r = cpuid_dump[leaf, idx]
         signature = ""
         for i in regs:
             for shift in range(0, 4):
-                c = chr((r[i] >> (shift * 8)) & 0xFF)
+                c = chr((cpuid_dump[leaf, idx, i] >> (shift * 8)) & 0xFF)
                 if c in string.printable:
                     signature = signature + c
                 else:
@@ -506,7 +505,7 @@ def run(test, params, env):
         bits = params["bits"].split()
         try:
             out = get_guest_cpuid(self, cpu_model, flags)
-            r = out[leaf, idx][reg]
+            r = out[leaf, idx, reg]
             logging.debug("CPUID(%s.%s).%s=0x%08x" % (leaf, idx, reg, r))
             for i in bits:
                 if (r & (1 << int(i))) == 0:

--- a/qemu/tests/cpuid.py
+++ b/qemu/tests/cpuid.py
@@ -146,6 +146,10 @@ def run(test, params, env):
 
     def find_cpu_obj(vm):
         """Find path of a valid VCPU object"""
+        cpus = vm.monitor.cmd('query-cpus')
+        if len(cpus) > 0 and cpus[0].has_key('qom_path'):
+            return cpus[0]['qom_path']
+        # if there's no qom_path on query-cpus
         roots = ['/machine/icc-bridge/icc', '/machine/unattached/device']
         for root in roots:
             try:


### PR DESCRIPTION
The QOM-mode CPUID test code is failing on newer QEMU versions because icc-bridge was removed. Use the newer query-cpus 'qom_path' field to get the QOM path for CPU objects.