### PR TITLE
disable rng dll register command

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -6,8 +6,8 @@
     no no_virtio_rng
     Windows:
         # Please update path of rng_dll_register_cmd to right path which included you driver
-        rng_dll_register_cmd = if not exist "C:\Windows\system32\viorngum.dll" copy PATH:\INCLUDEDRIVER\viorngum.dll C:\Windows\system32\ /y &&"
-        rng_dll_register_cmd += "rundll32 C:\Windows\system32\viorngum.dll,RegisterProvider"
+        #rng_dll_register_cmd = if not exist "C:\Windows\system32\viorngum.dll" copy PATH:\INCLUDEDRIVER\viorngum.dll C:\Windows\system32\ /y &&"
+        #rng_dll_register_cmd += "rundll32 C:\Windows\system32\viorngum.dll,RegisterProvider"
         session_cmd_timeout = 240
         read_rng_cmd  = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
         enable_verifier_cmd = "verifier.exe /standard /driver viorng.sys"


### PR DESCRIPTION
latest virtio-rng device driver register dll into system
after install driver, so disabled this step.

Signed-off-by: Xu Tian <xutian@redhat.com>