### PR TITLE
host-kernel: RHEL.5 and RHEL.6 host do not support serial option for ide-drive proterty. Need change to scsi-cd.

### DIFF
--- a/qemu/cfg/host-kernel/Host_RHEL/5.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/5.cfg
@@ -45,3 +45,7 @@
         images += "stg8 stg9 stg10 stg11 stg12 stg13 stg14 stg15 "
         images += "stg16 stg17 stg18 stg19 stg20 stg21 stg22 "
         images += "stg23 stg24"
+    # RHEL.6 host does not support serial option for ide-drive propterty,
+    # then use scsi-cd for it.
+    cdrom_test:
+        cd_format = scsi-cd

--- a/qemu/cfg/host-kernel/Host_RHEL/6.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6.cfg
@@ -20,3 +20,7 @@
         black_cmds = "block-stream block-job-cancel block-job-set-speed transaction blockdev-snapshot-sync __com.redhat_drive-mirror __com.redhat_block-reopen"
     monitor_cmds_check.human:
         black_cmds = "block_stream block_job_cancel block_job_set_speed transaction blockdev-snapshot-sync __com.redhat_drive_mirror __com.redhat_block_reopen"
+    # RHEL.5 host does not support serial option for ide-drive propterty,
+    # then use scsi-cd for it.
+    cdrom_test:
+        cd_format = scsi-cd


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>

id: 1285256