### PR TITLE
qemu.test.floppy_test/readonly_floppy: disable for pseries

### DIFF
--- a/qemu/tests/cfg/floppy_test.cfg
+++ b/qemu/tests/cfg/floppy_test.cfg
@@ -1,5 +1,6 @@
 - floppy_test: install setup image_copy unattended_install.cdrom
     type = floppy
+    no pseries
     start_vm = no
     floppies = "fl"
     guest_floppy_path = "/dev/fd0"

--- a/qemu/tests/cfg/readonly_floppy.cfg
+++ b/qemu/tests/cfg/readonly_floppy.cfg
@@ -1,6 +1,7 @@
 - readonly_floppy:
     virt_test_type = qemu
     type = readonly_floppy
+    no pseries
     floppies = "fl1 fl2"
     floppy_name_fl1 = "images/fd1.img"
     floppy_name_fl2 = "images/fd2.img"


### PR DESCRIPTION
As pseries does not support floppy, so need to disable related tests.

ID: 1279716