### PR TITLE
Move new travis infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,13 @@ branches:
     only:
         - master
 
-virtualenv:
-    system_site_packages: true
-
-before_script:
-    - echo "deb http://ppa.launchpad.net/lmr/autotest/ubuntu wily main" | sudo tee -a /etc/apt/sources.list
-    - sudo apt-get update -q
-    - sudo apt-get -y --force-yes install autotest
+sudo: false
 
 install:
-    - pip install sphinx tox simplejson MySQL-python pylint autopep8
-    - pip install inspektor
-    - pip install -r requirements.txt
+    - pip install Sphinx
+    - pip install -r requirements-travis.txt
 
 script:
+    - inspekt indent
     - inspekt lint
     - inspekt style

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ using virt test, and commit your changes.
 
 ::
 
+    inspekt indent
     inspekt lint
     inspekt style
 6) Fix any problems

--- a/qemu/tests/openflow_test.py
+++ b/qemu/tests/openflow_test.py
@@ -143,7 +143,7 @@ def run(test, params, env):
             else:
                 return True, out[1]
         except Exception, msg:
-                return False, msg
+            return False, msg
 
     def file_transfer(sessions, addresses, timeout):
         prepare_cmd = "dd if=/dev/zero of=/tmp/copy_file count=1024 bs=1M"

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,0 +1,9 @@
+coverage==3.6
+nose==1.3.0
+nosexcover==1.0.8
+tox==1.5.0
+virtualenv==1.9.1
+simplejson==3.8.1
+MySQL-python==1.2.5
+inspektor==0.1.19
+autotest==0.16.2


### PR DESCRIPTION
Move to the faster, container-based travis tesing infrastructure.
In order to do this, add a new requirements-travis.txt file that
concentrates the requirements of the testing job, plus cleanup
of .travis.yml and addition of sudo: false to that file.