### PR TITLE
tp-qemu: qemu_disk_img: disable those not supported versions for preallocation mode "full" and "falloc".

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -37,8 +37,18 @@
                                 - metadata:
                                     preallocated = metadata
                                 - falloc:
+                                    no Host_RHEL.m5 Host_RHEL.m6.u6
+                                    no Host_RHEL.m6.u0 Host_RHEL.m6.u1
+                                    no Host_RHEL.m6.u2 Host_RHEL.m6.u3
+                                    no Host_RHEL.m6.u4 Host_RHEL.m6.u5
+                                    no Host_RHEL.m7.u0 Host_RHEL.m7.u1
                                     preallocated = falloc
                                 - full:
+                                    no Host_RHEL.m5
+                                    no Host_RHEL.m6.u0 Host_RHEL.m6.u1
+                                    no Host_RHEL.m6.u2 Host_RHEL.m6.u3
+                                    no Host_RHEL.m6.u4 Host_RHEL.m6.u5
+                                    no Host_RHEL.m7.u0 Host_RHEL.m7.u1
                                     preallocated = full
                         - cluster_size:
                             variants:


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>

id: 1285602