### PR TITLE
tp-qemu: rng_bat: remove rng dll register.

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -5,9 +5,6 @@
     read_rng_timeout = 360
     no no_virtio_rng
     Windows:
-        # Please update path of rng_dll_register_cmd to right path which included you driver
-        #rng_dll_register_cmd = if not exist "C:\Windows\system32\viorngum.dll" copy PATH:\INCLUDEDRIVER\viorngum.dll C:\Windows\system32\ /y &&"
-        #rng_dll_register_cmd += "rundll32 C:\Windows\system32\viorngum.dll,RegisterProvider"
         session_cmd_timeout = 240
         read_rng_cmd  = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
         enable_verifier_cmd = "verifier.exe /standard /driver viorng.sys"

--- a/qemu/tests/rng_bat.py
+++ b/qemu/tests/rng_bat.py
@@ -51,7 +51,6 @@ def run(test, params, env):
     rng_data_rex = params.get("rng_data_rex", r".*")
     dev_file = params.get("filename_passthrough")
     timeout = float(params.get("login_timeout", 360))
-    rng_dll_register_cmd = params.get("rng_dll_register_cmd")
     read_rng_timeout = float(params.get("read_rng_timeout", "360"))
     cmd_timeout = float(params.get("session_cmd_timeout", "360"))
 
@@ -90,9 +89,6 @@ def run(test, params, env):
         raise error.TestFail(msg)
 
     error.context("Read virtio-rng device to get random number", logging.info)
-    if rng_dll_register_cmd:
-        logging.info("register 'viorngum.dll' into system")
-        session.cmd(rng_dll_register_cmd, timeout=120)
     output = session.cmd_output(read_rng_cmd, timeout=read_rng_timeout)
     if len(re.findall(rng_data_rex, output, re.M)) < 2:
         logging.debug("rng output: %s" % output)


### PR DESCRIPTION
For the current qemu, rng device can work without
 rng dll register.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1289831