### PR TITLE
tp-qemu: netperf_stress.py: sleep a while before set flag "env[netperf_run] = False"

### DIFF
--- a/qemu/tests/netperf_stress.py
+++ b/qemu/tests/netperf_stress.py
@@ -219,6 +219,7 @@ def run(test, params, env):
                                         n_client.is_netperf_running(),
                                         left_time, 0, 5,
                                         "Wait netperf test finish %ss" % left_time)
+            time.sleep(5)
     finally:
         for n_server in netperf_servers:
             if n_server:


### PR DESCRIPTION
When netperf_stress as a background case, need sleep a while
before set flag "env[netperf_run] = False", to avoid the other
cases have not got the flag "env[netperf_run]" changed.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1292688