### PR TITLE
pci_hotplug: replace virttest.aexpect with aexpect

### DIFF
--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -1,10 +1,10 @@
 import re
 import logging
 import string
+import aexpect
 
 from autotest.client.shared import error
 
-from virttest import aexpect
 from virttest import utils_misc
 from virttest import storage
 from virttest import utils_test


### PR DESCRIPTION
The commit 173d352 missed it.