### PR TITLE
fix boot_cpu_model.check_flag.cpu_host on Opteron_G5

### DIFF
--- a/qemu/deps/cpuid/cpuid_dump.txt
+++ b/qemu/deps/cpuid/cpuid_dump.txt
@@ -1,9 +1,9 @@
 x86       Opteron_G5 AMD Opteron 63xx class CPU
   family 21 model 2 stepping 0 level 13 xlevel 0x80000001a vendor "AuthenticAMD"
   feature_edx (sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de fpu)
-  feature_ecx (f16c avx xsave aes popcnt sse4.2|sse4_2 sse4.1|sse4_1 cx16 pma ssse3 pclmulqdq|pclmuldq pni|sse3)
+  feature_ecx (f16c avx xsave aes popcnt sse4.2|sse4_2 sse4.1|sse4_1 cx16 ssse3 pclmulqdq|pclmuldq pni|sse3)
   extfeature_edx (lm|i64 rdtscp  pdpe1gb fxsr mmx nx|xd pse36 pat cmov mca pge mtrr syscall apic cx8 mce pae msr tsc pse de fpu)
-  extfeature_ecx (tbm fma4 xop 3dnowprefetch misalignsse sse4a abm svm lahf_lm)
+  extfeature_ecx (tbm fma4 xop 3dnowprefetch misalignsse sse4a abm cr8_legacy  svm lahf_lm)
 
 x86       Opteron_G4 AMD Opteron 62xx class CPU
   family 21 model 1 stepping 2 level 13 xlevel 0x80000001a vendor "AuthenticAMD"

--- a/qemu/tests/cfg/boot_cpu_model.cfg
+++ b/qemu/tests/cfg/boot_cpu_model.cfg
@@ -10,7 +10,7 @@
         - cpu_host:
             cpu_model = "host"
         - model_cluster:
-            cpu_model_GenuineIntel = "Haswell SandyBridge Westmere Nehalem Penryn Conroe"
+            cpu_model_GenuineIntel = "Broadwell-noTSX Broadwell Haswell-noTSX Haswell SandyBridge Westmere Nehalem Penryn Conroe"
             cpu_model_AuthenticAMD = "Opteron_G5 Opteron_G4 Opteron_G3 Opteron_G2 Opteron_G1"
         - check_flag:
             # this case work on other guest as well
@@ -49,9 +49,13 @@
                 - remove_flag:
                     cpu_model_GenuineIntel = "SandyBridge"
                     cpu_model_AuthenticAMD = "Opteron_G3"
-                    cpu_model_flags = ",-sse4a,-xsave,-aes,-sse4.2"
+                    cpu_model_flags = ",-sse4a,-xsave,-aes,-sse4.2,+ht,+sep"
+                    cpu_model_flags_AuthenticAMD = ",-monitor,+vme,+lahf_lm,+cmp_legacy"
                 - cpuid_7_0_ebx_feature:
                     cpu_model_flags = ",+fsgsbase"
                     cpu_model = "SandyBridge"
                 - cpu_host:
                     cpu_model = "host"
+                    cpu_model_flags = ",+ht,+fma,+bmi1"
+                    cpu_model_flags_AuthenticAMD = ",+vme,+mmxext,+fxsr_opt,+osvw,+cmp_legacy,-x2apic,-tsc_deadline_timer"
+


### PR DESCRIPTION
fix boot_cpu_model.check_flag.remove_flag on Opteron_G5

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>