### PR TITLE
Replace the method of getting target drive path

### DIFF
--- a/generic/tests/cfg/dd_test.cfg
+++ b/generic/tests/cfg/dd_test.cfg
@@ -9,6 +9,9 @@
     image_snapshot_stg1 = no
     drive_index_stg1 = 3
     image_boot_stg1 = no
+    blk_extra_params_stg1 = "serial=TARGET_DISK0"
+    Host_RHEL.m6..ide:
+        blk_extra_params_stg1 = "wwn=0x5000123456789abc"
     dd_count = 1
     # last input and output disk
     dd_if_select = -1
@@ -19,9 +22,9 @@
             variants:
                 - zero2disk:
                     dd_if = ZERO
-                    dd_of = /dev/[shv]d?
+                    dd_of = stg1
                 - disk2null:
-                    dd_if = /dev/[shv]d?
+                    dd_if = stg1
                     dd_of = NULL
         - readonly:
             # ide, ahci don't support readonly disks
@@ -30,9 +33,9 @@
             variants:
                 - zero2disk:
                     dd_if = ZERO
-                    dd_of = /dev/[shv]d?
+                    dd_of = stg1
                     dd_stat = 1
                 - disk2null:
-                    dd_if = /dev/[shv]d?
+                    dd_if = stg1
                     dd_of = NULL
                     dd_stat = 0

--- a/generic/tests/cfg/lvm.cfg
+++ b/generic/tests/cfg/lvm.cfg
@@ -17,7 +17,12 @@
         - lvm_create:
             type = lvm
             force_create_image_stg1 = yes
+            blk_extra_params_stg1 = "serial=TARGET_DISK1"
             force_create_image_stg2 = yes
+            blk_extra_params_stg2 = "serial=TARGET_DISK2"
+            Host_RHEL.m6..ide:
+                blk_extra_params_stg1 = "wwn=0x5000123456789abc"
+                blk_extra_params_stg2 = "wwn=0x5000cba987654321"
             clean = no
         - lvm_fill: lvm_create
             type = fillup_disk

--- a/generic/tests/dd_test.py
+++ b/generic/tests/dd_test.py
@@ -8,6 +8,7 @@ import logging
 import aexpect
 
 from autotest.client.shared import error
+from virttest import utils_misc
 
 
 @error.context_aware
@@ -30,6 +31,12 @@ def run(test, params, env):
             return "/dev/random"
         elif filename == "URANDOM":
             return "/dev/urandom"
+        elif filename in params.objects("images"):
+            drive_id = params["blk_extra_params_%s" % filename].split("=")[1]
+            drive_path = utils_misc.get_linux_drive_path(session, drive_id)
+            if drive_path:
+                return drive_path
+            raise error.TestError("Failed to get '%s' drive path" % filename)
         else:
             # get all matching filenames
             try:

--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -67,7 +67,14 @@ def run(test, params, env):
                                                      data_dir.get_data_dir())
     data_image_dev = vm.get_block({'file': data_image_filename})
 
-    block_size_cmd = params["block_size_cmd"]
+    drive_path = ""
+    if params.get("os_type") == 'linux':
+        drive_id = params["blk_extra_params_%s" % data_image].split("=")[1]
+        drive_path = utils_misc.get_linux_drive_path(session, drive_id)
+        if not drive_path:
+            raise error.TestError("Failed to get '%s' drive path" % data_image)
+
+    block_size_cmd = params["block_size_cmd"].format(drive_path)
     block_size_pattern = params.get("block_size_pattern")
     need_reboot = params.get("need_reboot", "no") == "yes"
     accept_ratio = float(params.get("accept_ratio", 0))

--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -9,7 +9,10 @@
     image_name_stg = images/stg
     create_image_stg = yes
     force_create_image_stg = yes
-    block_size_cmd = "fdisk -l|grep /dev/*db"
+    blk_extra_params_stg = "serial=TARGET_DISK0"
+    Host_RHEL.m6..ide:
+        blk_extra_params_stg = "wwn=0x5000123456789abc"
+    block_size_cmd = "fdisk -l | grep {0}"
     block_size_pattern = ",\s+(\d+\s+b)ytes"
     disk_change_ratio = "1.5 0.5"
     guest_prepare_cmd = ""

--- a/qemu/tests/cfg/format_disk.cfg
+++ b/qemu/tests/cfg/format_disk.cfg
@@ -5,18 +5,21 @@
     boot_drive_disk1 = yes
     image_name_disk1 = images/storage
     image_size_disk1 = 10G
+    blk_extra_params_disk1 = "serial=TARGET_DISK0"
+    Host_RHEL.m6..ide:
+        blk_extra_params_disk1 = "wwn=0x5000123456789abc"
     force_create_image_disk1 = yes
     kill_vm = yes
     cmd_timeout = 1200
     # The following parameters will be overriden in guest-os config files.
     create_partition_cmd = ""
-    format_cmd = "cd /dev && for i in `ls | egrep [shv]db`;do yes |mkfs.ext3 $i; done"
+    format_cmd = "yes | mkfs.ext3 {0}"
     list_disk_cmd = ""
     set_online_cmd = ""
-    show_dev_cmd = "cd /dev && ls | egrep [shv]db"
-    mount_cmd =  "mkdir -p /media && cd /dev && ls | egrep [shv]db | xargs -I dev mount -t ext3 dev /media"
-    show_mount_cmd = "mount | grep -Eo '/dev/[shv]db'"
-    umount_cmd = "mount | grep -Eo '/dev/[shv]db' | xargs umount"
+    show_dev_cmd = "ls {0}"
+    mount_cmd =  "mkdir -p /media && mount -t ext3 {0} /media"
+    show_mount_cmd = "mount | grep {0}"
+    umount_cmd = "umount {0}"
     testfile_name = "/media/format_disk-test.txt"
     writefile_cmd = "echo %s > %s"
     readfile_cmd = "cat %s"


### PR DESCRIPTION
qemu.test: format_disk, block_resize
generic.test: lvm, dd_test

These above cases assumed the target drive path is "/dev/*db". However,
it would not be true in rhel ppc guest with using virtio-blk interface.
The fix will make these cases to get the target drive by serial or wwn.

ID: 1279721 1279719 1272397