### PR TITLE
qemu/tests: Add new case without_kvmclock for multi host migration

### DIFF
--- a/qemu/tests/cfg/multi_host.cfg
+++ b/qemu/tests/cfg/multi_host.cfg
@@ -87,6 +87,7 @@
                     reboot_method = system_reset
                     type = migration_multi_host_with_reboot
                 - timedrift:
+                    only Linux
                     rtc_drift = "slew"
                     type = migration_multi_host_timedrift
                     create_file = "touch /tmp/timedrift_test"
@@ -94,6 +95,13 @@
                     migrate_count = 6
                     migration_timeout = 240
                     time_diff_limit = 1.5
+                    check_clocksource_cmd = "cat /sys/devices/system/clocksource/clocksource0/current_clocksource"
+                    variants:
+                        - with_kvmclock:
+                            clocksource = "kvm-clock"
+                        - without_kvmclock:
+                            cpu_model_flags += ",-kvmclock"
+                            clocksource = "tsc"
                 - cancel_with_delay:
                     type = migration_multi_host_cancel
                     only after_login_vm


### PR DESCRIPTION
1. Add step for checking clocksource in guest.
2. Add new case without_kvmclock.

Signed-off-by: Shuping Cui <scui@redhat.com>

ID: 1298771