### PR TITLE
qemu/cfg/tests-example.cfg: longer test set should be named stable

### DIFF
--- a/qemu/cfg/tests-example.cfg
+++ b/qemu/cfg/tests-example.cfg
@@ -26,7 +26,7 @@ variants:
         only unattended_install.cdrom, boot, reboot, physical_resources_check, migrate..default, shutdown
 
     # This is an adaptation of our longer test (~8 hours). You *must* configure virtio driver install for windows
-    - @qemu_kvm_f18_sanity:
+    - @qemu_kvm_f18_stable:
         qemu_binary = /usr/bin/qemu-kvm
         qemu_img_binary = /usr/bin/qemu-img
         qemu_io_binary = /usr/bin/qemu-io


### PR DESCRIPTION
And not "sanity", which is intended to be a much shorter test set.

Signed-off-by: Cleber Rosa <crosa@redhat.com>