### PR TITLE
qemu.tests.qmp_event_notification: allow passing options to call-back function

### DIFF
--- a/qemu/tests/cfg/qmp_event_notification.cfg
+++ b/qemu/tests/cfg/qmp_event_notification.cfg
@@ -27,12 +27,14 @@
             event_check = "RESET"
             from_guest:
                 event_cmd = reboot
+                event_cmd_options = "ignore_all_errors=True"
             from_qmp:
                 event_cmd = system_reset
         - qmp_system_powerdown:
             from_guest:
                 event_check = "SHUTDOWN"
                 event_cmd = shutdown -h now
+                event_cmd_options = "ignore_all_errors=True"
             from_qmp:
                 event_check = "POWERDOWN"
                 event_cmd = system_powerdown

--- a/qemu/tests/qmp_event_notification.py
+++ b/qemu/tests/qmp_event_notification.py
@@ -29,26 +29,34 @@ def run(test, params, env):
     qmp_monitor = filter(lambda x: x.protocol == "qmp", vm.monitors)[0]
     humam_monitor = filter(lambda x: x.protocol == "human", vm.monitors)[0]
     callback = {"host_cmd": commands.getoutput,
-                "guest_cmd": session.get_command_output,
+                "guest_cmd": session.cmd,
                 "monitor_cmd": humam_monitor.send_args_cmd,
                 "qmp_cmd": qmp_monitor.send_args_cmd}
 
-    def send_cmd(cmd):
+    def send_cmd(cmd, options={}):
         if cmd_type in callback.keys():
-            return callback[cmd_type](cmd)
+            return callback[cmd_type](cmd, **options)
         else:
             raise error.TestError("cmd_type is not supported")
 
+    pre_event_cmd = params.get("pre_event_cmd", "")
+    pre_event_cmd_options = eval(
+        "dict({0})".format(params.get("pre_event_cmd_options", "")))
     event_cmd = params.get("event_cmd")
+    event_cmd_options = eval(
+        "dict({0})".format(params.get("event_cmd_options", "")))
+    post_event_cmd = params.get("post_event_cmd", "")
+    post_event_cmd_options = eval(
+        "dict({0})".format(params.get("post_event_cmd_options", "")))
     cmd_type = params.get("event_cmd_type")
     event_check = params.get("event_check")
     timeout = int(params.get("check_timeout", 360))
     action_check = params.get("action_check")
 
-    if params.get("pre_event_cmd"):
-        send_cmd(params.get("pre_event_cmd"))
+    if pre_event_cmd:
+        send_cmd(pre_event_cmd, pre_event_cmd_options)
 
-    send_cmd(event_cmd)
+    send_cmd(event_cmd, event_cmd_options)
 
     end_time = time.time() + timeout
     qmp_monitors = vm.get_monitors_by_type("qmp")
@@ -77,7 +85,7 @@ def run(test, params, env):
         raise error.TestFail("Did not receive qmp %s event notification"
                              % event_check)
 
-    if params.get("post_event_cmd"):
-        send_cmd(params.get("post_event_cmd"))
+    if post_event_cmd:
+        send_cmd(post_event_cmd, post_event_cmd_options)
     if session:
         session.close()


### PR DESCRIPTION
Running guest cmd "shutdown -h now" would cause a termination of shell
session, this would raise an exception that can fail the test. So add
the ability for passing "ignore_all_errors=True" to call-back function
which runs in guest.

ID: 1272378