### PR TITLE
Improve iozone_windows to support other disk test

### DIFF
--- a/generic/tests/cfg/iozone_windows.cfg
+++ b/generic/tests/cfg/iozone_windows.cfg
@@ -3,8 +3,10 @@
     only Windows
     type = iozone_windows
     cdrom_cd1 = isos/windows/winutils.iso
-    iozone_cmd = "%s:\Iozone\iozone.exe -azR -r 64k -n 1G -g 4G -M -b iozone.xls -f c:\testfile"
+    iozone_cmd = "%s:\Iozone\iozone.exe -azR -r 64k -n 1G -g 4G -M -b iozone.xls -f %s:\testfile"
+    disk_letter = "C"
     iozone_timeout = 7200
+    analysis_result = yes
     mem = 2048
     variants:
         - aio_native:

--- a/generic/tests/iozone_windows.py
+++ b/generic/tests/iozone_windows.py
@@ -1,12 +1,16 @@
 import logging
 import os
+import re
 
 from autotest.client import utils
 
+from avocado.core import exceptions
+from virttest import error_context
 from virttest import postprocess_iozone
 from virttest import utils_misc
 
 
+@error_context.context_aware
 def run(test, params, env):
     """
     Run IOzone for windows on a windows guest:
@@ -19,27 +23,71 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
+    def create_partition(create_partition_cmd, timeout, session):
+        has_dispart = re.findall("diskpart", create_partition_cmd, re.I)
+        if (params.get("os_type") == 'windows' and has_dispart):
+            error_context.context("Get disk list in guest")
+            list_disk_cmd = params["list_disk_cmd"]
+            status, output = session.cmd_status_output(list_disk_cmd,
+                                                       timeout=timeout)
+            for i in re.findall("Disk*.(\d+)\s+Offline", output):
+                error_context.context("Set disk '%s' to online status" % i,
+                              logging.info)
+                set_online_cmd = params["set_online_cmd"] % i
+                status, output = session.cmd_status_output(set_online_cmd,
+                                                           timeout=timeout)
+                if status != 0:
+                    raise exceptions.TestFail("Can not set disk online %s"
+                                               % output)
+
+        error_context.context("Create partition on disk", logging.info)
+        status, output = session.cmd_status_output(create_partition_cmd,
+                                                   timeout=timeout)
+        if status != 0:
+            raise exceptions.TestFail("Failed to create partition: %s"
+                                       % output)
+
+    def format_disk(timeout, session):
+        format_cmd = params["format_cmd"]
+        error_context.context("Format the disk with cmd '%s'" % format_cmd,
+                      logging.info)
+        status, output = session.cmd_status_output(format_cmd,
+                                                   timeout=timeout)
+        if status != 0:
+            raise exceptions.TestFail("Failed to format disk: %s" % output)
+
+    def iozone_test(result_path, analysisdir, disk_letter, session):
+        win_utils = utils_misc.get_winutils_vol(session)
+        iozone_cmd = params.get("iozone_cmd") % (win_utils, disk_letter)
+        t = int(params.get("iozone_timeout"))
+        error_context.context("Running IOzone command in guest, timeout %s"
+                              % t)
+        results = session.cmd_output(cmd=iozone_cmd, timeout=t)
+        if params.get("analysis_result", "no") == "yes":
+            utils.open_write_close(result_path, results)
+            logging.info("Iteration succeed, postprocessing")
+            a = postprocess_iozone.IOzoneAnalyzer(list_files=[result_path],
+                                                 output_dir=analysisdir)
+            a.analyze()
+            p = postprocess_iozone.IOzonePlotter(results_file=result_path,
+                                                 output_dir=analysisdir)
+            p.plot_all()
+
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=timeout)
-    results_path = os.path.join(test.resultsdir,
+    result_path = os.path.join(test.resultsdir,
                                 'raw_output_%s' % test.iteration)
     analysisdir = os.path.join(test.resultsdir, 'analysis_%s' % test.iteration)
+    create_partition_cmd = params.get("create_partition_cmd")
+    disk_letter = params.get("disk_letter")
+    if not disk_letter:
+        device_key = params.get("device_key", "VolumeName='Windows'")
+        disk_letter = utils_misc.get_win_disk_vol(session, device_key)
 
-    # Run IOzone and record its results
-    drive_letter = utils_misc.get_winutils_vol(session)
-    c = params["iozone_cmd"] % drive_letter
-    t = int(params.get("iozone_timeout"))
-    logging.info("Running IOzone command on guest, timeout %ss", t)
-    results = session.cmd_output(cmd=c, timeout=t)
-    utils.open_write_close(results_path, results)
-
-    # Postprocess the results using the IOzone postprocessing module
-    logging.info("Iteration succeed, postprocessing")
-    a = postprocess_iozone.IOzoneAnalyzer(list_files=[results_path],
-                                          output_dir=analysisdir)
-    a.analyze()
-    p = postprocess_iozone.IOzonePlotter(results_file=results_path,
-                                         output_dir=analysisdir)
-    p.plot_all()
+    if create_partition_cmd:
+        create_partition(create_partition_cmd, timeout, session)
+    if params.get("format_disk", "no") == "yes":
+        format_disk(timeout, session)
+    iozone_test(result_path, analysisdir, disk_letter, session)


### PR DESCRIPTION
iozone can be run in system disk currently,
add disk support as well, need to create the partition first.

ID: 1303003

 Signed-off-by: Suqin Huang <shuang@redhat.com>