### PR TITLE
qemu.tests.cfg: update sub-tests name

### DIFF
--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -84,11 +84,11 @@
         - hotplug:
             target_mem = "plug"
     variants sub_test:
-        - system_reset:
+        - vm_system_reset:
             sub_type = boot
             reboot_method = system_reset
             sleep_before_reset = 0
-        - reboot:
+        - guest_reboot:
             sub_type = boot
             reboot_method = shell
             kill_vm_on_error = yes


### PR DESCRIPTION
To avoid test name confilt with basic system_reset,
and reboot tests.

Signed-off-by: Xu Tian <xutian@redhat.com>