### PR TITLE
drive_mirror: test step update

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -57,7 +57,6 @@
                            type = drive_mirror_complete
                            variants:
                                - target_in_localfs:
-                                   open_target_image = yes
                                    boot_target_image = no
                                - target_in_nfs:
                                    image_type_target = nfs
@@ -68,14 +67,12 @@
                                    export_options = "rw,no_root_squash,async"
                                    setup_local_nfs = yes
                                    boot_target_image = yes
-                                   open_target_image = no
                                - target_to_iscsi:
                                    image_format_target = raw
                                    # target_image will ingore, target_image will generate automatically
                                    image_type_target = iscsi
                                    force_cleanup_target = yes
                                    host_setup_flag_target = 2
-                                   open_target_image = no
                                    boot_target_image = yes
                                    # Please replace below iscsi connection params before start your testing
                                    portal_ip_target = "192.168.1.2"

--- a/qemu/tests/drive_mirror_complete.py
+++ b/qemu/tests/drive_mirror_complete.py
@@ -1,8 +1,6 @@
 import logging
-import time
 
 from autotest.client.shared import error
-from autotest.client.shared import utils
 
 from virttest import data_dir
 from virttest import env_process
@@ -18,9 +16,11 @@ def run(test, params, env):
 
     1). boot vm, then mirror $source_image to $target_image
     2). wait for mirroring job go into ready status
-    3). compare $source image and $target_image file
-    4). reopen $target_image file if $open_target_image is 'yes'
-    5). boot vm from $target_image , and check guest alive
+    3). pause vm after vm in ready status
+    4). reopen $target_image file
+    5). compare $source image and $target_image file
+    6). resume vm
+    7). boot vm from $target_image and check vm is alive if necessary
 
     "qemu-img compare" is used to verify disk is mirrored successfully.
     """
@@ -32,31 +32,21 @@ def run(test, params, env):
         target_image = mirror_test.get_target_image()
         mirror_test.start()
         mirror_test.wait_for_steady()
-        error.context("Flush host pagecache", logging.info)
-        # really useless when drive_cache = 'none'
-        utils.system("sync")
         mirror_test.vm.pause()
-        time.sleep(5)
-        if params.get("open_target_image", "no") == "yes":
-            mirror_test.reopen()
-            device_id = mirror_test.vm.get_block({"file": target_image})
-            if device_id != mirror_test.device:
-                raise error.TestError("Mirrored image not being used by guest")
-        else:
-            error.context("Compare fully mirrored images", logging.info)
-            qemu_img.compare_images(source_image, target_image)
+        mirror_test.reopen()
+        device_id = mirror_test.vm.get_block({"file": target_image})
+        if device_id != mirror_test.device:
+            raise error.TestError("Mirrored image not being used by guest")
+        error.context("Compare fully mirrored images", logging.info)
+        qemu_img.compare_images(source_image, target_image)
         mirror_test.vm.resume()
-        mirror_test.vm.destroy()
         if params.get("boot_target_image", "no") == "yes":
+            mirror_test.vm.destroy()
             params = params.object_params(tag)
             if params.get("image_type") == "iscsi":
                 params["image_raw_device"] = "yes"
             env_process.preprocess_vm(test, params, env, params["main_vm"])
-            vm = env.get_vm(params["main_vm"])
-            timeout = int(params.get("login_timeout", 600))
-            session = vm.wait_for_login(timeout=timeout)
-            session.cmd(params.get("alive_check_cmd", "dir"), timeout=120)
-            session.close()
-            vm.destroy()
+            mirror_test = drive_mirror.DriveMirror(test, params, env, tag)
+        mirror_test.verify_alive()
     finally:
         mirror_test.clean()


### PR DESCRIPTION
1. Remove useless sync and wait steps
2. pause vm before reopen operation
3. compare source image and target image after reopen operation

Signed-off-by: Xu Tian <xutian@redhat.com>