### PR TITLE
tp-qemu: add configuration in autotest.control_test

### DIFF
--- a/generic/tests/cfg/autotest_control.cfg
+++ b/generic/tests/cfg/autotest_control.cfg
@@ -3,6 +3,12 @@
     virt_test_type = qemu libvirt
     only Linux
     type = autotest_control
+    # Notes:
+    #     Uncomment below 'network_proxies' to vist github websit via
+    # network proxy server, or update 'client_tests_url' to a private
+    # url to speed up download speed, if it's necessary.
+    #client_tests_url = https://codeload.github.com/autotest/autotest-client-tests/tar.gz/master
+    #network_proxies = "https_proxy: https://proxy.test.com:8080"
     test_timeout = 1800
     variants:
         - sleeptest:


### PR DESCRIPTION
Add autotest-client-tests url for download zip source and add
network_proxies configuration to support download source code via
proxy server.

Signed-off-by: Xu Tian <xutian@redhat.com>