### PR TITLE
qemu.spice: Adding libepoxy-devel rpm install for building spice-gtk

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -390,6 +390,7 @@ variants:
         libcacard_devel_url = path_to_libcacard_rpm
         source_highlight_url = path_to_source_highlight_rpm
         gtk_doc_url = path_to_gtk_doc_rpm
+        libepoxy_devel_url = path_to_libepoxy_devel_rpm
         only remote_viewer_rhel6devel_build_install
     - negative_qemu_spice_launch_badport:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.bad_port.no_password.dcp_off.1monitor.default_sc

--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -176,7 +176,7 @@ def build_install_spicegtk(vm_root_session, vm_script_path, params):
 
     if "release 7" in vm_root_session.cmd("cat /etc/redhat-release"):
         pkgsRequired = ["libogg-devel", "celt051-devel", "libcacard-devel",
-                        "source-highlight", "gtk-doc"]
+                        "source-highlight", "gtk-doc", "libepoxy-devel"]
     else:
         pkgsRequired = ["libogg-devel", "celt051-devel", "libcacard-devel"]
 


### PR DESCRIPTION
Building spice-gtk from upstream on RHEL 7.2 requires a new package
libepoxy-devel to be installed on the machine.

Reviewed By: Swapna Krishnan <skrishna@redhat.com>