### PR TITLE
qemu.cfg.host-kernel: Add option enable_check_mig_thread for Host_RHEL.7

### DIFF
--- a/qemu/cfg/host-kernel/Host_RHEL/7.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/7.cfg
@@ -2,6 +2,7 @@
     # RHEL-7 pointer
     host_kernel_ver_str += ".7"
     netdev_peer_re = "\s{2,}(.*?):.*?peer=(.*?)\n"
+    enable_check_mig_thread = yes
     drive_mirror:
         block_mirror_cmd = "drive-mirror"
         block_reopen_cmd = "block-job-complete"


### PR DESCRIPTION
Create the new thread when do migration only support
from Host_RHEL.7.0.

Signed-off-by: Shuping Cui <scui@redhat.com>

ID: 1321505
