### PR TITLE
generic/tests/netperf.py: use datadir.get_tmp_dir()

### DIFF
--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -96,7 +96,7 @@ def run(test, params, env):
         ssh_cmd(session, "echo 1 > /proc/sys/net/ipv4/conf/all/arp_ignore")
 
         download_link = params.get("netperf_download_link")
-        download_dir = data_dir.get_download_dir()
+        download_dir = data_dir.get_tmp_dir()
         md5sum = params.get("pkg_md5sum")
         pkg = utils.unmap_url_cache(download_dir, download_link, md5sum)
         remote.scp_to_remote(ip, shell_port, username, password, pkg, "/tmp")


### PR DESCRIPTION
Instead of get_download_dir(), which is really used to hold download
definition files, AKA as assets, the ".ini" files that define locations
and hashes such as the JeOS image files.

This is related to https://github.com/avocado-framework/avocado-vt/pull/439, more specifically https://github.com/avocado-framework/avocado-vt/pull/439/commits/d253d4b6e614f66520240b6117ab95d60d11851d

Signed-off-by: Cleber Rosa <crosa@redhat.com>