### PR TITLE
Change image_format_target from raw to qcow2 for simple_test.mirrorin…

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -68,7 +68,7 @@
                                    setup_local_nfs = yes
                                    boot_target_image = yes
                                - target_to_iscsi:
-                                   image_format_target = raw
+                                   image_format_target = qcow2
                                    # target_image will ingore, target_image will generate automatically
                                    image_type_target = iscsi
                                    force_cleanup_target = yes


### PR DESCRIPTION
Change image_format_target from raw to qcow2 for simple_test.mirroring.block_job_complete.target_to_iscsi, since there is image compare mismatch issue for a qcow2 source image with a raw mirror one.