### PR TITLE
qemu.tests: Small fix in invalid_parameter.py

### DIFF
--- a/qemu/tests/invalid_parameter.py
+++ b/qemu/tests/invalid_parameter.py
@@ -25,10 +25,10 @@ def run(test, params, env):
         vm.destroy()
     except Exception, emsg:
         error.context("Check guest exit status.")
-        if "(core dumped)" in emsg.reason:
+        if "(core dumped)" in str(emsg):
             raise error.TestFail("Guest core dumped with invalid parameters.")
         else:
-            logging.info("Guest quit as expect: %s" % emsg.reason)
+            logging.info("Guest quit as expect: %s" % str(emsg))
             return
 
     raise error.TestFail("Guest start normally, didn't quit as expect.")


### PR DESCRIPTION
Have no attribute 'reason' in class VMCreateError().

Signed-off-by: Shuping Cui <scui@redhat.com>

ID: 1218500