### PR TITLE
Update MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,16 +10,7 @@ In general, if you have a question, you should send an email to the Virt Test
 development mailing list and not any specific individual privately.
 
 
-Pull request maintenance - QEMU subtests
-----------------------------------------
-
-M: Jiri Zupka <jzupka@redhat.com>
-M: Lukas Doktor <ldoktor@redhat.com>
-M: Yiqiao Pu <ypu@redhat.com>
-M: Feng Yang <fyang@redhat.com>
-
-Pull request maintenance - openvswitch subtests
-------------------------------------------------
-
-M: Jiri Zupka <jzupka@redhat.com>
-
+L: Avocado-devel <avocado-devel@redhat.com>
+M: Xu Tian <xutian@redhat.com>
+M: Cong Li <coli@redhat.com>
+M: Jiangang Wei <weijg.fnst@cn.fujitsu.com>


### PR DESCRIPTION
The MAINTAINERS file is seriously outdated, this commit removes the
sections as they became unmaintained and uses volunteers with commit
rights and additionally the most active people from the last year as
there were not enough volunteers in this area.

I'd like to ask the majority of these people for confirmation (hopefully I used the right GH name).
Most active from the last year: @xutian @CongSmile @lmr @ypu @spcui
Ex maintainers: @jzupka @ypu @FengYang @ldoktor