### PR TITLE
hotplug_mem: increase hugepage number

### DIFF
--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -1,8 +1,11 @@
 # Notes:
-#    Before start testing, please ensure systemd is your guest OS
-#    is support memory hotplug;
+#    Before start testing, please ensure your host OS support hugepage,
+#    and ensure you host memory more than 6GB.
+#    And memory hotplug need guest OS support, so please ensure your
+#    guest OS really supported it.
 - hotplug_memory:
     type = hotplug_mem
+    mem_fixed = 1024
     slots_mem = 4
     size_mem = 1G
     maxmem_mem = 32G
@@ -61,12 +64,25 @@
             setup_hugepages = yes
             # mem path should be the hugpage path
             mem-path = /mnt/kvm_hugepage
-            # default pagesize is 2M, 2G guest memory need to allocate
-            # in hugepage, so page nubmer is:
-            #    target_hugepages = size_mem / page_size + 10
-            target_hugepages = 1034
             pre_command = "echo 3 > /proc/sys/vm/drop_caches"
             pre_command_noncritical = yes
+            variants:
+                - @2M_hugepage:
+                    # default pagesize is 2M, 2G guest memory need to allocate
+                    # in hugepage, so page nubmer is:
+                    #    target_hugepages = (size_mem / page_size) * 2 + 10
+                    target_hugepages = 2058
+                    expected_hugepage_size = 2048
+                - 1G_hugepage:
+                    # Warning:
+                    #     Please don't forget to update host kernel line to enable
+                    # 1G hugepage support before lanuch this test, else test will
+                    # failed.
+                    target_hugepages = 5
+                    expected_hugepage_size = 1048576
+                    only one
+                    only guest_reboot
+                    only no_policy
     variants operation:
         - unplug:
             no Windows


### PR DESCRIPTION
If memory file in hugepage, both build-in memory and hotpluged
memory allocate from hugepages, so page number should be double.

Signed-off-by: Xu Tian <xutian@redhat.com>