### PR TITLE
block_resize: fix ParamNotFound

### DIFF
--- a/qemu/tests/cfg/pci_hotplug.cfg
+++ b/qemu/tests/cfg/pci_hotplug.cfg
@@ -56,7 +56,8 @@
             sub_type_after_plug = block_resize
             create_image_stg = yes
             force_create_image_stg = yes
-            block_size_cmd = "fdisk -l|grep /dev/*db"
+            blk_extra_params_stg = "serial=TARGET_DISK0"
+            block_size_cmd = "fdisk -l | grep {0}"
             block_size_pattern = ",\s+(\d+\s+b)ytes"
             disk_change_ratio = "1.5 0.5"
             guest_prepare_cmd = ""
@@ -98,10 +99,8 @@
                 disk_change_ratio = 1.5 0.5
             RHEL.5:
                 need_reboot = yes
-            virtio_scsi..blk_virtio_blk:
-                block_size_cmd = "fdisk -l|grep /dev/vda"
-            virtio_blk..blk_virtio_scsi:
-                block_size_cmd = "fdisk -l|grep /dev/sda"
+            Host_RHEL.m6..ide:
+                blk_extra_params_stg = "wwn=0x5000123456789abc"
     variants:
         - nic_rtl8139:
             only hotplug_nic


### PR DESCRIPTION
The commit f83f336 change the method of getting target drive path,
which leads cases related block_resize fail for x86_64.
such as pci_hotplug.hotplug_block.blk_virtio_blk.with_block_resize

Error Message:
ParamNotFound: Mandatory parameter 'blk_extra_params_stg' is missing.
Check your cfg files for typos/mistakes

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>