### PR TITLE
pci_hotplug: remove hotplug_nic..with_block_resize cases

### DIFF
--- a/qemu/tests/cfg/pci_hotplug.cfg
+++ b/qemu/tests/cfg/pci_hotplug.cfg
@@ -53,6 +53,7 @@
             sub_type_after_unplug = boot
             reboot_method = system_reset
         - with_block_resize:
+            only hotplug_block
             sub_type_after_plug = block_resize
             create_image_stg = yes
             force_create_image_stg = yes


### PR DESCRIPTION
When we hotplug a NIC, there's no block device added.
so It's unreasonable to resize block device.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>