### PR TITLE
tp-qemu: Add different logical/physical_block_size for a boot case in…

### DIFF
--- a/qemu/tests/cfg/slof_boot.cfg
+++ b/qemu/tests/cfg/slof_boot.cfg
@@ -1,0 +1,13 @@
+- slof_boot: install setup image_copy unattended_install.cdrom
+    type = boot
+    restart_vm = yes
+    kill_vm_on_error = yes
+    login_timeout = 240
+    only ppc64 ppc64le
+    variants:
+        - with_sec_size_4096_512:
+            physical_block_size = 4096
+            logical_block_size = 512
+        - with_sec_size_512_512:
+            physical_block_size = 512
+            logical_block_size = 512


### PR DESCRIPTION
Add different logical/physical_block_size parameters for a boot case in slof feature (ppc only).
ID: 1324355

Signed-off-by: qzhang@redhat.com