### PR TITLE
Netstress kill guest

### DIFF
--- a/qemu/tests/trace_cmd_boot.py
+++ b/qemu/tests/trace_cmd_boot.py
@@ -71,7 +71,7 @@ def run(test, params, env):
                 error.context(txt, logging.info)
                 os.kill(trace_job.sp.pid, signal.SIGINT)
                 if not utils_misc.wait_for(lambda: not find_trace_cmd(),
-                                           180, 60, 3):
+                                           120, 60, 3):
                     logging.warn("trace-cmd could not finish after 120s.")
                 trace_job = None
                 utils.system(trace_report_cmd)


### PR DESCRIPTION
1. netstress_kill_guest: cleanup
    
    1) use wait_until_dead() instead of os.kill()
    2) remove setup_cmd/clean_cmd discarded by 0f39772
    3) round is reserved by python. so s/round/i/
    4) s/r_times/times/

2. trace_cmd_boot: trivial fix for wait time
    
    Log shows it wait for 120s, actually it cost 180s.
