### PR TITLE
tp-qemu: single_driver_install: some corrections of code.

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -8,7 +8,7 @@
     login_timeout = 360
     driver_install_timeout = 600
     tmp_folder = C:\tmp
-    guest_alias = r"Win7-32:w7\x86,Win7-64:w7\amd64,Win8-32:w8\x86,Win8-64:w8\amd64,Win8.1-32:w8.1\x86,Win8-64.1:w8.1\amd64,Win10-32:w10\x86,Win10-64:w10\amd64,Win2008-32:2k8\x86,Win2008-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12R2\amd64"
+    guest_alias = "Win7-32:w7\x86,Win7-64:w7\amd64,Win8-32:w8\x86,Win8-64:w8\amd64,Win8.1-32:w8.1\x86,Win8-64.1:w8.1\amd64,Win10-32:w10\x86,Win10-64:w10\amd64,Win2008-32:2k8\x86,Win2008-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12R2\amd64"
     driver_install_cmd = "python WIN_UTILS:\win_driver_install.py %s %s %s %s %s"
     show_file_ext_cmd = "reg add HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced /v HideFileExt /t REG_DWORD /d 0 /f"
     variants:

--- a/qemu/tests/single_driver_install.py
+++ b/qemu/tests/single_driver_install.py
@@ -83,6 +83,10 @@ def run(test, params, env):
             guest_list = dict([x.split(":") for x in alias_map.split(",")])
             guest_name = guest_list[guest_name]
 
+        # For driver virtio serial, the path name is not same as driver name,
+        # need udpate the path here.
+        if driver_name == "vioser":
+            driver_name = "vioserial"
         driver_path = r"%s:\%s\%s" % (vol_virtio, driver_name, guest_name)
         logging.debug("The driver which would be installed is %s" % driver_path)
 


### PR DESCRIPTION
1. fix a syntax error.
The end double quote of variant "guest_alias" will be
analyzed as a string \" in raw string.
2. Update the path of driver virtio serial.


Signed-off-by: Cong Li <coli@redhat.com>

id: 1334077