### PR TITLE
migration_multi_host_firewall_block: fix multiple exception

### DIFF
--- a/qemu/tests/migration_multi_host_firewall_block.py
+++ b/qemu/tests/migration_multi_host_firewall_block.py
@@ -133,7 +133,8 @@ def run(test, params, env):
                 stat = []
                 for vm in mig_data.vms:
                     stat.append(vm.monitor.get_status())
-            except qemu_monitor.MonitorProtocolError, qemu_monitor.QMPCmdError:
+            except (qemu_monitor.MonitorProtocolError,
+                    qemu_monitor.QMPCmdError):
                 logging.debug("Guest %s not working" % (vm))
 
         def check_vms_src(self, mig_data):
@@ -247,7 +248,8 @@ def run(test, params, env):
             try:
                 for vm in mig_data.vms:
                     vm.monitor.get_status()
-            except qemu_monitor.MonitorProtocolError, qemu_monitor.QMPCmdError:
+            except (qemu_monitor.MonitorProtocolError,
+                    qemu_monitor.QMPCmdError):
                 logging.debug("Guest %s not working" % (vm))
 
         def check_vms_dst(self, mig_data):


### PR DESCRIPTION
Enclose multiple exception(in one line) in parentheses.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>