### PR TITLE
tp-qemu: add missing param in cfgs who call case "driver_in_use".

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -33,6 +33,7 @@
             disk_index = 1
             format_disk = yes
             iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 4G -M -b iozone.xls -f ${disk_letter}:\testfile"
+            target_process = iozone.exe
             iozone_timeout = 7200
             wait_bg_time = 180
             driver_id_pattern = "(.*?):.*?VirtIO SCSI Disk Device"
@@ -52,6 +53,7 @@
             disk_index = 1
             format_disk = yes
             iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 4G -M -b iozone.xls -f ${disk_letter}:\testfile"
+            target_process = iozone.exe
             iozone_timeout = 7200
             wait_bg_time = 180
             driver_id_pattern = "(.*?):.*?VirtIO SCSI pass-through controller"
@@ -75,6 +77,7 @@
             ping_ext_host = "yes"
             ext_host_get_cmd = "ip route | awk '/default/ { print $3 }'"
             shell_client = "nc"
+            target_process = netperf.exe
         - with_balloon:
             driver_name = balloon
             balloon = balloon0

--- a/qemu/tests/cfg/netkvm_in_use.cfg
+++ b/qemu/tests/cfg/netkvm_in_use.cfg
@@ -21,6 +21,7 @@
     ping_ext_host = "yes"
     ext_host_get_cmd = "ip route | awk '/default/ { print $3 }'"
     shell_client = "nc"
+    target_process = netperf.exe
     variants:
         - before_bg_test:
             run_bg_flag = "before_bg_test"


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>

id: 1334977

