### PR TITLE
qemu/tests/cfg: remove unsupported method pxe.

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -161,10 +161,6 @@
             # TODO: does kvm need to prefix this with '--append'?
             extra_params = " ks=REPLACE_THIS_WITH_URL_OF_KS"
             url = REPLACE_THIS_WITH_TREE_URL
-        # Install guest using pxe/tftp  (virt-install --pxe)
-        - pxe:
-            only Linux
-            medium = pxe
         # Install guest using kernel/initrd pair from directory
         - kernel_initrd:
             only Linux


### PR DESCRIPTION
fix the error:
09:41:50 ERROR| Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_vt/test.py:401
09:41:50 ERROR| Traceback (most recent call last):
09:41:50 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_vt/test.py", line 177, in runTest
09:41:50 ERROR|     self._runTest()
09:41:50 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_vt/test.py", line 319, in _runTest
09:41:50 ERROR|     run_func(self, params, env)
09:41:50 ERROR|   File "/root/work/tp-qemu/generic/tests/unattended_install.py", line 14, in run
09:41:50 ERROR|     unattended_install.run(test, params, env)
09:41:50 ERROR|   File "/usr/lib/python2.7/site-packages/virttest/error_context.py", line 135, in new_fn
09:41:50 ERROR|     return fn(*args, **kwargs)
09:41:50 ERROR|   File "/usr/lib/python2.7/site-packages/virttest/tests/unattended_install.py", line 1175, in run
09:41:50 ERROR|     unattended_install_config.setup()
09:41:50 ERROR|   File "/usr/lib/python2.7/site-packages/virttest/tests/unattended_install.py", line 1027, in setup
09:41:50 ERROR|     self.medium)
09:41:50 ERROR| ValueError: Unexpected installation method pxe
09:41:50 ERROR|
09:41:50 ERROR| Traceback (most recent call last):