### PR TITLE
Add cfg file for a slof case to boot guest with dataplane

### DIFF
--- a/qemu/tests/cfg/slof_dataplane_boot.cfg
+++ b/qemu/tests/cfg/slof_dataplane_boot.cfg
@@ -1,0 +1,9 @@
+- slof_dataplane_boot: install setup image_copy unattended_install.cdrom
+    virt_test_type = qemu
+    type = boot
+    restart_vm = yes
+    kill_vm_on_error = yes
+    login_timeout = 240
+    only ppc64 ppc64le
+    extra_params += " -object iothread,id=iothread0"
+    blk_extra_params_image1 = "iothread=iothread0"


### PR DESCRIPTION
Test this case on ppc64le host, passed. 

03:39:23 INFO | PASS 1-smp_8.8192m.repeat1.run_test.Host_RHEL.m7.u2.qcow2.virtio_blk.up.virtio_net.RHEL.7.2.ppc64le.io-github-autotest-qemu.slof_dataplane_boot
