### PR TITLE
balloon_service: Fix undeclared variable

### DIFF
--- a/qemu/tests/balloon_service.py
+++ b/qemu/tests/balloon_service.py
@@ -32,7 +32,6 @@ def run(test, params, env):
 
         :param session: VM session.
         """
-        volume_name = params["cdrom_virtio"]
         key = "VolumeName like 'virtio-win%'"
         try:
             return utils_misc.get_win_disk_vol(session,

--- a/qemu/tests/cfg/balloon_service.cfg
+++ b/qemu/tests/cfg/balloon_service.cfg
@@ -27,7 +27,7 @@
     polling_interval = 2
     polling_sleep_time = 10
     free_mem_cmd = wmic os get FreePhysicalMemory
-    ratio = 0.5
+    check_mem_ratio = 0.1
     run_sub_test_after_balloon = no
     test_tags = "evict enlarge"
     balloon_type_evict = evict


### PR DESCRIPTION
'mem_check_ratio' isn't declared at balloon_service.cfg,
rathor than 'ratio'.
besides above, remove unused variable.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>