### PR TITLE
virtio_driver_sign_check: Use the recommended and unified path

### DIFF
--- a/qemu/tests/cfg/virtio_driver_sign_check.cfg
+++ b/qemu/tests/cfg/virtio_driver_sign_check.cfg
@@ -5,10 +5,10 @@
     # So need not add to our testing loop.
     type = virtio_driver_sign_check
     cdroms += " sdk virtio"
-    cdrom_virtio = /usr/share/virtio-win/virtio-win.iso
+    cdrom_virtio = isos/windows/virtio-win.iso
     cdrom_sdk = isos/windows/GRMSDKX_EN_DVD.iso
     floppies = "fl"
-    floppy_name = "/usr/share/virtio-win/virtio-win.vfd"
+    floppy_name = images/win7-64/virtio-win.vfd
     list_files_cmd = dir /s /b %s | find "%s"
     winsdk_au3 = autoit/winsdk.au3
     signtool_install = "D:\autoit3.exe c:\winsdk.au3"


### PR DESCRIPTION
Dispose of '/usr/share/virtio-win/',
Use 'isos/windows/' for cdrom_virtio,
Use 'images/win7-64/' for floppy_name.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>