### PR TITLE
performance: Fix no attribute 'wait_for_login'

### DIFF
--- a/qemu/tests/performance.py
+++ b/qemu/tests/performance.py
@@ -50,7 +50,7 @@ def cmd_runner_monitor(vm, monitor_cmd, test_cmd, guest_path, timeout=300):
             thread_kill(m_cmd, p_file)
 
     kill_thread_flag = Queue(1)
-    session = utils_test.wait_for_login(vm, 0, 300, 0, 2)
+    session = vm.wait_for_login(timeout=300)
     tag = vm.instance
     pid_file = "/tmp/monitor_pid_%s" % tag
     result_file = "/tmp/host_monitor_result_%s" % tag


### PR DESCRIPTION
utils_test.wait_for_login had been replaced with vm.wait_for_login
You can refer to virt-test/feea4fd.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>