### PR TITLE
for modual "aecpect", make it work 

### DIFF
--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -14,7 +14,10 @@ import sys
 import tempfile
 import random
 
-import aexpect
+try:
+    import aexpect
+except ImportError:
+    from virttest import aexpect
 
 from autotest.client.shared import error
 from autotest.client import utils


### PR DESCRIPTION
under both autotest-framework and avocado-framework

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>