### PR TITLE
qemu_img: improvements for the output

### DIFF
--- a/qemu/tests/qemu_img.py
+++ b/qemu/tests/qemu_img.py
@@ -363,7 +363,7 @@ def run(test, params, env):
                 utils.system(create_cmd, verbose=False)
             except error.CmdError:
                 raise error.TestFail("Could not create a overlay file!")
-            logging.info("overlay_file created!")
+            logging.info("overlay file (%s) created!" % overlay_file_name)
 
             # Set the qemu harddisk to the overlay file
             logging.info(
@@ -401,8 +401,10 @@ def run(test, params, env):
                 utils.system(cmitcmd, verbose=False)
             except error.CmdError:
                 raise error.TestFail("Could not commit the overlay file")
+            logging.info("overlay file (%s) committed!" % overlay_file_name)
 
-            # Start a new VM, using image_name as its harddisk
+            msg = "Start a new VM, using image_name as its harddisk"
+            error.context(msg, logging.info)
             params['image_name'] = pre_name
             vm_name = params['main_vm']
             env_process.preprocess_vm(test, params, env, vm_name)
@@ -527,9 +529,7 @@ def run(test, params, env):
             if status != 0:
                 raise error.TestError("dd failed")
 
-        # Shutdown guest
-        error.context("Shutdown command is sent, guest is going down...",
-                      logging.info)
+        error.context("Shutdown guest", logging.info)
         try:
             vm.graceful_shutdown(timeout=login_timeout)
         except Exception:


### PR DESCRIPTION
For example,
'session.sendline(params.get("shutdown_command"))' was discarded,
"Shutdown command is sent, ..." is inapproprivate.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>