### PR TITLE
multi_vms_nic: fix get wrong ip address for linux guest

### DIFF
--- a/qemu/tests/cfg/multi_vms_nic.cfg
+++ b/qemu/tests/cfg/multi_vms_nic.cfg
@@ -3,7 +3,6 @@
     no RHEL.3.9
     mac_filter = "HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+)"
     ip_filter = "inet addr:(.\d+.\d+.\d+.\d+)"
-    net_check_cmd = "ifconfig"
     # set 'strick_check = yes' to enable it.
     strick_check = no
     virt_test_type = qemu
@@ -11,9 +10,6 @@
     transfer_timeout = 1000
     type = multi_vms_nics
     ping_counts = 10
-    interface_ip_filter = "(eth\d+).*?HWaddr .\w+:\w+:\w+:\w+:\w+:\w+.*?inet addr:(.\d+.\d+.\d+.\d+)"
-    Fedora.18, RHEL.7:
-        interface_ip_filter = "(\w+):.*inet (.\d+.\d+.\d+.\d+).*?ether .\w+:\w+:\w+:\w+:\w+:\w+"
     file_create_cmd = "dd if=/dev/urandom of=/tmp/1 bs=100M count=1"
     # We can test multi nics in multi vms by setting nics.
     #nics += " nic2"


### PR DESCRIPTION
Current guest ip finding mechanism could not work if guest contains
multi nics. Use avocado api to get guest interface name and ip address.

Signed-off-by: Ping Li pingl@redhat.com