### PR TITLE
qemu_io_blkdebug: fix qemu-io cases timeout issue

### DIFF
--- a/qemu/tests/cfg/qemu_io_blkdebug.cfg
+++ b/qemu/tests/cfg/qemu_io_blkdebug.cfg
@@ -11,7 +11,7 @@
     image_cluster_size = 512
     err_command = "write 0 1G"
     err_event = "refblock_alloc"
-    errn_list = "1 2 3 4 5 6 7 8 9 10 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28"
+    errn_list = "1"
     re_std_msg = "error\s+code\s+\d+:\s+([a-zA-Z\/\-\s]+)$"
     test_timeout = 2000
     blkdebug_default = blkdebug/qemu_io_default.conf


### PR DESCRIPTION
As differnt errno are usually treated as the same code branch, test
one errno is good enough.

Signed-off-by: Ping Li pingl@redhat.com