### PR TITLE
mq_change_qnum.py: Using safe mode when execute cmd in guest via serial.

### DIFF
--- a/qemu/tests/mq_change_qnum.py
+++ b/qemu/tests/mq_change_qnum.py
@@ -41,7 +41,7 @@ def run(test, params, env):
         else:
             expect_status = 1
 
-        status, output = session.cmd_status_output(mq_set_cmd)
+        status, output = session.cmd_status_output(mq_set_cmd, safe=True)
         cur_queues_status = get_queues_status(session, ifname)
         if status != expect_status:
             err_msg = "Change queues number failed, "
@@ -62,7 +62,8 @@ def run(test, params, env):
         Get queues status
         """
         mq_get_cmd = "ethtool -l %s" % ifname
-        nic_mq_info = session.cmd_output(mq_get_cmd, timeout=timeout)
+        nic_mq_info = session.cmd_output(mq_get_cmd, timeout=timeout,
+                                         safe=True)
         queues_reg = re.compile(r"Combined:\s+(\d)", re.I)
         queues_info = queues_reg.findall(" ".join(nic_mq_info.splitlines()))
         if len(queues_info) != 2:


### PR DESCRIPTION
In serial sessions, frequently the kernel might print debug or
error messages that make read_up_to_prompt to timeout. Let's try
to be a little more robust and send a carriage return, to see if
we can get to the prompt when safe=True.

Signed-off-by: Cong Li <coli@redhat.com>

Based: https://github.com/autotest/aexpect/pull/6

id: 1330906