### PR TITLE
qemu_io_blkdebug: fix catcing exception for process.CmdError

### DIFF
--- a/qemu/tests/qemu_io_blkdebug.py
+++ b/qemu/tests/qemu_io_blkdebug.py
@@ -4,6 +4,7 @@ import ConfigParser
 
 from autotest.client.shared import error
 from autotest.client import utils
+from avocado.utils import process
 
 from virttest import qemu_io
 from virttest import data_dir
@@ -94,8 +95,8 @@ def run(test, params, env):
             try:
                 image_io.snapshot_del(blkdebug_cfg=blkdebug_cfg)
                 output = ""
-            except error.CmdError, err:
-                output = err.result_obj.stderr
+            except process.CmdError, err:
+                output = err.result.stderr
 
         # Remove the snapshot and base image after a round of test
         image_io.remove()


### PR DESCRIPTION
Correct the CmdError exception to get stderr, which is usefull for the caller

Signed-off-by: Ping Li pingl@redhat.com