### PR TITLE
qemu_io_blkdebug: update BlkdebugEvent for upstream change

### DIFF
--- a/qemu/tests/qemu_io_blkdebug.py
+++ b/qemu/tests/qemu_io_blkdebug.py
@@ -26,6 +26,10 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env:    Dictionary with test environment.
     """
+    if params.get("blkdebug_event_name_separator") == 'underscore':
+        blkdebug_event = params.get('err_event')
+        if "." in blkdebug_event:
+            params['err_event'] = blkdebug_event.replace(".", "_")
     tmp_dir = params.get("tmp_dir", "/tmp")
     blkdebug_cfg = utils_misc.get_path(tmp_dir, params.get("blkdebug_cfg",
                                                            "blkdebug.cfg"))


### PR DESCRIPTION
As upstream commit 5be5b7764f83cf9a535a22ecbd33710daf1fe210 has been
merged in the release qemu-kvm-rhev-2.6.0-1.el7, BlkdebugEvent are named 
with an underscore instead of a period. Update the related events according 
to new naming rules.

Signed-off-by: Ping Li pingl@redhat.com