### PR TITLE
Change the path of floppy images

### DIFF
--- a/qemu/tests/cfg/readonly_floppy.cfg
+++ b/qemu/tests/cfg/readonly_floppy.cfg
@@ -5,7 +5,7 @@
     floppies = "fl1 fl2"
     floppy_name_fl1 = "images/fd1.img"
     floppy_name_fl2 = "images/fd2.img"
-    pre_command = "dd if=/dev/urandom of=shared/data/images/fd1.img bs=512 count=2880&&  dd if=/dev/urandom of=shared/data/images/fd2.img bs=512 count=2880"
+    pre_command = "dd if=/dev/urandom of=/usr/share/avocado/data/avocado-vt/images/fd1.img bs=512 count=2880 && cp -af /usr/share/avocado/data/avocado-vt/images/fd{1.img,2.img}"
     format_floppy_timeout = 60
     floppy_readonly = yes
     # This command maybe different in differnet guests. It may covered by guest-os.cfg


### PR DESCRIPTION
First, The original relative path of floppy images are not exist. There is no
'data/images/' folders under 'shared' folder by default, It causes 'dd' command
failures.

If adding code into 'pre_command' of readonly_floppy.cfg to check/create
'shared/data/images/', Then the second issue jumps out:
Because 'process_command' function in env_process.py will perform
... "cd %s; %s" % (test.bindir, pre_command) ...
The test.bindir's value is assigned to '/usr/share/avocado-plugins-vt',
So we got 2 fl images under /usr/share/avocado-plugins-vt/shared/data/images/.
But in the final qemu command line parameters which generating by avocado,
The path of floppy image is /usr/share/avocado/data/avocado-vt/images/...

So I think that we insert 'cd /usr/share/avocado' to pre_command for ignoring
the effect of 'cd /usr/share/avocado-plugins-vt' and change the original
relative path info from 'shared/data/images/' to 'data/avocado-vt/images/' may
be a better choice.

Signed-off-by: Lin Ma <lma@suse.com>