### PR TITLE
Use function in framework to enable driver verifier

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -7,19 +7,13 @@
     Windows:
         # Please update path of rng_dll_register_cmd to right path which included you driver
         #rng_dll_register_cmd = if not exist "C:\Windows\system32\viorngum.dll" copy PATH:\INCLUDEDRIVER\viorngum.dll C:\Windows\system32\ /y &&"
-        #rng_dll_register_cmd += "rundll32 C:\Windows\system32\viorngum.dll,RegisterProvider"
         session_cmd_timeout = 240
         read_rng_cmd  = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
-        enable_verifier_cmd = "verifier.exe /standard /driver viorng.sys"
-        driver_verifier_cmd = "verifier.exe /querysettings"
-        driver_name = "viorng.sys"
+        driver_name = "viorng"
         rng_data_rex = "0x\w"
-        need_reboot = yes
     Linux:
         session_cmd_timeout = 360
         read_rng_cmd  = "dd if=/dev/hwrng  bs=1 count=10 2>/dev/null|hexdump"
-        enable_verifier_cmd = "rngd -r /dev/hwrng"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
-        driver_name = "virtio"
-        need_reboot = no
+        driver_name = virtio
         rng_data_rex = "\w+"

--- a/qemu/tests/rng_bat.py
+++ b/qemu/tests/rng_bat.py
@@ -1,24 +1,24 @@
 import re
 import logging
-
-from autotest.client.shared import error
-from autotest.client.shared import utils
+import aexpect
 
 from virttest import utils_misc
+from virttest import error_context
+from virttest import utils_test
+from virttest import funcatexit
+from avocado.core import exceptions
+from avocado.utils import process
 
 
-@error.context_aware
+@error_context.context_aware
 def run(test, params, env):
     """
     Qemu virtio-rng device test:
     1) boot guest with virtio-rng device
     3) check host random device opened by qemu (optional)
     4) enable driver verifier in guest
-    5) reboot guest (optional)
-    6) check device using right driver in guest.
-    7) read random data from guest.
-    8) stop vm
-    9) check vm relased host random device (optional)
+    5) check device using right driver in guest.
+    6) read random data from guest.
 
     :param test: QEMU test object
     :param params: Dictionary with the test parameters
@@ -34,7 +34,7 @@ def run(test, params, env):
         :return: False or True.
         """
         lsof_cmd = "lsof %s" % dev_file
-        output = utils.system_output(lsof_cmd, ignore_status=True)
+        output = process.system_output(lsof_cmd, ignore_status=True)
         return re.search(r"\s+%s\s+" % vm_pid, output, re.M)
 
     def set_winutils_letter(cmd, session, params):
@@ -47,61 +47,61 @@ def run(test, params, env):
             vol = "%s:" % vol
         return cmd.replace("X:", vol)
 
-    driver_name = params.get("driver_name")
     rng_data_rex = params.get("rng_data_rex", r".*")
     dev_file = params.get("filename_passthrough")
     timeout = float(params.get("login_timeout", 360))
     rng_dll_register_cmd = params.get("rng_dll_register_cmd")
     read_rng_timeout = float(params.get("read_rng_timeout", "360"))
     cmd_timeout = float(params.get("session_cmd_timeout", "360"))
-
-    error.context("Boot guest with virtio-rng device", logging.info)
+    error_context.context("Boot guest with virtio-rng device", logging.info)
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     vm_pid = vm.get_pid()
-    session = vm.wait_for_login(timeout=timeout)
-    session_cmds_key = ["read_rng_cmd",
-                        "enable_verifier_cmd",
-                        "driver_verifier_cmd"]
-    session_cmds = (set_winutils_letter(params.get(key), session, params)
-                    for key in session_cmds_key)
-    read_rng_cmd, enable_verifier_cmd, driver_verifier_cmd = session_cmds
+    driver_name = params["driver_name"]
 
     if dev_file:
-        error.context("Check '%s' used by qemu" % dev_file, logging.info)
+        error_context.context("Check '%s' used by qemu" % dev_file,
+                              logging.info)
         if not is_dev_used_by_qemu(dev_file, vm_pid):
             msg = "Qemu not using host passthrough "
             msg += "device '%s'" % dev_file
-            raise error.TestFail(msg)
+            raise exceptions.TestFail(msg)
 
-    error.context("enable driver verifier in guest", logging.info)
-    session.cmd(enable_verifier_cmd,
-                timeout=cmd_timeout, ignore_all_errors=True)
-    if params.get("need_reboot", "") == "yes":
-        vm.reboot()
+    if params["os_type"] == "windows":
+        try:
+            utils_test.qemu.setup_win_driver_verifier(driver_name,
+                                                      vm, timeout)
+            funcatexit.register(env, params.get("type"),
+                                utils_test.qemu.clear_win_driver_verifier,
+                                driver_name, vm, timeout)
+        except Exception, e:
+            raise exceptions.TestFail(e)
+    else:
+        error_context.context("verify virtio-rng device driver", logging.info)
         session = vm.wait_for_login(timeout=timeout)
+        verify_cmd = params["driver_verifier_cmd"]
+        try:
+            output = session.cmd_output(verify_cmd, timeout=cmd_timeout)
+        except aexpect.ShellTimeoutError:
+            err = "cat cmd timeout, pls check if it's a product bug"
+            raise exceptions.TestFail(err)
 
-    error.context("verify virtio-rng device driver", logging.info)
-    output = session.cmd_output(driver_verifier_cmd, timeout=cmd_timeout)
-    if not re.search(r"%s" % driver_name, output, re.M):
-        msg = "Verify device driver failed, "
-        msg += "guest report driver is %s, " % output
-        msg += "expect is '%s'" % driver_name
-        raise error.TestFail(msg)
+        if not re.search(r"%s" % driver_name, output, re.M):
+            msg = "Verify device driver failed, "
+            msg += "guest report driver is %s, " % output
+            msg += "expect is '%s'" % driver_name
+            raise exceptions.TestFail(msg)
 
-    error.context("Read virtio-rng device to get random number", logging.info)
+    error_context.context("Read virtio-rng device to get random number",
+                          logging.info)
+    session = vm.wait_for_login(timeout=timeout)
+    read_rng_cmd = set_winutils_letter(params.get("read_rng_cmd"),
+                                       session, params)
     if rng_dll_register_cmd:
         logging.info("register 'viorngum.dll' into system")
         session.cmd(rng_dll_register_cmd, timeout=120)
+
     output = session.cmd_output(read_rng_cmd, timeout=read_rng_timeout)
     if len(re.findall(rng_data_rex, output, re.M)) < 2:
-        logging.debug("rng output: %s" % output)
-        raise error.TestFail("Unable to read random numbers from guest.")
-
-    error.context("Stop guest", logging.info)
-    vm.destroy(gracefully=True)
-    if dev_file:
-        error.context("Check '%s' released by qemu" % dev_file, logging.info)
-        if is_dev_used_by_qemu(dev_file, vm_pid):
-            msg = "Qemu not release host device '%s' after it quit" % dev_file
-            raise error.TestFail(msg)
+        raise exceptions.TestFail("Unable to read random numbers from"
+                                  "guest: %s" % output)


### PR DESCRIPTION
1. use function in framework to enable driver verifier
2. no need to enable driver in linux guest
3. update code base on avocado framework

Signed-off-by: Suqin Huang <shuang@redhat.com>