### PR TITLE
fix wrong usage for qemu_has_option

### DIFF
--- a/qemu/tests/eject_media.py
+++ b/qemu/tests/eject_media.py
@@ -24,7 +24,8 @@ def run(test, params, env):
     :param env: Dictionary with test environment
     """
 
-    if not utils_misc.qemu_has_option("qmp"):
+    qemu_binary = utils_misc.get_qemu_binary(params)
+    if not utils_misc.qemu_has_option("qmp", qemu_binary):
         logging.warn("qemu does not support qmp. Human monitor will be used.")
     qmp_used = False
     vm = env.get_vm(params["main_vm"])

--- a/qemu/tests/macvtap_event_notification.py
+++ b/qemu/tests/macvtap_event_notification.py
@@ -22,7 +22,8 @@ def run(test, params, env):
     :param env: Dictionary with test environmen.
     """
 
-    if not utils_misc.qemu_has_option("qmp"):
+    qemu_binary = utils_misc.get_qemu_binary(params)
+    if not utils_misc.qemu_has_option("qmp", qemu_binary):
         error.TestNAError("This test case requires a host QEMU with QMP "
                           "monitor support")
     if params.get("nettype", "macvtap") != "macvtap":

--- a/qemu/tests/pci_hotunplug.py
+++ b/qemu/tests/pci_hotunplug.py
@@ -65,11 +65,8 @@ def run(test, params, env):
         error.context("modprobe the module %s" % module, logging.info)
         session.cmd("modprobe %s" % module)
 
-    # check monitor type
-    is_qmp_monitor = (utils_misc.qemu_has_option("qmp") and
-                      params.get("monitor_type") == "qmp")
     # Probe qemu to verify what is the supported syntax for PCI hotplug
-    if is_qmp_monitor:
+    if vm.monitor.protocol == "qmp":
         cmd_o = vm.monitor.info("commands")
     else:
         cmd_o = vm.monitor.send_args_cmd("help")

--- a/qemu/tests/qmp_event_notification.py
+++ b/qemu/tests/qmp_event_notification.py
@@ -19,7 +19,8 @@ def run(test, params, env):
     :param env: Dictionary with test environmen.
     """
 
-    if not utils_misc.qemu_has_option("qmp"):
+    qemu_binary = utils_misc.get_qemu_binary(params)
+    if not utils_misc.qemu_has_option("qmp", qemu_binary):
         error.TestNAError("This test case requires a host QEMU with QMP "
                           "monitor support")
     vm = env.get_vm(params["main_vm"])


### PR DESCRIPTION
commit 7ef4e5077731a9aba8853042ccbadf9370d24496
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Thu Jun 16 09:40:12 2016 +0800

    pci_hotunplug: improve the way to distinguish monitor type
    
    create_monitor() has chosen the proper monitor,
    We can use vm.monitor.protocol to distinguish between qmp and hmp.
    Not need to call qemu_has_option any more.
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>

commit 4ca787d74d375b611dd00e32b9b15ee6d0e18fd5
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Thu Jun 16 08:58:00 2016 +0800

    Fix wrong usage for qemu_has_option
    
    If the param 'qemu_path' is default,
    The utils_misc.qemu_has_option() takes qemu-kvm as test object,
    Not the qemu specified by user. It's definition as follow,
    
    def qemu_has_option(option, qemu_path="/usr/bin/qemu-kvm"):
        ....
    
    so call get_qemu_binary() to get the right test object(qemu)
    before calling qemu_has_option().
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>