### PR TITLE
Trivial fix for the usage of percentage

### DIFF
--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -762,13 +762,13 @@ def run(test, params, env):
                 except ZeroDivisionError:
                     logging.error("ZeroDivisionError in stats calculation")
                     stats[i] = False
-
             limit = 1 - float(params.get("cgroup_limit", 0.05))
+
             for i in range(1, len(stats)):
                 # Utilisation should be 100% - allowed treshold (limit)
                 if stats[i] < limit:
-                    logging.debug("%d: guest time is not >%s%% %s" % (i, limit,
-                                                                      stats[i]))
+                    logging.debug("%d: the utilisation of guest time is %s, "
+                                  "smaller than limit %s" % (i, stats[i], limit))
                     err.append(i)
 
         finally:

--- a/qemu/tests/migration_multi_host_with_speed_measurement.py
+++ b/qemu/tests/migration_multi_host_with_speed_measurement.py
@@ -213,5 +213,5 @@ def run(test, params, env):
         if real_speed > mig_speed + ack_speed:
             divergence = (1 - float(mig_speed) / float(real_speed)) * 100
             raise error.TestWarn("Average migration speed (%s MB/s) "
-                                 "is %3.1f %% higher than target (%s MB/s)" %
+                                 "is %3.1f%% higher than target (%s MB/s)" %
                                  (real_speed, divergence, mig_speed))

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -126,7 +126,7 @@ def run(test, params, env):
         if real_speed > mig_speed + ack_speed:
             divergence = (1 - float(mig_speed) / float(real_speed)) * 100
             raise error.TestWarn("Average migration speed (%s MB/s) "
-                                 "is %3.1f %% higher than target (%s MB/s)" %
+                                 "is %3.1f%% higher than target (%s MB/s)" %
                                  (real_speed, divergence, mig_speed))
 
     finally:


### PR DESCRIPTION
commit 74886e9c789073ce5306b0ba1fbcf5e63e59dd4d
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Tue Jun 21 11:24:45 2016 +0800

    cgroup: delete the percent sign
    
    The variable is decimal, not percentage
    No need to be followed by percent sign,
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>

commit 62c2b6d2984b738a01d3023f4ad3c045bea5827b
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Tue Jun 21 10:18:29 2016 +0800

    Fix format output for the ratio of migration speed
    
    delete spaces between number and "%"
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
