### PR TITLE
cpu_add: some updates of code.

### DIFF
--- a/qemu/tests/cfg/cpu_add.cfg
+++ b/qemu/tests/cfg/cpu_add.cfg
@@ -20,6 +20,7 @@
     variants:
         - one_cpu:
         - max_cpu:
+            max_cpus_need_hotplug = yes
             vcpu_need_hotplug = 251
             run_sub_test = yes
             sub_test_name = "boot"
@@ -28,15 +29,15 @@
             session_need_update = yes
             reboot_method = shell
         - cpuid_outof_range:
-            id_hotplug_vcpu0 = 255
+            cpuid_hotplug_vcpu0 = 255
             qmp_error_recheck = Unable to add CPU:.*, max allowed:.*
             human_error_recheck =  must be in range
         - invalid_vcpuid:
-            id_hotplug_vcpu0 = -1
+            cpuid_hotplug_vcpu0 = -1
             qmp_error_recheck = Invalid parameter type.*, expected:.*
             human_error_recheck =  integer is for 32-bit values
         - cpuid_already_exist:
-            id_hotplug_vcpu0 = 1
+            cpuid_hotplug_vcpu0 = 1
             qmp_error_recheck = Unable to add CPU:.*, it already exists
             human_error_recheck = already exists
         - add_after_stop:

--- a/qemu/tests/cpu_add.py
+++ b/qemu/tests/cpu_add.py
@@ -42,7 +42,7 @@ def run(test, params, env):
             offset = 0.0
         return offset
 
-    def qemu_guest_cpu_match(vm, vcpu_been_pluged=0, wait_time=60):
+    def qemu_guest_cpu_match(vm, vcpu_been_pluged=0, wait_time=300):
         """
         Check Whether the vcpus are matche
         """
@@ -104,6 +104,8 @@ def run(test, params, env):
     vm.verify_alive()
     session = vm.wait_for_login(timeout=timeout)
     maxcpus = vm.cpuinfo.maxcpus
+    if params.get("max_cpus_need_hotplug", "no") == "yes":
+        vcpu_need_hotplug = vcpu_need_hotplug - vm.cpuinfo.smp
 
     if ntp_sync_cmd:
         error.context("sync guest time via ntp server", logging.info)
@@ -112,7 +114,7 @@ def run(test, params, env):
         logging.info("stop ntp service in guest")
         session.cmd(ntp_service_stop_cmd)
 
-    error.context("Check if cpus in guest matche qemu cmd before hotplug",
+    error.context("Check if cpus in guest match qemu cmd before hotplug",
                   logging.info)
     qemu_guest_cpu_match(vm)
 
@@ -139,7 +141,7 @@ def run(test, params, env):
     for i in range(vcpu_need_hotplug):
         hotplug_vcpu_params = params.object_params("hotplug_vcpu%s" % i)
         plug_cpu_id = len(vm.vcpu_threads)
-        plug_cpu_id = hotplug_vcpu_params.get("id", plug_cpu_id)
+        plug_cpu_id = hotplug_vcpu_params.get("cpuid", plug_cpu_id)
 
         (status, output) = vm.hotplug_vcpu(plug_cpu_id, hotplug_add_cmd)
 


### PR DESCRIPTION
1. vcpu_need_hotplug for max_cpu scenario can not be a fixed num,
   should be vcpu_need_hotplug = vcpu_maxcpus - vm.cpuinfo.smp
2. Rename param "id" to "cpuid", as there is same param in the object.
3. Enlarge waiting time after hotplug cpus, 60s is not enough for
   max cpu hotplug.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1348826