### PR TITLE
multi_disk.cfg: Force to use aio=threads for scsi-generic disks created by scsi_debug

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -79,6 +79,7 @@
                             stg_params += "image_name:/dev/sd* "
                         - generic:
                             stg_params += "drive_cache:writethrough "
+                            stg_params += "image_aio:threads "
                             stg_params += "drive_format:scsi-generic "
                             stg_params += "image_name:/dev/sg* "
                 - multi_lun:


### PR DESCRIPTION
Signed-off-by: Nini Gu ngu@redhat.com

ID: 1348499