### PR TITLE
qemu_cpu.cfg updates for RHEL-7

### DIFF
--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -446,6 +446,27 @@
                             ignore_cpuid_leaves += " 0x80000001,0x00,edx,24"
 
 
+                    #FIXED BUG: RHEL-7.2 and older had feature aliases set on
+                    # some Intel CPU models. It was fixed without any compat code
+                    machine_type_rhel.rhel6, machine_type_rhel.rhel7.rhel700, machine_type_rhel.rhel7.rhel710, machine_type_rhel.rhel7.rhel720:
+                        cpu_model_intel.kvm64, cpu_model_intel.kvm32, cpu_model_intel.n270:
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,0"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,2"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,3"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,4"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,5"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,6"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,7"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,8"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,9"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,12"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,13"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,14"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,15"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,16"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,17"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,23"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,24"
 
                     #KNOWN BUG: the PMU CPUID leaf is unstable on QEMU 1.5 and
                     # older, so ignore it:

--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -422,6 +422,31 @@
                             ignore_cpuid_leaves += " 0x80000001,0x00,edx,23"
                             ignore_cpuid_leaves += " 0x80000001,0x00,edx,24"
 
+                    #FIXED BUG: QEMU v2.3 and older had feature aliases set
+                    # on some Intel models. It was fixed without any compat code,
+                    # so ignore them:
+                    machine_type_upstream.pc_1_0, machine_type_upstream.pc_1_1, machine_type_upstream.pc_1_2, machine_type_upstream.pc_1_3, machine_type_upstream.pc_q35_1_4, machine_type_upstream.pc_i440fx_1_4, machine_type_upstream.pc_q35_1_5, machine_type_upstream.pc_i440fx_1_5, machine_type_upstream.pc_q35_1_6, machine_type_upstream.pc_i440fx_1_6, machine_type_upstream.pc_q35_1_7, machine_type_upstream.pc_i440fx_1_7, machine_type_upstream.pc_q35_2_0, machine_type_upstream.pc_i440fx_2_0, machine_type_upstream.pc_q35_2_1, machine_type_upstream.pc_i440fx_2_1, machine_type_upstream.pc_q35_2_2, machine_type_upstream.pc_i440fx_2_2:
+                        cpu_model_intel.kvm64, cpu_model_intel.kvm32, cpu_model_intel.n270:
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,0"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,2"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,3"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,4"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,5"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,6"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,7"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,8"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,9"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,12"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,13"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,14"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,15"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,16"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,17"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,23"
+                            ignore_cpuid_leaves += " 0x80000001,0x00,edx,24"
+
+
+
                     #KNOWN BUG: the PMU CPUID leaf is unstable on QEMU 1.5 and
                     # older, so ignore it:
                     # (to be fixed on QEMU 1.6.0)

--- a/qemu/tests/cfg/qemu_cpu.cfg
+++ b/qemu/tests/cfg/qemu_cpu.cfg
@@ -204,6 +204,12 @@
                                                     machine_type_to_check = "pc-q35-rhel7.1.0"
                                                 - i440fx:
                                                     machine_type_to_check = "pc-i440fx-rhel7.1.0"
+                                        - rhel720:
+                                            variants:
+                                                - q35:
+                                                    machine_type_to_check = "pc-q35-rhel7.2.0"
+                                                - i440fx:
+                                                    machine_type_to_check = "pc-i440fx-rhel7.2.0"
                         - machine_type_upstream:
                             no Host_RHEL
                             variants:


### PR DESCRIPTION
Update CPUID test case config files to properly account for RHEL-7.2 known CPUID changes.