### PR TITLE
Remove node-name and granularity in drive-mirror related test for RHEL6

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -64,36 +64,43 @@
             start_firewall_cmd = "iptables -A INPUT -p tcp -d ${portal_ip_target} --dport 3260 -j DROP"
             # End
     variants:
-        - job_cancel:
-            before_steady = "cancel"
-            cancel_timeout_image1 = 3
-        - set_job_speed:
-            max_speed_image1 = 10M
-            before_steady = "set_speed"
-        - reset_job_speed:
-            default_speed_image1 = 10M
-            max_speed_image1 = 1M
-            before_steady = "set_speed"
-        - query_job_status:
-            before_steady = "query_status"
-            default_speed_image1 = 3M
-            max_speed_image1 = 10M
-        - job_complete:
+        - simple_test:
+            variants:
+                - job_cancel:
+                    before_steady = "cancel"
+                    cancel_timeout_image1 = 3
+                - set_job_speed:
+                    max_speed_image1 = 10M
+                    before_steady = "set_speed"
+                - reset_job_speed:
+                    default_speed_image1 = 10M
+                    max_speed_image1 = 1M
+                    before_steady = "set_speed"
+                - query_job_status:
+                    before_steady = "query_status"
+                    default_speed_image1 = 3M
+                    max_speed_image1 = 10M
+                - job_complete:
+                    type = drive_mirror_complete
+                    boot_target_image = no
+        - granularity:
             type = drive_mirror_complete
             boot_target_image = no
+            no Host_RHEL.m6
+            when_steady = check_granularity
             variants:
-                - granularity:
-                    when_steady = check_granularity
-                    variants:
-                        - 512:
-                            granularity = 512
-                            buf_count = 10
-                        - 67108864:
-                            granularity = 67108864
-                            buf_count = 2
-                - node_name:
-                    after_reopen = check_node_name
-                    node_name = "node2"
+                - 512:
+                    granularity = 512
+                    buf_count = 10
+                - 67108864:
+                    granularity = 67108864
+                    buf_count = 2
+        - node_name:
+            type = drive_mirror_complete
+            boot_target_image = no
+            no Host_RHEL.m6
+            after_reopen = check_node_name
+            node_name = "node2"
         - with_stress:
             type = drive_mirror_stress
             reopen_timeout = 600


### PR DESCRIPTION
Remove node-name and granularity in drive-mirror related test for RHEL6.
id: 1351903
Signed-off-by: Qianqian Zhu qizhu@redhat.com