### PR TITLE
check SR-IOV VF device on host before proceeding with test

### DIFF
--- a/qemu/tests/sr_iov_sanity.py
+++ b/qemu/tests/sr_iov_sanity.py
@@ -76,6 +76,9 @@ def run(test, params, env):
     device_type = params.get("device_type", "vf")
     if device_type == "vf":
         device_num = pci_assignable.get_vfs_count()
+        if device_num == 0:
+            msg = " No VF device found even after running SR-IOV setup"
+            raise error.TestFail(msg)
     elif device_type == "pf":
         device_num = len(pci_assignable.get_pf_vf_info())
     else:


### PR DESCRIPTION
There are scenarios where the SR-IOV VF devices would not be created on host due to some issues related to SR-IOV setup on Host. Currently we do not check if we have VFs loaded after test_setup.PciAssignable. This commit would introduce this check on qemu test side. There is another commit on avocado-vt/virttest which would print ERROR message to users when VF device are not created.