### PR TITLE
qemu.tests.virtio_console: modify the index value in test_hotplug_vir…

### DIFF
--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -1652,7 +1652,7 @@ def run(test, params, env):
         pause = float(params.get("virtio_console_pause", 0.1))
         vm = get_vm_with_ports()
         monitor = vm.monitors[0]
-        idx = 1
+        idx = len(get_virtio_ports(vm)[0])
         err = ""
         booted = False
         error.context("Hotplug while booting", logging.info)


### PR DESCRIPTION
…tio_pci

The old setting of 'idx' doesn't make sense because there are already couple of
virtio-serial-pci devices attaching to VM for virtio consoles. So hotplugging
a pci virtio-serial with the conflict device id causeing 'Duplicate ID' error.

The patch calculates the number of existed virtio console, Then assigns it to
the 'idx' to avoid the above error.

Signed-off-by: Lin Ma <lma@suse.com>