### PR TITLE
qemu.tests.cdrom: Remove node-names in qemu_cdrom_device for qemu 2.5+

### DIFF
--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -207,7 +207,7 @@ def run(test, params, env):
                 cdfile = file_list[0]
             else:
                 # try to deal with new qemu
-                tmp_re_str = r'%s: (\S*) \(.*\)' % qemu_cdrom_device
+                tmp_re_str = r'%s \(#.*\): (\S*)' % qemu_cdrom_device
                 file_list = re.findall(tmp_re_str, blocks)
                 if file_list:
                     cdfile = file_list[0]
@@ -651,6 +651,8 @@ def run(test, params, env):
                 # XXX: The device got from monitor might not match with the guest
                 # defice if there are multiple cdrom devices.
                 qemu_cdrom_device = get_empty_cdrom_device(vm)
+                if qemu_cdrom_device.find(' ') > 0:
+                    qemu_cdrom_device = qemu_cdrom_device[0:qemu_cdrom_device.find(' ')]
                 guest_cdrom_device = get_testing_cdrom_device(vm,
                                                               self.session,
                                                               cdrom_dev_list,
@@ -674,6 +676,8 @@ def run(test, params, env):
             error.context("Detecting the existence of a cdrom (qemu side)",
                           logging.info)
             qemu_cdrom_device = get_device(vm, iso_image)
+            if qemu_cdrom_device.find(' ') > 0:
+                qemu_cdrom_device = qemu_cdrom_device[0:qemu_cdrom_device.find(' ')]
             if params["os_type"] != "windows":
                 self.session.get_command_output("umount %s" % guest_cdrom_device)
             if params.get('cdrom_test_autounlock') == 'yes':


### PR DESCRIPTION
The output of 'info block' includes node-names information since qemu 2.5.
Some excess information(say (#blockXXX) ) will be saved into qemu_cdrom_device.
It causes qemu_cdrom_device containing inaccurate info, The functions which
using qemu_cdrom_device can't work any more, say eject_cdrom, change_media or
is_tray_opened ...

So this patch removed the node-names info from qemu_cdrom_device, and change the
regular expression a little bit in get_cdrom_file to reflect the change.

Signed-off-by: Lin Ma lma@suse.com
