### PR TITLE
qemu.tests: Unify usage of "source_image" in block_stream and drive_mirror related cases.

### DIFF
--- a/qemu/tests/block_stream.py
+++ b/qemu/tests/block_stream.py
@@ -31,7 +31,7 @@ def run(test, params, env):
     5) Check for backing file in sn1
     6) Check for the size of the sn1 should not exceeds image.img
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     stream_test = BlockStreamTest(test, params, env, tag)
     try:
         image_file = stream_test.get_image_file()

--- a/qemu/tests/block_stream_check_backingfile.py
+++ b/qemu/tests/block_stream_check_backingfile.py
@@ -65,7 +65,7 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     backingfile_test = BlockStreamCheckBackingfile(test, params, env, tag)
     try:
         backingfile_test.create_snapshots()

--- a/qemu/tests/block_stream_reboot.py
+++ b/qemu/tests/block_stream_reboot.py
@@ -54,7 +54,7 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     reboot_test = BlockStreamReboot(test, params, env, tag)
     try:
         reboot_test.action_before_start()

--- a/qemu/tests/block_stream_simple.py
+++ b/qemu/tests/block_stream_simple.py
@@ -31,7 +31,7 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     simple_test = BlockStreamSimple(test, params, env, tag)
     try:
         simple_test.create_snapshots()

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -19,9 +19,9 @@
     #block_reopen_cmd = "__com.redhat_drive-reopen"
     wait_timeout = 6000
     # wait_timeout: wait xx seconds for block mirror job go into steady status, aka offset equal image length
-    source_images = "image1"
+    source_image = "image1"
     target_image_image1 = "target"
-    # source_images: set which image will be mirroring to target, now only a image at one time;
+    # source_image: set which image will be mirroring to target, now only a image at one time;
     full_copy_image1 = "full"
     #for full image or top most
     default_speed_image1 = 0

--- a/qemu/tests/cfg/drive_mirror_negtive_tests.cfg
+++ b/qemu/tests/cfg/drive_mirror_negtive_tests.cfg
@@ -19,9 +19,9 @@
     #block_reopen_cmd = "__com.redhat_drive-reopen"
     wait_timeout = 6000
     # wait_timeout: wait xx seconds for block mirror job go into steady status, aka offset equal image length
-    source_images = "image1"
+    source_image = "image1"
     target_image_image1 = "target"
-    # source_images: set which image will be mirroring to target, now only a image at one time;
+    # source_image: set which image will be mirroring to target, now only a image at one time;
     full_copy_image1 = "full"
     #for full image or top most
     default_speed_image1 = 0

--- a/qemu/tests/drive_mirror_cancel.py
+++ b/qemu/tests/drive_mirror_cancel.py
@@ -15,7 +15,7 @@ def run_drive_mirror_cancel(test, params, env):
     4). flush iptables chain then check job canceled in 10s
 
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     mirror_test = drive_mirror.DriveMirror(test, params, env, tag)
     try:
         mirror_test.start()

--- a/qemu/tests/drive_mirror_complete.py
+++ b/qemu/tests/drive_mirror_complete.py
@@ -24,7 +24,7 @@ def run(test, params, env):
 
     "qemu-img compare" is used to verify disk is mirrored successfully.
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     qemu_img = qemu_storage.QemuImg(params, data_dir.get_data_dir(), tag)
     mirror_test = drive_mirror.DriveMirror(test, params, env, tag)
     try:

--- a/qemu/tests/drive_mirror_powerdown.py
+++ b/qemu/tests/drive_mirror_powerdown.py
@@ -48,7 +48,7 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     powerdown_test = DriveMirrorPowerdown(test, params, env, tag)
     try:
         powerdown_test.action_before_start()

--- a/qemu/tests/drive_mirror_reboot.py
+++ b/qemu/tests/drive_mirror_reboot.py
@@ -13,7 +13,7 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     reboot_test = drive_mirror.DriveMirror(test, params, env, tag)
     try:
         reboot_test.reboot("system_reset", False)

--- a/qemu/tests/drive_mirror_simple.py
+++ b/qemu/tests/drive_mirror_simple.py
@@ -45,7 +45,7 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    tag = params.get("source_images", "image1")
+    tag = params.get("source_image", "image1")
     repeats = int(params.get("repeat_times", 3))
     simple_test = DriveMirrorSimple(test, params, env, tag)
     try:


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>