### PR TITLE
timedrift: Fix wrong message for TestError

### DIFF
--- a/qemu/tests/timedrift_no_net.py
+++ b/qemu/tests/timedrift_no_net.py
@@ -49,12 +49,12 @@ def subw_guest_suspend(params, vm, session):
 def subw_guest_pause_resume(params, vm, session):
     vm.monitor.cmd("stop")
     if not vm.monitor.verify_status("paused"):
-        raise error.TestError("VM is not paused Current status: %s",
+        raise error.TestError("VM is not paused Current status: %s" %
                               vm.monitor.get_status())
     time.sleep(float(params.get("wait_timeout", "1800")))
     vm.monitor.cmd("cont")
     if not vm.monitor.verify_status("running"):
-        raise error.TestError("VM is not running. Current status: %s",
+        raise error.TestError("VM is not running. Current status: %s" %
                               vm.monitor.get_status())
 
 

--- a/qemu/tests/timedrift_no_net_win.py
+++ b/qemu/tests/timedrift_no_net_win.py
@@ -44,12 +44,12 @@ def subw_guest_suspend(params, vm, session):
 def subw_guest_pause_resume(params, vm, session):
     vm.monitor.cmd("stop")
     if not vm.monitor.verify_status("paused"):
-        raise error.TestError("VM is not paused Current status: %s",
+        raise error.TestError("VM is not paused Current status: %s" %
                               vm.monitor.get_status())
     time.sleep(float(params.get("wait_timeout", "1800")))
     vm.monitor.cmd("cont")
     if not vm.monitor.verify_status("running"):
-        raise error.TestError("VM is not running. Current status: %s",
+        raise error.TestError("VM is not running. Current status: %s" %
                               vm.monitor.get_status())
 
 


### PR DESCRIPTION
The error message has to use interpolation.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>