### PR TITLE
multi_vms_nic: fix packet lose during command ping.

### DIFF
--- a/qemu/tests/cfg/multi_vms_nic.cfg
+++ b/qemu/tests/cfg/multi_vms_nic.cfg
@@ -11,8 +11,14 @@
     type = multi_vms_nics
     ping_counts = 10
     file_create_cmd = "dd if=/dev/urandom of=/tmp/1 bs=100M count=1"
+    check_irqbalance_cmd = "service irqbalance status"
+    stop_irqbalance_cmd = "service irqbalance stop"
+    start_irqbalance_cmd = "service irqbalance start"
+    status_irqbalance = "Active: active|running"
     # We can test multi nics in multi vms by setting nics.
     #nics += " nic2"
+    kill_vm_before_test = yes
+    start_vm = no
     vms = "vm1 vm2 vm3 vm4"
     image_snapshot = yes
     # Set packet size used in ping test, we can test different packet size


### PR DESCRIPTION
To avoid the packet lose, need to make sure the vcpus + vhosts <= pcpus
and pin vcpus/vhosts into different cpu.

Signed-off-by: Ping Li pingl@redhat.com