### PR TITLE
qemu.tests.usb_storage: Fix serial params errors

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -187,6 +187,7 @@
         - usb_storage:
             type = usb_storage
             images += " stg"
+            blk_extra_params_stg = "serial=TARGET_DISK0"
             image_boot_image1 = yes
             image_name_stg = "images/usbdevice"
             image_format_stg = "qcow2"

--- a/qemu/tests/format_disk.py
+++ b/qemu/tests/format_disk.py
@@ -37,6 +37,12 @@ def run(test, params, env):
     if params.get("os_type") == 'linux':
         drive_name = params.objects("images")[-1]
         drive_id = params["blk_extra_params_%s" % drive_name].split("=")[1]
+        # If a device option(bool/str) in qemu cmd line doesn't have a value,
+        # qemu assigns the value as "on".
+        if drive_id == "NO_EQUAL_STRING":
+            drive_id = "on"
+        elif drive_id == "EMPTY_STRING":
+            drive_id = ""
         drive_path = utils_misc.get_linux_drive_path(session, drive_id)
         if not drive_path:
             raise error.TestError("Failed to get '%s' drive path" % drive_name)

--- a/qemu/tests/usb_storage.py
+++ b/qemu/tests/usb_storage.py
@@ -95,11 +95,10 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy()
 
-        new_params = params.copy()
         for option, value in options.iteritems():
-            new_params[option] = value
+            params[option] = value
         error.context("Restarting VM")
-        vm.create(params=new_params)
+        vm.create(params=params)
         vm.verify_alive()
 
     def _login():
@@ -123,7 +122,7 @@ def run(test, params, env):
     @error.context_aware
     def _check_serial_option(serial, regex_str, expect_str):
         error.context("Set serial option to '%s'" % serial, logging.info)
-        _restart_vm({"drive_serial_stg": serial})
+        _restart_vm({"blk_extra_params_stg": "serial=" + serial})
 
         error.context("Check serial option in monitor", logging.info)
         output = str(vm.monitor.info("qtree"))


### PR DESCRIPTION
The usb_storage tests report couple of errors, says:
* missing blk_extra_params_stg
* Expected: '520fa169-32f8-431f-9f1e-70992671d2e5', Actual: 'TARGET_DISK0'
('520fa169-..' is generated dynamically, 'TARGET_..' is my blk_extra_params_stg)
* Can not get drive path by id 'NO_EQUAL_STRING
* Can not get drive path by id 'EMPTY_STRING'

This patch fixes above issues.

Signed-off-by: Lin Ma <lma@suse.com>