### PR TITLE
qemu.tests：add case for migration with usb device

### DIFF
--- a/qemu/tests/usbdev_migration.py
+++ b/qemu/tests/usbdev_migration.py
@@ -1,0 +1,18 @@
+from autotest.client.shared import error
+from virttest.utils_test import qemu
+
+
+@error.context_aware
+def run(test, params, env):
+    """
+    KVM usb device check test:
+    1) Log into a guest
+    2) Verify if the vm with usb device can be migrated
+
+    :param test: kvm test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    usb = qemu.UsbDevTest(test, params, env)
+    usb.local_migration_usbdev(params.get("usb_type"),
+                               params.get("mig_protocol"))


### PR DESCRIPTION
qemu.tests：add case for migration with usb device
Deps on [631](https://github.com/avocado-framework/avocado-vt/pull/631)
Deps on [707](https://github.com/autotest/tp-qemu/pull/707l)
ID：1324319 1324313 1324324
