### PR TITLE
ethtool: fix wrong assignment for global variable

### DIFF
--- a/generic/tests/ethtool.py
+++ b/generic/tests/ethtool.py
@@ -92,11 +92,11 @@ def run(test, params, env):
 
     def ethtool_save_params(session):
         error.context("Saving ethtool configuration", logging.info)
-        pretest_status = ethtool_get(session)
+        return ethtool_get(session)
 
-    def ethtool_restore_params(session):
+    def ethtool_restore_params(session, status):
         error.context("Restoring ethtool configuration", logging.info)
-        ethtool_set(session, pretest_status)
+        ethtool_set(session, status)
 
     def compare_md5sum(name):
         txt = "Comparing md5sum of the files on guest and host"
@@ -239,7 +239,7 @@ def run(test, params, env):
         "gro": (ro_callback, ("rx",), ("lro",)),
         "lro": (rx_callback, (), ("gro",)),
     }
-    ethtool_save_params(session)
+    pretest_status = ethtool_save_params(session)
     failed_tests = []
     try:
         for f_type in supported_features:
@@ -288,7 +288,7 @@ def run(test, params, env):
 
         try:
             session = vm.wait_for_serial_login(timeout=login_timeout)
-            ethtool_restore_params(session)
+            ethtool_restore_params(session, pretest_status)
         except Exception, detail:
             logging.warn("Could not restore parameter of"
                          " eth card: '%s'", detail)


### PR DESCRIPTION
In python, variables that are only referenced inside a function
are implicitly global. And if a variable is assigned a new value
anywhere within the function's body, it's assumed to be a local.

so ethtool_save_params() doesn't truely store the ethtool status
into global variable 'pretest_status'. we can simply make use of
by 'global' to fix the problem, but it's not a good method.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>