### PR TITLE
qemu.tests.single_driver_install: workaround for windows system disk …

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -26,6 +26,10 @@
                 backend_type = passthrough
                 filename_passthrough = /dev/random
         - with_viostor:
+            # For latest windows guests, changing system disk driver between
+            # virtio_blk and virt_scsi will cause BSOD "INACCESSABLE_DEVICE".
+            # Do a workaround here to avoid such scenario.
+            no virtio_scsi
             driver_name = viostor
             device_name = "Red Hat VirtIO SCSI controller"
             drive_format_image1 = ide
@@ -36,6 +40,10 @@
             force_create_image_stg = yes
             remove_image_stg = yes
         - with_vioscsi:
+            # For latest windows guests, changing system disk driver between
+            # virtio_blk and virt_scsi will cause BSOD "INACCESSABLE_DEVICE".
+            # Do a workaround here to avoid such scenario.
+            no virtio_blk
             driver_name = vioscsi
             device_name = "Red Hat VirtIO SCSI pass-through controller"
             cd_format_fixed =ide


### PR DESCRIPTION
…driver change problem.

do a workaround to avoid chaning system disk driver between virtio_blk and virtio_scsi, which will cause BSOD "INACCESSABLE_DEVICE" for lastest windows guests.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1357507