### PR TITLE
virtio_console: Log guest output on sigio failure

### DIFF
--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -331,10 +331,11 @@ def run(test, params, env):
         guest_worker.cmd("virt.set_pool_want_return('%s', select.POLLOUT)" %
                          (port.name), 10)
         port.open()
-        match = guest_worker._cmd("virt.get_sigio_poll_return('%s')" %
-                                  (port.name), 10)[0]
+        match, data = guest_worker._cmd("virt.get_sigio_poll_return('%s')" %
+                                        (port.name), 10)
         if match == 1:
-            raise error.TestFail("Problem with HUP on console port.")
+            raise error.TestFail("Problem with HUP on console port:\n%s"
+                                 % data)
 
         # Test sigio when port receive data
         guest_worker.cmd("virt.set_pool_want_return('%s', select.POLLOUT |"


### PR DESCRIPTION
When the first check in sigio test fails, the exception does not log the
information from guest, which are essential in order to know why it went
wrong. Let's log it as well.

PS: I checked all other `guest_worker._cmd` uses and they already log
the data on failure.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>