### PR TITLE
live_snapshot: parameter "node-name" does not support on RHEL.5 and RHEL.6 QMP.

### DIFF
--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -21,6 +21,7 @@
                     image_cluster_size = 4096
                     after_finished = "reboot verify_alive"
                 - node_name:
+                    no Host_RHEL.m5, Host_RHEL.m6 
                     node_name = node1
                     snapshot_node_name = node2
         - with_reboot:


### PR DESCRIPTION
id: 1364760

Signed-off-by: Cong Li <coli@redhat.com>