### PR TITLE
qemu: Remove unnecessary cleanup in virtio_console test

### DIFF
--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -320,12 +320,10 @@ def run(test, params, env):
             params.get('virtio_console_params'))
         if port.is_open():
             port.close()
+            time.sleep(0.5)   # wait for SIGHUP to be emitted
 
-        # Read out the previous signals
-        guest_worker._cmd("virt.get_sigio_poll_return('%s')" % (port.name), 1)
         # Enable sigio on specific port
         guest_worker.cmd("virt.async('%s', True, 0)" % (port.name), 10)
-        guest_worker.cmd("virt.get_sigio_poll_return('%s')" % (port.name), 10)
 
         # Test sigio when port open
         guest_worker.cmd("virt.set_pool_want_return('%s', select.POLLOUT)" %


### PR DESCRIPTION
The removed functions are suppose to clean previously set signals, which
is not really needed as the `set_poll_want_return` itself cleans the
signals. The only exception is when we close the port so let's add a
0.5s delay in order to make sure the signal was already emitted and wont
corrupt the testing.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>