### PR TITLE
fix typo in migration.cfg

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -103,7 +103,7 @@
             copy_block_size = 100M
             kill_vm_gracefully_virt_test_vm2_data_server = yes
             start_vm_vm1 = no
-            images_vm1 = "$images image2"
+            images_vm1 = "${images} image2"
             image_boot_image2_vm1 = no
             image_name_image2_vm1 = "test"
             force_create_image_image2_vm1 = yes


### PR DESCRIPTION
Fix $image to ${image} in migration.cfg

ID: 1365768
Signed-off-by: Huiqing Ding huding@redhat.com
