### PR TITLE
Reduce stress and run time, too big stress caused case run ERROR.

### DIFF
--- a/qemu/tests/cfg/mq_change_qnum.cfg
+++ b/qemu/tests/cfg/mq_change_qnum.cfg
@@ -68,11 +68,11 @@
             wait_bg_time = 240
             run_bgstress = file_copy_stress
             bg_stress_run_flag = file_transfer_run
-            stress_timeout = 6000
-            filesize = 1500
+            stress_timeout = 360
+            filesize = 512
             transfer_timeout = 1500
             repeat_counts = 1000
-            scp_para_sessions = 6
+            scp_para_sessions = 4
         - under_migrate:
             wait_bg_time = 10
             run_bgstress = migration


### PR DESCRIPTION
1.reduce the filesize to 512
2.reduce the scp_para_sessions to 4
3.reduce the stress_timeout to 360

id: 1010795
Signed-off-by: weliao <weliao@redhat.com>