### PR TITLE
Add more scenerios to rng device test

### DIFF
--- a/qemu/tests/cfg/rng_stress.cfg
+++ b/qemu/tests/cfg/rng_stress.cfg
@@ -1,0 +1,35 @@
+- rng_stress:
+    type = rng_stress
+    kill_vm = yes
+    virt_test_type = qemu
+    read_rng_timeout = 360
+    sub_test = rng_bat
+    no no_virtio_rng
+    Windows:
+        session_cmd_timeout = 240
+        read_rng_cmd  = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        driver_name = "viorng"
+        rng_data_rex = "0x\w"
+        driver_id_cmd = X:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"
+        driver_check_cmd = X:\devcon\wxp_x86\devcon.exe status @DRIVER_ID
+        driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
+    Linux:
+        session_cmd_timeout = 360
+        read_rng_cmd  = "dd if=/dev/hwrng  bs=1 count=10 2>/dev/null|hexdump"
+        driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
+        driver_available_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_available"
+        driver_name = virtio
+        rng_data_rex = "\w+"
+    variants:
+        - two_device:
+            virtio_rngs += " rng1"
+            backend_rng1 = rng-random
+            backend_type = passthrough
+            filename_passthrough = /dev/random
+            switch_rng_cmd = "echo -n %s > /sys/class/misc/hw_random/rng_current"
+            pre_cmd = "dd if=/dev/random of=/dev/null bs=1024 count=10"
+            post_cmd = "dd if=/dev/random of=/dev/null bs=1024 count=10"
+        - one_device:
+            pre_cmd = "while true; do dd if=/dev/random of=/dev/null bs=1024 count=10; done &"
+            post_cmd = kill -9 `ps -a -o ppid,comm | grep dd | awk '{print $1}'`
+            ignore_status = True

--- a/qemu/tests/rng_stress.py
+++ b/qemu/tests/rng_stress.py
@@ -1,0 +1,88 @@
+import logging
+import aexpect
+import time
+import re
+
+from autotest.client import utils
+
+from virttest import error_context
+from virttest import utils_test
+from virttest.qemu_devices import qdevices
+from avocado.core import exceptions
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Boot up vm with one or more rng devices
+    2) Read from /dev/random in host (optional)
+    3) Run random read in guest
+    4) Switch rng device if there is more than on rng devices
+    5) Run random read in guest
+    6) Read from /dev/random in host (optional)
+    7) Clean random read in host (optional)
+    """
+
+    def get_rng_list(vm):
+        """
+        Get attached rng devices from device dictionary
+        """
+        rng_list = []
+        for device in vm.devices:
+            if isinstance(device, qdevices.QDevice):
+                if device.get_param("driver") == "virtio-rng-pci":
+                    rng_list.append(device)
+        return rng_list
+
+    def get_available_rng(session):
+        """
+        Get available rng devices from /sys/devices
+        """
+        verify_cmd = params["driver_available_cmd"]
+        try:
+            output = session.cmd_output_safe(verify_cmd)
+            rng_devices = re.findall(r"virtio_rng.\d+", output)
+        except aexpect.ShellTimeoutError:
+            err = "%s timeout, pls check if it's a product bug" % verify_cmd
+            raise exceptions.TestFail(err)
+        return rng_devices
+
+    login_timeout = int(params.get("login_timeout", 360))
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=login_timeout)
+    sub_test = params.get("sub_test")
+
+    if params.get("pre_cmd"):
+        error_context.context("Fetch data from host", logging.info)
+        utils.system(params.get("pre_cmd"))
+
+    error_context.context("Read rng device in guest", logging.info)
+    utils_test.run_virt_sub_test(test, params, env, sub_test)
+
+    if params.get("os_type") == "linux":
+        error_context.context("Query virtio rng device in guest",
+                              logging.info)
+        rng_devices = get_available_rng(session)
+        rng_attached = get_rng_list(vm)
+        if len(rng_devices) != len(rng_attached):
+            raise exceptions.TestFail("The devices get from rng_arriable"
+                                      " don't match the rng devices attached")
+
+        if len(rng_devices) > 1:
+            for rng_device in rng_devices:
+                error_context.context("Change virtio rng device to %s" %
+                                      rng_device, logging.info)
+                session.cmd_status(params.get("switch_rng_cmd") % rng_device)
+                error_context.context("Read from %s in guest" % rng_device,
+                                      logging.info)
+                utils_test.run_virt_sub_test(test, params, env, sub_test)
+
+    if params.get("post_cmd"):
+        end_time = time.time() + 20
+        while time.time() < end_time:
+            s = utils.system(params.get("post_cmd"),
+                             ignore_status=params.get("ignore_status",
+                                                      "False"))
+            if s == 0:
+                break


### PR DESCRIPTION
1. Fetch data from /dev/random in guest and host at the same time
2. Switch rng device and fetch data

Signed-off-by: Suqin Huang <shuang@redhat.com>