### PR TITLE
qemu.tests.block_stream: Add new test scenario for general block stream test.

### DIFF
--- a/qemu/tests/block_stream_stress.py
+++ b/qemu/tests/block_stream_stress.py
@@ -117,6 +117,7 @@ def run(test, params, env):
         stress_test.create_snapshots()
         stress_test.action_before_start()
         stress_test.start()
+        stress_test.action_when_streaming()
         stress_test.action_after_finished()
     finally:
         stress_test.clean()

--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -77,3 +77,9 @@
                 - data_plane:
                     iothreads = iothread0
                     blk_extra_params_image1 = "iothread=${iothreads}"
+                - cancel_async:
+                    wait_finished = no
+                    cancel_timeout_image1 = 3
+                    max_speed_image1 = 10M
+                    when_streaming = "pause_job set_speed resume_job cancel"
+                    after_finished = "start reboot verify_alive"


### PR DESCRIPTION
Steps should be: load_stress -> block_stream -> pause -> reset_speed ->
                 resume -> cancel -> block_stream -> reboot.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1368013