### PR TITLE
Add driver status check in rng_bat

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -11,6 +11,9 @@
         read_rng_cmd  = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
         driver_name = "viorng"
         rng_data_rex = "0x\w"
+        driver_id_cmd = X:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"
+        driver_check_cmd = X:\devcon\wxp_x86\devcon.exe status @DRIVER_ID
+        driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
     Linux:
         session_cmd_timeout = 360
         read_rng_cmd  = "dd if=/dev/hwrng  bs=1 count=10 2>/dev/null|hexdump"


### PR DESCRIPTION
random read sometimes failed because the driver status is "disabled"
check the status before read will make the failure more clear

Signed-off-by: Suqin Huang <shuang@redhat.com>