### PR TITLE
qemu.tests.block_stream: Enlarge timeout when reset speed to minimal.

### DIFF
--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -34,6 +34,7 @@
                          - max_speed:
                              expected_speed_image1 = 10485760
                          - min_speed:
+                             wait_timeout = 30000
                              expected_speed_image1 = 10
                 - cancel_sync:
                      wait_finished = no


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>

id: 1378367