### PR TITLE
ovs_qos.cfg: delete option 100,10 for rate_brust_pairs

### DIFF
--- a/qemu/tests/cfg/ovs_qos.cfg
+++ b/qemu/tests/cfg/ovs_qos.cfg
@@ -14,7 +14,7 @@
     netperf_test_duration = 120
     netperf_para_sessions = 1
     test_protocol = TCP_STREAM
-    rate_brust_pairs = 100,10 1000,100 10000,1000
+    rate_brust_pairs = 1000,100 10000,1000
     Windows:
         netperf_server_link_win = "netserver-2.6.0.exe"
         netperf_client_link_win = "netperf.exe"


### PR DESCRIPTION
Delete option 100,10 for rate_brust_pairs.
There is no such option in Polarion test case, this is unnecessary to test since it will generate zero throughput.
id: 1386070

sign-off-by: Wei Liao weliao@redhat.com
