### PR TITLE
qemu.tests.pci_hotplug: Add default value of "wait_secs_for_hook_up".

### DIFF
--- a/qemu/tests/cfg/netkvm_in_use.cfg
+++ b/qemu/tests/cfg/netkvm_in_use.cfg
@@ -64,3 +64,4 @@
             run_dhclient = no
             pci_num = 1
             repeat_times = 100
+            wait_secs_for_hook_up = 3

--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -225,7 +225,7 @@ def run(test, params, env):
                 raise error.TestFail("No new PCI device shown after executing "
                                      "monitor command: 'info pci'")
 
-            secs = int(params.get("wait_secs_for_hook_up"))
+            secs = int(params.get("wait_secs_for_hook_up", 3))
             if not utils_misc.wait_for(_new_shown, test_timeout, secs, 3):
                 raise error.TestFail("No new device shown in output of command "
                                      "executed inside the guest: %s" %

--- a/qemu/tests/pci_hotplug_check.py
+++ b/qemu/tests/pci_hotplug_check.py
@@ -230,7 +230,7 @@ def run(test, params, env):
                 raise error.TestFail("No new PCI device shown after "
                                      "executing monitor command: 'info pci'")
 
-            secs = int(params.get("wait_secs_for_hook_up"))
+            secs = int(params.get("wait_secs_for_hook_up", 3))
             if not utils_misc.wait_for(_new_shown, test_timeout, secs, 3):
                 raise error.TestFail("No new device shown in output of" +
                                      "command executed inside the " +


### PR DESCRIPTION
Signed-off-by: Cong Li coli@redhat.com

id: 1231126
