### PR TITLE
qemu.tests.live_snapshot_chain: update default value for "snapshot_num".

### DIFF
--- a/qemu/tests/live_snapshot_chain.py
+++ b/qemu/tests/live_snapshot_chain.py
@@ -30,7 +30,8 @@ def run(test, params, env):
             snapshot_tag = "sn%s" % i
             snapshot_chain += " %s" % snapshot_tag
             params["image_name_%s" % snapshot_tag] = "images/%s" % snapshot_tag
-        params["check_base_image_%s" % snapshot_tag] = "yes"
+        if snapshot_num > 0:
+            params["check_base_image_%s" % snapshot_tag] = "yes"
         return snapshot_chain
 
     def get_base_image(snapshot_chain, snapshot_file):
@@ -64,7 +65,7 @@ def run(test, params, env):
     vm.verify_alive()
     timeout = int(params.get("login_timeout", 360))
     snapshot_chain = params.get("snapshot_chain")
-    snapshot_num = int(params.get("snapshot_num", 20))
+    snapshot_num = int(params.get("snapshot_num", 0))
     file_create_cmd = params.get("file_create_cmd")
     file_check_cmd = params.get("file_check_cmd")
     file_dir = params.get("file_dir")


### PR DESCRIPTION
Previous "snapshot_num = 20" does not work for other cases except "long_chain".

Signed-off-by: Cong Li <coli@redhat.com>

id: 1108413