### PR TITLE
tp-qemu: remove useless config in host-kernel.cfg

### DIFF
--- a/qemu/cfg/host-kernel/Host_RHEL/6.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6.cfg
@@ -7,7 +7,6 @@
         query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
     virtio_net:
         vhost = "vhost=on"
-        nettype = bridge
         # enable_vhostfd only works with vhost=on
         enable_vhostfd = yes
     Win2008, Win2008r2, Win7:

--- a/qemu/cfg/host-kernel/Host_RHEL/7.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/7.cfg
@@ -15,7 +15,6 @@
         cpu_model_flags += ",hv_relaxed"
     virtio_net:
         vhost = "vhost=on"
-        nettype = bridge
         # enable_vhostfd only works with vhost=on
         enable_vhostfd = yes
     monitor_cmds_check.qmp:


### PR DESCRIPTION
Simulated hardware configuration include in guest-hw.cfg.
Drop extra configuration for virtio_net because it block
macvtap related tests.

ID: 1388817

Signed-off-by: Xu Tian <xutian@redhat.com>