### PR TITLE
qemu.tests.block_stream.with_stress.cancel_async: Update case steps.

### DIFF
--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -93,5 +93,4 @@
                     wait_finished = no
                     cancel_timeout_image1 = 3
                     max_speed_image1 = 10M
-                    when_streaming = "pause_job set_speed resume_job cancel"
-                    after_finished = "start reboot verify_alive"
+                    when_streaming = "pause_job set_speed resume_job cancel start wait_for_finished"


### PR DESCRIPTION
Need wait for block stream finished when streaming.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1368013