### PR TITLE
tp-qemu.multi_queues_test: fix vcpus count

### DIFF
--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -8,9 +8,10 @@
     no Host_RHEL.m5, Host_RHEL.m6
     type = multi_queues_test
     queues = 4
-    enable_msix_vectors = yes
+    kill_vm = yes
     tmp_dir = /home
     vhost = "vhost=on"
+    enable_msix_vectors = yes
     variants:
         - with_netperf:
             hostpassword = redhat
@@ -35,20 +36,30 @@
             variants:
                 - smp1:
                     smp_fixed = 1
-                - smpN:
-                    smp = 4
+                    vcpu_cores_fixed = 1
+                    vcpu_threads_fixed = 1
+                    vcpu_sockets_fixed = 1
+                - smp4:
+                    smp_fixed = 4
+                    queues = ${smp_fixed}
+                    vhostfds_len = ${smp_fixed}
+                    tapfds_len = ${smp_fixed}
                     variants:
                         - single_netperf_session:
                             netperf_para_sessions = 1
                         - multiple_netperf_session:
-                            netperf_para_sessions = 4
+                            netperf_para_sessions = ${smp_fixed}
                 - max_queues:
-                    queues = 8
-                    smp = 8
+                    smp_fixed = 8
+                    queues = ${smp_fixed}
+                    vhostfds_len = ${smp_fixed}
+                    tapfds_len = ${smp_fixed}
                 - cpu_affinity:
                     #this test smp must equal queues.
-                    smp = 4
-                    queues = 4
+                    smp_fixed = 4
+                    queues = ${smp_fixed}
+                    vhostfds_len = ${smp_fixed}
+                    tapfds_len = ${smp_fixed}
                     netperf_para_sessions = 1
                     netperf_taskset_cpu = 0
                     check_cpu_affinity = yes

--- a/generic/tests/multi_queues_test.py
+++ b/generic/tests/multi_queues_test.py
@@ -157,7 +157,7 @@ def run(test, params, env):
                 error.context("Check cpu affinity", logging.info)
                 vectors = params.get("vectors", None)
                 enable_msix_vectors = params.get("enable_msix_vectors")
-                expect_vectors = 2 * int(queues) + 1
+                expect_vectors = 2 * int(queues) + 2
                 if (not vectors) and (enable_msix_vectors == "yes"):
                     vectors = expect_vectors
                 if vectors and (vectors >= expect_vectors) and taskset_cpu:


### PR DESCRIPTION
    used postfix '_fixed' for params vcpu threads,
    cores and sockets to avoid these params overwrite
    in other configuration file.

ID: 1393237, 1241435

Signed-off-by: Xu Tian <xutian@redhat.com>