### PR TITLE
qemu.tests: use snapshot to avoid backup and retore steps

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -13,6 +13,9 @@
     only i386 x86_64 PAE ppc64 ppc64le
     no RHEL.3.9
     type = rh_kernel_update
+    start_vm = yes
+    kill_vm = yes
+    image_snapshot = yes
     rpm_timeout = 1200
     # Please update your file share web server url before test
     download_root_url = "http://download.xxx.com"


### PR DESCRIPTION
enable snapshot for disk image, and commit changes when OS updated.
so that we can skip logical about backup and restore OS.

ID: 1394120

Signed-off-by: Xu Tian <xutian@redhat.com>