### PR TITLE
qemu.tests.win_virtio_driver_update_test: fix dirve_format issue

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -77,6 +77,8 @@
             target_process = iozone.exe
             run_bgstress = iozone_windows
             drive_format_image1 = ide
+            q35:
+                drive_format_image1 = ahci
             images += " stg"
             image_name_stg = "images/storage"
             image_size_stg = 4G
@@ -96,6 +98,8 @@
             target_process = iozone.exe
             run_bgstress = iozone_windows
             drive_format_image1 = ide
+            q35:
+                drive_format_image1 = ahci
             images += " stg"
             image_name_stg = "images/storage"
             image_size_stg = 4G


### PR DESCRIPTION
Force ide drive_format  make create VM failed if VM is Q35 machine,
fix it by overwrite dirve_format to ahci if machine type is q35.

ID: 1593598

Signed-off-by: Xu Tian <xutian@redhat.com>