### PR TITLE
qemu.tests.win_virtio_driver_update_test.with_scsi: set cdrom format …

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -98,8 +98,10 @@
             target_process = iozone.exe
             run_bgstress = iozone_windows
             drive_format_image1 = ide
+            cd_format_fixed = ide
             q35:
                 drive_format_image1 = ahci
+                cd_format_fixed = ahci
             images += " stg"
             image_name_stg = "images/storage"
             image_size_stg = 4G


### PR DESCRIPTION
…to ide when using virtio_scsi.

cdrom won't be recognized if virtio_scsi driver is uninstalled,
which will cause install driver failed after uninstall.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1231072