### PR TITLE
qemu.test: Fix the command not matched for migrate_multi_host when using ide from rhel6 to rhel7 host

### DIFF
--- a/qemu/tests/cfg/multi_host.cfg
+++ b/qemu/tests/cfg/multi_host.cfg
@@ -28,6 +28,8 @@
             paused_after_start_vm = no
             need_to_login = yes
             preprocess_env = no
+            ide:
+                force_drive_format = ide-drive
 
             variants mig_protocol:
                 #Migration protocol.


### PR DESCRIPTION
           

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>