### PR TITLE
Update the letter of winutils to WIN_UTILS in cmd

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -11,9 +11,13 @@
         read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
         driver_name = "viorng"
         rng_data_rex = "0x\w"
-        driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
-        driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
+        i386:
+            driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
+            driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+        x86_64:
+            driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
+            driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
     Linux:
         session_cmd_timeout = 360
         read_rng_cmd  = "dd if=/dev/hwrng  bs=1 count=10 2>/dev/null|hexdump"

--- a/qemu/tests/cfg/rng_hotplug.cfg
+++ b/qemu/tests/cfg/rng_hotplug.cfg
@@ -9,12 +9,16 @@
     no no_virtio_rng
     Windows:
         session_cmd_timeout = 240
-        read_rng_cmd  = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
         driver_name = "viorng"
         rng_data_rex = "0x\w"
-        driver_id_cmd = X:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"
-        driver_check_cmd = X:\devcon\wxp_x86\devcon.exe status @DRIVER_ID
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
+        i386:
+            driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
+            driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+        x86_64:
+            driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
+            driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
     Linux:
         session_cmd_timeout = 360
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"

--- a/qemu/tests/cfg/rng_stress.cfg
+++ b/qemu/tests/cfg/rng_stress.cfg
@@ -7,12 +7,16 @@
     no no_virtio_rng
     Windows:
         session_cmd_timeout = 240
-        read_rng_cmd  = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
         driver_name = "viorng"
         rng_data_rex = "0x\w"
-        driver_id_cmd = X:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"
-        driver_check_cmd = X:\devcon\wxp_x86\devcon.exe status @DRIVER_ID
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
+        i386:
+            driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
+            driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+        x86_64:
+            driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
+            driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
     Linux:
         session_cmd_timeout = 360
         read_rng_cmd  = "dd if=/dev/random bs=1 count=10 2>/dev/null|hexdump"

--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -7,12 +7,18 @@
     suppress_exception = no
     run_bgstress = rng_bat
     session_cmd_timeout = 240
-    read_rng_cmd = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
+    read_rng_cmd = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
     rng_data_rex = "0x\w"
     driver_name = "viorng"
     cdrom_cd1 = isos/windows/winutils.iso
     no no_virtio_rng
     only Windows
+        i386:
+            driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
+            driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+        x86_64:
+            driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
+            driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
     variants:
         - before_bg_test:
             run_bg_flag = "before_bg_test"
@@ -20,7 +26,7 @@
             suppress_exception = yes
             run_bg_flag = "during_bg_test"
             target_process = random\w*.exe
-            read_rng_cmd = for /l %i in (1, 1, 1000) do "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
+            read_rng_cmd = for /l %i in (1, 1, 1000) do "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
         - after_bg_test:
             run_bg_flag = "after_bg_test"
     variants:

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -8,16 +8,14 @@
     kill_after_test = yes
     kill_vm_on_error = yes
     check_guest_bsod = yes
+    image_snapshot = yes
     login_timeout = 360
-    need_enable_verifier = yes
-    need_clear_verifier = yes
     driver_install_timeout = 600
     suppress_exception = no
     tmp_folder = C:\tmp
     guest_alias = "Win7-32:w7\x86,Win7-64:w7\amd64,Win8-32:w8\x86,Win8-64:w8\amd64,Win8-32.1:w8.1\x86,Win8-64.1:w8.1\amd64,Win10-32:w10\x86,Win10-64:w10\amd64,Win2008-32:2k8\x86,Win2008-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12R2\amd64"
     driver_install_cmd = "python WIN_UTILS:\win_driver_install.py %s %s %s %s %s"
     show_file_ext_cmd = "reg add HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced /v HideFileExt /t REG_DWORD /d 0 /f"
-    read_rng_cmd  = "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
     sub_test = win_virtio_driver_update_test
     variants:
         - uninstall_install:
@@ -30,7 +28,6 @@
             run_bg_flag = "before_bg_test"
         - during_bg_test:
             run_bg_flag = "during_bg_test"
-            read_rng_cmd = for /l %i in (1, 1, 1000) do "X:\random_%PROCESSOR_ARCHITECTURE%.exe"
             suppress_exception = yes
         - after_bg_test:
             run_bg_flag = "after_bg_test"
@@ -123,4 +120,14 @@
             target_process = random\w*.exe
             session_cmd_timeout = 240
             rng_data_rex = "0x\w"
+            read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
             driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
+            i386:
+                driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
+                driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+            x86_64:
+                driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
+                driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
+            during_bg_test:
+                read_rng_cmd = for /l %i in (1, 1, 1000) do "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+                driver_check_cmd = ""


### PR DESCRIPTION
the default letter of winutils.iso is WIN_UTILS

Signed-off-by: Suqin Huang <shuang@redhat.com>