### PR TITLE
qemu.tests: add case for external snapshot

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -125,14 +125,18 @@
         - info:
             type = qemu_disk_img_info
             guest_file_name_image1 = "${tmp_dir}/test.img"
-            image_chain += " sn1"
-            image_name_sn1 = "images/sn1"
-            image_format_sn1 = "qcow2"
-            guest_file_name_sn1 = "${tmp_dir}/sn1"
+            image_chain += " snA"
+            image_name_snA = "images/snA"
+            image_format_snA = "qcow2"
+            guest_file_name_snA = "${tmp_dir}/snA"
             variants:
                 - @default:
                 - backing_chain:
                     backing_chain = yes
+                - change_block_interface:
+                    drive_format_snA = ide
+                    q35:
+                        drive_format_snA = ahci
         - snapshot:
             type = qemu_disk_img_snapshot
             guest_file_name = "${tmp_dir}/test.img"

--- a/qemu/tests/qemu_disk_img_rebase.py
+++ b/qemu/tests/qemu_disk_img_rebase.py
@@ -1,4 +1,3 @@
-import re
 import copy
 import logging
 
@@ -29,28 +28,6 @@ class RebaseTest(qemu_disk_img.QemuImgTest):
         cache_mode = params.get("cache_mode")
         super(RebaseTest, self).rebase(params, cache_mode)
         return params
-
-    def check_backingfile(self):
-        out = self.get_info()
-        if not out:
-            msg = "Fail to get image('%s') info" % self.image_filename
-            raise error.TestFail(msg)
-        backingfile = re.search(r'backing file: +(.*)', out, re.M)
-        if self.base_tag == "null":
-            if backingfile:
-                msg = "Expected backing file is null!"
-                msg += " Actual backing file: %s" % backingfile
-                raise error.TestFail(msg)
-        else:
-            if backingfile:
-                if not (self.base_image_filename in backingfile.group(0)):
-                    msg = "Expected backing file: %s" % self.base_image_filename
-                    msg += " Actual backing file: %s" % backingfile
-                    raise error.TestFail(msg)
-            else:
-                msg = ("Could not find backing file for image '%s'" %
-                       self.image_filename)
-                raise error.TestFail(msg)
 
     def clean(self):
         params = self.params


### PR DESCRIPTION
1. move function to parent class fo reducing repetitive code.
2. correct the snapshot tag to get the right guest_file_name
for windows guest.
3. add case to change block interface for snapshot

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1374196, 1374199