### PR TITLE
Balloon_check: sleep before subtest check

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -210,12 +210,13 @@ class BallooningTest(MemoryBaseTest):
             elif should_quit == 0:
                 expect_mem = self.ori_mem
 
-            timeout = int(self.params.get("balloon_timeout", 100))
+            sleep_before_check = int(self.params.get("sleep_before_check", 0))
+            timeout = int(self.params.get("balloon_timeout", 100)) + sleep_before_check
             ballooned_mem = abs(self.ori_mem - expect_mem)
             msg = "Wait memory balloon back after "
             msg += params_tag['sub_test_after_balloon']
             mmem, gmem = utils_misc.wait_for(_memory_check_after_sub_test,
-                                             timeout, 0, 5, msg)
+                                             timeout, sleep_before_check, 5, msg)
 
             self.current_mmem = mmem
             self.current_gmem = gmem

--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -43,6 +43,7 @@
             kill_vm_on_error = yes
             reboot = yes
             session_need_update = yes
+            sleep_before_check = 90
         - balloon-shutdown:
             sub_test_after_balloon = "shutdown"
             shutdown_method = shell


### PR DESCRIPTION
qemu.tests.balloon_check: sleep 90s for guest reboot

balloon_check:
1.Set time sleep 90s before get guest's used memory after sub-test:reboot

Signed-off-by: Aihua Liang <aliang@redhat.com>

ID:1396878