### PR TITLE
driver_load_stress: Update parameter for iozone

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -34,7 +34,7 @@
             disk_letter = I
             disk_index = 1
             format_disk = yes
-            iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 4G -M -b iozone.xls -f ${disk_letter}:\testfile"
+            iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 2G -M -b iozone.xls -f ${disk_letter}:\testfile"
             target_process = iozone.exe
             iozone_timeout = 7200
             wait_bg_time = 180
@@ -57,7 +57,7 @@
             disk_letter = I
             disk_index = 1
             format_disk = yes
-            iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 4G -M -b iozone.xls -f ${disk_letter}:\testfile"
+            iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 2G -M -b iozone.xls -f ${disk_letter}:\testfile"
             target_process = iozone.exe
             iozone_timeout = 7200
             wait_bg_time = 180


### PR DESCRIPTION
Size of temporary file for iozone must be less than the disk size

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1397635