### PR TITLE
Two commits about balloon stress test

### DIFF
--- a/qemu/tests/balloon_stress.py
+++ b/qemu/tests/balloon_stress.py
@@ -37,9 +37,8 @@ def run(test, params, env):
         session.cmd(params.get("pre_cmd"))
 
     driver_name = params["driver_name"]
-    if params["os_type"] == "windows":
-        utils_test.qemu.setup_win_driver_verifier(driver_name, vm, timeout)
-        balloon_test = BallooningTestWin(test, params, env)
+    utils_test.qemu.setup_win_driver_verifier(driver_name, vm, timeout)
+    balloon_test = BallooningTestWin(test, params, env)
 
     error.context("Play video in guest", logging.info)
     play_video_cmd = params["play_video_cmd"]

--- a/qemu/tests/balloon_stress.py
+++ b/qemu/tests/balloon_stress.py
@@ -30,7 +30,6 @@ def run(test, params, env):
     vm.verify_alive()
 
     default_memory = int(params.get("default_memory", params['mem']))
-    unit = vm.monitor.protocol == "qmp" and 1048576 or 1
     timeout = float(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=timeout)
     # for media player configuration


### PR DESCRIPTION
commit 9c93182b6f7e3f44df454206247e6b794085c73b
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Wed Nov 23 15:56:33 2016 +0800

    balloon_stress: Remove the check for guest os type
    
    'only Windows' has been declared in balloon_in_use.cfg,
    and it's parent tests also declared the same filter in
    driver_load_stress.cfg and balloon_stress.cfg.
    so the check for os type is redundant.
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>

commit 61c80e531ae30ad229dce9adc93185634d257136
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Wed Nov 23 15:54:24 2016 +0800

    balloon_stress: clean up
    
    The method used to set memory balloon had been changed
    in 6a9d829, The 'unit' never be used.
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>