### PR TITLE
hotplug_mem: filter out 1G_hugepage tests for pseries

### DIFF
--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -89,6 +89,7 @@
                     only one
                     only guest_reboot
                     only no_policy
+                    no pseries
     variants operation:
         - unplug:
             no Windows


### PR DESCRIPTION
Filter out 1G_hugepage tests for pseries because it does
not support that huge page size.

ID: 1393231