### PR TITLE
 Fix an error , generate error command

### DIFF
--- a/qemu/tests/blk_stream.py
+++ b/qemu/tests/blk_stream.py
@@ -33,7 +33,7 @@ class BlockStream(block_copy.BlockCopy):
         default_speed = params.get("default_speed")
 
         error.context("start to stream block device", logging.info)
-        self.vm.block_stream(self.device, default_speed, base_image)
+        self.vm.block_stream(self.device.split(' ')[0], default_speed, base_image)
         status = self.get_status()
         if not status:
             raise error.TestFail("no active job found")


### PR DESCRIPTION
qemu-kvm 2.50 env.
self.device  got from get_block in qemu_vm.py, it is like 'drive_image1 (#block102)' using 'info block'.  (name and id)
(qemu) info block
drive_image1 (#block102): jeos-23-64.qcow2 (qcow2)

But we can only use 'drive_image1' in  function  self.vm.block_stream, otherwise ,it will generate a wrong command :
block_stream drive_image1 (#block168) 0B

error message:
2016-11-25 02:35:45,232 qemu_monitor     L0694 DEBUG| (monitor hmp1)    invalid size
2016-11-25 02:35:45,232 qemu_monitor     L0694 DEBUG| (monitor hmp1)    Try "help block_stream" for more information