### PR TITLE
Improvements in tests used by Spice

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -354,43 +354,26 @@ variants:
     - install_win_guest:
         only qemu_kvm_windows_install_guest
     - build_install_qxl:
-        build_install_pkg = xf86-video-qxl
+        install_pkgs = spice-protocol xorg-x11-drv-qxl
         vm_name = guest
         dst_dir = /tmp
-        libpciaccess_devel_url = path_to_libpciaccess_rpm
-        xorg_x11_server_devel_url = path_to_xorgx11server_rpm
-        xorg_x11_util_macros_url = path_to_xorgx11utilmacros_rpm
-        libfontenc_devel_url = path_to_libfontenc_devel_rpm
-        libXfont_devel_url = path_to_libXfont_devel_rpm
         only remote_viewer_rhel6devel_build_install
     - build_install_virtviewer:
-        build_install_pkg = virt-viewer
+        install_pkgs = spice-protocol virt-viewer
+        remove_pkgs = gnome-boxes vinagre
         vm_name = client
         dst_dir = /tmp
-        spice_gtk_devel_url = path_to_spice_gtk_devel_rpm
-        spice_gtk3_devel_url = path_to_spice_gtk3_devel_rpm
-        spice_protocol_url = path_to_spice_protocol_rpm
-        spice_glib_devel_url = path_to_spice_glib_devel_rpm
-        libcacard_devel_url = path_to_libcacard_rpm
-        celt051_devel_url = path_to_celt051_rpm
-        libogg_devel_url = path_to_libogg_rpm
         only remote_viewer_rhel6devel_build_install
     - build_install_vdagent:
-        build_install_pkg = spice-vd-agent
+        install_pkgs = spice-protocol spice-vdagent
         vm_name = guest
         dst_dir = /tmp
-        libpciaccess_devel_url = path_to_libpciaccess_rpm
         only remote_viewer_rhel6devel_build_install
     - build_install_spicegtk:
-        build_install_pkg = spice-gtk
+        install_pkgs = spice-protocol spice-gtk3
+        remove_pkgs = gnome-boxes vinagre
         vm_name = client
         dst_dir = /tmp
-        celt051_devel_url = path_to_celt051_rpm
-        libogg_devel_url = path_to_libogg_rpm
-        libcacard_devel_url = path_to_libcacard_rpm
-        source_highlight_url = path_to_source_highlight_rpm
-        gtk_doc_url = path_to_gtk_doc_rpm
-        libepoxy_devel_url = path_to_libepoxy_devel_rpm
         only remote_viewer_rhel6devel_build_install
     - negative_qemu_spice_launch_badport:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.bad_port.no_password.dcp_off.1monitor.default_sc

--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -1,263 +1,76 @@
 """
-rv_build_install.py - Builds and installs packages specified
-                      using the build_install.py script
+rv_build_install.py - Builds and installs packages specified from @spice/nightly
+                      copr repository
+                      https://copr.fedorainfracloud.org/coprs/g/spice/nightly/
 
-Requires: connected binaries remote-viewer, Xorg, gnome session, git
+Requires: connected binaries remote-viewer, Xorg, gnome session
 
 """
 import logging
-import os
-import time
-import re
-
-from aexpect import ShellCmdError
 
 from autotest.client.shared import error
-
 from virttest import utils_spice
-from virttest import data_dir
 
 
-def connect_to_vm(vm_name, env, params):
-    """
-    Connects to VM and powers it on and gets session information
+class InstallPackages(object):
+    def __init__(self, params, env):
+        self.params = params
+        self.env = env
 
-    :param vm_name: name of VM to connect to
-    :param params: Dictionary with test parameters.
-    :param env: Test environment.
-    """
+        self.connect()
+    # __init__()
 
-    vm = env.get_vm(params[vm_name + "_vm"])
-    vm.verify_alive()
-    vm_root_session = vm.wait_for_login(
-        timeout=int(params.get("login_timeout", 360)),
-        username="root", password="123456")
-    logging.info("VM %s is up and running" % vm_name)
-    return (vm, vm_root_session)
+    def connect(self):
+        """
+        Connects to VM and powers it on and gets session information
+        """
+        vm_name = self.params.get("vm_name")
+        self.vm = self.env.get_vm(self.params[vm_name + "_vm"])
+        self.vm.verify_alive()
+        self.vm_root_session = self.vm.wait_for_login(
+            timeout=int(self.params.get("login_timeout", 360)),
+            username="root", password="123456")
 
+        logging.info("VM %s is up and running" % vm_name)
+    # connect()
 
-def install_req_pkgs(pkgsRequired, vm_root_session, params):
-    """
-    Checks to see if packages are installed and if not, installs the package
+    def setup(self):
+        remove_pkgs = self.params.get("remove_pkgs")
+        if remove_pkgs:
+            logging.info("Removing packages: '%s'" % remove_pkgs)
+            self.vm_root_session.cmd("yum -y remove %s" % remove_pkgs)
 
-    :params rpms_to_install: List of packages to check
-    :params vm_root_session: Session object of VM
-    :param params: Dictionary with test parameters.
-    """
+        utils_spice.deploy_epel_repo(self.vm_root_session, self.params)
 
-    for pkgName in pkgsRequired:
-        logging.info("Checking to see if %s is installed" % pkgName)
-        try:
-            vm_root_session.cmd("rpm -q %s" % pkgName)
-        except:
-            rpm = params.get(re.sub("-", "_", pkgName) + "_url")
-            logging.info("Installing %s from %s" % (pkgName, rpm))
-            try:
-                vm_root_session.cmd("yum -y localinstall %s" % rpm,
-                                    timeout=300)
-            except:
-                logging.info("Could not install %s" % pkgName)
+        # yum-plugin-copr for epel https://copr.fedorainfracloud.org/coprs/alonid/yum-plugin-copr/
+        logging.info("Installing yum-plugin-copr for epel")
+        self.vm_root_session.cmd("yum -y install https://copr-be.cloud.fedoraproject.org/results/alonid/yum-plugin-copr/epel-7-x86_64/00110045-yum-plugin-copr/yum-plugin-copr-1.1.31-508.el7.centos.noarch.rpm")
 
+        # enable spice/nightly copr https://copr.fedorainfracloud.org/coprs/g/spice/nightly/
+        logging.info("Enabling @spice/nightly copr repository")
+        self.vm_root_session.cmd("yum -y copr enable @spice/nightly")
+    # setup()
 
-def build_install_spiceprotocol(vm_root_session, vm_script_path, params):
-    """
-    Build and install spice-protocol in the VM
+    def pkg_install(self):
+        install_pkgs = self.params.get("install_pkgs")
+        if not install_pkgs:
+            raise error.TestFail("No package specified for installation")
 
-    :param vm_root_session:  VM Session object.
-    :param vm_script_path: path where to find build_install.py script
-    :param params: Dictionary with test parameters.
-    """
-
-    utils_spice.deploy_epel_repo(vm_root_session, params)
-
-    # In RHEL6, pyparsing is in EPEL but in RHEL7, it's part of
-    # the main product repo
-    if "release 6" in vm_root_session.cmd("cat /etc/redhat-release"):
-        try:
-            cmd = "yum --disablerepo=\"*\" " + \
-                  "--enablerepo=\"epel\" -y install pyparsing"
-            output = vm_root_session.cmd(cmd, timeout=300)
-            logging.info(output)
-        except:
-            logging.error("Not able to install pyparsing!")
-
-    output = vm_root_session.cmd("%s -p spice-protocol" % (vm_script_path))
-    logging.info(output)
-    if re.search("Return code", output):
-        raise error.TestFail("spice-protocol was not installed properly")
-
-
-def build_install_qxl(vm_root_session, vm_script_path, params):
-    """
-    Build and install QXL in the VM
-
-    :param vm_root_session:  VM Session object.
-    :param vm_script_path: path where to find build_install.py script
-    :param params: Dictionary with test parameters.
-    """
-
-    # Checking to see if required packages exist and if not, install them
-    pkgsRequired = ["libpciaccess-devel", "xorg-x11-util-macros",
-                    "xorg-x11-server-devel", "libfontenc-devel",
-                    "libXfont-devel"]
-    install_req_pkgs(pkgsRequired, vm_root_session, params)
-
-    output = vm_root_session.cmd("%s -p xf86-video-qxl" % (vm_script_path),
-                                 timeout=600)
-    logging.info(output)
-    if re.search("Return code", output):
-        raise error.TestFail("qxl was not installed properly")
-
-
-def build_install_virtviewer(vm_root_session, vm_script_path, params):
-    """
-    Build and install virt-viewer in the VM
-
-    :param vm_root_session:  VM Session object.
-    :param vm_script_path: path where to find build_install.py script
-    :param params: Dictionary with test parameters.
-    """
-
-    # Building spice-gtk from tarball before building virt-viewer
-    build_install_spicegtk(vm_root_session, vm_script_path, params)
-
-    try:
-        output = vm_root_session.cmd("killall remote-viewer")
+        logging.info("Installing packages from @spice/nightly copr: '%s'" % install_pkgs)
+        output = self.vm_root_session.cmd("yum -y install %s" % install_pkgs, timeout=300)
         logging.info(output)
-    except ShellCmdError, err:
-        logging.error("Could not kill remote-viewer " + err.output)
+    # pkg_install()
 
-    try:
-        output = vm_root_session.cmd("yum -y remove virt-viewer", timeout=120)
-        logging.info(output)
-    except ShellCmdError, err:
-        logging.error("virt-viewer package couldn't be removed! " + err.output)
+    def finish(self):
+        utils_spice.clear_interface(self.vm)
+    # finish()
 
-    if "release 7" in vm_root_session.cmd("cat /etc/redhat-release"):
-        pkgsRequired = ["libogg-devel", "celt051-devel",
-                        "spice-glib-devel", "spice-gtk3-devel"]
-    else:
-        pkgsRequired = ["libogg-devel", "celt051-devel"]
-
-    install_req_pkgs(pkgsRequired, vm_root_session, params)
-
-    output = vm_root_session.cmd("%s -p virt-viewer" % (vm_script_path),
-                                 timeout=600)
-    logging.info(output)
-    if re.search("Return code", output):
-        raise error.TestFail("virt-viewer was not installed properly")
-
-    # Get version of remote-viewer after install
-    try:
-        output = vm_root_session.cmd("which remote-viewer;"
-                                     "LD_LIBRARY_PATH=/usr/local/lib"
-                                     " remote-viewer --version")
-        logging.info(output)
-    except ShellCmdError, err:
-        logging.error("Can't get version number!" + err.output)
-
-
-def build_install_spicegtk(vm_root_session, vm_script_path, params):
-    """
-    Build and install spice-gtk in the VM
-
-    :param vm_root_session:  VM Session object.
-    :param vm_script_path: path where to find build_install.py script
-    :param params: Dictionary with test parameters.
-    """
-
-    # Get version of spice-gtk before install
-    try:
-        output = vm_root_session.cmd("LD_LIBRARY_PATH=/usr/local/lib"
-                                     " remote-viewer --spice-gtk-version")
-        logging.info(output)
-    except:
-        logging.error(output)
-
-    if "release 7" in vm_root_session.cmd("cat /etc/redhat-release"):
-        pkgsRequired = ["libogg-devel", "celt051-devel", "libcacard-devel",
-                        "source-highlight", "gtk-doc", "libepoxy-devel"]
-    else:
-        pkgsRequired = ["libogg-devel", "celt051-devel", "libcacard-devel"]
-
-    install_req_pkgs(pkgsRequired, vm_root_session, params)
-
-    try:
-        cmd = "yum --disablerepo=\"*\" " + \
-              "--enablerepo=\"epel\" -y install perl-Text-CSV"
-        output = vm_root_session.cmd(cmd, timeout=300)
-        logging.info(output)
-    except:
-        logging.error(output)
-
-    # spice-gtk needs to built from tarball before building virt-viewer on RHEL6
-    pkgName = params.get("build_install_pkg")
-    if pkgName != "spice-gtk":
-        tarballLocation = "http://www.spice-space.org/download/gtk/spice-gtk-0.30.tar.bz2"
-        cmd = "%s -p spice-gtk --tarball %s" % (vm_script_path, tarballLocation)
-        output = vm_root_session.cmd(cmd, timeout=600)
-        logging.info(output)
-        if re.search("Return code", output):
-            raise error.TestFail("spice-gtk was not installed properly")
-        else:
-            logging.info("spice-gtk was installed")
-
-    else:
-        output = vm_root_session.cmd("%s -p spice-gtk" % (vm_script_path),
-                                     timeout=600)
-        logging.info(output)
-        if re.search("Return code", output):
-            raise error.TestFail("spice-gtk was not installed properly")
-
-    # Get version of spice-gtk after install
-    try:
-        output = vm_root_session.cmd("LD_LIBRARY_PATH=/usr/local/lib"
-                                     " remote-viewer --spice-gtk-version")
-        logging.info(output)
-    except:
-        logging.error(output)
-
-
-def build_install_vdagent(vm_root_session, vm_script_path, params):
-    """
-    Build and install spice-vdagent in the VM
-
-    :param vm_root_session: VM Session object.
-    :param vm_script_path: path where to find build_install.py script
-    :param params: Dictionary with test parameters.
-    """
-
-    # Get current version of spice-vdagent
-    try:
-        output = vm_root_session.cmd("spice-vdagent -h")
-        logging.info(output)
-    except:
-        logging.error(output)
-
-    pkgsRequired = ["libpciaccess-devel"]
-    install_req_pkgs(pkgsRequired, vm_root_session, params)
-
-    output = vm_root_session.cmd("%s -p spice-vd-agent" % (vm_script_path),
-                                 timeout=600)
-    logging.info(output)
-    if re.search("Return code", output):
-        raise error.TestFail("spice-vd-agent was not installed properly")
-
-    # Restart vdagent
-    try:
-        output = vm_root_session.cmd("service spice-vdagentd restart")
-        logging.info(output)
-        if re.search("fail", output, re.IGNORECASE):
-            raise error.TestFail("spice-vd-agent was not started properly")
-    except:
-        raise error.TestFail("spice-vd-agent was not started properly")
-
-    # Get version number of spice-vdagent
-    try:
-        output = vm_root_session.cmd("spice-vdagent -h")
-        logging.info(output)
-    except:
-        logging.error(output)
+    def install(self):
+        self.setup()
+        self.pkg_install()
+        self.finish()
+    # run()
+#InstallPackages
 
 
 def run(test, params, env):
@@ -265,49 +78,14 @@ def run(test, params, env):
     Build and install packages from git on the client or guest VM
 
     Supported configurations:
-    build_install_pkg: name of the package to get from git, build and install
+    install_pkgs: name of the package to install
+    remove_pkgs: name of the packages to remove before installing
 
     :param test: QEMU test object.
     :param params: Dictionary with the test parameters.
     :param env: Dictionary with test environment.
     """
 
-    # Collect test parameters
-    pkgName = params.get("build_install_pkg")
-    script = params.get("script")
-    vm_name = params.get("vm_name")
-    dst_dir = params.get("dst_dir")
-
-    # Path of the script on the VM
-    vm_script_path = os.path.join(dst_dir, script)
-
-    # Get root session for the VM
-    (vm, vm_root_session) = connect_to_vm(vm_name, env, params)
-
-    # location of the script on the host
-    host_script_path = os.path.join(data_dir.get_deps_dir(), "spice", script)
-
-    logging.info("Transferring the script to %s,"
-                 "destination directory: %s, source script location: %s",
-                 vm_name, vm_script_path, host_script_path)
-
-    vm.copy_files_to(host_script_path, vm_script_path, timeout=60)
-    time.sleep(5)
-
-    # All packages require spice-protocol
-    build_install_spiceprotocol(vm_root_session, vm_script_path, params)
-
-    # Run build_install.py script
-    if pkgName == "xf86-video-qxl":
-        build_install_qxl(vm_root_session, vm_script_path, params)
-    elif pkgName == "spice-vd-agent":
-        build_install_vdagent(vm_root_session, vm_script_path, params)
-    elif pkgName == "spice-gtk":
-        build_install_spicegtk(vm_root_session, vm_script_path, params)
-    elif pkgName == "virt-viewer":
-        build_install_virtviewer(vm_root_session, vm_script_path, params)
-    else:
-        logging.info("Not supported right now")
-        raise error.TestFail("Incorrect Test_Setup")
-
-    utils_spice.clear_interface(vm)
+    pkg = InstallPackages(params, env)
+    pkg.install()
+# run()

--- a/qemu/tests/rv_input.py
+++ b/qemu/tests/rv_input.py
@@ -298,19 +298,12 @@ def run(test, params, env):
 
     # Get test type and perform proper test
     test_type = params.get("config_test")
-    test_mapping = {'type_and_func_keys': test_type_and_func_keys,
-                    'leds_and_esc_keys': test_leds_and_esc_keys,
-                    'nonus_layout': test_nonus_layout,
-                    'leds_migration': test_leds_migration}
-    test_parameters = {
-        'type_and_func_keys': (client_vm, guest_session, params),
-        'leds_and_esc_keys': (client_vm, guest_session, params),
-        'nonus_layout': (client_vm, guest_session, params),
-        'leds_migration': (client_vm, guest_vm, guest_session, params)}
-
+    test_mapping = {'type_and_func_keys': (test_type_and_func_keys, (client_vm, guest_session, params)),
+                    'leds_and_esc_keys': (test_leds_and_esc_keys, (client_vm, guest_session, params)),
+                    'nonus_layout': (test_nonus_layout, (client_vm, guest_session, params)),
+                    'leds_migration': (test_leds_migration, (client_vm, guest_vm, guest_session, params))}
     try:
-        func = test_mapping[test_type]
-        args = test_parameters[test_type]
+        func, args = test_mapping[test_type]
     except:
         raise error.TestFail("Unknown type of test")
 


### PR DESCRIPTION
The first patch is just a small cosmetic improvement, and it was around for a little while, so I decided to submit it together. If by any reason you don't like the change, I don't really mind.

What this pull request is really about is rewrite of rv_buildinstall.py to make use of recently [created copr repository for upstream spice packages](https://copr.fedorainfracloud.org/coprs/g/spice/nightly/), instead of dealing with building each component manually.

I did run a local test, but my environment is limited, so I am currently waiting for a complete run in Beaker that contemplates all cases. In the meanwhile, this is up for appreciation.