### PR TITLE
qemu.tests: Update q35 configurations for some cases.

### DIFF
--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -19,6 +19,8 @@
     image_name_stg2 = images/storage2
     image_format_stg2 = qcow2
     drive_format_stg2 = "ide"
+    q35:
+        drive_format_stg2 = ahci
     image_size_stg2 = 2G
     force_create_image_stg2 = yes
     remove_image_stg2 = yes

--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -34,7 +34,7 @@
             device_name = "Red Hat VirtIO SCSI controller"
             drive_format_image1 = ide
             q35:
-                drive_format_image1 = ide
+                drive_format_image1 = ahci
             images += " stg"
             image_name_stg = "images/storage"
             image_size_stg = 4G


### PR DESCRIPTION
1. fix typo in single_driver_install.cfg.
2. add q35 configurations in boot_order_check.cfg.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1400456