### PR TITLE
drive_mirror.cfg: Disable host rhel6 support for pause_resume_job.

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -100,7 +100,7 @@
                     buf_count = 2
         - node_name:
             type = drive_mirror_complete
-            boot_target_image = no
+            boot_target_image = yes
             no Host_RHEL.m6
             after_reopen = check_node_name
             node_name = "node2"

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -81,6 +81,7 @@
                     default_speed_image1 = 3M
                     max_speed_image1 = 10M
                 - pause_resume_job:
+                    no Host_RHEL.m6
                     before_steady = "pause_job resume_job"
                 - job_complete:
                     type = drive_mirror_complete


### PR DESCRIPTION
1. Disable host rhel6 support for pause_resume_job.
2. Reboot guest after mirroring with node name. 

id: 1330404, 1330410, 1360154
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>