### PR TITLE
single_driver_install.cfg: param "kill_after_test" is invalid now, using "kill_vm" instead

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -2,7 +2,7 @@
     type = single_driver_install
     only Windows
     cdroms += " virtio winutils"
-    kill_after_test = yes
+    kill_vm = yes
     login_timeout = 360
     need_uninstall = no
     driver_install_timeout = 600

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -5,7 +5,7 @@
     monitors = qmp1
     cdroms += " virtio winutils"
     image_snapshot_image1 = yes
-    kill_after_test = yes
+    kill_vm = yes
     kill_vm_on_error = yes
     check_guest_bsod = yes
     login_timeout = 360


### PR DESCRIPTION
id: 1401289
Signed-off-by: Yanan Fu <yfu@redhat.com>