### PR TITLE
drive_mirror.cfg: Extend gruanularity512 wait_timeout

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -88,11 +88,12 @@
                     boot_target_image = no
         - granularity:
             type = drive_mirror_complete
-            boot_target_image = no
+            boot_target_image = yes
             no Host_RHEL.m6
             when_steady = check_granularity
             variants:
                 - 512:
+                    wait_timeout = 36000
                     granularity = 512
                     buf_count = 10
                 - 67108864:


### PR DESCRIPTION
Extend gruanularity512 wait_timeout, and reopen after mirroring
id: 1330414, 1342425
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>