### PR TITLE
Update /dev/hwrng to /dev/random for rng random read

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -20,7 +20,7 @@
             driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
     Linux:
         session_cmd_timeout = 360
-        read_rng_cmd  = "dd if=/dev/hwrng  bs=1 count=10 2>/dev/null|hexdump"
+        read_rng_cmd  = "dd if=/dev/random  bs=1 count=10 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
         driver_name = virtio
         rng_data_rex = "\w+"

--- a/qemu/tests/cfg/rng_hotplug.cfg
+++ b/qemu/tests/cfg/rng_hotplug.cfg
@@ -22,7 +22,7 @@
     Linux:
         session_cmd_timeout = 360
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
-        read_rng_cmd  = "dd if=/dev/hwrng  bs=1 count=10 2>/dev/null|hexdump"
+        read_rng_cmd  = "dd if=/dev/random  bs=1 count=10 2>/dev/null|hexdump"
         driver_name = "virtio"
         rng_data_rex = "\w+"
         restart_rngd = "service rngd restart"


### PR DESCRIPTION
Need to use /dev/random instead of /dev/hwrng

/dev/random is the place from where we should always read.
/dev/hwrng will be available to read if there is a hardware rng device

id:1403651