### PR TITLE
qemu.tests: free caches in block copy test

### DIFF
--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -3,8 +3,13 @@
 #
 - block_stream:
     no raw qed vmdk
+    monitors = qmp1
+    monitor_type = qmp
+    main_monitor = qmp1
     backup_image_before_testing = yes
     restore_image_after_testing = yes
+    pre_command = "sync && echo 3 >/proc/sys/vm/drop_caches"
+    post_command = "sync && echo 3 >/proc/sys/vm/drop_caches"
     wait_finished = yes
     source_image = image1
     default_speed_image1 = 0

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -9,6 +9,8 @@
     main_monitor = qmp1
     backup_image_before_testing = yes
     restore_image_after_testing = yes
+    pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
+    post_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
     # Recent QEMU upstream (and the variants shipped by recent distros) use
     # drive-mirror and block-job-complete
     block_mirror_cmd = drive-mirror

--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -8,6 +8,8 @@
     source_image = image1
     snapshot_file = live_snapshot_img
     snapshot_mode = "absolute-paths"
+    pre_command = "sync && echo 3 >/proc/sys/vm/drop_caches"
+    post_command = "sync && echo 3 >/proc/sys/vm/drop_caches"
     create_cmd = "dd if=/dev/urandom of=%s bs=1M count=1024"
     file_create = /var/tmp/file
     clean_cmd = rm -f

--- a/qemu/tests/cfg/live_snapshot_chain.cfg
+++ b/qemu/tests/cfg/live_snapshot_chain.cfg
@@ -14,6 +14,8 @@
     check_alive_cmd = "ls"
     kill_vm = yes
     remove_snapshot_images = yes
+    pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
+    post_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
     variants:
         - pause:
             file_create =


### PR DESCRIPTION
block job test will eat a lots of caches in testing,
free caches  after test to avoid VM hang memory.

ID: 1267186

Signed-off-by: Xu Tian <xutian@redhat.com>