### PR TITLE
drive_mirror: Remove mirroring  to qcow2 on iscsi.

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -50,7 +50,8 @@
             setup_local_nfs = yes
             boot_target_image = yes
         - on_iscsi:
-            image_format_target = raw
+            only raw
+            only 2raw
             # target_image will ingore, target_image will generate automatically
             image_type_target = iscsi
             force_cleanup_target = yes


### PR DESCRIPTION
Remove mirroring to qcow2 on iscsi.

When drive mirroring with qcow2 image on iscsi, it will cause mismatch issue, which is caused by iscsi instead of qemu,
so only test raw image on iscsi, qcow2 matrix will be covered with local and nfs storage.

id: 1353787
Sign-off-by: Qianqian Zhu <qizhu@redhat.com>