### PR TITLE
qemu.tests:get "prompt,linesep,status_test_command" from OS's config file

### DIFF
--- a/qemu/tests/flow_caches_stress_test.py
+++ b/qemu/tests/flow_caches_stress_test.py
@@ -83,6 +83,10 @@ def run(test, params, env):
     passwd = params.get("hostpasswd", "123456")
     client = params.get("shell_client", "ssh")
     port = params.get("shell_port", "22")
+    shell_prompt = params.get("shell_prompt", "^root@.*[\#\$]\s*$|#")
+    linesep = params.get("shell_linesep", "\n").decode('string_escape')
+    status_test_command = params.get("status_test_command", "echo $?")
+
     compile_option_client = params.get("compile_option_client", "")
     compile_option_server = params.get("compile_option_server", "")
 
@@ -112,6 +116,9 @@ def run(test, params, env):
                                                  g_md5sum, g_client_link,
                                                  username=username,
                                                  password=password,
+                                                 prompt=prompt,
+                                                 linesep=linesep,
+                                                 status_test_command=status_test_command,
                                                  compile_option=compile_option_client)
 
     netperf_server = utils_netperf.NetperfServer(netperf_server_ip,
@@ -120,6 +127,9 @@ def run(test, params, env):
                                                  netperf_link,
                                                  client, port,
                                                  password=passwd,
+                                                 prompt=prompt,
+                                                 linesep=linesep,
+                                                 status_test_command=status_test_command,
                                                  compile_option=compile_option_server)
     try:
         error.base_context("Run netperf test between host and guest.")

--- a/qemu/tests/migration_with_netperf.py
+++ b/qemu/tests/migration_with_netperf.py
@@ -57,6 +57,9 @@ def run(test, params, env):
     passwd = params.get("hostpassword", "redhat")
     client = params.get("shell_client", "ssh")
     port = params.get("shell_port", "22")
+    prompt = params.get("shell_prompt", "^root@.*[\#\$]\s*$|#")
+    linesep = params.get("shell_linesep", "\n").decode('string_escape')
+    status_test_command = params.get("status_test_command", "echo $?")
     compile_option_client_h = params.get("compile_option_client_h", "")
     compile_option_server_h = params.get("compile_option_server_h", "")
     compile_option_client_g = params.get("compile_option_client_g", "")
@@ -89,17 +92,26 @@ def run(test, params, env):
                                                        port=port,
                                                        username=username,
                                                        password=password,
+                                                       prompt=prompt,
+                                                       linesep=linesep,
+                                                       status_test_command=status_test_command,
                                                        compile_option=compile_option_client_g)
         netperf_server_h = utils_netperf.NetperfServer(remote_ip,
                                                        server_path,
                                                        md5sum,
                                                        netperf_link,
                                                        password=passwd,
+                                                       prompt=prompt,
+                                                       linesep=linesep,
+                                                       status_test_command=status_test_command,
                                                        install=False,
                                                        compile_option=compile_option_server_h)
         netperf_client_h = utils_netperf.NetperfClient(remote_ip, client_path,
                                                        md5sum, netperf_link,
                                                        password=passwd,
+                                                       prompt=prompt,
+                                                       linesep=linesep,
+                                                       status_test_command=status_test_command,
                                                        compile_option=compile_option_client_h)
         netperf_server_g = utils_netperf.NetperfServer(guest_address,
                                                        g_server_path,
@@ -109,6 +121,9 @@ def run(test, params, env):
                                                        port=port,
                                                        username=username,
                                                        password=password,
+                                                       prompt=prompt,
+                                                       linesep=linesep,
+                                                       status_test_command=status_test_command,
                                                        compile_option=compile_option_server_g)
         error.base_context("Run netperf test between host and guest")
         error.context("Start netserver in guest.", logging.info)

--- a/qemu/tests/multi_nics_stress.py
+++ b/qemu/tests/multi_nics_stress.py
@@ -62,6 +62,9 @@ def run(test, params, env):
     shell_client = params.get("shell_client")
     shell_port = params.get("shell_port")
     os_type = params.get("os_type")
+    shell_prompt = params.get("shell_prompt", "^root@.*[\#\$]\s*$|#")
+    linesep = params.get("shell_linesep", "\n").decode('string_escape')
+    status_test_command = params.get("status_test_command", "echo $?")
     host_ip = utils_net.get_host_ip_address(params)
     ping_count = int(params.get("ping_count", 10))
     compile_option_client = params.get("compile_option_client", "")
@@ -94,6 +97,12 @@ def run(test, params, env):
                                                 shell_client)
             s_info["shell_port"] = params.get("shell_port_%s" % server,
                                               shell_port)
+            s_info["shell_prompt"] = params.get("shell_prompt_%s" % server,
+                                                shell_prompt)
+            s_info["linesep"] = params.get("linesep_%s" % server,
+                                           linesep)
+            s_info["status_test_command"] = params.get("status_test_command_%s" % server,
+                                                       status_test_command)
         else:
             err = "Only support setup netperf server in guest."
             raise error.TestError(err)
@@ -129,6 +138,12 @@ def run(test, params, env):
                                             shell_client)
         c_info["shell_port"] = params.get("shell_port_%s" % client,
                                           shell_port)
+        c_info["shell_prompt"] = params.get("shell_prompt_%s" % client,
+                                            shell_prompt)
+        c_info["linesep"] = params.get("linesep_%s" % client,
+                                       linesep)
+        c_info["status_test_command"] = params.get("status_test_command_%s" % client,
+                                                   status_test_command)
     else:
         err = "Only support setup netperf client in guest."
         raise error.TestError(err)
@@ -177,6 +192,9 @@ def run(test, params, env):
                                                port=c_info["shell_port"],
                                                username=c_info["username"],
                                                password=c_info["password"],
+                                               prompt=c_info["shell_prompt"],
+                                               linesep=c_info["linesep"],
+                                               status_test_command=c_info["status_test_command"],
                                                compile_option=compile_option_client)
         netperf_clients.append(n_client)
     error.context("Setup netperf server.", logging.info)
@@ -195,6 +213,9 @@ def run(test, params, env):
                                                port=s_info["shell_port"],
                                                username=s_info["username"],
                                                password=s_info["password"],
+                                               prompt=s_info["shell_prompt"],
+                                               linesep=s_info["linesep"],
+                                               status_test_command=s_info["status_test_command"],
                                                compile_option=compile_option_server)
         netperf_servers.append(n_server)
 

--- a/qemu/tests/netperf_stress.py
+++ b/qemu/tests/netperf_stress.py
@@ -34,6 +34,9 @@ def run(test, params, env):
     shell_client = params.get("shell_client")
     shell_port = params.get("shell_port")
     os_type = params.get("os_type")
+    shell_prompt = params.get("shell_prompt", "^root@.*[\#\$]\s*$|#")
+    linesep = params.get("shell_linesep", "\n").decode('string_escape')
+    status_test_command = params.get("status_test_command", "echo $?")
     compile_option_client = params.get("compile_option_client", "")
     compile_option_server = params.get("compile_option_server", "")
     host_ip = utils_net.get_host_ip_address(params)
@@ -60,6 +63,12 @@ def run(test, params, env):
                                                 shell_client)
             s_info["shell_port"] = params.get("shell_port_%s" % server,
                                               shell_port)
+            s_info["shell_prompt"] = params.get("shell_prompt_%s" % server,
+                                                shell_prompt)
+            s_info["linesep"] = params.get("linesep_%s" % server,
+                                           linesep)
+            s_info["status_test_command"] = params.get("status_test_command_%s" % server,
+                                                       status_test_command)
         else:
             if server == "localhost":
                 s_info["ip"] = host_ip
@@ -76,6 +85,12 @@ def run(test, params, env):
                                                 "ssh")
             s_info["shell_port"] = params.get("shell_port_%s" % server,
                                               "22")
+            s_info["shell_prompt"] = params.get("shell_prompt_%s" % server,
+                                                "^\[.*\][\#\$]\s*$")
+            s_info["linesep"] = params.get("linesep_%s" % server,
+                                           "\n")
+            s_info["status_test_command"] = params.get("status_test_command_%s" % server,
+                                                       "echo $?")
         server_infos.append(s_info)
 
     for client in netperf_client:
@@ -97,6 +112,12 @@ def run(test, params, env):
                                                 shell_client)
             c_info["shell_port"] = params.get("shell_port_%s" % client,
                                               shell_port)
+            c_info["shell_prompt"] = params.get("shell_prompt_%s" % client,
+                                                shell_prompt)
+            c_info["linesep"] = params.get("linesep_%s" % client,
+                                           linesep)
+            c_info["status_test_command"] = params.get("status_test_command_%s" % client,
+                                                       status_test_command)
         else:
             if client == "localhost":
                 c_info["ip"] = host_ip
@@ -113,6 +134,12 @@ def run(test, params, env):
                                                 "ssh")
             c_info["shell_port"] = params.get("shell_port_%s" % client,
                                               "23")
+            c_info["shell_prompt"] = params.get("shell_prompt_%s" % client,
+                                                "^\[.*\][\#\$]\s*$")
+            c_info["linesep"] = params.get("linesep_%s" % client,
+                                           "\n")
+            c_info["status_test_command"] = params.get("status_test_command_%s" % client,
+                                                       "echo $?")
         client_infos.append(c_info)
 
     netperf_link = params.get("netperf_link")
@@ -149,6 +176,9 @@ def run(test, params, env):
                                                port=c_info["shell_port"],
                                                username=c_info["username"],
                                                password=c_info["password"],
+                                               prompt=c_info["shell_prompt"],
+                                               linesep=c_info["linesep"],
+                                               status_test_command=c_info["status_test_command"],
                                                compile_option=compile_option_client)
         netperf_clients.append(n_client)
 
@@ -167,6 +197,9 @@ def run(test, params, env):
                                                port=s_info["shell_port"],
                                                username=s_info["username"],
                                                password=s_info["password"],
+                                               prompt=s_info["shell_prompt"],
+                                               linesep=s_info["linesep"],
+                                               status_test_command=s_info["status_test_command"],
                                                compile_option=compile_option_server)
         netperf_servers.append(n_server)
 

--- a/qemu/tests/netperf_udp.py
+++ b/qemu/tests/netperf_udp.py
@@ -66,6 +66,9 @@ def run(test, params, env):
     host_password = params.get("hostpassword")
     client = params.get("shell_client")
     port = params.get("shell_port")
+    prompt = params.get("shell_prompt", "^root@.*[\#\$]\s*$|#")
+    linesep = params.get("shell_linesep", "\n").decode('string_escape')
+    status_test_command = params.get("status_test_command", "echo $?")
     compile_option_client = params.get("compile_option_client", "")
     compile_option_server = params.get("compile_option_server", "")
 
@@ -118,6 +121,9 @@ def run(test, params, env):
                                                  client, port,
                                                  username=guest_username,
                                                  password=guest_password,
+                                                 prompt=prompt,
+                                                 linesep=linesep,
+                                                 status_test_command=status_test_command,
                                                  compile_option=compile_option_client)
 
     netperf_server = utils_netperf.NetperfServer(netserver_ip,
@@ -127,6 +133,9 @@ def run(test, params, env):
                                                  s_client, s_port,
                                                  username=s_username,
                                                  password=s_password,
+                                                 prompt=prompt,
+                                                 linesep=linesep,
+                                                 status_test_command=status_test_command,
                                                  compile_option=compile_option_server)
 
     # Get range of message size.

--- a/qemu/tests/ovs_qos.py
+++ b/qemu/tests/ovs_qos.py
@@ -131,8 +131,8 @@ def run(test, params, env):
             """
             login_timeout = float(params.get("login_timeout", 360))
             clear_iptables_cmd = "service iptables stop; iptables -F"
-            guest_info = ["username", "password", "shell_client",
-                          "shell_port", "os_type"]
+            guest_info = ["status_test_command", "shell_linesep", "shell_prompt",
+                          "username", "password", "shell_client", "shell_port", "os_type"]
             vms_info = []
             for _ in params.get("vms").split():
                 info = map(
@@ -186,6 +186,9 @@ def run(test, params, env):
                     client=info[-3],
                     password=info[-4],
                     username=info[-5],
+                    prompt=info[-6],
+                    linesep=info[-7].decode('string_escape'),
+                    status_test_command=info[-8],
                     compile_option=compile_option_server)
                 netperf_servers.append((server, vm))
                 continue
@@ -205,6 +208,9 @@ def run(test, params, env):
                     client=info[-3],
                     password=info[-4],
                     username=info[-5],
+                    prompt=info[-6],
+                    linesep=info[-7].decode('string_escape'),
+                    status_test_command=info[-8],
                     compile_option=compile_option_client)
                 netperf_clients.append((client, vm))
                 continue


### PR DESCRIPTION
tests.netperf_stress:
1.add params of "prompt,linesep, status_test_command"
2.pass these params to "NetperfServer/NetperfClient"

tests.netperf_udp:
1.add params of "prompt,linesep, status_test_command"
2.pass these params to "NetperfServer/NetperfClient"

tests.flow_caches_stress_test:
1.add params of "prompt,linesep, status_test_command"
2.pass these params to "NetperfServer/NetperfClient"

tests.migration_with_netperf:
1.add params of "prompt,linesep, status_test_command"
2.pass these params to "NetperfServer/NetperfClient"

tests.multi_nics_stress:
1.add params of "prompt,linesep, status_test_command"
2.pass these params to "NetperfServer/NetperfClient"

tests.ovs_qos:
1.add params of "prompt,linesep, status_test_command"
2.pass these params to "NetperfServer/NetperfClient"

Signed-off-by:Aihua Liang<aliang@redhat.com>

ID: 1263919, 1261786