### PR TITLE
qemu.tests.multi_disk.all_drive_format_types: update usb controller o…

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -60,6 +60,9 @@
                 stg_params = "drive_format:virtio,scsi-hd,usb2"
             usbs += " default-ehci"
             usb_type_default-ehci = usb-ehci
+            Host_RHEL.m6:
+                usbs = "default-ehci"
+                usb_type_default-ehci = ich9-usb-ehci1
         - virtio_scsi_variants:
             only virtio_scsi
             # virtio-scsi driver support from RHEL6.3


### PR DESCRIPTION
…n RHEL.6 host.

1. usb-ehci controller can not connect with low-speed usb device when machine type is rhel6.* .
2. In base.cfg, default add ich9-usb-ehci1 controller, so redefine it in this scenario on RHEL.6 host.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1310605