### PR TITLE
qemu.tests.block_hotplug: some improvements for the code.

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -17,7 +17,7 @@
     variants:
         - one_pci:
             blk_num = 1
-            repeat_times = 300
+            repeat_times = 3
         - multi_pci:
             blk_num = 2
             repeat_times = 3
@@ -30,6 +30,8 @@
 
     variants:
         - @default:
+        - with_repetition:
+            repeat_times = 300
         - with_reboot:
             sub_type_after_unplug = boot
             reboot_method = shell

--- a/qemu/tests/stop_continue.py
+++ b/qemu/tests/stop_continue.py
@@ -92,3 +92,5 @@ def run(test, params, env):
             op_timeout = float(params.get("clean_op_timeout", 60))
             session.cmd(clean_op, timeout=op_timeout, ignore_all_errors=True)
         session.close()
+        if session_bg:
+            session_bg.close()


### PR DESCRIPTION
1. block_hotplug.cfg: add separate scenario for repeated plug/unplug, no need repeat 300 times for each scenario when one pci.
2. block_hotplug.py: get and close a separate session when using it to fix file descriptor out of range problem.
3. stop_continue.py: close session when test finished.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1332870