### PR TITLE
qemu.tests.single_driver_install:update virtio serial device name to keep same with the latest virtio-win version

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -62,8 +62,6 @@
         - with_vioserial:
             driver_name = vioser
             device_name = "VirtIO Serial Driver"
-            Host_RHEL.m6, Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2:
-                device_name = "VirtIO-Serial Driver"
             virtio_ports = "vs"
             virtio_port_type = serialport
         - with_balloon:


### PR DESCRIPTION
According to new policy, all RHEL host will use the latest virtio-win drivers.
 And latest virtio-win serial driver use "VirtIO Serial Driver".

id: 1408629

Signed-off-by: Yanan Fu <yfu@redhat.com>