### PR TITLE
disable xhci on RHEL.6 host.

### DIFF
--- a/qemu/tests/cfg/pci_devices.cfg
+++ b/qemu/tests/cfg/pci_devices.cfg
@@ -43,6 +43,7 @@
     variants:
         - xhci_controller:
             test_device_type = xhci
+            no Host_RHEL.m6
         - ehci_controller:
             test_device_type = ehci
         - uhci_controller:


### PR DESCRIPTION
xhci is not supported on RHEL.6 host.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1408899