### PR TITLE
qemu.tests.cluster_size_check.negative: disable cluster_size=0 scenar…

### DIFF
--- a/qemu/tests/cfg/cluster_size_check.cfg
+++ b/qemu/tests/cfg/cluster_size_check.cfg
@@ -18,3 +18,5 @@
         - negative_testing:
             status_error = "yes"
             cluster_size_set = "0k 4M"
+            Host_RHEL.m6:
+                cluster_size_set = "4M"


### PR DESCRIPTION
…io on RHEL.6 host.

qemu-img should not create image when cluster_size=0.
There are some problems of cluster_size=0 on RHEL.6 host and which will not be fixed,
so remove this scenario on RHEL.6 host.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1408917