### PR TITLE
disable block job pause and resume for storage migration on RHEL.6 host.

### DIFF
--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -99,3 +99,5 @@
                     cancel_timeout_image1 = 3
                     max_speed_image1 = 10M
                     when_streaming = "pause_job set_speed resume_job cancel start wait_for_finished"
+                    Host_RHEL.m6:
+                        when_streaming = "set_speed cancel start wait_for_finished"


### PR DESCRIPTION
block job pause and resume for storage migration are not supported on RHEL.6 host.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1409046