### PR TITLE
qemu.tests: some updates for live_snapshot negative tests.

### DIFF
--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -93,14 +93,6 @@
                     reboot_method = "system_reset"
                     when_start = "reboot"
                     after_finished = "verify_alive"
-        - negative_test:
-            type = live_snapshot_negative_test
-            variants:
-                - @default:
-                    match_str = "Could not create file: No such file or directory"
-                - existing_mode:
-                    snapshot_mode = "existing"
-                    match_str = "Could not open '%s': No such file or directory"
         - transaction:
             type = live_snapshot_transaction
             images += " sn1 sn2"

--- a/qemu/tests/cfg/live_snapshot_negative.cfg
+++ b/qemu/tests/cfg/live_snapshot_negative.cfg
@@ -1,0 +1,24 @@
+- live_snapshot_negative:
+    virt_test_type = qemu
+    type = live_snapshot_negative
+    no raw vmdk qed
+    kill_vm = yes
+    monitor_type = qmp
+    monitors = qmp1
+    source_image = image1
+    snapshot_file = live_snapshot_img
+    snapshot_mode = "absolute-paths"
+    create_cmd = "dd if=/dev/urandom of=%s bs=1M count=1024"
+    file_create = /var/tmp/file
+    clean_cmd = rm -f
+    variants:
+        - simple_test:
+            type = live_snapshot_negative
+            variants:
+                - @default:
+                    match_str = "Could not create file: No such file or directory"
+                    Host_RHEL.m6:
+                        match_str = "error while creating qcow2: No such file or directory"
+                - existing_mode:
+                    snapshot_mode = "existing"
+                    match_str = "Could not open '%s': No such file or directory"

--- a/qemu/tests/live_snapshot_negative.py
+++ b/qemu/tests/live_snapshot_negative.py
@@ -8,7 +8,7 @@ from qemu.tests.live_snapshot_basic import LiveSnapshot
 from avocado.core import exceptions
 
 
-class LiveSnapshotNegativeTest(LiveSnapshot):
+class LiveSnapshotNegative(LiveSnapshot):
 
     """
     Provide basic functions for live snapshot negative test cases.
@@ -66,5 +66,5 @@ def run(test, params, env):
     """
     image_tag = params.get("image_name", "image1")
     image_params = params.object_params(image_tag)
-    snapshot_test = LiveSnapshotNegativeTest(test, image_params, env, image_tag)
+    snapshot_test = LiveSnapshotNegative(test, image_params, env, image_tag)
     snapshot_test.create_snapshot()


### PR DESCRIPTION
1. separate live snapshot negative tests from live_snapshot.cfg to a new configuration.
2. rename live_snapshot_negative_test.py to live_snapshot_negative.py for a uniform format.
   And also rename the class name in it.
3. update error match string for RHEL.6 host.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1409054