### PR TITLE
pxe_boot: avoid to set bootindex to disk

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -3,6 +3,7 @@
     type = pxe_boot
     requires_root = yes
     images = pxe
+    image_boot_pxe = no
     image_name_pxe = images/pxe-test
     image_size_pxe = 1G
     force_create_image_pxe = yes


### PR DESCRIPTION
Avoid to set bootindex to disk.

ID: 1377165