### PR TITLE
improve the script of readonly_disk

### DIFF
--- a/qemu/tests/cfg/readonly_disk.cfg
+++ b/qemu/tests/cfg/readonly_disk.cfg
@@ -8,9 +8,12 @@
     image_size_data = 1G
     force_create_image_data = yes
     copy_cmd = copy /Y %s %s
-    src_file = WIN_UTIL:\README
+    drive_letter = "I:"
+    src_file = WIN_UTILS:\README
+    dst_file = ${drive_letter}"\\dst_file"
+    dst_file_readonly = ${drive_letter}"\\dst_file_readonly"
     # Please make the disk_letter the same in create_partition_cmd and format_cmd
-    disk_letter = I
+
     variants:
         - @default:
         - with_wrerror:


### PR DESCRIPTION
ID: 1162412
    
1. replace the vols using function set_winutils_letter.
    2. print the output of the cmd executed in guest.

 (1/2) smp_16.16384m.repeat1.run_test.Host_RHEL.m6.u9.qcow2.virtio_scsi.up.virtio_net.Win7.x86_64.sp1.io-github-autotest-qemu.readonly_disk: PASS (433.68 s)
 (2/2) smp_16.16384m.repeat1.run_test.Host_RHEL.m6.u9.qcow2.virtio_scsi.up.virtio_net.Win7.x86_64.sp1.io-github-autotest-qemu.readonly_disk.with_wrerror: PASS (433.83 s)


Signed-off-by: Meng Yang meyang@redhat.com