### PR TITLE
Print error info when iometer_windows test failed

### DIFF
--- a/generic/tests/iometer_windows.py
+++ b/generic/tests/iometer_windows.py
@@ -7,14 +7,15 @@ import time
 import re
 import os
 
-from autotest.client.shared import error
+from avocado.core import exceptions
 
 from virttest import data_dir
+from virttest import error_context
 from virttest import utils_misc
 from virttest import utils_test
 
 
-@error.context_aware
+@error_context.context_aware
 def run(test, params, env):
     """
     Run Iometer for Windows on a Windows guest:
@@ -38,22 +39,22 @@ def run(test, params, env):
     # format the target disk
     utils_test.run_virt_sub_test(test, params, env, "format_disk")
 
-    error.context("Install Iometer", logging.info)
+    error_context.context("Install Iometer", logging.info)
     cmd_timeout = int(params.get("cmd_timeout", 360))
     ins_cmd = params["install_cmd"]
     vol_utils = utils_misc.get_winutils_vol(session)
     if not vol_utils:
-        raise error.TestError("WIN_UTILS CDROM not found")
+        raise exceptions.TestError("WIN_UTILS CDROM not found")
     ins_cmd = re.sub("WIN_UTILS", vol_utils, ins_cmd)
     session.cmd(cmd=ins_cmd, timeout=cmd_timeout)
     time.sleep(0.5)
 
-    error.context("Register Iometer", logging.info)
+    error_context.context("Register Iometer", logging.info)
     reg_cmd = params["register_cmd"]
     reg_cmd = re.sub("WIN_UTILS", vol_utils, reg_cmd)
     session.cmd_output(cmd=reg_cmd, timeout=cmd_timeout)
 
-    error.context("Prepare icf for Iometer", logging.info)
+    error_context.context("Prepare icf for Iometer", logging.info)
     icf_name = params["icf_name"]
     ins_path = params["install_path"]
     res_file = params["result_file"]
@@ -61,7 +62,7 @@ def run(test, params, env):
     vm.copy_files_to(icf_file, "%s\\%s" % (ins_path, icf_name))
 
     # Run Iometer
-    error.context("Start Iometer", logging.info)
+    error_context.context("Start Iometer", logging.info)
     session.cmd("cd %s" % ins_path)
     logging.info("Change dir to: %s" % ins_path)
     run_cmd = params["run_cmd"]
@@ -69,7 +70,9 @@ def run(test, params, env):
     logging.info("Set Timeout: %ss" % run_timeout)
     run_cmd = run_cmd % (icf_name, res_file)
     logging.info("Execute Command: %s" % run_cmd)
-    session.cmd(cmd=run_cmd, timeout=run_timeout)
-
-    error.context("Copy result '%s' to host" % res_file, logging.info)
+    s, o = session.cmd_status_output(cmd=run_cmd, timeout=100)
+    error_context.context("Copy result '%s' to host" % res_file, logging.info)
     vm.copy_files_from(res_file, test.resultsdir)
+
+    if s != 0:
+        raise exceptions.TestFail("iometer test failed. {}".format(o))


### PR DESCRIPTION
ID: 1270217 
    
1. replace cmd to cmd_status_output,when iometer failed
    print the iometer error info

Signed-off-by: Meng Yang meyang@redhat.com