### PR TITLE
qemu.tests: fix type error in get block device by file

### DIFF
--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -75,6 +75,7 @@ class BlockCopy(object):
         """
         image_file = storage.get_image_filename(self.parser_test_args(),
                                                 self.data_dir)
+        image_file = os.path.realpath(image_file)
         logging.info("image filename: %s" % image_file)
         return self.vm.get_block({"file": image_file})
 

--- a/qemu/tests/rh_kernel_update.py
+++ b/qemu/tests/rh_kernel_update.py
@@ -435,6 +435,7 @@ def run(test, params, env):
     error.context("OS updated, commit changes to disk", logging.info)
     base_dir = params.get("images_base_dir", data_dir.get_data_dir())
     image_filename = storage.get_image_filename(params, base_dir)
+    image_filename = os.path.realpath(image_filename)
     logging.info("image file name: %s" % image_filename)
     block = vm.get_block({"backing_file": image_filename})
     vm.monitor.send_args_cmd("commit %s" % block)


### PR DESCRIPTION
qemu used real-path for image file, so convert image file
path to real-path to avoid error in get block device by
image filename

Signed-off-by: Xu Tian <xutian@redhat.com>