### PR TITLE
Switch the kernel source code version to support ppc arch kernel compiling

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -150,12 +150,12 @@
             after_reopen = "reboot verify_alive"
         - with_powerdown:
             type = drive_mirror_powerdown
-            app_check_cmd = "test -d  ${tmp_dir}/linux-2.6.35.14"
-            download_link = "https://www.kernel.org/pub/linux/kernel/v2.6/longterm/v2.6.35/linux-2.6.35.14.tar.gz"
-            pkg_md5sum = "15e4021ffcb47b93c218083e1f2734a7"
-            install_cmd = "tar xzvf ${tmp_dir}/linux-2.6.35.14.tar.gz -C ${tmp_dir}/"
-            config_cmd = "cd ${tmp_dir}/linux-2.6.35.14 && make defconfig"
-            start_cmd = "cd ${tmp_dir}/linux-2.6.35.14 && make clean && make -j `grep processor /proc/cpuinfo|wc -l` && make modules"
+            app_check_cmd = "test -d  ${tmp_dir}/linux-4.8.1"
+            download_link = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.8.1.tar.gz"
+            pkg_md5sum = "8c6622686cf26f49ba454ef919e0e0c2"
+            install_cmd = "tar xzvf ${tmp_dir}/linux-4.8.1.tar.gz -C ${tmp_dir}/"
+            config_cmd = "cd ${tmp_dir}/linux-4.8.1 && make defconfig"
+            start_cmd = "cd ${tmp_dir}/linux-4.8.1 && make clean && make -j `grep processor /proc/cpuinfo|wc -l` && make modules"
             check_cmd = "pidof make"
             stop_cmd = "pkill -g make && rm -rf ${tmp_dir}/linux*"
             before_start = "load_stress"


### PR DESCRIPTION
ID:1263071

Signed-off-by: Zhengtong <zhengtli@redhat.com>
linux-2.6 doesn't support ppc64le compiling , update it to linux-4.8 version.