### PR TITLE
multi_disk_random_hotplug: Add codes to handle the hot_unplug error caused by cmd '__com.redhat_drive_del'

### DIFF
--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -7,11 +7,11 @@
     stg_image_name = "images/stg%s"
     stg_image_num = 20
     repeat_times = 3
-    wait_between_hotplugs = 0
-    wait_after_hotplug = 3
-    wait_between_unplugs = 0
+    wait_between_hotplugs = 2
+    wait_after_hotplug = 10
+    wait_between_unplugs = 2
     # since image check is executed after unplug wait can be 0
-    wait_after_unplug = 0
+    wait_after_unplug = 10
     Linux:
         # We have multiple disks so just ignor first one of each type
         no_stress_cmds = 100
@@ -37,8 +37,8 @@
         - @serial:
         - parallel:
             multi_disk_type = parallel
-            monitors += " TestHMP1 TestHMP2 TestQMP1 TestQMP2"
-            monitor_type_TestHMP1 = human
-            monitor_type_TestHMP2 = human
+            monitors += " TestQMP1 TestQMP2 TestQMP3 TestQMP4"
             monitor_type_TestQMP1 = qmp
             monitor_type_TestQMP2 = qmp
+            monitor_type_TestQMP3 = qmp
+            monitor_type_TestQMP4 = qmp


### PR DESCRIPTION
1. Add codes to handle unplug error caused by cmd '__com.redhat_drive_del'
2. Change all monitors to QMP ones
3. Add sleep time between/after hotplugs/unplugs

ID: 1303513

Signed-off-by: Nini Gu <ngu@redhat.com>