### PR TITLE
qemu.tests.block_hotplug: set bootindex=0 for system disk.

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -3,6 +3,7 @@
     no ide
     virt_test_type = qemu libvirt
     type = block_hotplug
+    bootindex_image1 = 0
     images += " stg0"
     boot_drive_stg0 = no
     image_name_stg0 = images/storage0


### PR DESCRIPTION
In some enterprises, the default bootindex is -1 for system disk,
which means cancel the boot index.
If hotplug a data disk then reboot guest, qemu may set the data
disk with higher bootindex, which depends on different enterprises'
policies.
As above, need set bootindex=0 for system disk.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1412718