### PR TITLE
drive_mirror: Redistribute boot_target_image to meet cases description.

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -34,6 +34,7 @@
     tmp_dir = "/tmp"
     repeat_times = 3
     cancel_timeout = 5
+    #For drive_mirror_complete, target image will not be boot by default, as boot_target_image=no
     variants:
         - 2qcow2:
             image_format_target = "qcow2"
@@ -41,7 +42,6 @@
             image_format_target = "raw"
     variants:
         - @on_localfs:
-            boot_target_image = no
         - on_nfs:
             image_type_target = nfs
             nfs_mount_dir = "/mnt/nfs"
@@ -50,7 +50,6 @@
             export_dir = "/home/nfs"
             export_options = "rw,no_root_squash,async"
             setup_local_nfs = yes
-            boot_target_image = yes
         - on_iscsi:
             only raw
             only 2raw
@@ -58,7 +57,6 @@
             image_type_target = iscsi
             force_cleanup_target = yes
             host_setup_flag_target = 2
-            boot_target_image = yes
             # Please replace below iscsi connection params before start your testing
             emulated_image_target = images/iscsi-storage.raw
             portal_ip_target = "127.0.0.1"
@@ -87,7 +85,7 @@
                     before_steady = "pause_job resume_job"
                 - job_complete:
                     type = drive_mirror_complete
-                    boot_target_image = no
+                    boot_target_image = yes
         - granularity:
             type = drive_mirror_complete
             boot_target_image = yes


### PR DESCRIPTION
Redistribute boot_target_image to meet cases description.
id: 1146789, 1330404
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>