### PR TITLE
Fix typo and cfg of fio_windows

### DIFF
--- a/qemu/tests/cfg/fio_windows.cfg
+++ b/qemu/tests/cfg/fio_windows.cfg
@@ -1,13 +1,16 @@
 - fio_windows:
     type = fio_windows
     only Windows
-    test_timeout = 600
-    install_path = "C:\fio"
+    cmd_timeout = 600
     log_file = "C:\fio_log.txt"
+    image_snapshot = yes
     i386, i686:
-        install_cmd = "msiexec /a DRIVE:\fio-x86.msi /qn TARGETDIR=${install_path}"
+        install_path = "C:\Program Files\fio"
+        install_cmd = 'msiexec /a DRIVE:\fio-x86.msi /qn TARGETDIR="${install_path}"'
     x86_64:
-        install_cmd = "msiexec /a DRIVE:\fio-x64.msi /qn TARGETDIR=${install_path}"
-    config_cmd = 'setx -m path "%PATH%;${install_path}\fio;"'
+        install_path = "C:\Program Files (x86)\fio"
+        install_cmd = 'msiexec /a DRIVE:\fio-x64.msi /qn TARGETDIR="${install_path}"'
+    #config_cmd = 'setx -m path "%PATH%;${install_path}\fio;"'
     fio_cmd = '"${install_path}\fio\fio.exe" --name=fiotest --rw=randrw --iodepth=4 --bs=4k'
-    fio_cmd += ' --size=1G --ioengine=windowsaio --numjobs=4 --runtime=${test_timeout} > ${log_file}'
+    fio_cmd += ' --size=1G --ioengine=windowsaio --numjobs=4 --runtime=${cmd_timeout} > ${log_file}'
+


### PR DESCRIPTION
1. fix typo error and improve finally, which will cover the key error
2. update test_timeout to cmd_timeout as the name is the same as job timeout in framework

Signed-off-by: Suqin Huang <shuang@redhat.com>

id:1412887