### PR TITLE
host-kernel: remove cpu flag "hv_relaxed" as some win guest failed to boot with it

### DIFF
--- a/qemu/cfg/host-kernel/Host_RHEL/6/4.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/4.cfg
@@ -10,4 +10,7 @@
         cpu_info = "pc,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
     Windows:
         #hv_relaxed option is supported since RHEL.6.4, 1043730#c2
-        cpu_model_flags += ",hv_relaxed"
+        # but the guest from win2012 always failed to boot with
+        # '-cpu SandyBridge/Opteron_G4' + hv_relaxed flag, for details: bug#1063124
+        # so commented it, will re-open it when bug#1063124 fixed.
+        # cpu_model_flags += ",hv_relaxed"

--- a/qemu/cfg/host-kernel/Host_RHEL/6/5.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/5.cfg
@@ -10,4 +10,7 @@
         cpu_info = "pc,rhel6.5.0,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
     Windows:
         #hv_relaxed option is supported since RHEL.6.4, 1043730#c2
-        cpu_model_flags += ",hv_relaxed"
+        # but the guest from win2012 always failed to boot with
+        # '-cpu SandyBridge/Opteron_G4' + hv_relaxed flag, for details: bug#1063124
+        # so commented it, will re-open it when bug#1063124 fixed.
+        # cpu_model_flags += ",hv_relaxed"

--- a/qemu/cfg/host-kernel/Host_RHEL/6/6.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/6.cfg
@@ -8,4 +8,7 @@
         cpu_info = "pc,rhel.6.6.0,rhel6.5.0,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
     Windows:
         #hv_relaxed option is supported since RHEL.6.4
-        cpu_model_flags += ",hv_relaxed"
+        # but the guest from win2012 always failed to boot with
+        # '-cpu SandyBridge/Opteron_G4' + hv_relaxed flag, for details: bug#1063124
+        # so commented it, will re-open it when bug#1063124 fixed.
+        # cpu_model_flags += ",hv_relaxed"

--- a/qemu/cfg/host-kernel/Host_RHEL/6/7.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/7.cfg
@@ -8,4 +8,7 @@
         cpu_info = "pc,rhel.6.6.0,rhel6.5.0,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
     Windows:
         #hv_relaxed option is supported since RHEL.6.4
-        cpu_model_flags += ",hv_relaxed"
+        # but the guest from win2012 always failed to boot with
+        # '-cpu SandyBridge/Opteron_G4' + hv_relaxed flag, for details: bug#1063124
+        # so commented it, will re-open it when bug#1063124 fixed.
+        # cpu_model_flags += ",hv_relaxed"

--- a/qemu/cfg/host-kernel/Host_RHEL/6/8.cfg
+++ b/qemu/cfg/host-kernel/Host_RHEL/6/8.cfg
@@ -8,4 +8,7 @@
         cpu_info = "pc,rhel.6.6.0,rhel6.5.0,rhel6.4.0,rhel6.3.0,rhel6.2.0,rhel6.1.0,rhel6.0.0,rhel5.5.0,rhel5.4.4,rhel5.4.0"
     Windows:
         #hv_relaxed option is supported since RHEL.6.4
-        cpu_model_flags += ",hv_relaxed"
+        # but the guest from win2012 always failed to boot with
+        # '-cpu SandyBridge/Opteron_G4' + hv_relaxed flag, for details: bug#1063124
+        # so commented it, will re-open it when bug#1063124 fixed.
+        # cpu_model_flags += ",hv_relaxed"


### PR DESCRIPTION
 As bug 1063124: Fail to boot windows 2012/win8.1/win8 x86_64 guest with '-cpu SandyBridge/Opteron_G4' with hv_relaxed flag, remove this flag ans add note.

Signed-off-by: Yanan Fu <yfu@redhat.com>