### PR TITLE
flow_caches_stress_test: Fix undefined name 'prompt'

### DIFF
--- a/qemu/tests/flow_caches_stress_test.py
+++ b/qemu/tests/flow_caches_stress_test.py
@@ -83,7 +83,7 @@ def run(test, params, env):
     passwd = params.get("hostpasswd", "123456")
     client = params.get("shell_client", "ssh")
     port = params.get("shell_port", "22")
-    shell_prompt = params.get("shell_prompt", "^root@.*[\#\$]\s*$|#")
+    prompt = params.get("shell_prompt", "^root@.*[\#\$]\s*$|#")
     linesep = params.get("shell_linesep", "\n").decode('string_escape')
     status_test_command = params.get("status_test_command", "echo $?")
 


### PR DESCRIPTION
The commit 2687b22 "qemu.tests:modify netperf related script"
assigns shell prompt to variable 'shell_prompt',
but pass 'prompt' to utils_netperf.NetperfServer().

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>