### PR TITLE
check virtual mechine is alive or not before sending command

### DIFF
--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -1926,7 +1926,9 @@ def run(test, params, env):
         finally:
             error.context("Cleanup")
 
-            session.cmd("true")
+            if vm.is_alive():
+                session.cmd("true")
+
             session.close()
 
             del(cgroup)


### PR DESCRIPTION
When test cgroup.memory_memsw_limit, the qemu process will be
killed because of exceeding limit. So sending command "true"
will lead to ShellTimeOut error. When test cgroup.memory_limit,
although exceeding limit, the qemu process won't be killed.
So sending command is ok.