### PR TITLE
multi_disk_random_hotplug: Update the usb controller for RHEL.6 host

### DIFF
--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -31,6 +31,9 @@
                 stg_params = "fmt:virtio,virtio_scsi,usb2"
             usbs += " ehci"
             usb_type_ehci = usb-ehci
+            Host_RHEL.m6:
+                usbs= "ehci"
+                usb_type_ehci = ich9-usb-ehci1
         - single_type:
             no ide, ahci, scsi
     variants:


### PR DESCRIPTION
usb-echi controller could not be used to attach usb-tablet in RHEL.6 host, so update to use the ich9-usb-ehci1 one

ID: 1426498

Signed-off-by: Nini Gu <ngu@redhat.com>