### PR TITLE
qemu.migration: disable automem to avoid migration failed

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -1,5 +1,6 @@
 - migrate: install setup image_copy unattended_install.cdrom
     type = migration
+    automem = no
     migration_test_command = help
     migration_bg_command = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"
     migration_bg_check_command = pgrep tcpdump


### PR DESCRIPTION
Enable automem maybe cause source VM command line different
with destination VM command line. This case, migration test
maybe failed, so disable it to avoid unexpected test fail.

Signed-off-by: Xu Tian <xutian@redhat.com>