### PR TITLE
qemu_io_blkdebug: replace perror with  os.strerror

### DIFF
--- a/qemu/tests/cfg/qemu_io_blkdebug.cfg
+++ b/qemu/tests/cfg/qemu_io_blkdebug.cfg
@@ -12,7 +12,6 @@
     err_command = "write 0 1G"
     err_event = "refblock_alloc"
     errn_list = "1"
-    re_std_msg = "error\s+code\s+\d+:\s+([a-zA-Z\/\-\s]+)$"
     test_timeout = 2000
     blkdebug_default = blkdebug/qemu_io_default.conf
     check_image = no


### PR DESCRIPTION
As command perror is not installed in some hosts, replace
perror with os.strerror

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1409205