### PR TITLE
check_block_size: Add test for windows guest

### DIFF
--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -1,8 +1,8 @@
 - check_block_size:
-    only Linux
-    only virtio_blk
     no Host_RHEL.m5
     no RHEL.3 RHEL.4 RHEL.5
+    #No cmd support physical_block_size check for Win7,Win2008 and Win2008r2
+    no Win7 Win2008
     type = check_block_size
     virt_test_type = qemu
     kill_vm = yes
@@ -11,12 +11,19 @@
     index_enable = no
     image_name_stg = "images/check_block_size_image"
     image_size_stg = 20G
+    image_verify_bootable = no
     force_create_image_stg = yes
     drive_serial_stg = "TARGET_DISK0"
     cdroms += " unattended"
     unattended_delivery_method = cdrom
     chk_phy_blk_cmd = "cat /sys/block/%s/queue/physical_block_size"
     chk_log_blk_cmd = "cat /sys/block/%s/queue/logical_block_size"
+    chk_blks_cmd_windows = "powershell "get-disk|format-list""
+    variants:
+        - extra_cdrom_ks:
+            no 4096_4096
+        - base:
+            only 4096_4096
     variants:
         - 4096_4096:
             need_install = no


### PR DESCRIPTION
qemu.tests.check_block_size: add support for windows guest

qemu.tests.check_block_size:
1.add block check cmd for windows

qemu.tests.cfg.check_block_size:
1.add test guest--windows
2.disable win7,win2008 and win2008r2 temporarily for no suitable disk_check_cmd
3.divided cases to base and installation(avoid vfd installation)

Signed-off-by:Aihua Liang<aliang@redhat.com>

ID:1134252