### PR TITLE
qcow2perf: drop the outdate variants

### DIFF
--- a/qemu/tests/cfg/qcow2perf.cfg
+++ b/qemu/tests/cfg/qcow2perf.cfg
@@ -90,12 +90,3 @@
                 - cache_writethrough:
                     no Host_RHEL.m5
                     cache_mode = writethrough
-       - summary_qcow2perf:
-            start_vm = yes
-            type = performance
-            test = qcow2perf
-            summary_results = yes
-            marks = "TIME:real\s+([\d\.]+)h([\d\.]+)m([\d\.]+)s|real\s+([\d\.]+)m([\d\.]+)s|real\s+([\d\.]+)s"
-            file_list = "qcow2perf.*results"
-            no_table_list = "read writeoffset0 writeoffset1"
-            thread_tag = " "


### PR DESCRIPTION
Drop the variants summary_qcow2perf as there is no requirement to track.

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1408924