### PR TITLE
rh_qemu_iotests: drop parameter --force

### DIFF
--- a/qemu/tests/cfg/rh_qemu_iotests.cfg
+++ b/qemu/tests/cfg/rh_qemu_iotests.cfg
@@ -10,7 +10,7 @@
     check_image = no
     query_format = "%{NAME}-%{VERSION}-%{RELEASE}.src.rpm"
     download_rpm_cmd = brew download-build --rpm %s
-    get_src_cmd = rpm -ivhf %s && rpmbuild -bp %s --nodeps --force
+    get_src_cmd = rpm -ivhf %s && rpmbuild -bp %s --nodeps
     rpmbuild_clean_cmd = rpmbuild --clean %s --nodeps
     iotests_result_pattern = "Failed\s*(\d+)\s*of\s*(\d+)\s*test"
     variants:


### PR DESCRIPTION
Drop the parameter "--force", rpmbuild will apply all
patches to source code.

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1431319