### PR TITLE
fix re in block_copy.py

### DIFF
--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -254,7 +254,7 @@ class BlockCopy(object):
         blocks = self.vm.monitor.info("block")
         try:
             if isinstance(blocks, str):
-                image_regex = '%s.*\s+file=(\S*)' % self.device
+                image_regex = '%s.*(?:\)\:|file=)\s*(\S*)' % self.device.split(" ")[0]
                 image_file = re.findall(image_regex, blocks)
                 return image_file[0]
 


### PR DESCRIPTION
In qemu2.6, the information looks like:
"drive_image1 (#block183): /.../jeos-23-64.qcow2 (qcow2)"
In qemu1.5，the information looks like:
"drive_image1: removable=0 io-status=ok file=/.../jeos-23-64.qcow2
ro=0 drv=qcow2 encrypted=0 bps=0 bps_rd=0 bps_wr=0 iops=0 iops_rd=0"
The re want to find the "/.../jeos-23-64.qcow2".
'%s.*(?:\)\:|file=)\s*(\S*)' is work for both qemu1.5 and qemu2.6.

Signed-off-by: yanwang <yan.wang@easystack.cn>