### PR TITLE
Add "flexible_nic_index = yes" for multi nics related cases

### DIFF
--- a/qemu/tests/cfg/multi_nics_hotplug.cfg
+++ b/qemu/tests/cfg/multi_nics_hotplug.cfg
@@ -5,6 +5,7 @@
     type = nic_hotplug
     run_dhclient = yes
     nic_hotplug_count = 4
+    flexible_nic_index = yes
     RHEL.4, RHEL.5:
         additional_operation = yes
     variants:

--- a/qemu/tests/cfg/multi_nics_stress.cfg
+++ b/qemu/tests/cfg/multi_nics_stress.cfg
@@ -2,6 +2,7 @@
     virt_test_type = qemu
     type = multi_nics_stress
     kill_vm = yes
+    flexible_nic_index = yes
     image_snapshot = yes
     hostpassword = redhat
     # nic1 is for control, nic2 is for data connection

--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -5,6 +5,7 @@
     no RHEL.3.9
     nics += ' nic2 nic3 nic4 nic5 nic6 nic7 nic8'
     kill_vm = no
+    flexible_nic_index = yes
     mac_filter = "HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+)"
     ip_filter = "inet addr:(.\d+.\d+.\d+.\d+)"
     net_check_cmd = "ifconfig"

--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -14,6 +14,7 @@
         - with_netkvm:
             driver_name = netkvm
             nics += " nic2"
+            flexible_nic_index = yes
             nic_model_nic1 = virtio
             nic_model_nic2 = rtl8139
             device_name = "Red Hat VirtIO Ethernet Adapter"


### PR DESCRIPTION
when boot vm with multi nics, sometimes wrong nic index will cause
login guest failed,flexible_nic_index=yes can help avoid this issue

Signed-off-by: Yanan Fu <yfu@redhat.com>