### PR TITLE
qemu.test.pxe_query_cpus: stop VM until subtest began

### DIFF
--- a/qemu/tests/pxe_query_cpus.py
+++ b/qemu/tests/pxe_query_cpus.py
@@ -57,6 +57,7 @@ def run(test, params, env):
 
     params["start_vm"] = "yes"
     params["kvm_vm"] = "yes"
+    params["paused_after_start_vm"] = "yes"
 
     env_process.preprocess_vm(test, params, env, params["main_vm"])
     bg = utils.InterruptedThread(utils_test.run_virt_sub_test,
@@ -67,6 +68,7 @@ def run(test, params, env):
         bg.start()
         error.context("Query cpus in loop", logging.info)
         vm = env.get_vm(params["main_vm"])
+        vm.resume()
         while True:
             count += 1
             try:


### PR DESCRIPTION
There is an issue that the tftp packages has already arrived before the
script starting to snoop them, so stop VM until subtest began.

ID: 1439569