### PR TITLE
ksm_overcommit: Correct ksm_overcommit_guest.py path

### DIFF
--- a/qemu/tests/ksm_overcommit.py
+++ b/qemu/tests/ksm_overcommit.py
@@ -642,8 +642,8 @@ def run(test, params, env):
     logging.debug(utils_test.get_memory_info(lvms))
 
     # Copy ksm_overcommit_guest.py into guests
-    shared_dir = os.path.dirname(data_dir.get_data_dir())
-    vksmd_src = os.path.join(shared_dir, "scripts", "ksm_overcommit_guest.py")
+    vksmd_src = os.path.join(data_dir.get_shared_dir(),
+                             "scripts", "ksm_overcommit_guest.py")
     dst_dir = "/tmp"
     for vm in lvms:
         vm.copy_files_to(vksmd_src, dst_dir)


### PR DESCRIPTION
Correct the path of the script 'ksm_overcommit_guest.py'.
Signed-off-by: Yumei Huang <yuhuang@redhat.com>
ID: 1438134