### PR TITLE
drive_mirror_negative_tests: Setup iscsi target on localhost.

### DIFF
--- a/qemu/tests/cfg/drive_mirror_negative_tests.cfg
+++ b/qemu/tests/cfg/drive_mirror_negative_tests.cfg
@@ -52,14 +52,16 @@
             boot_target_image = yes
             start_firewall_cmd = "iptables -A INPUT -p tcp -d 127.0.0.1 --dport 2049 -j DROP"
         - on_iscsi:
-            image_format_target = raw
+            only raw
+            only 2raw
             # target_image will ingore, target_image will generate automatically
             image_type_target = iscsi
             force_cleanup_target = yes
             host_setup_flag_target = 2
             boot_target_image = yes
             # Please replace below iscsi connection params before start your testing
-            portal_ip_target = "192.168.1.2"
+            emulated_image_target = images/iscsi-storage.raw
+            portal_ip_target = "127.0.0.1"
             initiator_target = "iqn.2010-07.test.org:kvmautotest"
             target_target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-test"
             start_firewall_cmd = "iptables -A INPUT -p tcp -d ${portal_ip_target} --dport 3260 -j DROP"


### PR DESCRIPTION
Setup iscsi target on localhost for negative tests.

id: 1415588
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>