### PR TITLE
win_virtio_serial_data_transfer_reboot: fix the bug of verifier

### DIFF
--- a/qemu/tests/win_virtio_serial_data_transfer_reboot.py
+++ b/qemu/tests/win_virtio_serial_data_transfer_reboot.py
@@ -72,7 +72,7 @@ def run(test, params, env):
     if "vioser.sys" not in output:
         verify_cmd = params.get("vioser_verify_cmd",
                                 "verifier.exe /standard /driver vioser.sys")
-        session.cmd(verify_cmd, timeout=360)
+        session.cmd(verify_cmd, timeout=360, ok_status=[0, 2])
         session = vm.reboot(session=session, timeout=timeout)
         output = session.cmd(check_cmd, timeout=360)
         if "vioser.sys" not in output:


### PR DESCRIPTION
According the following msdn doc, the return code 2 of a verifier
command can be ignored since it is harmless.

  https://msdn.microsoft.com/en-us/windows/hardware/drivers/devtest/verifier-command-line

ID: 1438140