### PR TITLE
qemu.tests.cfg.usb.cfg: fix usb controller speed mismatch problem

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -55,6 +55,7 @@
         - without_usb_hub:
         - with_usb_hub:
             no usb_nodev
+            no usb-ehci
             usb_devices += " hub1"
             usb_type_hub1 = usb-hub
             usb_port_hub1 = "2"
@@ -85,6 +86,8 @@
         - @usb_nodev:
             only usb_storage, usb_host, usb_multi_disk
         - usb_kbd:
+            Host_RHEL.m6:
+                no usb-ehci
             only usb_boot, usb_reboot, usb_hotplug
             usb_type = "usb-kbd"
             info_usb_name = "QEMU USB Keyboard"
@@ -93,6 +96,8 @@
             vendor = "Adomax Technology Co., Ltd"
             product = "QEMU USB Keyboard"
         - usb_mouse:
+            Host_RHEL.m6:
+                no usb-ehci
             only usb_boot, usb_reboot, usb_hotplug
             usb_type = "usb-mouse"
             info_usb_name = "QEMU USB Mouse"
@@ -101,6 +106,8 @@
             vendor = "Adomax Technology Co., Ltd"
             product = "QEMU USB Mouse"
         - usb_tablet:
+            Host_RHEL.m6:
+                no usb-ehci
             only usb_boot, usb_reboot, usb_hotplug
             usb_type = "usb-tablet"
             info_usb_name = "QEMU USB Tablet"
@@ -109,6 +116,7 @@
             vendor = "Adomax Technology Co., Ltd"
             product = "QEMU USB Tablet"
         - usb_ccid:
+            no usb-ehci
             only usb_boot, usb_reboot, usb_hotplug
             usb_type = "usb-ccid"
             info_usb_name = "QEMU USB CCID"
@@ -127,6 +135,7 @@
             vendor = ""
             product = "QEMU USB Audio"
         - usb_hub:
+            no usb-ehci
             only usb_boot, usb_reboot, usb_hotplug
             usb_type = usb-hub
             info_usb_name = "QEMU USB Hub"


### PR DESCRIPTION
added 'no usb-ehci' into usb-hub and usb-ccid related variants to drop
these cases.

Signed-off-by: Haotong Chen <hachen@redhat.com>

ID: 1441539