### PR TITLE
qemu.tests.cfg.boot_from_device.cfg:add nec-usb-xhci support

### DIFF
--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -16,14 +16,22 @@
             dev_name = hard-drive
             bootindex_image1 = 0
         - boot_from_usb_stg:
+            variants:
+                - usb-ehci:
+                    usb_type_usb1 = usb-ehci
+                    drive_format_stg = "usb2"
+                - nec-xhci:
+                    no RHEL.3, RHEL.4, RHEL.5
+                    no Win2000, WinXP, Win2003, WinVista
+                    no Host_RHEL.m6
+                    usb_type_usb1 = nec-usb-xhci
+                    drive_format_stg = "usb3" 
             dev_name = usb-storage
             usb_devices = ""
             usbs = usb1
-            usb_type_usb1 = usb-ehci
             images += " stg"
             image_name_stg = "images/usbdevice"
             image_format_stg = "qcow2"
-            drive_format_stg = "usb2"
             image_size_stg = 100M
             create_image_stg = yes
             remove_image_stg = yes


### PR DESCRIPTION
add "usb-ehci" and "nec-xhci" variants into boot_from_usb_stg，
so that it will test both controllers.

Signed-off-by: Haotong Chen <hachen@redhat.com>

ID: 1369672