### PR TITLE
qemu.tests: skip generate serivce file if it exist

### DIFF
--- a/qemu/tests/cfg/virtio_port_login.cfg
+++ b/qemu/tests/cfg/virtio_port_login.cfg
@@ -15,7 +15,7 @@
             RHEL.6:
                 pre_cmd += "sed -i '/ACTIVE_CONSOLES/c ACTIVE_CONSOLES="/dev/tty[1-6] /dev/vport0p1"' /etc/sysconfig/init;"
             RHEL.7:
-                pre_cmd += "ln -s /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@vport0p1.service;"
+                pre_cmd += "systemctl |grep vport0 || ln -s /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@vport0p1.service;"
                 pre_cmd += "systemctl enable serial-getty@vport0p1.service"
         - virtio_console:
             login_console = vc1
@@ -23,5 +23,5 @@
             RHEL.6:
                 pre_cmd += "sed -i '/ACTIVE_CONSOLES/c ACTIVE_CONSOLES="/dev/tty[1-6] /dev/hvc0"' /etc/sysconfig/init;"
             RHEL.7:
-                pre_cmd += "ln -s /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@hvc0.service;"
+                pre_cmd += "systemctl | grep hvc0 || ln -s /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@hvc0.service;"
                 pre_cmd += "systemctl enable serial-getty@hvc0.service"


### PR DESCRIPTION
udev in latest rhel linux can generate serivce file for new
vport and vconsole, skip generate if the file exist in guest
os to avoid unexpect exception.

ID: 1157474

Signed-off-by: Xu Tian <xutian@redhat.com>