### PR TITLE
ppc64le: qemu_option_check, Add spapr-vlan device support and disable rtl8139&e1000 for power platform

### DIFF
--- a/qemu/tests/cfg/qemu_option_check.cfg
+++ b/qemu/tests/cfg/qemu_option_check.cfg
@@ -6,6 +6,11 @@
         - virtio-net:
             device_name = virtio-net-pci
         - e1000:
+            no ppc64,ppc64le
             device_name = e1000
         - rtl8139:
+            no ppc64,ppc64le
             device_name = rtl8139
+        - spapr-vlan:
+            only ppc64,ppc64le
+            device_name = spapr-vlan


### PR DESCRIPTION
ID: 1443887
On power platform , rtl8139 and e1000 nic device are not supported. 
This patch disabled these two device and enabled spapr-vlan device which is specific for power