### PR TITLE
Update balloon_time default value

### DIFF
--- a/qemu/tests/balloon_boot_in_pause.py
+++ b/qemu/tests/balloon_boot_in_pause.py
@@ -75,7 +75,7 @@ class BallooningTestPause(BallooningTest):
                 raise exceptions.TestFail("Balloon memory fail with error"
                                           " message: %s" % e)
         compare_mem = new_mem
-        balloon_timeout = float(self.params.get("balloon_timeout", 100))
+        balloon_timeout = float(self.params.get("balloon_timeout", 240))
         status = utils_misc.wait_for((lambda: compare_mem ==
                                       self.get_ballooned_memory()),
                                      balloon_timeout)

--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -98,7 +98,6 @@ class BallooningTest(MemoryBaseTest):
         except Exception, e:
             if self.params.get('illegal_value_check', 'no') == 'no' and new_mem != self.get_ballooned_memory():
                 raise error.TestFail("Balloon memory fail with error message: %s" % e)
-        time.sleep(60)
         if new_mem > self.ori_mem:
             compare_mem = self.ori_mem
         elif new_mem == 0:
@@ -109,7 +108,7 @@ class BallooningTest(MemoryBaseTest):
         else:
             compare_mem = new_mem
 
-        balloon_timeout = float(self.params.get("balloon_timeout", 100))
+        balloon_timeout = float(self.params.get("balloon_timeout", 240))
         status = utils_misc.wait_for((lambda: compare_mem ==
                                       self.get_ballooned_memory()),
                                      balloon_timeout)


### PR DESCRIPTION
100s is a little short for some host, update the default value to 300,
otherwise need to update lots cfg file

Signed-off-by: Suqin Huang <shuang@redhat.com>

id: 1446042