### PR TITLE
drive_mirror: remove granularity check since qemu2.9 disable the guranularity display in block job info.

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -90,7 +90,6 @@
             type = drive_mirror_complete
             boot_target_image = yes
             no Host_RHEL.m6
-            when_steady = check_granularity
             variants:
                 - 512:
                     wait_timeout = 36000

--- a/qemu/tests/drive_mirror.py
+++ b/qemu/tests/drive_mirror.py
@@ -66,22 +66,6 @@ class DriveMirror(block_copy.BlockCopy):
         return self.vm.get_block({"file": image_file})
 
     @error.context_aware
-    def check_granularity(self):
-        """
-        Check granularity value as set.
-        """
-        device_id = self.get_device()
-        info = self.vm.monitor.info_block().get(device_id)
-        if "granularity" in self.params:
-            target_gran = int(self.params["granularity"])
-            dirty_bitmap = info.get("dirty-bitmaps", "0")
-            granularity = int(dirty_bitmap[0].get("granularity", "0"))
-            if granularity != target_gran:
-                raise error.TestFail(
-                    "Granularity unmatched. Target is %d, result is %d" %
-                    (target_gran, granularity))
-
-    @error.context_aware
     def check_node_name(self):
         """
         Check node name as set, after block job complete.


### PR DESCRIPTION
Remove granularity check since qemu2.9 disable the guranularity display in block job info. Only make sure block mirror success also fit test case requirement.
id: 1443419

Signed-off-by: Qianqian Zhu <qizhu@redhat.com>