### PR TITLE
Update driver load stress cfg file

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -102,23 +102,24 @@
             run_bgstress = balloon_stress
             bg_stress_run_flag = balloon_test
             set_bg_stress_flag = yes
+            wait_bg_time = 180
             free_mem_cmd = wmic os get FreePhysicalMemory
-            video_url = http://FILESHARE.COM/pub/section2/kvmauto/video/big_buck_bunny_480p_stereo.avi
-            i386:
-                program_files = "%ProgramFiles%"
+            session_cmd_timeout = 240
+            video_test = win_video_play
             x86_64:
                 program_files = "%ProgramFiles(x86)%"
-            session_cmd_timeout = 240
-            # disable first startup guide for windows media player
-            pre_cmd = "reg add HKLM\SOFTWARE\Policies\Microsoft\WindowsMediaPlayer /v GroupPrivacyAcceptance  /t REG_DWORD /f /d 00000001"
-            # enable repeat mode of windows media player
-            pre_cmd += " & reg add HKCU\Software\Microsoft\MediaPlayer\Preferences /v ModeLoop /t REG_DWORD /d 1 /f"
-            play_video_cmd  = taskkill /IM wmplayer.exe /F & "${program_files}\Windows Media Player\wmplayer.exe"  "${video_url}"  /play /fullscreen
-            check_playing_cmd = "tasklist|findstr /I wmplayer"
-            stop_player_cmd = "taskkill /IM wmplayer.exe /F"
-            # reset media player play mode
-            post_cmd += "reg add HKCU\Software\Microsoft\MediaPlayer\Preferences /v ModeLoop /t REG_DWORD /d 0 /f"
-            target_process = wmplayer.exe
+            i386:
+                program_files = "%ProgramFiles%"
+            #Disable first startup guide for windows media player
+            wmplayer_reg_cmd = "reg add HKLM\SOFTWARE\Policies\Microsoft\WindowsMediaPlayer /v GroupPrivacyAcceptance  /t REG_DWORD /f /d 00000001"
+            wmplayer_path = "${program_files}\Windows Media Player\wmplayer.exe"
+            #Install kmplayer if wmplayer is not installed default
+            kmplayer_install_cmd = "start /wait WIN_UTILS:\kmplayer\%s\KMPlayer-setup.exe /SP- /VERYSILENT"
+            kmplayer_path = "${program_files}\KMPlayer\kmplayer.exe"
+            video_url = http://fileshare.com/Peppa_Pig_39_The_Tree_House.avi
+            play_video_cmd = '"%s" "%s" /play /fullscreen'
+            target_process = \w+mplayer.exe
+            guest_alias = "Win2008-sp2-32:2k8\x86,Win2008-sp2-64:2k8\amd64,Win2008-r2-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12\amd64"
         - with_viorng:
             no no_virtio_rng
             driver_name = viorng


### PR DESCRIPTION
    
    1. Update the cfg base on the update of balloon_stress cfg file
    2. Set the balloon_test flag in the get_memory_boundary,
    as the balloon operation is executed, and becasue the boundary balloon time
    is different for different mem, which will make the wait_time different.
id: 1426039