### PR TITLE
qemu.tests.boot_order_check: Update boot_order_check config

### DIFF
--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -44,11 +44,11 @@
             boot_fail_infos = "Booting from Hard Disk.*"
             boot_fail_infos += "Boot failed: not a bootable disk.*"
             boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out"
+            boot_fail_infos += "No more network devices"
         - bootorder1:
             bootorder_type = "type1"
             bootorder = 'nic1 -> stg2 -> nic2 -> nic3'
@@ -58,13 +58,13 @@
             bootindex_nic2 = 3
             bootindex_nic3 = 5
             boot_fail_infos = "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "Booting from Hard Disk.*"
             boot_fail_infos += "Boot failed: not a bootable disk.*"
             boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out"
+            boot_fail_infos += "No more network devices"
         - bootorder2:
             bootorder_type = "type2"
             bootorder = 'nic1 -> nic2 -> nic3 -> image1'
@@ -74,9 +74,9 @@
             bootindex_nic2 = 2
             bootindex_nic3 = 3
             boot_fail_infos = "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
-            boot_fail_infos += "Connection timed out.*"
+            boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "Booting from Hard Disk"


### PR DESCRIPTION
Del the unmatched sentences for status checking, update to matched ones. 

ID: 1447594

Signed-off-by: Sitong Liu <siliu@redhat.com>