### PR TITLE
Enable migrate.with_file_transfer on JeOS

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -74,7 +74,6 @@
             stress_stop_cmd = "killall autotest"
             type = migration_after_vm_paused
         - with_file_transfer:
-            no JeOS
             iterations = 1
             type = migration_with_file_transfer
         - mig_dest_problem:


### PR DESCRIPTION
There is no need to disable this test on JeOS, it does not require any
extra programs on guest, nor features unavailable there. The only issue
might be using too big file, but the default setting works well.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>