### PR TITLE
qemu.tests: Add sleep after remote-viewer cmd

### DIFF
--- a/qemu/tests/rv_connect.py
+++ b/qemu/tests/rv_connect.py
@@ -7,6 +7,7 @@ Requires: binaries remote-viewer, Xorg, netstat
 """
 import logging
 import socket
+import time
 
 from aexpect import ShellStatusError
 from aexpect import ShellCmdError
@@ -259,6 +260,7 @@ def launch_rv(client_vm, guest_vm, params):
     if not params.get("rv_verify") == "only":
         try:
             client_session.cmd(cmd)
+            time.sleep(50)
         except ShellStatusError:
             logging.debug("Ignoring a status exception, will check connection"
                           "of remote-viewer later")


### PR DESCRIPTION
Sometimes the time between running remote-viewer command
and verifying the connection was established is not enough and
the test fails. Adding a sleep of few seconds helps in verifying 
connection after connection is established

Reviewed By: Swapna Krishnan <skrishna@redhat.com>