### PR TITLE
qemu.tests: Increasing waittime from 5 to 15 seconds

### DIFF
--- a/qemu/tests/rv_connect.py
+++ b/qemu/tests/rv_connect.py
@@ -281,7 +281,7 @@ def launch_rv(client_vm, guest_vm, params):
             utils_spice.wait_timeout(5)  # Wait for remote-viewer to launch
             str_input(client_vm, ticket)
 
-        utils_spice.wait_timeout(5)  # Wait for conncetion to establish
+        utils_spice.wait_timeout(15)  # Wait for conncetion to establish
 
     is_rv_connected = True
 


### PR DESCRIPTION
Sometimes, the tests fail since it takes longer to startup and the
test doesn't wait for remote-viewer to completely start up

Reviewed-By: Swapna Krishnan <skrishna@redhat.com>