### PR TITLE
Update MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,6 +11,6 @@ development mailing list and not any specific individual privately.
 
 
 L: Avocado-devel <avocado-devel@redhat.com>
-M: Xu Tian <xutian@redhat.com>
+M: Xu Han <xuhan@redhat.com>
 M: Cong Li <coli@redhat.com>
 M: Jiangang Wei <weijg.fnst@cn.fujitsu.com>


### PR DESCRIPTION
The MAINTAINERS file is seriously outdated, this commit removes the
sections as they became unmaintained and uses volunteers with commit
rights and additionally the most active people from the last year.

Signed-off-by: Cong Li <coli@redhat.com>