### PR TITLE
qemu.cfg: Updating for RHEL 7

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -28,6 +28,7 @@ spice_info = None
 listening_addr = None
 certdb=None
 gencerts=None
+check_vm_needs_restart = no
 
 # Only qcow2 file format
 only qcow2
@@ -55,7 +56,7 @@ variants:
     - os:
         variants:
             - RHEL:
-                only Linux.RHEL.6.devel.x86_64
+                only Linux.RHEL.7.devel.x86_64
             - Windows:
                 image_size = 30G
                 only Win7.x86_64.sp1
@@ -126,6 +127,7 @@ variants:
                 spice_x509_server_subj = /C=CZ/L=BRNO/O=SPICE/CN=
                 spice_secure_channels = main, inputs
                 spice_client_host_subject = yes
+                check_vm_needs_restart = yes
                 variants:
                     - key_password:
                         spice_x509_secure = yes
@@ -208,7 +210,7 @@ variants:
                 spice_ipv6=no
 variants:
 
-    - qemu_kvm_rhel6devel_install_client:
+    - qemu_kvm_rhel7devel_install_client:
         image_name += "_client"
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
@@ -221,38 +223,38 @@ variants:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
         only unattended_install.cdrom.floppy_ks.default_install.aio_native
 
-    - qemu_kvm_rhel6devel_install_guest:
+    - qemu_kvm_rhel7devel_install_guest:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
         only unattended_install.cdrom.extra_cdrom_ks.default_install.aio_native
 
-    - @remote_viewer_rhel6develssl:
+    - @remote_viewer_rhel7develssl:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.ssl.key_password.password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64
 
-    - @remote_viewer_rhel6devel_quick:
+    - @remote_viewer_rhel7devel_quick:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64
 
-    - @remote_viewer_rhel6devel_password:
+    - @remote_viewer_rhel7devel_password:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.7.devel.x86_64
 
-    - @remote_viewer_rhel6devel_build_install:
+    - @remote_viewer_rhel7devel_build_install:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_build_install.RHEL.6.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_build_install.RHEL.7.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.7.devel.x86_64
 
     - @remote_viewer_win_guest_quick:
         only os.Windows
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
         #rv_connect_win is specifically a test meant for a windows guest and a rhel client, rv_connect cannot be used.
-        only rv.rw.rv_connect.RHEL.6.devel.x86_64
+        only rv.rw.rv_connect.RHEL.7.devel.x86_64
 
-    - @spice_negative_rhel6devel:
+    - @spice_negative_rhel7devel:
         only os.RHEL
         only negative_create
 
@@ -260,97 +262,97 @@ variants:
         only os.RHEL
         rv_verify = yes
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64
 
-    - @rv_disconnect_rhel6devel:
+    - @rv_disconnect_rhel7devel:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_disconnect.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_disconnect.RHEL.7.devel.x86_64
 
-    - @spice_migrate_rhel6devel:
+    - @spice_migrate_rhel7devel:
         kill_on_vms = "client_vm"
         kill_app_name = "remote-viewer"
         only os.RHEL
         variants:
             - no_ssl:
                 only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-                only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_migrate.default.RHEL.6.devel.x86_64, rv.rr.rv_disconnect.RHEL.6.devel.x86_64
+                only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_migrate.default.RHEL.7.devel.x86_64, rv.rr.rv_disconnect.RHEL.7.devel.x86_64
             - ssl:
                 only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.ssl.key_password.password.dcp_off.1monitor.default_sc
-                only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_migrate.default.RHEL.6.devel.x86_64, rv.rr.rv_disconnect.RHEL.6.devel.x86_64
+                only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_migrate.default.RHEL.7.devel.x86_64, rv.rr.rv_disconnect.RHEL.7.devel.x86_64
             - ssl_reboot:
                 only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.ssl.key_password.password.dcp_off.1monitor.default_sc
-                only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_migrate.with_reboot.RHEL.6.devel.x86_64, rv.rr.rv_disconnect.RHEL.6.devel.x86_64
+                only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_migrate.with_reboot.RHEL.7.devel.x86_64, rv.rr.rv_disconnect.RHEL.7.devel.x86_64
             - ssl_video:
                 kill_app_name = "totem"
                 kill_on_vms = "guest_vm"
                 iterations = 1
                 only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.ssl.key_password.password.dcp_off.1monitor.default_sc
-                only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_video.RHEL.6.devel.x86_64, rv.rr.rv_migrate.default.RHEL.6.devel.x86_64, rv.rr.rv_disconnect.RHEL.6.devel.x86_64
+                only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_video.RHEL.7.devel.x86_64, rv.rr.rv_migrate.default.RHEL.7.devel.x86_64, rv.rr.rv_disconnect.RHEL.7.devel.x86_64
             - ssl_vdagent:
                 config_test = "positive_client_to_guest"
                 only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.ssl.key_password.password.dcp_off.1monitor.default_sc
-                only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_migrate.default.RHEL.6.devel.x86_64, rv.rr.rv_copyandpaste.RHEL.6.devel.x86_64, rv.rr.rv_disconnect.RHEL.6.devel.x86_64
+                only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_migrate.default.RHEL.7.devel.x86_64, rv.rr.rv_copyandpaste.RHEL.7.devel.x86_64, rv.rr.rv_disconnect.RHEL.7.devel.x86_64
 
-    - @rv_fullscreen_rhel6devel:
+    - @rv_fullscreen_rhel7devel:
         spice_port = 3050
         clear_interface = no
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.password.dcp_off.1monitor.default_sc
-        only rv.rr.fullscreen_setup.RHEL.6.devel.x86_64, rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_fullscreen.RHEL.6.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.6.devel.x86_64
+        only rv.rr.fullscreen_setup.RHEL.7.devel.x86_64, rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_fullscreen.RHEL.7.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.7.devel.x86_64
 
-    - @rv_smartcard_rhel6devel:
+    - @rv_smartcard_rhel7devel:
         spice_port = 3060
         clear_interface = no
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.smartcard
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.smartcard_setup.RHEL.6.devel.x86_64, rv.rr.rv_smartcard.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.smartcard_setup.RHEL.7.devel.x86_64, rv.rr.rv_smartcard.RHEL.7.devel.x86_64
 
-    - @rv_logging_rhel6devel:
+    - @rv_logging_rhel7devel:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_logging.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_logging.RHEL.7.devel.x86_64
 
-    - @rv_vdagent_rhel6devel:
+    - @rv_vdagent_rhel7devel:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_vdagent.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_vdagent.RHEL.7.devel.x86_64
 
-    - @rv_copyandpaste_rhel6devel:
+    - @rv_copyandpaste_rhel7devel:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_copyandpaste.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_copyandpaste.RHEL.7.devel.x86_64
 
-    - @rv_copyandpaste_dcp_rhel6devel:
+    - @rv_copyandpaste_dcp_rhel7devel:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_on.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_copyandpaste.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_copyandpaste.RHEL.7.devel.x86_64
 
-    - @rv_input_rhel6devel:
+    - @rv_input_rhel7devel:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_input.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_input.RHEL.7.devel.x86_64
 
-    - @rv_audio_rhel6devel:
+    - @rv_audio_rhel7devel:
         only os.RHEL
         soundcards_vm1 = hda
         variants:
             - pc:
                 only spice.default_ipv.pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-                only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_audio.RHEL.6.devel.x86_64
+                only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_audio.RHEL.7.devel.x86_64
             - no_pc:
                 only spice.default_ipv.no_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-                only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_audio.RHEL.6.devel.x86_64
+                only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_audio.RHEL.7.devel.x86_64
 
-    - @rv_vmshutdown_rhel6devel:
+    - @rv_vmshutdown_rhel7devel:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_vmshutdown.RHEL.6.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.7.devel.x86_64, rv.rr.rv_vmshutdown.RHEL.7.devel.x86_64, rv.rr.client_guest_shutdown.RHEL.7.devel.x86_64
 
 variants:
     #The following are all the individual tests for spice
     - create_vms:
-        only qemu_kvm_rhel6devel_install_guest, qemu_kvm_rhel6devel_install_client
+        only qemu_kvm_rhel7devel_install_guest, qemu_kvm_rhel7devel_install_client
     - install_win_guest:
         only qemu_kvm_windows_install_guest
     - build_install_qxl:
@@ -362,7 +364,7 @@ variants:
         xorg_x11_util_macros_url = path_to_xorgx11utilmacros_rpm
         libfontenc_devel_url = path_to_libfontenc_devel_rpm
         libXfont_devel_url = path_to_libXfont_devel_rpm
-        only remote_viewer_rhel6devel_build_install
+        only remote_viewer_rhel7devel_build_install
     - build_install_virtviewer:
         build_install_pkg = virt-viewer
         vm_name = client
@@ -374,13 +376,13 @@ variants:
         libcacard_devel_url = path_to_libcacard_rpm
         celt051_devel_url = path_to_celt051_rpm
         libogg_devel_url = path_to_libogg_rpm
-        only remote_viewer_rhel6devel_build_install
+        only remote_viewer_rhel7devel_build_install
     - build_install_vdagent:
         build_install_pkg = spice-vd-agent
         vm_name = guest
         dst_dir = /tmp
         libpciaccess_devel_url = path_to_libpciaccess_rpm
-        only remote_viewer_rhel6devel_build_install
+        only remote_viewer_rhel7devel_build_install
     - build_install_spicegtk:
         build_install_pkg = spice-gtk
         vm_name = client
@@ -391,276 +393,277 @@ variants:
         source_highlight_url = path_to_source_highlight_rpm
         gtk_doc_url = path_to_gtk_doc_rpm
         libepoxy_devel_url = path_to_libepoxy_devel_rpm
-        only remote_viewer_rhel6devel_build_install
+        only remote_viewer_rhel7devel_build_install
     - negative_qemu_spice_launch_badport:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.bad_port.no_password.dcp_off.1monitor.default_sc
-        only spice_negative_rhel6devel
+        only spice_negative_rhel7devel
     - negative_qemu_spice_launch_badic:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.bad_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only spice_negative_rhel6devel
+        only spice_negative_rhel7devel
     - negative_qemu_spice_launch_badjpegwc:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.bad_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only spice_negative_rhel6devel
+        only spice_negative_rhel7devel
     - negative_qemu_spice_launch_badzlib:
         only spice.default_ipv.default_pc.default_sv.bad_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only spice_negative_rhel6devel
+        only spice_negative_rhel7devel
     - negative_qemu_spice_launch_badsv:
         only spice.default_ipv.default_pc.bad_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only spice_negative_rhel6devel
+        only spice_negative_rhel7devel
     - negative_qemu_spice_launch_badpc:
         only spice.default_ipv.bad_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only spice_negative_rhel6devel
+        only spice_negative_rhel7devel
     - remote_viewer_test:
-        only remote_viewer_rhel6devel_quick
+        only remote_viewer_rhel7devel_quick
     #The following ipv6 test is not a true test of ipv6, it is converting an
     #ipv4 address to ipv6, and verify the ipv6 format can be accepted.  The pure
     #ipv6 address cannot be tested because the network is not setup to support
     #ipv6
     - remote_viewer_ipv6_addr:
         listening_addr = ipv6
-        only remote_viewer_rhel6devel_quick
+        only remote_viewer_rhel7devel_quick
     - rv_qemu_report_ipv6:
         listening_addr = ipv6
         spice_info = ipv6
-        only remote_viewer_rhel6devel_quick
+        only remote_viewer_rhel7devel_quick
     - rv_connect_passwd:
-        only remote_viewer_rhel6devel_password
+        only remote_viewer_rhel7devel_password
     - rv_connect_menu:
         rv_parameters_from = menu
-        only remote_viewer_rhel6devel_quick
+        only remote_viewer_rhel7devel_quick
     - rv_connect_wrong_passwd:
         test_type = negative
+        check_vm_needs_restart = yes
         spice_password_send = incorrectpass
-        only remote_viewer_rhel6devel_password
+        only remote_viewer_rhel7devel_password
     - rv_qemu_password:
         qemu_password = qemupassword
-        only remote_viewer_rhel6devel_quick
+        only remote_viewer_rhel7devel_quick
     - rv_qemu_password_overwrite:
         qemu_password = qemupassword
-        only remote_viewer_rhel6devel_password
+        only remote_viewer_rhel7devel_password
     - guestvmshutdown_cmd:
         shutdownfrom = cmd
-        only rv_vmshutdown_rhel6devel
+        only rv_vmshutdown_rhel7devel
     - guestvmshutdown_qemu:
         shutdownfrom = qemu_monitor
-        only rv_vmshutdown_rhel6devel
+        only rv_vmshutdown_rhel7devel
     - remote_viewer_fullscreen_test:
         full_screen = yes
-        only rv_fullscreen_rhel6devel
+        only rv_fullscreen_rhel7devel
     - remote_viewer_fullscreen_test_neg:
         full_screen = no
-        only rv_fullscreen_rhel6devel
+        only rv_fullscreen_rhel7devel
     - remote_viewer_winguest_test:
         only remote_viewer_win_guest_quick
     - remote_viewer_disconnect_test:
         kill_app_name = "remote-viewer"
         kill_on_vms = "client_vm"
-        only rv_disconnect_rhel6devel
+        only rv_disconnect_rhel7devel
     - remote_viewer_ssl_test:
         kill_app_name = "remote-viewer"
         kill_on_vms = "client_vm"
-        only remote_viewer_rhel6develssl
+        only remote_viewer_rhel7develssl
     - rv_ssl_explicit_hs:
         ssltype = "explicit_hs"
-        only remote_viewer_rhel6develssl
+        only remote_viewer_rhel7develssl
     - rv_ssl_implicit_hs:
         ssltype = "implicit_hs"
         spice_client_host_subject = no
-        only remote_viewer_rhel6develssl
+        only remote_viewer_rhel7develssl
     - rv_ssl_invalid_explicit_hs:
         test_type = negative
         ssltype = "invalid_explicit_hs"
-        only remote_viewer_rhel6develssl
+        only remote_viewer_rhel7develssl
     - rv_ssl_invalid_implicit_hs:
         test_type = negative
         spice_client_host_subject = no
         ssltype = "invalid_implicit_hs"
-        only remote_viewer_rhel6develssl
+        only remote_viewer_rhel7develssl
     - spice_migrate_simple:
-        only spice_migrate_rhel6devel.no_ssl
+        only spice_migrate_rhel7devel.no_ssl
     - spice_migrate_ssl:
-        only spice_migrate_rhel6devel.ssl
+        only spice_migrate_rhel7devel.ssl
     - spice_migrate_reboot:
-        only spice_migrate_rhel6devel.ssl_reboot
+        only spice_migrate_rhel7devel.ssl_reboot
     - spice_migrate_video:
-        only spice_migrate_rhel6devel.ssl_video
+        only spice_migrate_rhel7devel.ssl_video
     - spice_migrate_vdagent:
-        only spice_migrate_rhel6devel.ssl_vdagent
+        only spice_migrate_rhel7devel.ssl_vdagent
     - start_vdagent_test:
         vdagent_test = start
-        only rv_vdagent_rhel6devel
+        only rv_vdagent_rhel7devel
     - stop_vdagent_test:
         vdagent_test = stop
-        only rv_vdagent_rhel6devel
+        only rv_vdagent_rhel7devel
     - restart_start_vdagent_test:
         vdagent_test = restart_start
-        only rv_vdagent_rhel6devel
+        only rv_vdagent_rhel7devel
     - restart_stop_vdagent_test:
         vdagent_test = restart_stop
-        only rv_vdagent_rhel6devel
+        only rv_vdagent_rhel7devel
     - copy_client_to_guest_pos:
         config_test = "positive_client_to_guest"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copy_guest_to_client_pos:
         config_test = "positive_guest_to_client"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copy_client_to_guest_neg:
         config_test = "negative_client_to_guest"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copy_guest_to_client_neg:
         config_test = "negative_guest_to_client"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copy_guest_to_client_dcp_neg:
         config_test = "negative_guest_to_client"
-        only rv_copyandpaste_dcp_rhel6devel
+        only rv_copyandpaste_dcp_rhel7devel
     - copy_client_to_guest_dcp_neg:
         config_test = "negative_client_to_guest"
-        only rv_copyandpaste_dcp_rhel6devel
+        only rv_copyandpaste_dcp_rhel7devel
     - copyimg_client_to_guest_pos:
         config_test = "positive_client_to_guest_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copyimg_guest_to_client_pos:
         config_test = "positive_guest_to_client_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copyimg_client_to_guest_neg:
         config_test = "negative_client_to_guest_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copyimg_guest_to_client_neg:
         config_test = "negative_guest_to_client_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copyimg_client_to_guest_dcp_neg:
         config_test = "negative_client_to_guest_image"
-        only rv_copyandpaste_dcp_rhel6devel
+        only rv_copyandpaste_dcp_rhel7devel
     - copyimg_guest_to_client_dcp_neg:
         config_test = "negative_guest_to_client_image"
-        only rv_copyandpaste_dcp_rhel6devel
+        only rv_copyandpaste_dcp_rhel7devel
     - copy_client_to_guest_largetext_pos:
         config_test = "positive_client_to_guest"
         #Currently only testing 256KB, this is due to a bug on pygtk
         #When the bug gets resolved the amount should be increased
         text_to_test=262144
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copy_guest_to_client_largetext_pos:
         config_test = "positive_guest_to_client"
         # Currently only testing 256KB, this is due to a bug on pygtk
         # When the bug gets resolved the amount should be increased
         text_to_test=262144
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copy_client_to_guest_largetext_10mb_pos:
         # This 10MB test will fail on RHEL6devel because of a pygtk bug
         config_test = "positive_client_to_guest"
         text_to_test=10485760
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copy_guest_to_client_largetext_10mb_pos:
         # This 10MB test will fail on RHEL6devel because of a pygtk bug
         config_test = "positive_guest_to_client"
         text_to_test=10485760
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copybmpimg_client_to_guest_pos:
         image_type = bmp
         config_test = "positive_client_to_guest_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copybmpimg_guest_to_client_pos:
         image_type = bmp
         config_test = "positive_guest_to_client_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copyimg_medium_client_to_guest_pos:
         image_tocopy_name = Image.png
         final_image = MediumPNGTest.png
         config_test = "positive_client_to_guest_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copyimg_medium_guest_to_client_pos:
         image_tocopy_name = Image.png
         final_image = MediumPNGTest.png
         config_test = "positive_guest_to_client_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copyimg_large_client_to_guest_pos:
         image_tocopy_name = Image-large.png
         final_image = LargePNGTest.png
         config_test = "positive_client_to_guest_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - copyimg_large_guest_to_client_pos:
         image_tocopy_name = Image-large.png
         final_image = LargePNGTest.png
         config_test = "positive_guest_to_client_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - restart_vdagent_copy_client_to_guest_pos:
         config_test = "positive_restart_client_to_guest"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - restart_vdagent_copy_guest_to_client_pos:
         config_test = "positive_restart_guest_to_client"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - restart_vdagent_copyimg_client_to_guest_pos:
         config_test = "positive_restart_client_to_guest_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - restart_vdagent_copyimg_guest_to_client_pos:
         config_test = "positive_restart_guest_to_client_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - restart_vdagent_copybmpimg_client_to_guest_pos:
         image_type = bmp
         config_test = "positive_restart_client_to_guest_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - restart_vdagent_copybmpimg_guest_to_client_pos:
         image_type = bmp
         config_test = "positive_restart_guest_to_client_image"
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - restart_vdagent_copy_client_to_guest_largetext_pos:
         config_test = "positive_restart_client_to_guest"
         #Currently only testing 256KB, this is due to a bug on pygtk
         #When the bug gets resolved the amount should be increased
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - restart_vdagent_copy_guest_to_client_largetext_pos:
         config_test = "positive_restart_guest_to_client"
         #Currently only testing 256KB, this is due to a bug on pygtk
         #When the bug gets resolved the amount should be increased
         text_to_test=262144
-        only rv_copyandpaste_rhel6devel
+        only rv_copyandpaste_rhel7devel
     - keyboard_input_leds_and_esc_keys:
         full_screen = yes
         config_test = "leds_and_esc_keys"
-        only rv_input_rhel6devel
+        only rv_input_rhel7devel
     - keyboard_input_non-us_layout:
         full_screen = yes
         config_test = "nonus_layout"
-        only rv_input_rhel6devel
+        only rv_input_rhel7devel
     - keyboard_input_type_and_func_keys:
         full_screen = yes
         config_test = "type_and_func_keys"
-        only rv_input_rhel6devel
+        only rv_input_rhel7devel
     - keyboard_input_leds_migration:
         full_screen = yes
         config_test = "leds_migration"
-        only rv_input_rhel6devel
+        only rv_input_rhel7devel
     - audio_compression:
         audio_tgt = "~/tone.wav"
         audio_rec = "~/rec.wav"
         audio_src = #path to your audio file (recommend generating a square/sine wave)
-        only rv_audio_rhel6devel.pc
+        only rv_audio_rhel7devel.pc
     - audio_no_compression:
         audio_tgt = "~/tone.wav"
         audio_rec = "~/rec.wav"
         audio_src = #path to your audio file (recommend generating a square/sine wave)
-        only rv_audio_rhel6devel.no_pc
+        only rv_audio_rhel7devel.no_pc
     - disable_audio:
         audio_tgt = "~/tone.wav"
         audio_rec = "~/rec.wav"
         disable_audio = "yes"
         audio_src = #path to your audio file (recommend generating a square/sine wave)
-        only rv_audio_rhel6devel.pc
+        only rv_audio_rhel7devel.pc
     - migrate_audio:
         audio_tgt = "~/tone.wav"
         audio_rec = "~/rec.wav"
         audio_src = #path to your audio file (recommend generating a square/sine wave)
         config_test = migration
         rv_audio_treshold = 529200
-        only rv_audio_rhel6devel.pc
+        only rv_audio_rhel7devel.pc
     - remote_viewer_smartcard_certinfo:
         smartcard_testtype = "pkcs11_listcerts"
         gencerts = "cert1,cert2,cert3"
         certdb = "/etc/pki/nssdb/"
         self_sign = True
         trustargs = "CT,CT,CT"
-        only rv_smartcard_rhel6devel
+        only rv_smartcard_rhel7devel
     - remote_viewer_smartcard_certdetail:
         smartcard_testtype = "pklogin_finder"
         gencerts = "cert1,cert2,cert3"
@@ -671,35 +674,35 @@ variants:
         certcheckstr2 = "verifing the certificate #"
         certcheck3 = "Couldn't verify Cert: Issuer certificate is invalid."
         certcheck4 = "verify_certificate() failed:"
-        only rv_smartcard_rhel6devel
+        only rv_smartcard_rhel7devel
     - qxl_logging:
-        only rv_logging_rhel6devel
+        only rv_logging_rhel7devel
     - spice_vdagent_logging:
         logtest = spice-vdagent
-        only rv_logging_rhel6devel
+        only rv_logging_rhel7devel
     - rv_proxy:
         spice_proxy = http://${proxy_ip}
-        only remote_viewer_rhel6devel_quick
+        only remote_viewer_rhel7devel_quick
     - rv_from_file_basic:
         rv_parameters_from = file
-        only remote_viewer_rhel6devel_quick
+        only remote_viewer_rhel7devel_quick
     - rv_from_file_proxy:
         spice_proxy = http://${proxy_ip}
         rv_parameters_from = file
-        only remote_viewer_rhel6devel_quick
+        only remote_viewer_rhel7devel_quick
     - rv_from_file_ssl:
         rv_parameters_from = file
-        only remote_viewer_rhel6develssl
+        only remote_viewer_rhel7develssl
     - proxy_migrate:
         spice_proxy = http://${proxy_ip}:3128
-        only spice_migrate_rhel6devel.no_ssl
+        only spice_migrate_rhel7devel.no_ssl
     - rv_from_file_password:
         rv_parameters_from = file
-        only remote_viewer_rhel6devel_password
+        only remote_viewer_rhel7devel_password
     - rv_from_file_fullscreen:
         full_screen = yes
         rv_parameters_from = file
-        only rv_fullscreen_rhel6devel
+        only rv_fullscreen_rhel7devel
 
 #Running all RHEL Client, RHEL Guest Spice Tests
 only create_vms, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_disconnect_test, guestvmshutdown_cmd, guestvmshutdown_qemu, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration, rv_connect_passwd, rv_connect_wrong_passwd, rv_qemu_password, rv_qemu_password_overwrite, spice_migrate_simple, spice_migrate_ssl, spice_migrate_reboot, spice_migrate_video, spice_migrate_vdagent, rv_ssl_invalid_explicit_hs, rv_ssl_invalid_implicit_hs, rv_ssl_implicit_hs, rv_ssl_explicit_hs, rv_connect_menu, audio_compression, audio_no_compression, disable_audio, migrate_audio, remote_viewer_ipv6_addr, rv_qemu_report_ipv6, start_vdagent_test, stop_vdagent_test, restart_start_vdagent_test, restart_stop_vdagent_test, remote_viewer_smartcard_certdetail, remote_viewer_smartcard_certinfo, rv_proxy, rv_from_file_basic, rv_from_file_proxy, rv_from_file_ssl, proxy_migrate, rv_from_file_password, rv_from_file_fullscreen


### PR DESCRIPTION
Updating the tests-spice.cfg file for RHEL 7 and also removing
the need to restart the VM for every test as only some tests need
it.

Reviewed By: Swapna Krishnan <skrishna@redhat.com>