### PR TITLE
fio_perf: add support for ppc64 and ppc64le and remove localfs dataplane in fio block performance test

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -1,5 +1,5 @@
 - fio_perf:
-    only x86_64
+    only x86_64,ppc64,ppc64le
     type = fio_perf
     numa_node = -1
     block_size = "4k 16k 64k 256k"
@@ -16,6 +16,9 @@
         guest_ver_cmd = "uname -r"
         compile_cmd = "make && make install"
         pre_cmd = "i=`/bin/ls /dev/[vs]db` && mkfs.xfs $i > /dev/null; partprobe; umount /mnt; mount $i /mnt"
+        ppc64, ppc64le:
+            virtio_blk:
+                pre_cmd = "i=`/bin/ls /dev/vda` && mkfs.xfs $i > /dev/null; partprobe; umount /mnt; mount $i /mnt"
         drop_cache = "sync && echo 3 > /proc/sys/vm/drop_caches"
         guest_result_file = /tmp/fio_result
         fio_cmd = "fio --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/mnt/%s --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=/tmp/fio_result &> /dev/null"
@@ -39,12 +42,10 @@
                     image_name_disk1 = /mnt/storage2
                     Linux:
                         vhost_nic1 =
-                        iothreads = iothread0
-                        virtio_blk, virtio_scsi:
-                            blk_extra_params_image1 = "iothread=${iothreads}"
                 - nfs_block:
                     image_name_disk1 = images/storage2
         - raw_disk:
+            no ppc64,ppc64le
             image_raw_device_disk1 = yes
             vhost_nic1 =
             variants:


### PR DESCRIPTION
Add support for ppc64 and ppc64le in fio block performance test. Because we usually don't test dataplane nether x86_64 nor ppc, I remove dataplane configuration.
bug id: 1460906
Signed-off-by: yama <yama@redhat.com>