### PR TITLE
Netperf: add restart_network=True for multiple nics on vm

### DIFF
--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -159,7 +159,7 @@ def run(test, params, env):
         server_cyg = None
 
     if len(params.get("nics", "").split()) > 1:
-        vm.wait_for_login(nic_index=1, timeout=login_timeout)
+        vm.wait_for_login(nic_index=1, timeout=login_timeout, restart_network=True)
         server_ctl_ip = vm.wait_for_get_address(1, timeout=5)
 
     logging.debug(commands.getoutput("numactl --hardware"))


### PR DESCRIPTION
Ideally, guest needs to boot up with two nics, one is for connection,
the other is for testing. but in mostly guest, only one ONBOOT=yes
in configuration ifcfg-ethx, need to force to restart_network on vm.

Signed-off-by: Wenli Quan <wquan@redhat.com>

id :1464915