### PR TITLE
viorng_in_use: add missing parameter

### DIFF
--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -16,9 +16,11 @@
         i386:
             driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+            driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
         x86_64:
             driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
+            driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
     variants:
         - before_bg_test:
             run_bg_flag = "before_bg_test"


### PR DESCRIPTION
viorng_in_use: add missing parameter

viorng_in_use call subtest rng_bat, but param 'driver_id_pattern' is
not defined in the configuration file of viorng_in_use, so need to
add it accordingly.

Signed-off-by: Li Jin <lijin@redhat.com>

ID:1466218