### PR TITLE
drive_mirror_installation: add test case for mirroring during installation.

### DIFF
--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -120,22 +120,18 @@
             reopen_timeout = 600
             variants:
                 - heavyload:
+                    before_start = "load_stress"
+                    after_reopen = "unload_stress reboot verify_alive"
                     variants:
                         - stress:
-                            before_start = "load_stress"
                             when_steady = "reopen"
-                            after_reopen = "unload_stress reboot verify_alive"
                         - stop:
-                            before_start = "load_stress"
                             before_steady = "stop"
                             when_steady = "reopen resume"
-                            after_reopen = "unload_stress reboot verify_alive"
                         - check_steady:
-                            before_start = "load_stress"
                             when_steady = "verify_steady"
                             #seconds to verify offset not decrease when guest in steady status
                             hold_on_timeout = 300
-                            after_reopen = "unload_stress reboot verify_alive"
                 - dd:
                     app_check_cmd = "dd --help"
                     start_cmd = "dd if=/dev/urandom of=/tmp/dd.img bs=4k count=500000"
@@ -161,3 +157,26 @@
             before_start = "load_stress"
             when_steady = "powerdown"
             after_reopen ="verify_alive"
+        - with_installation:
+            type = drive_mirror_installation
+            wait_timeout = 36000
+            default_speed = 10240000
+            only on_localfs
+            need_install = yes
+            start_vm = no
+            images = "stg"
+            image_name_stg = "images/drive_mirror_installation"
+            image_size_stg = 20G
+            boot_drive_stg = yes
+            source_image = "stg"
+            target_image_stg = "target"
+            medium = cdrom
+            force_create_image_stg = yes
+            image_aio = threads
+            unattended_delivery_method = cdrom
+            cdroms += " unattended"
+            index_enable = no
+            backup_image_before_testing = no
+            Linux:
+                kernel = debug_vmlinuz
+                initrd = debug_initrd.img

--- a/qemu/tests/drive_mirror_installation.py
+++ b/qemu/tests/drive_mirror_installation.py
@@ -1,0 +1,37 @@
+import time
+import random
+
+from virttest import utils_test
+from virttest import utils_misc
+
+from qemu.tests import drive_mirror
+
+
+def run(test, params, env):
+    """
+    drive_mirror_stress test:
+    1). guest installation
+    2). start mirror during guest installation
+    3). after installation complete, reboot guest verfiy guest reboot correctly.
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    args = (test, params, env)
+    bg = utils_misc.InterruptedThread(utils_test.run_virt_sub_test, args,
+                                      {"sub_type": "unattended_install"})
+    bg.start()
+    utils_misc.wait_for(bg.is_alive, timeout=10)
+    time.sleep(random.uniform(60, 200))
+    tag = params["source_image"]
+    mirror_test = drive_mirror.DriveMirror(test, params, env, tag)
+    mirror_test.trash_files.append(mirror_test.image_file)
+    try:
+        mirror_test.start()
+        mirror_test.wait_for_steady()
+        mirror_test.reopen()
+        bg.join()
+    finally:
+        mirror_test.clean()


### PR DESCRIPTION
drive_mirror_installation: add test case for mirroring during installation.

1. drive_mirror.cfg: Simplify stress part.
2. drive_mirror.py: get image name from params directly, fix path error when get from storage.

id: 1330412
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>