### PR TITLE
sr_iov_hotplug: Enabled static ip configuration for hotplugged interface

### DIFF
--- a/qemu/tests/cfg/sr_iov.cfg
+++ b/qemu/tests/cfg/sr_iov.cfg
@@ -39,6 +39,7 @@
             pci_num = 2
             repeat_times = 2
             wait_secs_for_hook_up = 3
+            assign_static_ip = "yes"
         - vf_hot_unplug:
             type = pci_hotunplug
             pci_assignable = vf
@@ -56,6 +57,7 @@
             pci_num = 2
             repeat_times = 500
             test_timeout = 10000
+            assign_static_ip = "yes"
         - vf_guest_suspend:
             no Host_RHEL.m6
             variants:


### PR DESCRIPTION
1. After hotplugging the sriov vf interfaces, test might fail due to unavailibilty of
ip address and interface remains inactive. param assign_static_ip can be set if static
ip configuration is required.

2. Removed autotest dependencies.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>