### PR TITLE
usb_storage: unmount usb disk before running subsequent tests

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -216,6 +216,7 @@
             format_cmd = "yes |mkfs $(readlink -f `ls /dev/disk/by-path/* | grep usb`)"
             list_disk_cmd = ""
             set_online_cmd = ""
+            chk_mount_cmd = "grep -qs $(readlink -f `ls /dev/disk/by-path/* | grep usb`) /proc/mounts"
             mount_cmd =  "mount $(readlink -f `ls /dev/disk/by-path/* | grep usb`) /media"
             umount_cmd = "umount $(readlink -f `ls /dev/disk/by-path/* | grep usb`)"
             testfile_name = "/media/usb_storage-test.txt"


### PR DESCRIPTION
The guest will auto mount usb disk after reboot when the usb disk
was made file system. Since removable usb disk will not available,
unmount the usb disk before running subsequent tests.

Bug id: 1452071

Signed-off-by: Haotong Chen <hachen@redhat.com>