### PR TITLE
multi_disk_random_hotplug.cfg: add ppc64le and ppc64 wait time

### DIFF
--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -10,6 +10,8 @@
     wait_between_hotplugs = 2
     wait_after_hotplug = 10
     wait_between_unplugs = 2
+    ppc64le,ppc64:
+        wait_between_unplugs = 20    
     # since image check is executed after unplug wait can be 0
     wait_after_unplug = 10
     Linux:


### PR DESCRIPTION
Need more time to wait between unplugs on ppc64le and ppc64.

bug id : 1443474
Signed-off-by: Yongxue Hong <yhong@redhat.com>