### PR TITLE
virtio_port_login.virtio_console : correct the port login timeout error

### DIFF
--- a/qemu/tests/cfg/virtio_port_login.cfg
+++ b/qemu/tests/cfg/virtio_port_login.cfg
@@ -12,16 +12,27 @@
             # Should not allow to login guest via virtio serial
             login_console = vs1
             pre_cmd = "grep vport0p1 /etc/securetty || echo vport0p1 >>/etc/securetty;"
+            pre_cmd_extra = "systemctl unmask serial-getty@vport0p1.service; systemctl enable serial-getty@vport0p1.service;"
+            clean_cmd = "systemctl disable serial-getty@vport0p1.service;"
             RHEL.6:
-                pre_cmd += "sed -i '/ACTIVE_CONSOLES/c ACTIVE_CONSOLES="/dev/tty[1-6] /dev/vport0p1"' /etc/sysconfig/init;"
-            RHEL.7:
-                pre_cmd += "systemctl |grep vport0 || ln -s /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@vport0p1.service;"
-                pre_cmd += "systemctl enable serial-getty@vport0p1.service"
+                clean_cmd = ""
+                pre_cmd_extra = "sed -i '/ACTIVE_CONSOLES/c ACTIVE_CONSOLES="/dev/tty[1-6] /dev/vport0p1"' /etc/sysconfig/init;"
+            RHEL.7.0,RHEL.7.1:
+                pre_cmd_extra = "systemctl unmask serial-getty@vport0p1.service;"
+                pre_cmd_extra += "ln -sf /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@vport0p1.service;"
+                pre_cmd_extra += "echo -e "[Install]\nWantedBy=getty.target" >> /etc/systemd/system/serial-getty@vport0p1.service;"
+                pre_cmd_extra += "systemctl enable serial-getty@vport0p1.service;"
         - virtio_console:
             login_console = vc1
             pre_cmd = "grep hvc0 /etc/securetty || echo hvc0 >> /etc/securetty;"
+            pre_cmd_extra = "systemctl unmask serial-getty@hvc0.service;systemctl enable serial-getty@hvc0.service;"
+            clean_cmd = "systemctl disable serial-getty@hvc0.service;"
             RHEL.6:
-                pre_cmd += "sed -i '/ACTIVE_CONSOLES/c ACTIVE_CONSOLES="/dev/tty[1-6] /dev/hvc0"' /etc/sysconfig/init;"
-            RHEL.7:
-                pre_cmd += "systemctl | grep hvc0 || ln -s /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@hvc0.service;"
-                pre_cmd += "systemctl enable serial-getty@hvc0.service"
+                clean_cmd = ""
+                pre_cmd_extra = "sed -i '/ACTIVE_CONSOLES/c ACTIVE_CONSOLES="/dev/tty[1-6] /dev/hvc0"' /etc/sysconfig/init;"
+            RHEL.7.0,RHEL.7.1:
+                pre_cmd_extra = "systemctl unmask serial-getty@hvc0.service;"
+                pre_cmd_extra += "ln -sf /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@hvc0.service;"
+                pre_cmd_extra += "echo -e "[Install]\nWantedBy=getty.target" >> /etc/systemd/system/serial-getty@hvc0.service;"
+                pre_cmd_extra += "systemctl enable serial-getty@hvc0.service;"
+

--- a/qemu/tests/virtio_port_login.py
+++ b/qemu/tests/virtio_port_login.py
@@ -25,7 +25,7 @@ class ConsoleLoginTest(utils_virtio_port.VirtioPortTest):
     @error.context_aware
     def pre_step(self):
         error.context("Config guest and reboot it", logging.info)
-        pre_cmd = self.params.get("pre_cmd")
+        pre_cmd = self.params.get("pre_cmd") + self.params.get("pre_cmd_extra")
         session = self.vm.wait_for_login(timeout=360)
         session.cmd(pre_cmd, timeout=240)
         session = self.vm.reboot(session=session, timeout=900, serial=False)
@@ -109,6 +109,9 @@ def run(test, params, env):
                 logging.info("sending command: %s" % cmd)
                 output = session.cmd_output(cmd, timeout=240)
                 logging.info("output:%s" % output)
+        clean_cmd = params["clean_cmd"]
+        session.cmd(clean_cmd, timeout=180)
+        session.close()
     except Exception:
         console_test.cleanup()
         raise


### PR DESCRIPTION
id: 1468452
Serial-getty@hvc0.service failed to be enabled because hvc0.service has been masked and linked to /dev/null.

Signed-off-by: Sitong Liu <siliu@redhat.com>