### PR TITLE
fio_perf: add NVMe backend for block performance test

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -54,14 +54,17 @@
             no ppc64,ppc64le
             image_raw_device_disk1 = yes
             vhost_nic1 =
+            Linux:
+                fio_cmd = "i=`/bin/ls /dev/[vs]db` && fio --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=$i --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=/tmp/fio_result &> /dev/null"
+            Windows:
+                fio_cmd = 'cmd /c C:\fio-2.0.15-x64\fio.exe --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=\\.\PHYSICALDRIVE1 --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output="C:\\fio_result"'
             variants:
                 - fusion-io:
                     #Pls specify your own fusion-io ssd in the host.
                     image_name_disk1 = /dev/fioa
-                    Linux:
-                        fio_cmd = "i=`/bin/ls /dev/[vs]db` && fio --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=$i --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=/tmp/fio_result &> /dev/null"
-                    Windows:
-                        fio_cmd = 'cmd /c C:\fio-2.0.15-x64\fio.exe --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=\\.\PHYSICALDRIVE1 --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output="C:\\fio_result"'
+                - NVMe:
+                    #Pls specify your own NVMe disk in the host.
+                    image_name_disk1 = /dev/nvme0n1
     variants:
         - single_disk:
             images += " disk1"

--- a/qemu/tests/fio_perf.py
+++ b/qemu/tests/fio_perf.py
@@ -209,7 +209,7 @@ def run(test, params, env):
                 if s:
                     raise exceptions.TestFail("Failed to online disk: %s" % o)
     # format disk
-    if format:
+    if format == "True":
         session.cmd(pre_cmd, cmd_timeout)
 
     # get order_list


### PR DESCRIPTION
NVMe backend is new test requirement.
bug id: 1467831
Signed-off-by: yama <yama@redhat.com>