### PR TITLE
timedrift_with_stop: Add test cases for rtc_base=localtime and 2006-06-17

### DIFF
--- a/generic/tests/cfg/timedrift.cfg
+++ b/generic/tests/cfg/timedrift.cfg
@@ -1,6 +1,9 @@
 - timedrift: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu libvirt
     rtc_drift = "slew"
+    rtc_clock = host
+    drift_threshold = 10
+    drift_threshold_single = 3
     variants:
         - shared_ntp_date:
             variants:
@@ -27,29 +30,13 @@
                 - with_migration:
                     type = timedrift_with_migration
                     migration_iterations = 3
-                    drift_threshold = 10
-                    drift_threshold_single = 3
                 - with_reboot:
                     type = timedrift_with_reboot
                     reboot_iterations = 1
-                    drift_threshold = 10
-                    drift_threshold_single = 3
                 - with_stop:
-                    # starting from Win2012 Windows no longer relies on number of injected RTC interrupts for time keeping,
-                    # and the time drift is seen because "stop" monitor command also stops PM timer,
-                    # so this is unsupported scenario from Win2012.
-                    Windows:
-                        only Win2000, WinXP, Win2003, WinVista, Win7, Win2008
                     type = timedrift_with_stop
                     stop_interations = 1
                     stop_time = 60
-                    drift_threshold = 10
-                    drift_threshold_single = 3
-                    variants:
-                        - clock_host:
-                            rtc_clock = host
-                        - clock_vm:
-                            rtc_clock = vm
             variants:
                 - ntp:
                     no JeOS
@@ -77,25 +64,31 @@
             test_duration = 600
             smp = 2
             stop_time = 60
-            drift_threshold = 10
         - with_signal_stop:
-            # starting from Win2012 Windows no longer relies on number of injected RTC interrupts for time keeping,
-            # and the time drift is seen because "stop" monitor command also stops PM timer,
-            # so this is unsupported scenario from Win2012.
-            Windows:
-                only Win2000, WinXP, Win2003, WinVista, Win7, Win2008
             no RHEL.3.9, RHEL.4
             type = timedrift_with_stop
             stop_interations = 1
             stop_with_signal = yes
             stop_time = 60
-            drift_threshold = 10
-            drift_threshold_single = 3
-            variants:
-                - clock_host:
-                    rtc_clock = host
-                - clock_vm:
-                    rtc_clock = vm
+    variants:
+        - clock_host:
+            # starting from Win2012 Windows no longer relies on number of injected RTC interrupts for time keeping,
+            # and the time drift is seen because "stop" monitor command also stops PM timer,
+            # so this is unsupported scenario from Win2012.
+            Windows:
+                only Win2000, WinXP, Win2003, WinVista, Win7, Win2008
+            rtc_clock = host
+        - clock_vm:
+            rtc_clock = vm
+    variants:
+        - base_utc:
+            only Linux
+            rtc_base = utc
+        - base_localtime:
+            only Windows
+            rtc_base = localtime
+        - base_date:
+            rtc_base = 2006-06-17
     variants:
         - no_pvclock:
             only RHEL.4.9


### PR DESCRIPTION
    1. Add rtc_base/rtc_clock to timedrift.cfg
    2. Add hardware clock check for rtc_clock=host

id: 1468135, 1468136, 1468137, 1468138

Signed-off-by: Huiqing Ding <huding@redhat.com>