### PR TITLE
Rh_kernel_update: enlarge timeout of install_rpm to 30mins to avoid case failed in bad network traffic.

### DIFF
--- a/qemu/tests/rh_kernel_update.py
+++ b/qemu/tests/rh_kernel_update.py
@@ -42,7 +42,7 @@ def run(test, params, env):
         logging.debug("Brew URL is %s" % url)
         return url
 
-    def install_rpm(session, url, upgrade=False, nodeps=False, timeout=600):
+    def install_rpm(session, url, upgrade=False, nodeps=False, timeout=3600):
         # install a package from brew
         cmd = "rpm -ivhf %s" % url
         if upgrade:


### PR DESCRIPTION
Maxinum 15 mins spend in my 5 tests, set double redundancy for extreme network.

Signed-off-by: Wenli Quan <wquan@redhat.com>

id : 1469028