### PR TITLE
New case: boot guest with snapshot=on and data plane enable

### DIFF
--- a/qemu/tests/cfg/data_plane_snapshot.cfg
+++ b/qemu/tests/cfg/data_plane_snapshot.cfg
@@ -1,0 +1,12 @@
+- data_plane_snapshot:
+    virt_test_type = qemu
+    type = boot
+    image_snapshot = yes
+    only Host_RHEL.m7
+    only virtio_blk virtio_scsi
+    iothreads = iothread0
+    virtio_blk:
+        blk_extra_params_image1 = "iothread=${iothreads}"
+    virtio_scsi:
+        no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+        bus_extra_params_image1 = "iothread=${iothreads}"


### PR DESCRIPTION
New case: boot guest with data plane enable and snapshot=on
Signed-off-by:Aihua Liang <aliang@redhat.com>

Bug id:1434267