### PR TITLE
vfio-pci: Add a nic when boot guest with pf/vf

### DIFF
--- a/qemu/tests/cfg/device_assignment.cfg
+++ b/qemu/tests/cfg/device_assignment.cfg
@@ -7,7 +7,10 @@
     variants:
         - multi_pf_boot:
             type = boot
-            nics = "nic1 nic2"
+            nics = "nic1 nic2 nic3"
+            pci_assignable_nic1 = no
+            nic_model_nic1 = virtio
+            driver_option = 0
         - emulation_nic_pf_boot:
             nics = "nic1 nic2"
             type = boot

--- a/qemu/tests/cfg/sr_iov.cfg
+++ b/qemu/tests/cfg/sr_iov.cfg
@@ -6,7 +6,11 @@
     variants:
         - vf_boot:
             type = boot
-            pci_assignable_nic1 = vf
+            nics = "nic1 nic2"
+            pci_assignable_nic1 = no
+            nic_model_nic1 = virtio
+            pci_assignable_nic2 = vf
+            driver_option = 1
         - multi_vf_boot:
             type = boot
             nics = "nic1 nic2 nic3 nic4"


### PR DESCRIPTION
Add a nic when boot guest with pf/vf, so guest can get an IP address, multi_pf_boot and vf_boot cases can pass.

Signed-off-by: Yumei Huang <yuhuang@redhat.com>
ID: 1468525, 1468528

Depens on https://github.com/avocado-framework/avocado-vt/pull/1087