### PR TITLE
virtio_console.py: update and extend test for boot_to_much_ports and disable the data test for console

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -61,6 +61,7 @@
                             virtio_console_test = rw_host_offline_big_data
                         - rw_blocking_mode:
                             only Linux
+                            only virtserialport
                             virtio_console_test = rw_blocking_mode
                         - rw_nonblocking_mode:
                             only Linux
@@ -68,6 +69,7 @@
                             only virtserialport
                             virtio_console_test = rw_nonblocking_mode
                         - basic_loopback:
+                            no virtconsole
                             virtio_console_test = basic_loopback
                 - @with_vm:
                     # Works with virtconsole, but is not the comon usage, don't test by default

--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -228,10 +228,13 @@
                             # arm doesn't use pci bus
                             no aarch64
                             extra_params = " -device virtio-serial-pci,max_ports=32"
+                            extra_params_rhev = " -device virtio-serial-pci,max_ports=512"
                             start_vm = no
                             virtio_console_test = failed_boot
                             virtio_console_params = "maximum ports supported: 31"
+                            virtio_console_params_rhev = "maximum ports supported: 511"
                             virtio_ports = ""
+                            version_params = "1.\d.\d-"
     variants:
         # Use only single virtio-serial-pci
         - spread_linear:

--- a/qemu/tests/cfg/virtio_port_login.cfg
+++ b/qemu/tests/cfg/virtio_port_login.cfg
@@ -7,6 +7,7 @@
     virtio_port_type_vc1 = "virtio_console"
     shell_cmd_list = " \ls -l , cat /proc/cmdline, ifconfig -a, mkdir -p /tmp/test, rm -rf /tmp/test"
     image_snapshot = yes
+    clean_cmd = ""
     variants:
         - virtio_serial:
             # Should not allow to login guest via virtio serial
@@ -23,5 +24,6 @@
             RHEL.6:
                 pre_cmd += "sed -i '/ACTIVE_CONSOLES/c ACTIVE_CONSOLES="/dev/tty[1-6] /dev/hvc0"' /etc/sysconfig/init;"
             RHEL.7:
+                clean_cmd += "rm -rf /etc/systemd/system/serial-getty@hvc0.service"
                 pre_cmd += "systemctl | grep hvc0 || ln -s /usr/lib/systemd/system/serial-getty@.service /etc/systemd/system/serial-getty@hvc0.service;"
                 pre_cmd += "systemctl enable serial-getty@hvc0.service"

--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -14,10 +14,12 @@ import socket
 import threading
 import traceback
 import time
+import re
 from subprocess import Popen
 
 from autotest.client import utils
 from autotest.client.shared import error
+from avocado.utils import process
 
 from virttest import qemu_virtio_port
 from virttest import env_process
@@ -1805,6 +1807,14 @@ def run(test, params, env):
         :param cfg: virtio_console_params - Expected error message.
         """
         exp_error_message = params['virtio_console_params']
+        version_params = params["version_params"]
+        qemu_binary = utils_misc.get_qemu_binary(params)
+        output = str(process.run(qemu_binary + " --version"))
+        re_comp = re.compile(r'\d+.\d+.\d+-\d+..+')
+        output_list = re_comp.findall(output)
+        if not re.search(version_params, output_list[0]):
+            params["extra_params"] = params.get("extra_params_rhev")
+            exp_error_message = params.get("virtio_console_params_rhev")
         env_process.preprocess(test, params, env)
         vm = env.get_vm(params["main_vm"])
         try:

--- a/qemu/tests/virtio_port_login.py
+++ b/qemu/tests/virtio_port_login.py
@@ -26,8 +26,11 @@ class ConsoleLoginTest(utils_virtio_port.VirtioPortTest):
     def pre_step(self):
         error.context("Config guest and reboot it", logging.info)
         pre_cmd = self.params.get("pre_cmd")
+        clean_cmd = self.params.get("clean_cmd")
         session = self.vm.wait_for_login(timeout=360)
-        session.cmd(pre_cmd, timeout=240)
+        session.cmd_output_safe(clean_cmd, timeout=240)
+        output_cmd = session.cmd_output_safe(pre_cmd, timeout=240)
+        logging.info("Cmd output: %s" % output_cmd)
         session = self.vm.reboot(session=session, timeout=900, serial=False)
         self.__sessions__.append(session)
 


### PR DESCRIPTION
Port number has been extended from 32 to 512 for 2.*.* version, so update test case.
Data transfer test for console is invalid.

id: 1472105, 1468463, 1468458
Signed-off-by: Sitong Liu <siliu@redhat.com>
