### PR TITLE
RFC: Added support to run avocado tests inside guest

### DIFF
--- a/generic/tests/avocado_guest.py
+++ b/generic/tests/avocado_guest.py
@@ -1,0 +1,32 @@
+from virttest import utils_test
+
+
+def run(test, params, env):
+    """
+    Run an avocado test inside a guest.
+
+    :param test: QEMU test object.
+    :param params: Dictionary with test parameters.
+    :param env: Dictionary with the test environment.
+    """
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    timeout = int(params.get("test_timeout", 3600))
+    testlist = []
+    avocadoinstalltype = params.get("avocadoinstalltype", "pip")
+    avocadotestrepo = params.get("avocadotestrepo",
+                                 "https://github.com/avocado-framework-tests/avocado-misc-tests.git")
+    avocadotest = params.get("avocadotest", "cpu/ebizzy.py")
+    avocadomux = params.get("avocadomux", "")
+    avocadotestargs = params.get("avocadotestargs", "")
+    for index, item in enumerate(avocadotest.split(',')):
+        try:
+            mux = ''
+            mux = avocadomux.split(',')[index]
+        except IndexError:
+            pass
+        testlist.append((item, mux))
+    utils_test.run_avocado(vm, params, test, testlist, timeout=timeout,
+                           testrepo=avocadotestrepo,
+                           installtype=avocadoinstalltype, reinstall=False,
+                           add_args=avocadotestargs, ignore_result=False)

--- a/generic/tests/cfg/avocado_guest.cfg
+++ b/generic/tests/cfg/avocado_guest.cfg
@@ -1,0 +1,13 @@
+- avocado_guest: install setup image_copy unattended_install.cdrom
+    no JeOS
+    virt_test_type = qemu libvirt
+    only Linux
+    type = avocado_guest
+    test_timeout = 1800
+    variants:
+        - ebizzy:
+            avocadotest = "cpu/ebizzy.py"
+            avocadomux = ""
+        - ebizzy_stress:
+            avocadotest = "cpu/ebizzy.py,perf/stress.py"
+            avocadomux = ","


### PR DESCRIPTION
Added test to support avocado tests run inside guest

Single or multiple avocado tests can be run by single
invocation of this test.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>

Changes from previous version:
Added support for multiple tests