### PR TITLE
timerdevice_boot: Add reboot test case for rtc_base = "2006-06-17"

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -41,6 +41,13 @@
                 - base_localtime:
                     only Windows
                     rtc_base = localtime
+                - base_date:
+                    Windows:
+                        only Win2000, WinXP, Win2003, WinVista, Win7, Win2008
+                    check_chronyd_active_cmd = "service chronyd status | grep 'active (running)'"
+                    mask_chronyd_cmd = "systemctl stop chronyd && systemctl mask chronyd"
+                    unmask_chronyd_cmd = "systemctl unmask chronyd"
+                    rtc_base = 2006-06-17
             variants:
                 - clksource_unchanged:
                     only Windows

--- a/qemu/tests/timerdevice_boot.py
+++ b/qemu/tests/timerdevice_boot.py
@@ -11,9 +11,11 @@ from virttest import utils_disk
 from virttest import utils_test
 from virttest import env_process
 from virttest import funcatexit
+from virttest import error_context
 
 
 @error.context_aware
+@error_context.context_aware
 def run(test, params, env):
     """
     Timer device boot guest:
@@ -35,12 +37,75 @@ def run(test, params, env):
     :param env: Dictionary with the test environment.
     """
     def verify_guest_clock_source(session, expected):
+        """
+        Verify the clock source of the guest
+
+        :param session: the guest session
+        :param expected: the expected clock source
+        """
         error.context("Check the current clocksource in guest", logging.info)
         cmd = "cat /sys/devices/system/clocksource/"
         cmd += "clocksource0/current_clocksource"
         if expected not in session.cmd(cmd):
             raise error.TestFail(
                 "Guest didn't use '%s' clocksource" % expected)
+
+    def verify_base_date_system_time():
+        """
+        When setting rtc_base to be a date,
+        verify the guest system should be this date
+        """
+        time_command = params["time_command"]
+        time_filter_re = params["time_filter_re"]
+        time_format = params["time_format"]
+        if params["os_type"] == "linux":
+            time_command = "%s -u" % time_command
+        (host_time, guest_time) = utils_test.get_time(session, time_command,
+                                                      time_filter_re, time_format)
+        guest_time = time.strftime('%Y-%m-%d %H', time.localtime(guest_time))
+        logging.info("guest_time:%s", guest_time)
+        if guest_time != '%s 00' % params["rtc_base"]:
+            if session:
+                session.close()
+            test.fail("Guest time is %s and not from %s 00:00"
+                      % (guest_time, params["rtc_base"]))
+
+    def compare_time(host_time, guest_time, time_type):
+        """
+        Compare host time and system time, which difference should
+        be less than the valued defined in cfg file
+
+        :param host_time: the time of host
+        :param guest_time: the time of guest
+        :param time_type: the type of time. the value is "system" or "hardware"
+        """
+        drift = abs(float(host_time) - float(guest_time))
+        if drift > timerdevice_drift_threshold:
+            if session:
+                session.close()
+            test.fail("The guest's %s time is different with"
+                      " host's. Host time: '%s', guest time:"
+                      " '%s'" % (time_type, host_time, guest_time))
+
+    def verify_guest_time():
+        """
+        Verify the difference of guest time and host time should
+        be less than the value defined in the cfg file
+        """
+        error_context.context("Check the system time on guest and host",
+                              logging.info)
+        (host_sys_time, guest_sys_time) = utils_test.get_time(session,
+                                                              time_command,
+                                                              time_filter_re,
+                                                              time_format)
+        compare_time(host_sys_time, guest_sys_time, "system")
+        error_context.context("Check the hardware time on guest and host",
+                              logging.info)
+        get_hw_time_cmd = params.get("get_hw_time_cmd")
+        if get_hw_time_cmd:
+            host_hw_time = utils.system_output(get_hw_time_cmd)
+            guest_hw_time = session.cmd(get_hw_time_cmd)
+            compare_time(host_hw_time, guest_hw_time, "hardware")
 
     error.context("Sync the host system time with ntp server", logging.info)
     utils.system("ntpdate clock.redhat.com")
@@ -128,26 +193,31 @@ def run(test, params, env):
     time_format = params["time_format"]
     timerdevice_drift_threshold = params.get("timerdevice_drift_threshold", 3)
 
-    error.context("Check the system time on guest and host", logging.info)
-    (host_time, guest_time) = utils_test.get_time(session, time_command,
-                                                  time_filter_re, time_format)
-    drift = abs(float(host_time) - float(guest_time))
-    if drift > timerdevice_drift_threshold:
-        raise error.TestFail("The guest's system time is different with"
-                             " host's. Host time: '%s', guest time:"
-                             " '%s'" % (host_time, guest_time))
-
-    get_hw_time_cmd = params.get("get_hw_time_cmd")
-    if get_hw_time_cmd:
-        error.context(
-            "Check the hardware time on guest and host", logging.info)
-        host_time = utils.system_output(get_hw_time_cmd)
-        guest_time = session.cmd(get_hw_time_cmd)
-        drift = abs(float(host_time) - float(guest_time))
-        if drift > timerdevice_drift_threshold:
-            raise error.TestFail("The guest's hardware time is different with"
-                                 " host's. Host time: '%s', guest time:"
-                                 " '%s'" % (host_time, guest_time))
+    if params["rtc_base"] in ("utc", "localtime"):
+        verify_guest_time()
+    else:
+        if params["os_type"] == "linux":
+            check_chronyd_active_cmd = params["check_chronyd_active_cmd"]
+            chronyd_output = session.cmd_output_safe(check_chronyd_active_cmd)
+            chronyd_active = re.search("active", chronyd_output)
+            logging.info("chronyd_output:%s\n, chronyd_active:%s", chronyd_output, chronyd_active)
+            # if chronyd service is enabled
+            # Mask chronyd service, shutdown the guest
+            # Boot guest again
+            if chronyd_active:
+                error_context.context("Mask chronyd service")
+                mask_chronyd_cmd = params["mask_chronyd_cmd"]
+                session.cmd_output_safe(mask_chronyd_cmd)
+                error_context.context("Shoutdown the guest")
+                vm.destroy()
+                env.unregister_vm(vm.name)
+                error_context.context("Boot the guest", logging.info)
+                vm_name = params["main_vm"]
+                env_process.preprocess_vm(test, params, env, vm_name)
+                vm = env.get_vm(vm_name)
+                vm.verify_alive()
+                session = vm.wait_for_login(timeout=timeout)
+        verify_base_date_system_time()
 
     if params.get("timerdevice_reboot_test") == "yes":
         sleep_time = params.get("timerdevice_sleep_time")
@@ -158,23 +228,17 @@ def run(test, params, env):
             time.sleep(sleep_time)
 
         session = vm.reboot()
-        error.context("Check the system time on guest and host", logging.info)
-        (host_time, guest_time) = utils_test.get_time(session, time_command,
-                                                      time_filter_re, time_format)
-        drift = abs(float(host_time) - float(guest_time))
-        if drift > timerdevice_drift_threshold:
-            raise error.TestFail("The guest's system time is different with"
-                                 " host's. Host time: '%s', guest time:"
-                                 " '%s'" % (host_time, guest_time))
 
-        get_hw_time_cmd = params.get("get_hw_time_cmd")
-        if get_hw_time_cmd:
-            error.context(
-                "Check the hardware time on guest and host", logging.info)
-            host_time = utils.system_output(get_hw_time_cmd)
-            guest_time = session.cmd(get_hw_time_cmd)
-            drift = abs(float(host_time) - float(guest_time))
-            if drift > timerdevice_drift_threshold:
-                raise error.TestFail("The guest's hardware time is different with"
-                                     " host's. Host time: '%s', guest time:"
-                                     " '%s'" % (host_time, guest_time))
+        if params["rtc_base"] in ("utc", "localtime"):
+            verify_guest_time()
+        else:
+            verify_base_date_system_time()
+
+    if params["os_type"] == "linux":
+        # Unmask chronyd service
+        if chronyd_active:
+            error_context.context("Unmask chronyd service")
+            unmask_chronyd_cmd = params["unmask_chronyd_cmd"]
+            session.cmd_output_safe(unmask_chronyd_cmd)
+    if session:
+        session.close()


### PR DESCRIPTION
    1. Add rtc_base = "2006-06-17" to timerdevice.cfg
    2. Add system time check when base="2006-06-17"

id: 1468139 1468140

Signed-off-by: Huiqing Ding <huding@redhat.com>