### PR TITLE
set_link: update parameter name of function wait_for_get_address to follow its definition

### DIFF
--- a/qemu/tests/set_link.py
+++ b/qemu/tests/set_link.py
@@ -190,8 +190,7 @@ def run(test, params, env):
 
     change_queues = False
     guest_ifname = ""
-    guest_ip = vm.wait_for_get_address(nic_index_or_name=0, timeout=240)
-    host_ip = utils_net.get_host_ip_address(params)
+    guest_ip = vm.wait_for_get_address(nic_index=0, timeout=240)
     # Win guest '2' represent 'Connected', '7' represent 'Media disconnected'
     win_media_connected = params.get("win_media_connected", "2")
     win_media_disconnected = params.get("win_media_disconnected", "7")


### PR DESCRIPTION
ID: 1477801
Update parameter name of function wait_for_get_address to follow its definition. Meanwhile, delete the host_ip parameter which is not used any more.
 