### PR TITLE
set_link: correct the interface name passed to the connection checking function

### DIFF
--- a/qemu/tests/set_link.py
+++ b/qemu/tests/set_link.py
@@ -90,7 +90,7 @@ def run(test, params, env):
             utils_misc.wait_for(lambda: env["run_change_queues"], 30, 0, 2,
                                 "wait queues change start")
         time.sleep(0.5)
-        output = utils_test.ping(guest_ip, 10, interface=guest_ifname,
+        output = utils_test.ping(guest_ip, 10, interface=host_interface,
                                  timeout=20, session=None)[1]
         if not link_up and utils_test.get_loss_ratio(output) < 80:
             err_msg = "guest network still connecting after down the link"
@@ -207,6 +207,9 @@ def run(test, params, env):
 
     netdev_id = vm.virtnet[0].netdev_id
     device_id = vm.virtnet[0].device_id
+    host_interface = None
+    if vm.virtnet[0].netdst:
+        host_interface = vm.virtnet[0].netdst
     expect_down_status = params.get("down-status", "down")
     expect_up_status = params.get("up-status", "up")
     operstate_always_up = params.get("operstate_always_up", "no") == "yes"


### PR DESCRIPTION
ID:1479658
Once a time, patches updated the method to check the network connection b/w guest and host. But the interface name was not updated meanwhile, this will cause problems if the interface name of guest and host is different.

Signed-off-by: Zhengtong <zhengtli@redhat.com>