### PR TITLE
change nics_virt-tests-vm1 to vm1 in multi_nics_stress.cfg

### DIFF
--- a/qemu/tests/cfg/multi_nics_stress.cfg
+++ b/qemu/tests/cfg/multi_nics_stress.cfg
@@ -6,10 +6,10 @@
     image_snapshot = yes
     hostpassword = redhat
     # nic1 is for control, nic2 is for data connection
-    vms += " vm2 vm3 vm4 vm5"
+    vms = "vm1 vm2 vm3 vm4 vm5"
     netperf_client = ${main_vm}
     netperf_server = "vm2 vm3 vm4 vm5"
-    nics_virt-tests-vm1 = 'nic1 nic2 nic3 nic4'
+    nics_vm1 = 'nic1 nic2 nic3 nic4'
     test_protocols = "TCP_STREAM TCP_MAERTS TCP_SENDFILE UDP_STREAM TCP_RR TCP_CRR UDP_RR"
     netperf_sessions = 1
     package_sizes = 1500


### PR DESCRIPTION
change vm name to vm1 in order to boot 4 nics on vm1 as before

id:1479121

Signed-off-by: Yu Wang <wyu@redhat.com>