### PR TITLE
New case: boot guest under different machine type with data plane enable

### DIFF
--- a/qemu/tests/boot_with_machine_types.py
+++ b/qemu/tests/boot_with_machine_types.py
@@ -1,0 +1,54 @@
+import logging
+import re
+
+from virttest import error_context
+from virttest import utils_misc
+from virttest import env_process
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    boot with different machine type:
+    1) get supported machine type
+    2) boot guest with different machine types
+
+    :param test: kvm test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    error_context.context("Get supported machine type", logging.info)
+    qemu_binary = utils_misc.get_qemu_binary(params)
+    machine_types = []
+    machine_type_mapping = {"pc": ["i440FX", "RHEL 6"], "q35": ["Q35"], "pseries": ["pSeries"],
+                            "arm64-pci:virt": ["ARM"], "arm64-mmio:virt": ["ARM"], "s390-ccw-virtio": ["S390"]}
+    for m_type, s_name in zip(*utils_misc.get_support_machine_type(qemu_binary)):
+        for item in machine_type_mapping[params["machine_type"]]:
+            if item in s_name:
+                if "arm64" in params["machine_type"]:
+                    m_type = re.sub(r'(?<=:)\w+', m_type, params["machine_type"])
+                machine_types.append(m_type)
+    if not machine_types:
+        test.fail("Failed to get machine types")
+    else:
+        logging.info("Actual supported machine types are: " + ', '.join(map(str, machine_types)))
+
+        for m_type in machine_types:
+            params["machine_type"] = m_type
+            params["start_vm"] = "yes"
+            vm_name = params['main_vm']
+            error_context.context("Start vm with machine type '%s'"
+                                  % m_type, logging.info)
+            env_process.preprocess(test, params, env)
+            vm = env.get_vm(vm_name)
+            vm.verify_alive()
+            timeout = int(params.get("login_timeout", 360))
+            session = vm.wait_for_login(timeout=timeout)
+            if not session.is_responsive():
+                session.close()
+                test.fail("Start vm with machine type:%s fail" % m_type)
+
+            session.close()
+            error_context.context("Quit guest and check the process quit normally",
+                                  logging.info)
+            vm.destroy(gracefully=False)

--- a/qemu/tests/cfg/data_plane_boot.cfg
+++ b/qemu/tests/cfg/data_plane_boot.cfg
@@ -1,8 +1,6 @@
-- data_plane_snapshot:
+- data_plane_boot:
     virt_test_type = qemu
-    type = boot
-    image_snapshot = yes
-    only Host_RHEL.m7
+    no Host_RHEL.m6
     only virtio_blk virtio_scsi
     iothreads = iothread0
     virtio_blk:
@@ -10,3 +8,10 @@
     virtio_scsi:
         no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
         bus_extra_params_image1 = "iothread=${iothreads}"
+    variants:
+        - snapshot:
+            type = boot
+            image_snapshot = yes
+        - machine_type:
+            type = boot_with_machine_types
+            start_vm = no


### PR DESCRIPTION
New case: boot guest under different machine type with data plane enable
Merge data_plane_snapshot.cfg to data_plane_boot.cfg

Signed-off-by: Aihua Liang <aliang@redhat.com>

Bug id:1467485