### PR TITLE
 qemu.tests.qemu_guest_agent:add guest agent read/write file case

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -86,6 +86,9 @@
             no Windows
             gagent_check_type = fsfreeze
             gagent_fs_test_cmd = "rm -f /tmp/foo; echo foo > /tmp/foo"
+        - check_guest_file:
+            no Windows
+            gagent_check_type = read_write_guestfile
         - check_snapshot:
             # fsfreeze series commands can't run on windows guest.
             type = qemu_guest_agent_snapshot

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -775,6 +775,54 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         # Finally, do something after thaw.
         self._action_after_fsthaw(test, params, env)
 
+    def gagent_check_read_write_guestfile(self, test, params, env):
+        """
+        Test guest agent commands "guest-file-open/write/read/close"
+
+        Test steps:
+        1) open file with mode "w+" in guest.
+        2) write "hello world" to file.
+        3) close file.
+        4) open file with mode "r+" in guest.
+        5) read file
+        6) close file
+
+        :param test: kvm test object
+        :param params: Dictionary with the test parameters
+        :param env: Dictionary with test environmen.
+        """
+        agent_file = "/tmp/agentfile"
+        #if file not exist,mode "w+" will create a new file
+        open_cmd = "guest-file-open"
+        open_args_w = {"path": agent_file, "mode": "w+"}
+        #open agent_file and get result
+        ret = int(self.gagent.file_operate(open_args_w, open_cmd))
+
+        #write "hello world" to file
+        write_cmd = "guest-file-write"
+        write_str = "aGVsbG8gd29ybGQhCg=="
+        write_args = {"handle": ret, "buf-b64": write_str}
+        ret_write = self.gagent.file_operate(write_args, write_cmd)
+
+        #close agent file
+        close_cmd = "guest-file-close"
+        close_args_w = {"handle": ret}
+        self.gagent.file_operate(close_args_w, close_cmd)
+        #mode r+ open an exist file only
+        open_args_r = {"path": agent_file, "mode": "r+"}
+        ret = int(self.gagent.file_operate(open_args_r, open_cmd))
+
+        #read agent file's context to match "hello world"
+        read_cmd = "guest-file-read"
+        read_args = {"handle": ret, "count": 1024}
+        ret_read = self.gagent.file_operate(read_args, read_cmd)
+        if not ret_read["buf-b64"] == write_str:
+            test.fail("Read the contents and files do not match")
+        close_args_r = {"handle": ret}
+        self.gagent.file_operate(close_args_r, close_cmd)
+        if os.path.exists(agent_file):
+            os.remove(agent_file)
+
     def run_once(self, test, params, env):
         QemuGuestAgentTest.run_once(self, test, params, env)
 


### PR DESCRIPTION
This patch depend on another patch 
1.open a file via agent command guest-file-open
2.write content to file via agent command guest-file-write
3.read content from file via agent command guest-file-read
4.close current file via agent command guest-file-close

id:1468931 1468933 1468932 1468524

Signed-off-by: Xiangchun Fu <xfu@redhat.com>