### PR TITLE
zero_copy: Check nettype for zero_copy test

### DIFF
--- a/qemu/deps/timedrift/get_tsc.c
+++ b/qemu/deps/timedrift/get_tsc.c
@@ -12,6 +12,7 @@
 
 typedef unsigned long long u64;
 
+#if defined(__x86_64__)
 u64 rdtsc(void)
 {
 	unsigned tsc_lo, tsc_hi;
@@ -19,6 +20,16 @@ u64 rdtsc(void)
 	asm volatile("rdtsc" : "=a"(tsc_lo), "=d"(tsc_hi));
 	return tsc_lo | (u64)tsc_hi << 32;
 }
+#elif defined(__aarch64__)
+u64 rdtsc(void)
+{
+	u64 tsc;
+
+	asm volatile("mrs %0, CNTVCT_EL0" : "=r" (tsc) : : );
+
+	return tsc;
+}
+#endif
 
 int main(void)
 {

--- a/qemu/tests/cfg/tsc_drift.cfg
+++ b/qemu/tests/cfg/tsc_drift.cfg
@@ -4,6 +4,11 @@
     type = tsc_drift
     drift_threshold = 10
     interval = 30
-    required_cpu_flags = "constant_tsc"
-    pre_command = "/usr/bin/python shared/scripts/check_cpu_flag.py"
     smp_min = 2
+    variants:
+        - x86_tsc:
+            only i386 x86_64
+            required_cpu_flags = "constant_tsc"
+            pre_command = "/usr/bin/python shared/scripts/check_cpu_flag.py"
+        - aarch64_tsc:
+            only aarch64

--- a/qemu/tests/zero_copy.py
+++ b/qemu/tests/zero_copy.py
@@ -52,6 +52,9 @@ def run(test, params, env):
         enable_zerocopytx_in_host(False)
 
     error.context("Boot vm with 'vhost=on'", logging.info)
+    if params.get("nettype") == "user":
+        raise error.TestNAError("Unable start test with user networking,"
+                                " please change nettype.")
     params["vhost"] = "vhost=on"
     params["start_vm"] = 'yes'
     login_timeout = int(params.get("login_timeout", 360))


### PR DESCRIPTION
In current qemu, user networking (i.e. "-netdev user") doesn't
support "vhost" option. This patch checks the nettype in
configuration. If nettype="user", it will give a warning and
cancel zero_copy test instead of flaging it as an error.

Signed-off-by: Wei Huang <wei@redhat.com>