### PR TITLE
clock_getres: Add support for arm

### DIFF
--- a/generic/deps/clock_getres/clock_getres.c
+++ b/generic/deps/clock_getres/clock_getres.c
@@ -41,6 +41,8 @@ int main(void) {
 	fclose(fr);
 #if defined(__powerpc64__)
 	if (!strncmp(clocksource, "timebase", strlen("timebase"))) {
+#elif defined(__aarch64__)
+	if (!strncmp(clocksource, "arch_sys_counter", strlen("arch_sys_counter"))) {
 #else
 	if (!strncmp(clocksource, "kvm-clock", strlen("kvm-clock"))) {
 #endif


### PR DESCRIPTION
Arm uses "arch_sys_counter" and not "kvm-clock". Let's adjust the
sources to cope with that.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>