### PR TITLE
generic.tests.boot_vm_in_hugepage: Add multi variants to test with different hugepage size

### DIFF
--- a/generic/tests/cfg/boot_vm_in_hugepage.cfg
+++ b/generic/tests/cfg/boot_vm_in_hugepage.cfg
@@ -10,9 +10,13 @@
     pre_command_noncritical = yes
     pre_command = "echo 3 > /proc/sys/vm/drop_caches"
     variants:
-        - 2M_hugepage:
+        - 2M:
             expected_hugepage_size = 2048
-        - 1G_hugepage:
+        - 16M:
+            expected_hugepage_size = 16384
+        - 512M:
+            expected_hugepage_size = 524288
+        - 1G:
             # Notes:
             #    Before start testing, please ensure your host OS support 1G hugepage.
             #    Please don't forget to update host kernel line to enable 1G hugepage


### PR DESCRIPTION
Only 2M and 1G can not cover all the hugepage size, add 16M and 512M too.

id:1488303
Signed-off-by: Yanan Fu <yfu@redhat.com>