### PR TITLE
autotest.parallel_dd: add a parameter

### DIFF
--- a/generic/tests/cfg/autotest_control.cfg
+++ b/generic/tests/cfg/autotest_control.cfg
@@ -109,6 +109,7 @@
         - signaltest:
             test_control_file = signaltest.control
         - parallel_dd:
+            blk_extra_params_stg = "serial=TARGET_DISK0"
             test_timeout = 36000
             images += " stg"
             image_format_stg = qcow2

--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -51,6 +51,8 @@
         - multi_disk_install:
             no ide
             only unattended_install..cdrom
+            ks_disk_specified = yes
+            blk_extra_params_image1 = "serial=SYSTEM_DISK0"
             images += " stg stg2 stg3 stg4 stg5 stg6 stg7 stg8 stg9 stg10 stg11 stg12 stg13 stg14 stg15 stg16 stg17 stg18 stg19 stg20 stg21 stg22 stg23 stg24"
             image_name_stg = images/storage
             image_name_stg2 = images/storage2


### PR DESCRIPTION
Add the parameter blk_extra_params_stg for a given disk

Signed-off-by: Yongxue Hong <yhong@redhat.com>

ID: 1474001