### PR TITLE
smbios_table: Support for arm

### DIFF
--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -56,6 +56,11 @@ def run(test, params, env):
         qemu_binary = utils_misc.get_qemu_binary(params)
         tmp = utils_misc.get_support_machine_type(qemu_binary)
         (support_machine_types, expect_system_versions) = tmp
+        machine_type = params.get("machine_type", "")
+        if ':' in machine_type:
+            prefix = machine_type.split(':', 1)[0]
+            support_machine_types = ["%s:%s" % (prefix, m_type)
+                                     for m_type in support_machine_types]
 
     failures = []
     for m_type in support_machine_types:


### PR DESCRIPTION
The smbios_table test sets machine type, but arm is a bit different and
it requires the `arm64*` prefix to correctly detect the machine. Let's
allow that by inheriting the prefix from the original `machine_type`.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>