### PR TITLE
zero_copy: Check nettype for zero_copy test

### DIFF
--- a/qemu/tests/zero_copy.py
+++ b/qemu/tests/zero_copy.py
@@ -52,6 +52,9 @@ def run(test, params, env):
         enable_zerocopytx_in_host(False)
 
     error.context("Boot vm with 'vhost=on'", logging.info)
+    if params.get("nettype") == "user":
+        test.cancel("Unable start test with user networking, please "
+                    "change nettype.")
     params["vhost"] = "vhost=on"
     params["start_vm"] = 'yes'
     login_timeout = int(params.get("login_timeout", 360))


### PR DESCRIPTION
In current qemu, user networking (i.e. "-netdev user") doesn't
support "vhost" option. This patch checks the nettype in
configuration. If nettype="user", it will give a warning and
cancel zero_copy test instead of flaging it as an error.

Signed-off-by: Wei Huang <wei@redhat.com>