### PR TITLE
multi_disk_install: add parameters for system disk

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -51,6 +51,9 @@
         - multi_disk_install:
             no ide
             only unattended_install..cdrom
+            serial_name = SYSTEM_DISK0
+            blk_extra_params_image1 = "serial=${serial_name}"
+            cmd_only_use_disk = "ignoredisk --only-use=disk/by-id/*${serial_name}"
             images += " stg stg2 stg3 stg4 stg5 stg6 stg7 stg8 stg9 stg10 stg11 stg12 stg13 stg14 stg15 stg16 stg17 stg18 stg19 stg20 stg21 stg22 stg23 stg24"
             image_name_stg = images/storage
             image_name_stg2 = images/storage2


### PR DESCRIPTION
Add two parameters for comfirming the system disk

Signed-off-by: Yongxue Hong <yhong@redhat.com>

ID: 1489761