### PR TITLE
cfg.usb_device_check:add multi_hubs_in_parallel

### DIFF
--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -53,3 +53,15 @@
         - multi_hubs_in_series:
             no usb-ehci
             usb_topology = '{"usb-hub":5}'
+        - multi_hubs_in_parallel:
+            no usb-ehci
+            usb_topology = '{"usb-hub":9}'
+            port_d0 = 1
+            port_d1 = 1.1
+            port_d2 = 1.2
+            port_d3 = 1.3
+            port_d4 = 1.4
+            port_d5 = 1.5
+            port_d6 = 1.6
+            port_d7 = 1.7
+            port_d8 = 1.8


### PR DESCRIPTION
add case add multi_hubs_in_parallel, it attachs eight hubs on one hub

id: 1491103

Signed-off-by: Haotong Chen <hachen@redhat.com>