### PR TITLE
migrate.cfg: fix migrate.between_vhost_novhost cannot run on RHEL7 host

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -160,7 +160,6 @@
                     test_type = "stress_memory_heavy"
         - between_vhost_novhost:
             no JeOS
-            only Host_RHEL.m6
             no Host_RHEL.m6.u1
             migrate_between_vhost_novhost = "yes"
             type = migration_with_file_transfer


### PR DESCRIPTION
delete "only Host_RHEL.m6" in cfg file

Signed-off-by: Yu Wang <wyu@redhat.com>

id: 1491527