### PR TITLE
usb_device_check: add check input devices under hub

### DIFF
--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -10,6 +10,9 @@
     type = usb_device_check
     # usb device info name
     usb-hub = "QEMU USB Hub"
+    usb-mouse = "QEMU USB Mouse"
+    usb-kbd = "QEMU USB Keyboard"
+    usb-tablet = "QEMU USB Tablet"
 
     # usb controllers
     variants:
@@ -65,3 +68,9 @@
             port_d6 = 1.6
             port_d7 = 1.7
             port_d8 = 1.8
+        - input_devices_under_one_hub:
+            no usb-ehci
+            usb_topology = '{"usb-hub":1,"usb-mouse":1,"usb-kbd":1,"usb-tablet":1}'
+        - input_devices_under_two_tier_hub:
+            no usb-ehci
+            usb_topology = '{"usb-hub":2,"usb-mouse":1,"usb-kbd":1,"usb-tablet":1}'


### PR DESCRIPTION
Add two cases for input devices:
input_devices_under_one_hub,
it attachs usb mouse kbd and tablet on one hub.
input_devices_under_two_tier_hub,
it attachs usb mouse kbd and tablet on a two-tier hub.

id: 1491551 1491547

Signed-off-by: Haotong Chen <hachen@redhat.com>