### PR TITLE
viorng_in_use: Live migration while rng device in use

### DIFF
--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -52,3 +52,6 @@
             sub_test = boot
             reboot_method = system_reset
             sleep_before_reset = 20
+        - with_live_migration:
+            sub_test = migration
+            suppress_exception = no


### PR DESCRIPTION
Add with_live_migration variant to support live migraion during
virtio rng is in use.

Signed-off-by: Li Jin <lijin@redhat.com>

ID:1231659