### PR TITLE
Add usb hub negative tests

### DIFF
--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -53,9 +53,20 @@
 
     # usb topology
     variants:
+        - hub_speed_mismatch:
+            only usb-ehci
+            type = usb_device_check_negative
+            usb_topology = '{"usb-hub":1}'
+            error_info = "Warning: speed mismatch trying to attach usb device"
         - multi_hubs_in_series:
             no usb-ehci
-            usb_topology = '{"usb-hub":5}'
+            variants:
+                - 5_layer:
+                    usb_topology = '{"usb-hub":5}'
+                - 6_layer:
+                    type = usb_device_check_negative
+                    usb_topology = '{"usb-hub":6}'
+                    error_info = "usb hub chain too deep"
         - multi_hubs_in_parallel:
             no usb-ehci
             usb_topology = '{"usb-hub":9}'

--- a/qemu/tests/usb_device_check.py
+++ b/qemu/tests/usb_device_check.py
@@ -27,10 +27,10 @@ def run(test, params, env):
         else:
             test.fail(output)
 
-    # parse the usb toplogy from cfg
+    # parse the usb topology from cfg
     parsed_devs = parse_usb_topology(params)
 
-    logging.info("starting vm according to the usb toplogy")
+    logging.info("starting vm according to the usb topology")
     env_process.process(test, params, env,
                         env_process.preprocess_image,
                         env_process.preprocess_vm)

--- a/qemu/tests/usb_device_check_negative.py
+++ b/qemu/tests/usb_device_check_negative.py
@@ -1,0 +1,33 @@
+import logging
+
+from virttest import (env_process,
+                      error_context,
+                      virt_vm)
+from qemu.tests.usb_common import parse_usb_topology
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    The usb devices negative test
+
+    1) Boot guest with invalid usb devices
+    2) Verify QEMU error info
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+    # parse the usb topology from cfg
+    parse_usb_topology(params)
+    logging.info("starting vm according to the usb topology")
+    error_info = params["error_info"]
+    error_context.context(("verify [%s] is reported by QEMU..." %
+                          error_info), logging.info)
+    try:
+        env_process.process(test, params, env,
+                            env_process.preprocess_image,
+                            env_process.preprocess_vm)
+    except virt_vm.VMCreateError, e:
+        if error_info not in e.output:
+            test.fail("%s is not reported by QEMU" % error_info)


### PR DESCRIPTION
Add multi_hubs_in_series negative and hub_speed_mismatch in
usb_device_check_negative.py.
Add a new usb_device_check_negative.py to run the negative test.
Fix typos.


id: 1492615 1492970

Signed-off-by: Haotong Chen <hachen@redhat.com>