### PR TITLE
usb_device_check: add check max_devices_under_one_hub and mouse/tablet/kbd cases

### DIFF
--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -88,3 +88,15 @@
         - max_devices_under_one_hub:
             no usb-ehci
             usb_topology = '{"usb-hub":1,"usb-mouse":8}'
+        - usb_mouse:
+            Host_RHEL.m6:
+                no usb-ehci
+            usb_topology = '{"usb-mouse":1}'
+        - usb_mouse_and_tablet:
+            Host_RHEL.m6:
+                no usb-ehci
+            usb_topology = '{"usb-mouse":1,"usb-tablet":1}'
+        - usb_kbd:
+            Host_RHEL.m6:
+                no usb-ehci
+            usb_topology = '{"usb-kbd":1}'

--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -85,3 +85,6 @@
         - input_devices_under_two_tier_hub:
             no usb-ehci
             usb_topology = '{"usb-hub":2,"usb-mouse":1,"usb-kbd":1,"usb-tablet":1}'
+        - max_devices_under_one_hub:
+            no usb-ehci
+            usb_topology = '{"usb-hub":1,"usb-mouse":8}'

--- a/qemu/tests/usb_common.py
+++ b/qemu/tests/usb_common.py
@@ -1,6 +1,9 @@
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
-from collections import OrderedDict, Counter
+from collections import OrderedDict
 
 from virttest import utils_misc
 
@@ -106,8 +109,9 @@ def verify_usb_device_in_guest(params, session, devs):
             if dev[1] not in output:
                 return False
         # match number of devices
-        counter = Counter(dev[1] for dev in devs)
-        for k, v in counter.items():
+        dev_list = [dev[1] for dev in devs]
+        dev_nums = dict((i, dev_list.count(i)) for i in dev_list)
+        for k, v in dev_nums.items():
             if output.count(k) != v:
                 return False
         return True


### PR DESCRIPTION
Add max_devices_under_one_hub, to check 8 usb mouse attatced to one usb hub.
Add usb_mouse, to check a usb mouse attached without usb hub.
usb_mouse_and_tablet checks a usb mouse and tablet without usb hub.
usb_kbd checks a usb keyboard without usb hub.
usb_common: modified imported modules to make it compatible with both python 2.6 and 2.7

id: 1493404 1493413 1493420 1493423 1494469

Signed-off-by: Haotong Chen hachen@redhat.com
