### PR TITLE
virtio_console.py: disable module virtio_console while port is open.

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -80,6 +80,7 @@
                        # Destructive tests
                         - rmmod:
                             only Linux
+                            mod_check = 'lsmod | grep virtio_console'
                             virtio_console_test = rmmod
                         - migration:
                             # Arm doesn't support migration


### PR DESCRIPTION
Improving case steps. Remove module 'virtio_console' while port is open but not in use,
and add basic loop test before and after removing kernel module 'virtio_console'.

id: 1483440
Signed-off-by: Sitong Liu <siliu@redhat.com>