### PR TITLE
timerdevice_clock_drift_with_sleep: fix bugs

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -1,6 +1,7 @@
 - timerdevice:
     no Host_RHEL.m5, Host_RHEL.m6
     restart_vm = yes
+    host_cpu_cnt_cmd = "cat /proc/cpuinfo | grep "physical id" | wc -l"
     variants:
         - tscwrite:
             only Fedora.19, RHEL.7
@@ -9,7 +10,6 @@
             msr_tools_cmd = "a=$(rdmsr -d 0x00000010); echo -e ibase=16\\n $a  | tail -n 1 | while read n; do wrmsr 0x00000010 $(($n+100000000000)); echo $n; done"
         - clock_drift_with_sleep:
             only RHEL
-            no up
             type = timerdevice_clock_drift_with_sleep
             rtc_base = utc
             rtc_clock = host
@@ -17,7 +17,6 @@
         - clock_drift_with_ntp:
             only Fedora.19, RHEL.7
             type = timerdevice_clock_drift_with_ntp
-            host_cpu_cnt_cmd = "cat /proc/cpuinfo | grep "physical id" | wc -l"
             test_run_timeout = 7200
         - change_guest_clksource:
             only RHEL


### PR DESCRIPTION
    1. Remove "no up" in cfg file and check host cpu num to get vcpu num
    2. Fix the expected result, the elapsed time should > 10s and < 11s
    3. Add definition for "host_cpu_cnt_cmd" in cfg file

ID: 1468145

Signed-off-by: Huiqing Ding <huding@redhat.com>