### PR TITLE
smbios_tables: fix incorrect parsing of SMBIOS system.version info

### DIFF
--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -56,6 +56,11 @@ def run(test, params, env):
         qemu_binary = utils_misc.get_qemu_binary(params)
         tmp = utils_misc.get_support_machine_type(qemu_binary)
         (support_machine_types, expect_system_versions) = tmp
+        # remove alias machine types to prevent duplication
+        for version in expect_system_versions:
+            if 'alias of' in version:
+                index = expect_system_versions.index(version)
+                del support_machine_types[index]
         machine_type = params.get("machine_type", "")
         if ':' in machine_type:
             prefix = machine_type.split(':', 1)[0]
@@ -90,13 +95,12 @@ def run(test, params, env):
                     smbios_set_para = params.object_params(sm_type).get(key,
                                                                         default_key_para)
                 else:
-                    key_index = support_machine_types.index(m_type)
-                    smbios_set_para = expect_system_versions[key_index]
+                    smbios_set_para = m_type
 
                 if smbios_get_para == notset_output:
                     smbios_get_para = default_key_para
 
-                if (smbios_set_para not in smbios_get_para):
+                if (smbios_get_para not in smbios_set_para):
                     e_msg = ("%s.%s mismatch, Set '%s' but guest is : '%s'"
                              % (sm_type, key, smbios_set_para,
                                 smbios_get_para))


### PR DESCRIPTION
In QEMU, the default SMBIOS system.version is configured as mc->name (see
pc_q35.c and pc_piix.c). This mc->name field is the machine types (i.e. 1st
column of "-M ?"), instead of the system versions. Using x86 as an example,
"-M ?" shows the following lists:

upported machines are:
pc                   Standard PC (i440FX + PIIX, 1996) (alias of pc-i440fx-2.6)
pc-i440fx-2.6        Standard PC (i440FX + PIIX, 1996) (default)
pc-i440fx-2.5        Standard PC (i440FX + PIIX, 1996)
...                  ....

Inside a x86 guest VM, "smbios -t 1" shows the version as "Version:
pc-i440fx-2.6" instead of "Standard PC (i440FX + PIIX, 1996)". Therefore
we should use the machine types as the expected parameter during verification.
This patch addresses the problem by setting smbios_set_para = m_type, instead
of using expect_system_versions[key_index].

The second problem is the alias. Alias creates duplicated, useless efforts and
it also causes confusion because "-M ?" doesn't match the system
version in the guest OS. Using "pc" as an example. It is an alias of
"pc-i440fx-2.6". So guest VM SMBIOS will see "pc-i440fx-2.6" instead of "pc".
This causes failures during SMBIOS tests. To solve this problem, this patch
removes alias from the test cases.

The last problem is related to the prefix added by AArch64 machine types.
AArch64 adds either "arm64-pci:" or "arm64-mmios:" as the prefix to machine
types. So during SMBIOS verfication, we match the smbios_get_para to
smbios_set_para, instead of the other way around.

Signed-off-by: Wei Huang <wei@redhat.com>