### PR TITLE
qemu.tests: Update invoking of test_setup.PciAssignable

### DIFF
--- a/qemu/tests/sr_iov_hotplug.py
+++ b/qemu/tests/sr_iov_hotplug.py
@@ -265,7 +265,8 @@ def run(test, params, env):
             kvm_params=params.get("kvm_default"),
             vf_filter_re=params.get("vf_filter_re"),
             pf_filter_re=params.get("pf_filter_re"),
-            device_driver=device_driver)
+            device_driver=device_driver,
+            pa_type=params.get("pci_assignable"))
 
     pa_pci_ids = vm.pci_assignable.request_devs(devices)
     # Modprobe the module if specified in config file

--- a/qemu/tests/sr_iov_sanity.py
+++ b/qemu/tests/sr_iov_sanity.py
@@ -70,7 +70,8 @@ def run(test, params, env):
         kvm_params=params.get("kvm_default"),
         vf_filter_re=params.get("vf_filter_re"),
         pf_filter_re=params.get("pf_filter_re"),
-        device_driver=device_driver)
+        device_driver=device_driver,
+        pa_type=params.get("pci_assignable"))
 
     devices = []
     device_type = params.get("device_type", "vf")


### PR DESCRIPTION
qemu.tests: Update invoking of test_setup.PciAssignable accordingly.
Depends on https://github.com/avocado-framework/avocado-vt/pull/1152.
Signed-off-by: Yumei Huang <yuhuang@redhat.com>