### PR TITLE
Netperf: add jumbo test scenario

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -68,14 +68,18 @@
     # environment.
     RHEL, Fedora:
         get_status_in_guest = yes
-    #Linux:
+    Linux:
     #    log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.sh
     #    log_guestinfo_exec = bash
     #    log_guestinfo_path = /tmp/log_guestinfo.sh
-    #Windows:
+        server_mtu_cmd = "ifconfig %s mtu %s"
+    Windows:
     #    log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.bat
     #    log_guestinfo_exec = cmd /c
     #    log_guestinfo_path = C:\log_guestinfo.bat
+        server_mtu_cmd = "netsh interface ipv4 set subinterface "%s" mtu=%s"
+    client_mtu_cmd = "ifconfig %s mtu %s"
+    host_mtu_cmd = "ifconfig %s mtu %s"
     variants:
         - guest_guest:
             no Jeos
@@ -121,3 +125,9 @@
                     cygwin_start = C:\rhcygwin\Cygwin.bat -i /Cygwin-Terminal.ico -
                     netserv_start_cmd = netserver
                     netperf_install_cmd = cd netperf-2.6.0; ./configure --enable-burst --enable-demo=yes; make; make install
+    variants:
+        - jumbo:
+            mtu = 9000
+            # please config physical nic name of client for jumbo frame case by uncommenting it
+            # client_physical_nic = <your_client_physical_nic>
+        - default:


### PR DESCRIPTION
When netdst is switch, set specified mtu on host/client/guest
(linux/windows) before netperf start tests.

Signed-off-by: Wenli Quan <wquan@redhat.com>

ID: 1485855