### PR TITLE
virtio_console.py: update and extend test for boot_to_much_ports

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -61,6 +61,8 @@
                             virtio_console_test = rw_host_offline_big_data
                         - rw_blocking_mode:
                             only Linux
+                            # Works with virtconsole, but is not the comon usage, don't test by default
+                            only virtserialport
                             virtio_console_test = rw_blocking_mode
                         - rw_nonblocking_mode:
                             only Linux
@@ -68,6 +70,8 @@
                             only virtserialport
                             virtio_console_test = rw_nonblocking_mode
                         - basic_loopback:
+                            # loopback test between two ports
+                            no virtconsole
                             virtio_console_test = basic_loopback
                 - @with_vm:
                     # Works with virtconsole, but is not the comon usage, don't test by default
@@ -227,11 +231,15 @@
                         - boot_too_much_ports:
                             # arm doesn't use pci bus
                             no aarch64
-                            extra_params = " -device virtio-serial-pci,max_ports=32"
+                            # max_ports extended in rhev7: "rhev7,lower_version"
+                            max_ports_invalid = "512,32"
+                            max_ports_valid = "511,31"
+                            extra_params = " -device virtio-serial-pci,max_ports=%s"
                             start_vm = no
                             virtio_console_test = failed_boot
-                            virtio_console_params = "maximum ports supported: 31"
+                            virtio_console_params = "maximum ports supported: %s"
                             virtio_ports = ""
+                            qemu_version_pattern = "2\.\d+\.\d+"
     variants:
         # Use only single virtio-serial-pci
         - spread_linear:


### PR DESCRIPTION
(1) update and extend test for boot_to_much_ports
Port number has been extended from 32 to 512 for 2.x.x version, so update test case.

(2) disable loopback test between consoles
Data transfer test for console is invalid according the former test result.

(3) update error module with error_context
(4) remove try.. except in run() that covers every function
Without it step, exceptions can also be correctly raised in separate function, so delete this step to avoid importing avocado.core in this script.

id: 1472105, 1468463, 1468458

Signed-off-by: Sitong Liu <siliu@redhat.com>