### PR TITLE
block_stream: Set default base to None.

### DIFF
--- a/qemu/tests/blk_stream.py
+++ b/qemu/tests/blk_stream.py
@@ -15,7 +15,7 @@ class BlockStream(block_copy.BlockCopy):
 
     def __init__(self, test, params, env, tag):
         super(BlockStream, self).__init__(test, params, env, tag)
-        self.base_image = self.image_file
+        self.base_image = None
         self.ext_args = {}
 
     def parser_test_args(self):

--- a/qemu/tests/block_stream_check_backingfile.py
+++ b/qemu/tests/block_stream_check_backingfile.py
@@ -36,6 +36,8 @@ class BlockStreamCheckBackingfile(blk_stream.BlockStream):
             self.test.fail(msg)
 
     def check_backingfile_exist(self):
+        if not self.base_image:
+            self.test.error("No backing file specified.")
         backingfile = self.get_backingfile()
         if backingfile != self.base_image:
             msg = "The backing file from monitor does not meet expectation. "
@@ -60,6 +62,7 @@ class BlockStreamCheckBackingfile(blk_stream.BlockStream):
         """
         Set values for backing-file option
         """
+        self.base_image = self.image_file
         absolute_path = self.params["absolute_path"]
         if absolute_path == "yes":
             backing_file = self.base_image


### PR DESCRIPTION
base image option: only sectors above this image are streamed.(optional)
So if there is only one snapshot, base->sn1, the stream will start from sn1
to sn1, that means no data streamed, so it will complete immediately and
still have base as it backing file, which cause backing file check failed.

Fix:
1. By default set base option to None. Currently only case
block_stream.backingfile_option need to set this option.
2. Set base to guest image_file only when call set_backingfile() function.
3. If base is none, then check_backingfile_exist() should not be called,
it will report error.

id: 1496671
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>