### PR TITLE
win_irq_check: check balloon and rng's irq value in windows guest

### DIFF
--- a/qemu/tests/cfg/win_irq_check.cfg
+++ b/qemu/tests/cfg/win_irq_check.cfg
@@ -1,0 +1,21 @@
+- win_irq_check:
+    only Windows
+    type = win_irq_check
+    kill_vm = yes
+    login_timeout = 360
+    irq_cmd = type c:\msinfo.txt |findstr /i /c:"%s" |findstr /i "^irq.*ok"
+    variants:
+        - with_balloon:
+            driver_name = balloon
+            device_name = "VirtIO Balloon Driver"
+            balloon = balloon0
+            balloon_dev_devid = balloon0
+            balloon_dev_add_bus = yes
+        - with_viorng:
+            driver_name = viorng
+            device_name = "VirtIO RNG Device"
+            no_virtio_rng:
+                virtio_rngs += " rng0"
+                backend_rng0 = rng-random
+                backend_type = passthrough
+                filename_passthrough = /dev/urandom

--- a/qemu/tests/win_irq_check.py
+++ b/qemu/tests/win_irq_check.py
@@ -1,0 +1,55 @@
+import logging
+import re
+
+from virttest import error_context
+from virttest import utils_test
+
+
+# This decorator makes the test function aware of context strings
+@error_context.context_aware
+def run(test, params, env):
+    """
+    QEMU windows guest vitio device irq check test
+
+    1) Start guest with virtio device.
+    2) Make sure driver verifier enabled in guest.
+    3) Get irq info in guest.
+    4) Check the value of irq number.
+
+    :param test: QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+    def irq_check(session, device_name):
+        """
+        Return virtio device's irq number
+        :param session: use for sending cmd
+        :param device_name: virtio device's name
+        :param driver_name: virtio driver's name
+        """
+        status, irq_dev_info = session.cmd_status_output(params["irq_cmd"]
+                                                         % device_name)
+        if status:
+            test.fail("Can't get %s's irq info." % device_name)
+        irq_value = re.split('\s+', irq_dev_info)[1]
+        logging.info("irq number is %s" % irq_value)
+        return int(irq_value)
+
+    driver = params["driver_name"]
+    device_name = params["device_name"]
+    timeout = int(params.get("login_timeout", 360))
+    error_context.context("Boot guest with %s device" % driver, logging.info)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=timeout)
+
+    utils_test.qemu.windrv_verify_running(session, test, driver, timeout)
+    utils_test.qemu.setup_win_driver_verifier(driver, vm, timeout)
+
+    error_context.context("Check %s's irq number" % device_name, logging.info)
+    irq_num = irq_check(session, device_name)
+    if irq_num < 0:
+        test.fail("%s's irq is not correct." % device_name,
+                  logging.info)
+    if session:
+        session.close()


### PR DESCRIPTION
Add new case to check balloon and rng's irq value in windows guest.

Signed-off-by: Xiaoling Gao <xiagao@redhat.com>

based on: https://github.com/avocado-framework/avocado-vt/pull/1201

ID: 1455810