### PR TITLE
rh_kernel_update: updated kernel_re and knl_dbginfo_re

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -54,19 +54,19 @@
         install_virtio = yes
         verify_virtio = yes
     x86_64:
-        kernel_re = .*kernel-%s.el.*.x86_64.*
-        knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.x86_64.*
+        kernel_re = .*kernel-%s.el[^.]+\.x86_64.*
+        knl_dbginfo_re = .*kernel-debuginfo-.*.el[^.]+\.x86_64.*
     PAE:
-        kernel_re = .*kernel-PAE-%s.el.*.i686.*
+        kernel_re = .*kernel-PAE-%s.el[^.]+\.i686.*
     i386:
-        kernel_re = .*kernel-%s.el.*.i686.*
-        knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.i686.*
+        kernel_re = .*kernel-%s.el[^.]+\.i686.*
+        knl_dbginfo_re = .*kernel-debuginfo-.*.el[^.]+\.i686.*
     ppc64:
-        kernel_re = .*kernel-%s.el.*.ppc64\..*
-        knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.ppc64\..*
+        kernel_re = .*kernel-%s.el[^.]+\.ppc64\..*
+        knl_dbginfo_re = .*kernel-debuginfo-.*.el[^.]+\.ppc64\..*
     ppc64le:
-        kernel_re = .*kernel-%s.el.*.ppc64le.*
-        knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.ppc64le.*
+        kernel_re = .*kernel-%s.el[^.]+\.ppc64le.*
+        knl_dbginfo_re = .*kernel-debuginfo-.*.el[^.]+\.ppc64le.*
     aarch64:
-        kernel_re = .*kernel-%s.el.*.aarch64.*
-        knl_dbginfo_re = .*kernel-debuginfo-.*.el.*.aarch64.*
+        kernel_re = .*kernel-%s.el[^.]+\.aarch64.*
+        knl_dbginfo_re = .*kernel-debuginfo-.*.el[^.]+\.aarch64.*


### PR DESCRIPTION
Make kernel_re and knl_dbginfo_re more strict to avoide updating
guest kernel to unstable versions.

id: 1500249
Signed-off-by: Haotong Chen <hachen@redhat.com>