### PR TITLE
balloon_hotplug:reboot/shutdown guest after plug/unplug balloon device

### DIFF
--- a/qemu/tests/balloon_hotplug.py
+++ b/qemu/tests/balloon_hotplug.py
@@ -3,6 +3,7 @@ import time
 
 from virttest.qemu_devices import qdevices
 from virttest import error_context
+from virttest import utils_test
 from qemu.tests import balloon_check
 from avocado.core import exceptions
 
@@ -15,13 +16,30 @@ def run(test, params, env):
     1) Boot up guest w/o balloon device.
     2) Hoplug balloon device and check hotplug successfully or not.
     3) Do memory balloon.
-    4) Unplug balloon device and check unplug successfully or not.
+    4) Reboot/shutdown guest after hotplug balloon device(option)
+    5) Do memory balloon after guest reboot(option)
+    6) Unplug balloon device and check unplug successfully or not.
+    7) Reboot/shutdown guest after unplug balloon device(option)
 
     :param test:   QEMU test object.
     :param params: Dictionary with the test parameters.
     :param env:    Dictionary with test environment.
     """
+
+    def run_pm_test(pm_test, plug_type):
+        """
+        Run pm(reboot/system_reset/shutdown) related test after balloon
+        device is hot-plug or hot-unplug
+        :param pm_test: power management test name,e.g. reboot/shutdown
+        :param plug_type:balloon device plug operation,e.g.hot_plug or hot_unplug
+        """
+        error_context.context("Run %s test after %s balloon device"
+                              % (pm_test, plug_type), logging.info)
+        utils_test.run_virt_sub_test(test, params, env, pm_test)
+
     pause = float(params.get("virtio_balloon_pause", 3.0))
+    pm_test_after_plug = params.get("pm_test_after_plug")
+    pm_test_after_unplug = params.get("pm_test_after_unplug")
     idx = 0
     err = ""
     vm = env.get_vm(params["main_vm"])
@@ -51,6 +69,15 @@ def run(test, params, env):
                               logging.info)
         balloon_check.run(test, params, env)
 
+        if pm_test_after_plug:
+            run_pm_test(pm_test_after_plug, "hot-plug")
+            # run balloon test after reboot,skip followed test if
+            # pm_test_after_plug is shutdown
+            if vm.is_alive():
+                balloon_check.run(test, params, env)
+            else:
+                return
+
         error_context.context("Unplug balloon device for %d times" % (i+1),
                               logging.info)
         out = new_dev.unplug(vm.monitor)
@@ -62,9 +89,13 @@ def run(test, params, env):
         if not ver_out:
             err += ("\nDevice is still in qtree %ss after unplug:\n%s"
                     % (pause, vm.monitor.info("qtree")))
-
         if err:
             logging.error(vm.monitor.info("qtree"))
             raise exceptions.TestFail("Error occurred while hotpluging "
                                       "virtio-pci. Iteration %s, monitor "
                                       "output:%s" % (i, err))
+        else:
+            if pm_test_after_unplug:
+                run_pm_test(pm_test_after_unplug, "hot-unplug")
+                if not vm.is_alive():
+                    return

--- a/qemu/tests/cfg/balloon_hotplug.cfg
+++ b/qemu/tests/cfg/balloon_hotplug.cfg
@@ -3,9 +3,11 @@
     type = balloon_hotplug
     monitor_type = qmp
     monitors = qmp1
-    balloon_repeats = 100
+    balloon_repeats = 1
     virtio_balloon_pause = 10.0
     free_mem_cmd = cat /proc/meminfo |grep MemFree
+    reboot_method = shell
+    shutdown_method = shell
     Linux:
         ratio = 1
     Windows:
@@ -14,3 +16,19 @@
     test_tags = "evict enlarge"
     balloon_type_evict = evict
     balloon_type_enlarge = enlarge
+    variants:
+        - @default:
+            balloon_repeats = 100
+        - with_reboot:
+            pm_test_after_unplug = boot
+            pm_test_after_plug = boot
+        - with_system_reset:
+            pm_test_after_unplug = boot
+            pm_test_after_plug = boot
+            reboot_method = system_reset
+        - with_shutdown_after_unplug:
+            pm_test_after_unplug = shutdown
+            check_img = yes
+        - with_shutdown_after_plug:
+            pm_test_after_plug = shutdown
+            check_img = yes


### PR DESCRIPTION
add optional steps to support reboot/shutdown guest after hotplug
or hot-unplug balloon devices

Signed-off-by: Li Jin <lijin@redhat.com>

ID:1456107,1456149,1456150,1456108