### PR TITLE
qemu.tests.win_heavyload: Stress on a data disk instead of system disk

### DIFF
--- a/qemu/tests/cfg/win_heavyload.cfg
+++ b/qemu/tests/cfg/win_heavyload.cfg
@@ -2,6 +2,12 @@
     type = win_heavyload
     only Windows
     timeout = 600
+    images += " data"
+    image_name_data = "images/data_disk"
+    image_size_data = 4G
+    force_create_image_data = yes
+    disk_letter = "I:"
+    disk_index = 1
     # If autostress eq yes case will autotest generate start command like,
     # heavyload /CPU n /FILE n /MEMORY n /DURATION timeout /START
     autostress = yes


### PR DESCRIPTION
1. Add a new disk for stress test, avoid affecting system disk.
2. Correct the command of "test_installed_cmd"
3. Extend 2 senconds to wait for heavyload exit completely

id: 1437304
Signed-off-by: Yanan Fu <yfu@redhat.com>