### PR TITLE
openflow_acl_test: remove two telnet sub-cases for Windows guests

### DIFF
--- a/qemu/tests/cfg/openflow_acl_test.cfg
+++ b/qemu/tests/cfg/openflow_acl_test.cfg
@@ -77,6 +77,7 @@
                 access_cmd_linux = curl -L www.redhat.com --connect-timeout 10
                 access_cmd_windows = cd C:\lynx && lynx.exe --dump www.redhat.com
             ssh, telnet:
+                only Linux
                 vms = "virt-tests-vm1 virt-tests-vm2"
                 access_targets = virt-tests-vm2 localhost
                 extra_target = localhost
@@ -91,6 +92,8 @@
             extra_target = localhost
             ftp, website:
                 setup_targets = localhost virt-tests-vm2
+            telnet:
+                only Linux
         - accessed_deny_all_target:
             acl_disabled = yes
             access_targets = virt-tests-vm1


### PR DESCRIPTION
openflow_acl_test: remove two telnet sub-cases for Windows guests because telnet server is no longer supported

1. access_deny_all_target.telnet
2. access_deny_special_target.telnet

ID: 1475103

Signed-off-by: Xiyue Wang <xiywang@redhat.com>