### PR TITLE
Netperf: disable params take_regular_screendumps and store_vm_register

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -4,6 +4,8 @@
     kill_vm = yes
     image_snapshot = yes
     setup_ksm = no
+    take_regular_screendumps = no
+    store_vm_register = no
     # Please update following comments params when you need special cfg for
     # your test nic cards
     # nic1 is for control, nic2 is for data connection


### PR DESCRIPTION
Enabled that two params bring a slightly cpu enlarge in test, so diable
them for performance issue.

Signed-off-by: Wenli Quan <wquan@redhat.com>

ID: 1501049