### PR TITLE
Netperf: disable ksm for performance issue

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -3,6 +3,7 @@
     type = netperf
     kill_vm = yes
     image_snapshot = yes
+    setup_ksm = no
     # Please update following comments params when you need special cfg for
     # your test nic cards
     # nic1 is for control, nic2 is for data connection

--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -94,6 +94,7 @@ def run(test, params, env):
         ssh_cmd(session, "service iptables stop", ignore_status=True)
         ssh_cmd(session, "systemctl stop firewalld.service", ignore_status=True)
         ssh_cmd(session, "echo 1 > /proc/sys/net/ipv4/conf/all/arp_ignore")
+        ssh_cmd(session, "echo 0 > /sys/kernel/mm/ksm/run", ignore_status=True)
 
         download_link = params.get("netperf_download_link")
         download_dir = data_dir.get_tmp_dir()


### PR DESCRIPTION
Ksm uses a lot of processing power, we need to disable it. it takes
30% cpu usage (16cpus) in my tests.

Signed-off-by: Wenli Quan <wquan@redhat.com>

ID: 502942