### PR TITLE
usb_device_check: add windows test support

### DIFF
--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -6,13 +6,27 @@
     usbs = "usbtest"
     usb_bus = "usbtest.0"
     cmd_timeout = 300
-    chk_usb_info_cmd = "lsusb -v"
     type = usb_device_check
-    # usb device info name
-    usb-hub = "QEMU USB Hub"
-    usb-mouse = "QEMU USB Mouse"
-    usb-kbd = "QEMU USB Keyboard"
-    usb-tablet = "QEMU USB Tablet"
+    chk_usb_info_cmd = "lsusb -v"
+    # usb device info for qemu
+    usb_hub_for_qemu = "QEMU USB Hub"
+    usb_mouse_for_qemu = "QEMU USB Mouse"
+    usb_kbd_for_qemu = "QEMU USB Keyboard"
+    usb_tablet_for_qemu = "QEMU USB Tablet"
+    # usb device info for Linux guest
+    usb_hub_for_guest = "QEMU USB Hub" 
+    usb_mouse_for_guest = "QEMU USB Mouse"
+    usb_kbd_for_guest = "QEMU USB Keyboard"
+    usb_tablet_for_guest = "QEMU USB Tablet"
+    Windows:
+        chk_usb_info_cmd = 'wmic path Win32_USBControllerDevice get Dependent | find "USB"'
+        # usb device info for Windows guest
+        usb_hub_for_guest = "VID_0409&PID_55AA"
+        # they are same in Windows
+        usb_mouse_for_guest = "VID_0627&PID_0001"
+        usb_kbd_for_guest = "VID_0627&PID_0001"
+        usb_tablet_for_guest = "VID_0627&PID_0001"
+
 
     # usb controllers
     variants:

--- a/qemu/tests/usb_common.py
+++ b/qemu/tests/usb_common.py
@@ -2,6 +2,7 @@ try:
     import simplejson as json
 except ImportError:
     import json
+import logging
 
 from collections import OrderedDict
 
@@ -30,23 +31,30 @@ def parse_usb_topology(params):
     return parsed_devs
 
 
-def collect_usb_dev(params, vm, parsed_devs):
+def collect_usb_dev(params, vm, parsed_devs, suffix):
     """
     Collect usb device information of parsed_devs.
 
     :param params: Dictionary with the test parameters.
     :param vm: Virtual machine object.
     :param parsed_devs: A list of parsed usb devices.
-    :return: A list of tuple contains (id, type, port) of a
-             usb device.
+    :params suffix: A string to read different cfg,
+                    choose from("for_monitor", "for_guest")
+    :return: A list of list contains information of usb devices for
+             verification,[id(eg.d0), info(eg.usb-hub), port(eg.1)]
+             the info will change based on suffix.
     """
+    def _change_dev_info_key(parsed_type, suffix):
+        info_key = parsed_type.replace("-", "_")
+        return "_".join([info_key, suffix])
+
     devs = []
     for parsed_dev in parsed_devs:
         key = list(parsed_dev.keys())[0]
         usb_dev_id = "usb-%s" % key[9:]
-        usb_dev_type = params[parsed_dev[key]]
+        usb_dev_info = params[_change_dev_info_key(parsed_dev[key], suffix)]
         usb_dev_port = str(vm.devices.get(usb_dev_id).get_param("port"))
-        devs.append((usb_dev_id, usb_dev_type, usb_dev_port))
+        devs.append([usb_dev_id, usb_dev_info, usb_dev_port])
     return devs
 
 
@@ -107,18 +115,25 @@ def verify_usb_device_in_guest(params, session, devs):
         # each dev must in the output
         for dev in devs:
             if dev[1] not in output:
+                logging.info("%s does not exist")
                 return False
         # match number of devices
         dev_list = [dev[1] for dev in devs]
         dev_nums = dict((i, dev_list.count(i)) for i in dev_list)
         for k, v in dev_nums.items():
-            if output.count(k) != v:
+            logging.info("the number of %s is %s" % (k, v))
+            count = output.count(k)
+            if count != v:
+                logging.info("expected %s %s, got %s in the guest" %
+                             (v, k, count))
                 return False
         return True
 
     res = utils_misc.wait_for(_verify_guest_usb,
                               float(params["cmd_timeout"]),
-                              text="wait for getting guest usb devices info")
+                              step=5.0,
+                              text="wait for getting guest usb devices info"
+                              )
 
     if res:
         return (True, "all given devices are verified in the guest")

--- a/qemu/tests/usb_device_check.py
+++ b/qemu/tests/usb_device_check.py
@@ -37,13 +37,16 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
 
-    devs = collect_usb_dev(params, vm, parsed_devs)
+    # collect usb dev information for qemu check
+    devs = collect_usb_dev(params, vm, parsed_devs, "for_qemu")
 
-    error_context.context("verify usb devices information in monitor...",
+    error_context.context("verify usb devices information in qemu...",
                           logging.info)
     result, output = verify_usb_device_in_monitor_qtree(vm, devs)
     _check_test_step_result(result, output)
 
+    # collect usb dev information for guest check
+    devs = collect_usb_dev(params, vm, parsed_devs, "for_guest")
     login_timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=login_timeout)
 


### PR DESCRIPTION
Make all current usb device check cases support for Windows.

id: 1504516
Signed-off-by: Haotong Chen <hachen@redhat.com>