### PR TITLE
virtio-win drivers sign check Test

### DIFF
--- a/qemu/tests/cfg/virtio_driver_sign_check.cfg
+++ b/qemu/tests/cfg/virtio_driver_sign_check.cfg
@@ -1,16 +1,24 @@
 - virtio_driver_sign_check:
     virt_test_type = qemu
-    only Win7.x86_64
-    # This script only need run once for every virtio driver version.
-    # So need not add to our testing loop.
+    only Windows
     type = virtio_driver_sign_check
-    cdroms += " sdk virtio"
-    cdrom_virtio = isos/windows/virtio-win.iso
-    cdrom_sdk = isos/windows/GRMSDKX_EN_DVD.iso
+    cdroms += " virtio"
+    cdrom_virtio = isos/windows/virtio-win.iso.el7
+    floppy_readonly = yes
     floppies = "fl"
-    floppy_name = images/win7-64/virtio-win.vfd
-    list_files_cmd = dir /s /b %s | find "%s"
-    winsdk_au3 = autoit/winsdk.au3
-    signtool_install = "D:\autoit3.exe c:\winsdk.au3"
-    signtool_cmd = "c:\Program Files\Microsoft SDKs\Windows\v7.0\Bin\signtool.exe" verify /v /kp /c %s %s
-    drive_list = F: A:
+    list_files_cmd = 'dir /s /b %s | find "%s"'
+    drive_volume = A:
+    tested_drivers = "Balloon pvpanic viorng vioserial vioinput NetKVM netkvm vioscsi viostor"
+    guest_alias = "Win7-32:w7\x86,Win7-64:w7\amd64,Win8-32:w8\x86,Win8-64:w8\amd64,Win8-32.1:w8.1\x86,Win8-64.1:w8.1\amd64,Win10-32:w10\x86,Win10-64:w10\amd64,Win2008-sp2-32:2k8\x86,Win2008-sp2-64:2k8\amd64,Win2008-r2-64:2k8R2\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12R2\amd64,Win2016-64:2k16\amd64"
+    guest_alias_fl = "Win7-32:i386\Win7,Win7-64:amd64\Win7,Win8-32:i386\Win8,Win8-64:amd64\Win8,Win8-32.1:i386\Win8.1,Win8-64.1:amd64\Win8.1,Win10-32:i386\Win10,Win10-64:amd64\Win10,Win2008-sp2-32:i386\Win2008,Win2008-sp2-64:amd64\Win2008,Win2008-r2-64:amd64\Win2008R2,Win2012-64:amd64\Win2012,Win2012-64r2:amd64\Win2012R2,Win2016-64:amd64\Win2016"
+    i386:
+        floppy_name = isos/windows/virtio-win_x86.vfd.el7
+    x86_64:
+        floppy_name = isos/windows/virtio-win_amd64.vfd.el7
+    Win2008..sp2:
+        signtool_path_key = "WLK"
+    Win2008..r2, Win7, Win8, Win2012:
+        signtool_path_key = "HCK"
+    Win10, Win2016:
+        signtool_path_key = "HLK"
+    signtool_cmd = "WIN_UTILS:\signtool\Signtool_%%PROCESSOR_ARCHITECTURE%%_${signtool_path_key}.exe" verify /v /kp /c %s %s

--- a/qemu/tests/virtio_driver_sign_check.py
+++ b/qemu/tests/virtio_driver_sign_check.py
@@ -1,19 +1,17 @@
 import logging
-import os
 import re
-import time
 
-from autotest.client.shared import error
-
+from virttest import error_context
 from virttest import utils_misc
 
 
+@error_context.context_aware
 def run(test, params, env):
     """
     KVM windows virtio driver signed status check test:
     1) Start a windows guest with virtio driver iso/floppy
-    2) Install windows SDK in guest.
-    3) use SignTool.exe to verify whether block driver digital signed
+    2) Generate a tested driver file list.
+    3) use SignTool.exe to verify whether all drivers digital signed
 
     :param test: QEMU test object
     :param params: Dictionary with the test parameters
@@ -21,67 +19,135 @@ def run(test, params, env):
     """
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
-
-    def is_sdksetup_finished():
-        s, o = session.cmd_status_output("tasklist | find \"SDK\"")
-        if s:
-            return True
-        else:
-            return False
-
-    timeout = float(params.get("login_timeout", 240))
+    timeout = float(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=timeout)
-    signtool_install = params.get("signtool_install")
-    au3_link = params.get("winsdk_au3", "autoit/winsdk.au3")
-    au3_link = os.path.join(test.bindir, au3_link)
     signtool_cmd = params.get("signtool_cmd")
     list_files_cmd = params.get("list_files_cmd")
-    drive_list = params.get("drive_list")
-    vm.copy_files_to(au3_link, "c:\\")
-    drivers = {}
-    logging.info("Install sdk in guest if signtool is not available.")
-    session.cmd_status_output(signtool_install, timeout=360)
-    # Wait until guest start install sdk.
-    time.sleep(10)
-    logging.info("Waiting for guest sdk setup ...")
-    utils_misc.wait_for(is_sdksetup_finished, timeout=1800)
-    results_all = """All the signature check log:\n"""
+    drive_volume_list = params.objects("drive_volume")
     fails_log = """Failed signature check log:\n"""
+    results_all = """All the signature check log:\n"""
     fail_num = 0
     fail_drivers = []
-    logging.info("Running SignTool command in guest...")
+    virtio_drivers = []
+    drivers = {}
+    need_test_driver = params.objects("tested_drivers")
+
+    def get_os_arch_path(alias_map):
+        """
+        Get the os path and arch path which would be tested.
+
+        :param session: VM session.
+        :param alias_map: all guest_name and os path + arch path mapping info.
+
+        :return os_arch_path_list: Return the os_arch_path_list.
+        """
+        guest_name = params["guest_name"]
+        guest_list = dict([x.split(":") for x in alias_map.split(",")])
+        os_arch_path = guest_list[guest_name]
+        global os_arch_path_list
+        os_arch_path_list = os_arch_path.split("\\")
+        return os_arch_path_list
+
+    def filter_all_tested_cat_files(cat_files):
+        """
+        In all suffix '.cat' files, select that will be tested '.cat' file.
+
+        :param cat_files:all suffix '.cat' files.
+        :return True:correct os path, arch path and the dirver_dir
+        belong in need_test_driver list, return True.
+        """
+        pattern = r'(\w:)\\(.+?)\\(.+?)\\(.+?)[\.|\\]'
+        ret = re.match(pattern, cat_files, re.I)
+        disk_name = ret.group(1)
+        os_name = ret.group(3)
+
+        if disk_name == "A:":
+            get_os_arch_path(alias_map=params.get("guest_alias_fl"))
+            os_path = os_arch_path_list[1]
+            arch_path = os_arch_path_list[0]
+            plat_name = ret.group(2)
+            driver_dir = ret.group(4)
+        else:
+            get_os_arch_path(alias_map=params.get("guest_alias"))
+            os_path = os_arch_path_list[0]
+            arch_path = os_arch_path_list[1]
+            driver_dir = ret.group(2)
+            plat_name = ret.group(4)
+
+        if (os_name == os_path) and (plat_name == arch_path):
+            if driver_dir in need_test_driver:
+                return True
+
+    def match_cat_and_verified_file(filterd_cat_file):
+        """
+        Tuple each selected '.cat' file and with same directory '.sys' file;
+        Tuple each selected '.cat' file and with same directory '.inf' file;
+        Tuple each selected '.cat' file and with same directory 'Wdf' file.
+
+        Collect all tuples in virtio_drivers list to be used signtool test.
+
+        :param filterd_cat_file:each filterd suffix '.cat' file
+        """
+        pattern = r'\w:\\(.+?)\\(.+?)\\(.+?)[\.|\\]'
+        match_ret = re.match(pattern, filterd_cat_file)
+        driver_dir = match_ret.group()
+
+        driver_sys = filter(lambda x: driver_dir in x, drivers['.sys'])
+        driver_inf = filter(lambda x: driver_dir in x, drivers['.inf'])
+        driver_wdf = filter(lambda x: driver_dir in x, drivers['Wdf'])
+
+        cat_sys = map(lambda x: (filterd_cat_file, x), driver_sys)
+        cat_inf = map(lambda x: (filterd_cat_file, x), driver_inf)
+        cat_wdf = map(lambda x: (filterd_cat_file, x), driver_wdf)
+        cat_parm = cat_sys + cat_inf + cat_wdf
+        virtio_drivers.extend(cat_parm)
+
     try:
-        for drive in drive_list.split():
-            for type in ['.cat', '.sys']:
+        error_context.context("Running SignTool check test in guest...",
+                              logging.info)
+        key = "VolumeName like 'virtio-win%'"
+        disk_letter = utils_misc.get_win_disk_vol(session, condition=key) + ":"
+        drive_volume_list.append(disk_letter)
+
+        for drive in drive_volume_list:
+            for type in ['.cat', '.sys', '.inf', 'Wdf']:
                 driver = session.cmd_output(list_files_cmd % (drive, type)).\
                     splitlines()[1:-1]
                 drivers[type] = driver
-            files = zip(drivers['.cat'], drivers['.sys'])
-            for cat, sys in files:
-                cmd = signtool_cmd % (cat, sys)
-                s, result = session.cmd_status_output(cmd)
-                if s:
-                    msg = "Fail command: %s. Output: %s" % (cmd, result)
-                    raise error.TestFail(msg)
+
+            cat_list = filter(filter_all_tested_cat_files, drivers['.cat'])
+            map(match_cat_and_verified_file, cat_list)
+
+            for driver_file in virtio_drivers:
+                test_cmd = signtool_cmd % (driver_file[0], driver_file[1])
+                test_cmd = utils_misc.set_winutils_letter(session, test_cmd)
+                status, result = session.cmd_status_output(test_cmd)
+                if status:
+                    msg = "Fail command: %s. Output: %s" % (test_cmd, result)
+                    logging.error(msg)
                 results_all += result
                 re_suc = "Number of files successfully Verified: ([0-9]*)"
                 try:
-                    suc_num = re.findall(re_suc, result)[0]
+                    suc_num = re.findall(re_suc, result, re.M)[0]
                 except IndexError:
                     msg = "Fail to get Number of files successfully Verified"
-                    raise error.TestFail(msg)
+                    logging.error(msg)
+                    suc_num = 0
 
                 if int(suc_num) != 1:
                     fails_log += result
                     fail_num += 1
-                    fail_driver = cat + " " + sys
-                    fail_drivers.append(fail_driver)
+                    fail_drivers.append(driver_file[1])
+            virtio_drivers = []
+
         if fail_num > 0:
             msg = "Following %s driver(s) signature checked failed." % fail_num
             msg += " Please refer to fails.log for details error log:\n"
             msg += "\n".join(fail_drivers)
-            raise error.TestFail(msg)
+            test.fail(msg)
 
     finally:
-        open("fails.log", "w").write(fails_log)
-        open("results.log", "w").write(results_all)
+        with open("%s/fails.log" % test.resultsdir, "w") as fp1:
+            fp1.write(fails_log)
+        with open("%s/result.log" % test.resultsdir, "w") as fp2:
+            fp2.write(results_all)


### PR DESCRIPTION
1. Boot a guest with latest virtio-win.iso and virtio-win.vfd files
2. Run signtool.exe verify for each driver '.sys', '.inf' and 'Wdf**.dll'files.

id:1375853

Signed-off-by: peixiu <phou@redhat.com>