### PR TITLE
Netperf: tweak configuration according whitepaper

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -62,6 +62,8 @@
     ppc64le:
         setup_cmd = "cd /tmp && rm -rf netperf-2.6.0 && tar xvfj netperf-2.6.0.tar.bz2 && cd netperf-2.6.0 && ./configure --build=ppc64le --enable-burst --enable-demo=yes  && make"
     log_hostinfo_script = scripts/rh_perf_log_hostinfo_script.sh
+    host_tuned_profile = "tuned-adm profile virtual-host"
+    client_tuned_profile = "tuned-adm profile virtual-host"
     # Now the get status functions are implemented for RHEL and Fedora guests.
     # Not test with other guests, please set this depends on your guest os
     # environment.
@@ -71,14 +73,23 @@
     #    log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.sh
     #    log_guestinfo_exec = bash
     #    log_guestinfo_path = /tmp/log_guestinfo.sh
+        server_tuned_profile = "tuned-adm profile virtual-guest"
         server_mtu_cmd = "ifconfig %s mtu %s"
     Windows:
     #    log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.bat
     #    log_guestinfo_exec = cmd /c
     #    log_guestinfo_path = C:\log_guestinfo.bat
         server_mtu_cmd = "netsh interface ipv4 set subinterface "%s" mtu=%s"
+        i386, x86_64:
+            cpu_model_flags = ",hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0xfff"
     client_mtu_cmd = "ifconfig %s mtu %s"
     host_mtu_cmd = "ifconfig %s mtu %s"
+    env_setup_cmd = "systemctl stop firewalld.service || service iptables stop;"
+    env_setup_cmd += " echo 2 > /proc/sys/net/ipv4/conf/all/arp_ignore;"
+    env_setup_cmd += " echo 0 > /sys/kernel/mm/ksm/run;"
+    env_setup_cmd += " echo 0 > /proc/sys/kernel/watchdog;"
+    env_setup_cmd += " echo 0 > /proc/sys/kernel/nmi_watchdog;"
+    env_setup_cmd += " setenforce 1"
     variants:
         - guest_guest:
             no Jeos

--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -54,13 +54,13 @@
     shell_prompt_host =  \[root@.{0,50}][\#\$]
     #Test base env configration
     ver_cmd = rpm -q qemu-kvm
-    netperf_version = 2.6.0
-    netperf_pkg = performance/netperf-2.6.0.tar.bz2
-    setup_cmd = "cd /tmp && rm -rf netperf-2.6.0 && tar xvfj netperf-2.6.0.tar.bz2 && cd netperf-2.6.0 && ./configure --enable-burst --enable-demo=yes && make"
+    netperf_version = 2.7.1
+    netperf_pkg = performance/netperf-2.7.1.tar.bz2
+    setup_cmd = "cd /tmp && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && ./configure --enable-burst --enable-demo=yes && make"
     ppc64:
-        setup_cmd = "cd /tmp && rm -rf netperf-2.6.0 && tar xvfj netperf-2.6.0.tar.bz2 && cd netperf-2.6.0 && ./configure --build=ppc64 --enable-burst --enable-demo=yes  && make"
+        setup_cmd = "cd /tmp && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && ./configure --build=ppc64 --enable-burst --enable-demo=yes  && make"
     ppc64le:
-        setup_cmd = "cd /tmp && rm -rf netperf-2.6.0 && tar xvfj netperf-2.6.0.tar.bz2 && cd netperf-2.6.0 && ./configure --build=ppc64le --enable-burst --enable-demo=yes  && make"
+        setup_cmd = "cd /tmp && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && ./configure --build=ppc64le --enable-burst --enable-demo=yes  && make"
     log_hostinfo_script = scripts/rh_perf_log_hostinfo_script.sh
     host_tuned_profile = "tuned-adm profile virtual-host"
     client_tuned_profile = "tuned-adm profile virtual-host"


### PR DESCRIPTION
1. virtual-host tuned profile on server and client
2. virtual-guest tuned profile on vm
3. disable watchdog
4. hyper-v enlightenment for windows guest with  -cpu ,hv_time,
hv_relaxed,hv_vapic,hv_spinlocks=0x1fff

Signed-off-by: Wenli Quan <wquan@redhat.com>

    Netperf: add support for rhel8
    
    1. add support for python3.6
    2. update linux netperf to latest 2.7.1
    3. re-design the logic for getting server_ip/server_ctl/server_ctl_ip

ID: 1501046, 1642875