### PR TITLE
Correct logic for device's boot_fail

### DIFF
--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -9,8 +9,8 @@
     Host_RHEL.m7:
         boot_menu_key = "esc"
     boot_menu_hint = "Press .*(F12|ESC) for boot menu"
-    boot_fail_info = "Booting from Hard Disk...;"
-    boot_fail_info += "Boot failed: not a bootable disk"
+    boot_entry_info = "Booting from Hard Disk..."
+    boot_fail_info = "Boot failed: not a bootable disk"
     variants:
         - boot_from_hard_drive:
             dev_name = hard-drive
@@ -65,8 +65,8 @@
             cdroms = "test"
             cdrom_test = /tmp/test.iso
             cd_format = scsi-cd
-            boot_fail_info = "Booting from DVD/CD...;"
-            boot_fail_info += "Boot failed: Could not read from CDROM"
+            boot_entry_info = "Booting from DVD/CD..."
+            boot_fail_info = "Boot failed: Could not read from CDROM"
             variants:
                 - with_local_iso:
                     bootindex_test = 0


### PR DESCRIPTION
In boot_from_device.check_boot_result(), although console output
boot_fail msg, the test result will be set to pass. The logic is
not reasonable, correct it.

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1506101