### PR TITLE
qemu_guest_agent: Support "guest-set-user-password"  for windows guest

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -8,6 +8,7 @@
     gagent_status_cmd = "service qemu-guest-agent status"
     gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
     Windows:
+        ga_username = "Administrator"
         deps = no
         i386:
             qemu_ga_pkg = qemu-ga-x86.msi
@@ -51,13 +52,13 @@
         - check_sync_delimited:
             gagent_check_type = sync_delimited
         - check_set_user_password:
-            no Windows
             gagent_check_type = set_user_password
             image_snapshot = yes
             variants:
                 - no_crypto:
-                    new_password = "abcdef"
+                    new_password = "Abc_123"
                 - crypto:
+                    no Windows
                     new_password = "123456"
                     crypted = "yes"
         - check_get_vcpus:

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -415,22 +415,21 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         """
         old_password = params.get("password", "")
         new_password = params.get("new_password", "123456")
+        ga_username = params.get("ga_username", "root")
         crypted = params.get("crypted", "") == "yes"
+        error_context.context("Change guest's password.")
         try:
-            if crypted:
-                self.gagent.set_user_password(new_password, crypted)
-            else:
-                self.gagent.set_user_password(new_password)
-            error_context.context("check if the guest could be login by new password",
+            self.gagent.set_user_password(new_password, crypted, ga_username)
+            error_context.context("Check if the guest could be login by new password",
                                   logging.info)
             self._gagent_verify_password(self.vm, new_password)
 
         except guest_agent.VAgentCmdError:
-            raise error.TestError("Failed to set the new password for guest")
+            test.fail("Failed to set the new password for guest")
 
         finally:
-            error_context.context("reset back the password of guest", logging.info)
-            self.gagent.set_user_password(old_password)
+            error_context.context("Reset back the password of guest", logging.info)
+            self.gagent.set_user_password(old_password, username=ga_username)
 
     @error_context.context_aware
     def gagent_check_get_vcpus(self, test, params, env):


### PR DESCRIPTION
1.Qemu-ga cmd "guest-set-user-password" support windows guest without encryption.
2.Change new password to a complex one for windows requirment.

ID: 1490227 

Signed-off-by: Xiaoling Gao <xiagao@redhat.com>