### PR TITLE
qemu.tests.win_heavyload: backup image before test and restore it after test

### DIFF
--- a/multi_host_migration/tests/cfg/multi_host.cfg
+++ b/multi_host_migration/tests/cfg/multi_host.cfg
@@ -222,6 +222,8 @@
                        unload_stress_in_the_end = no
                        sleep_before_migration = 10
                        bg_stress_test = win_heavyload
+                       backup_image_before_testing = yes
+                       restore_image_after_testing = yes
                        config_cmd = 'setx -m path "%PATH%;${install_path};"'
                        install_cmd = "start /wait DRIVE:\HeavyLoadSetup.exe /verysilent"
                        check_running_cmd = "tasklist | findstr /I  HeavyLoad.exe"

--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -142,6 +142,8 @@
                 timeout = 600
                 autostress = yes
                 sub_type = win_heavyload
+                backup_image_before_testing = yes
+                restore_image_after_testing = yes
                 install_path = "C:\Program Files (x86)\JAM Software\HeavyLoad"
                 config_cmd = 'setx -m path "%PATH%;${install_path};"'
                 install_cmd = "start /wait DRIVE:\HeavyLoadSetup.exe /verysilent"

--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -62,6 +62,8 @@
             type = live_snapshot_stress
             variants:
                 - with_stress:
+                    backup_image_before_testing = yes
+                    restore_image_after_testing = yes
                     Windows:
                         timeout = 600
                         autostress = yes

--- a/qemu/tests/cfg/win_heavyload.cfg
+++ b/qemu/tests/cfg/win_heavyload.cfg
@@ -2,6 +2,8 @@
     type = win_heavyload
     only Windows
     timeout = 600
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
     # If autostress eq yes case will autotest generate start command like,
     # heavyload /CPU n /FILE n /MEMORY n /DURATION timeout /START
     autostress = yes

--- a/qemu/tests/win_heavyload.py
+++ b/qemu/tests/win_heavyload.py
@@ -67,81 +67,71 @@ def run(test, params, env):
     start_cmd = params.get("start_cmd", start_cmd)
     check_running_cmd = "tasklist|findstr /I heavyload"
     check_running_cmd = params.get("check_running_cmd", check_running_cmd)
-    test_installed_cmd = "dir '%s'|findstr /I heavyload" % install_path
+    test_installed_cmd = 'dir "%s"|findstr /I heavyload' % install_path
     test_installed_cmd = params.get("check_installed_cmd", test_installed_cmd)
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     timeout = float(params.get("login_timeout", 240))
     session = vm.wait_for_login(timeout=timeout)
-    try:
-        installed = session.cmd_status(test_installed_cmd) == 0
-        if not installed:
-            download_url = params.get("download_url")
-            if download_url:
-                dst = r"c:\\"
-                pkg_md5sum = params["pkg_md5sum"]
-                error_context.context("Download HeavyLoadSetup.exe", logging.info)
-                pkg = utils.unmap_url_cache(tmp_dir,
-                                            download_url, pkg_md5sum)
-                vm.copy_files_to(pkg, dst)
-            else:
-                dst = r"%s:\\" % utils_misc.get_winutils_vol(session)
 
-            error_context.context("Install HeavyLoad in guest", logging.info)
-            install_cmd = params["install_cmd"]
-            install_cmd = re.sub(r"DRIVE:\\+", dst, install_cmd)
-            session.cmd(install_cmd)
-            config_cmd = params.get("config_cmd")
-            if config_cmd:
-                session.cmd(config_cmd)
-
-        error_context.context("Start heavyload in guest", logging.info)
-        # genery heavyload command automaticly
-        if params.get("autostress") == "yes":
-            free_mem = utils_misc.get_free_mem(session, "windows")
-            free_disk = utils_misc.get_free_disk(session, "C:")
-            start_cmd = '"%s\heavyload.exe"' % params["install_path"]
-            start_cmd = add_option(start_cmd, 'CPU', params["smp"])
-            start_cmd = add_option(start_cmd, 'MEMORY', free_mem)
-            start_cmd = add_option(start_cmd, 'FILE', free_disk)
+    installed = session.cmd_status(test_installed_cmd) == 0
+    if not installed:
+        download_url = params.get("download_url")
+        if download_url:
+            dst = r"c:\\"
+            pkg_md5sum = params["pkg_md5sum"]
+            error_context.context("Download HeavyLoadSetup.exe", logging.info)
+            pkg = utils.unmap_url_cache(tmp_dir,
+                                        download_url, pkg_md5sum)
+            vm.copy_files_to(pkg, dst)
         else:
-            start_cmd = params["start_cmd"]
-        # reformat command to ensure heavyload started as except
-        test_timeout = int(params.get("timeout", "60"))
-        steping = 60
-        if test_timeout < 60:
-            logging.warn("Heavyload use mins as unit of timeout, given timeout "
-                         "is too small (%ss), force set to 60s", test_timeout)
-            test_timeout = 60
-            steping = 30
-        start_cmd = add_option(start_cmd, 'DURATION', test_timeout / 60)
-        start_cmd = add_option(start_cmd, 'START', '')
-        start_cmd = add_option(start_cmd, 'AUTOEXIT', '')
-        logging.info("heavyload cmd: %s" % start_cmd)
-        session.sendline(start_cmd)
-        if not loop_session_cmd(session, check_running_cmd):
-            test.error("heavyload process is not started")
+            dst = r"%s:\\" % utils_misc.get_winutils_vol(session)
 
-        sleep_before_migration = int(params.get("sleep_before_migration",
-                                                "0"))
-        time.sleep(sleep_before_migration)
+        error_context.context("Install HeavyLoad in guest", logging.info)
+        install_cmd = params["install_cmd"]
+        install_cmd = re.sub(r"DRIVE:\\+", dst, install_cmd)
+        session.cmd(install_cmd)
+        config_cmd = params.get("config_cmd")
+        if config_cmd:
+            session.cmd(config_cmd)
 
-        error_context.context("Verify vm is alive", logging.info)
-        utils_misc.wait_for(vm.verify_alive,
-                            timeout=test_timeout, step=steping)
-    finally:
-        # in migration test, no need to stop heavyload on src host
-        cleanup_in_the_end = params.get("unload_stress_in_the_end", "yes")
-        if cleanup_in_the_end == "yes":
-            error_context.context("Stop load and clean tmp files", logging.info)
-            if not installed and download_url:
-                utils.system("rm -f %s/HeavyLoad*.exe" % tmp_dir)
-                session.cmd("del /f /s %sHeavyLoad*.exe" % dst)
-            if not session.cmd_status(check_running_cmd):
-                try:
-                    session.cmd(stop_cmd, timeout=120)
-                except:
-                    logging.warn("Unable to terminate heavyload process")
-        if session:
-            session.close()
+    error_context.context("Start heavyload in guest", logging.info)
+    # genery heavyload command automaticly
+    if params.get("autostress") == "yes":
+        free_mem = utils_misc.get_free_mem(session, "windows")
+        free_disk = utils_misc.get_free_disk(session, "C:")
+        start_cmd = '"%s\heavyload.exe"' % params["install_path"]
+        start_cmd = add_option(start_cmd, 'CPU', params["smp"])
+        start_cmd = add_option(start_cmd, 'MEMORY', free_mem)
+        start_cmd = add_option(start_cmd, 'FILE', free_disk)
+    else:
+        start_cmd = params["start_cmd"]
+    # reformat command to ensure heavyload started as except
+    test_timeout = int(params.get("timeout", "60"))
+    steping = 60
+    if test_timeout < 60:
+        logging.warn("Heavyload use mins as unit of timeout, given timeout "
+                     "is too small (%ss), force set to 60s", test_timeout)
+        test_timeout = 60
+        steping = 30
+    start_cmd = add_option(start_cmd, 'DURATION', test_timeout / 60)
+    start_cmd = add_option(start_cmd, 'START', '')
+    start_cmd = add_option(start_cmd, 'AUTOEXIT', '')
+    logging.info("heavyload cmd: %s" % start_cmd)
+    session.sendline(start_cmd)
+    if not loop_session_cmd(session, check_running_cmd):
+        test.error("heavyload process is not started")
+
+    sleep_before_migration = int(params.get("sleep_before_migration",
+                                            "0"))
+    time.sleep(sleep_before_migration)
+
+    error_context.context("Verify vm is alive", logging.info)
+    utils_misc.wait_for(vm.verify_alive,
+                        timeout=test_timeout * 1.2, step=steping)
+
+    if not session.cmd_status(check_running_cmd):
+        test.fail("heavyload doesn't exist normally")
+    if session:
+        session.close()


### PR DESCRIPTION
1. To avoid heavyload process damage guest image which will effect other
    testing, backup the image before testing and restore it after test finished.
2. After heavyload test finished, keep guest running for a while to make sure
    it work well.


id: 1437304
Signed-off-by: Yanan Fu <yfu@redhat.com>