### PR TITLE
pvpanic: add new cases related pvpanic

### DIFF
--- a/qemu/tests/cfg/pvpanic.cfg
+++ b/qemu/tests/cfg/pvpanic.cfg
@@ -1,0 +1,38 @@
+- pvpanic: install setup image_copy unattended_install.cdrom
+    virt_test_type = qemu
+    type = driver_in_use
+    run_bgstress = pvpanic
+    disable_shutdown = yes
+    monitor_type = qmp
+    event_check = "GUEST_PANICKED"
+    driver_name = "pvpanic"
+    suppress_exception = yes
+    crash_method = nmi
+    timeout = 360
+    wait_bg_time = 720
+    run_bg_flag = "before_bg_test" 
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
+    set_kdump_cmd = "systemctl disable kdump.service && systemctl stop kdump.service"
+    set_panic_cmd = "echo 1 > /proc/sys/kernel/unknown_nmi_panic"
+    RHEL.6:
+        set_kdump_cmd = "chkconfig kdump off && service kdump stop"
+    Windows:
+        no Host_RHEL.m6
+        set_panic_cmd = 'wmic class stdregprov call SetDwordValue hDefKey="&h80000002" sSubKeyName="SYSTEM\CurrentControlSet\Control\CrashControl" sValueName="NMICrashDump" uValue=1'
+    variants:
+        - with_stop_continue:
+            sub_test = stop_continue
+        - with_shutdown:
+            sub_test = shutdown
+            shutdown_method = shell
+        - with_reboot:
+            sub_test = boot
+            reboot_count = 1
+            reboot_method = shell
+        - with_system_reset:
+            sub_test = boot
+            reboot_method = system_reset
+            sleep_before_reset = 20
+        - with_live_migration:
+            sub_test = migration

--- a/qemu/tests/cfg/pvpanic_basic.cfg
+++ b/qemu/tests/cfg/pvpanic_basic.cfg
@@ -1,0 +1,19 @@
+- pvpanic_basic: install setup image_copy unattended_install.cdrom
+    virt_test_type = qemu
+    type = pvpanic
+    monitor_type = qmp
+    event_check = "GUEST_PANICKED"
+    driver_name = "pvpanic"
+    timeout = 360
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
+    set_kdump_cmd = "systemctl disable kdump.service && systemctl stop kdump.service"
+    set_panic_cmd = "echo 1 > /proc/sys/kernel/unknown_nmi_panic"
+    RHEL.6:
+        set_kdump_cmd = "chkconfig kdump off && service kdump stop"
+    Windows:
+        no Host_RHEL.m6
+        set_panic_cmd = 'wmic class stdregprov call SetDwordValue hDefKey="&h80000002" sSubKeyName="SYSTEM\CurrentControlSet\Control\CrashControl" sValueName="NMICrashDump" uValue=1'
+    variants:
+        - nmi:
+            crash_method = nmi

--- a/qemu/tests/pvpanic.py
+++ b/qemu/tests/pvpanic.py
@@ -1,0 +1,113 @@
+import logging
+import time
+
+from virttest import error_context
+from virttest import utils_test
+
+
+def setup_test_environment(test, params, vm, session):
+    """
+    Setup environment configuration modification.
+    Operation includds disable kdumpservice, configure
+    unknown_nmi_panic for linux, or modify the register value for
+    windows, in order to trigger crash.
+
+    :param test: test object
+    :param params: parameters
+    :vm: target vm
+    :session: session created by loggin the vm
+    """
+    timeout = int(params.get("timeout", 360))
+    if params.get("os_type") == "linux":
+        # stop kdump service and enable unknown_nmi_panic
+        setup_cmds = [params.get("set_kdump_cmd"),
+                      params.get("set_panic_cmd")]
+    else:
+        # modify the register for windows
+        setup_cmds = [params.get("set_panic_cmd")]
+    for cmd in setup_cmds:
+        status, output = session.cmd_status_output(cmd, timeout)
+        if status:
+            test.error("Command '%s' failed, status: %s, output: %s" %
+                       (cmd, status, output))
+    if params.get("os_type") == "windows":
+        vm.reboot(session, timeout=timeout)
+
+
+def check_qmp_events(vm, event_name, timeout=360):
+    """
+    Check whether certain qmp event appeared in vm.
+
+    :param vm: target virtual machine
+    :param event_name: target event name, such as 'GUEST_PANICKED'
+    :param timeout: check time
+    """
+
+    end_time = time.time() + timeout
+    logging.info("Try to get qmp events %s in %s seconds!" %
+                 (event_name, timeout))
+    while time.time() < end_time:
+        if vm.monitor.get_event(event_name):
+            logging.info("Receive qmp %s event notification", event_name)
+            vm.monitor.clear_event(event_name)
+            return True
+        time.sleep(5)
+    return False
+
+
+def trigger_crash(test, vm, params):
+    """
+    Trigger system crash with certain method
+
+    :param vm: target vm
+    :parma params: test params
+    """
+    # to do: will add other crash method
+    crash_method = params.get("crash_method")
+    if crash_method == "nmi":
+        vm.monitor.nmi()
+    else:
+        test.cancel("Crash trigger method %s not supported, "
+                    "please check cfg file for mistake.", crash_method)
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    pvpanic test
+
+    1) Log into the guest
+    2) Check if the driver is installed and verified (only for win)
+    3) Stop kdump service and modify unknown_nmi_panic(for linux)
+       or modify register value(for win)
+    4) Trigger a crash by nmi
+    5) Check the event in qmp
+
+    :param test: kvm test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    timeout = int(params.get("timeout", 360))
+    event_check = params.get("event_check", "GUEST_PANICKED")
+    error_context.context("Boot guest with pvpanic device", logging.info)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=timeout)
+    if params.get("os_type") == "windows":
+        error_context.context("Check if the driver is installed and "
+                              "verified", logging.info)
+        driver_name = params.get("driver_name", "pvpanic")
+        utils_test.qemu.windrv_verify_running(session, test, driver_name,
+                                              timeout)
+        utils_test.qemu.setup_win_driver_verifier(driver_name, vm, timeout)
+
+    error_context.context("Setup crash evironment for test", logging.info)
+    setup_test_environment(test, params, vm, session)
+    error_context.context("Trigger crash", logging.info)
+    trigger_crash(test, vm, params)
+
+    error_context.context("Check the panic event in qmp", logging.info)
+    if not check_qmp_events(vm, event_check, timeout):
+        test.fail("Did not receive qmp %s event notification"
+                  % event_check)


### PR DESCRIPTION
new cases related pvpanic:
1. check pvpanic event after trigger crash by nmi
2. do nmi crash after system_reset/reboot/shutdown/stop_cont
3. do nmi crash after migration

Signed-off-by: Yu Wang wyu@redhat.com

based on: avocado-framework/avocado-vt#1236

id:1457076  1508736 1509834 1508737