### PR TITLE
qemu_disk_img: Drop the temporary image from boot list

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -171,6 +171,7 @@
                         - to_new:
                             rebase_list = "snC > new"
                             images = "image1 new"
+                            boot_drive_new = no
                             force_create_image_new = "yes"
                             remove_image_new = "yes"
                             image_name_new = "images/new"


### PR DESCRIPTION
The temproray image new.qcow2 is used to test the scenario qemu-img
rebase, Should not be booted up. Since qemu 2.10, image locking is
enabled which make multiple QEMU processes cannot write to the same
image, even if boot snapshot and backing file at the same time are
not allowed.

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1509832