### PR TITLE
Install netkvm/viostor/vioscsi driver from floopy disk

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -7,9 +7,23 @@
     need_uninstall = no
     driver_install_timeout = 600
     tmp_folder = C:\tmp
+    nic_model_nic1 = rtl8139
     guest_alias = "Win7-32:w7\x86,Win7-64:w7\amd64,Win8-32:w8\x86,Win8-64:w8\amd64,Win8-32.1:w8.1\x86,Win8-64.1:w8.1\amd64,Win10-32:w10\x86,Win10-64:w10\amd64,Win2008-sp2-32:2k8\x86,Win2008-sp2-64:2k8\amd64,Win2008-r2-64:2k8R2\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12R2\amd64,Win2016-64:2k16\amd64"
+    guest_alias_fl = "Win7-32:i386\Win7,Win7-64:amd64\Win7,Win8-32:i386\Win8,Win8-64:amd64\Win8,Win8-32.1:i386\Win8.1,Win8-64.1:amd64\Win8.1,Win10-32:i386\Win10,Win10-64:amd64\Win10,Win2008-sp2-32:i386\Win2008,Win2008-sp2-64:amd64\Win2008,Win2008-r2-64:amd64\Win2008R2,Win2012-64:amd64\Win2012,Win2012-64r2:amd64\Win2012R2,Win2016-64:amd64\Win2016"
     driver_install_cmd = "python WIN_UTILS:\win_driver_install.py %s %s %s %s %s"
     show_file_ext_cmd = "reg add HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced /v HideFileExt /t REG_DWORD /d 0 /f"
+    vol_virtio_key = "VolumeName like '%virtio-win%'"
+    variants:
+        - @default:
+        - with_floopy:
+            run_with_floopy = yes
+            vol_virtio_key = "DeviceId like 'A:'"
+            floppy_readonly = yes
+            floppies = "floopy"
+            i386:
+                floppy_name = isos/windows/virtio-win.latest_prewhql.vfd.i386
+            x86_64:
+                floppy_name = isos/windows/virtio-win.latest_prewhql.vfd.x86_64
     variants:
         - with_netkvm:
             driver_name = netkvm
@@ -19,6 +33,7 @@
             nic_model_nic2 = rtl8139
             device_name = "Red Hat VirtIO Ethernet Adapter"
         - with_viorng:
+            no with_floopy
             driver_name = viorng
             device_name = "VirtIO RNG Device"
             no_virtio_rng:
@@ -61,11 +76,13 @@
             force_create_image_stg = yes
             remove_image_stg = yes
         - with_vioserial:
+            no with_floopy
             driver_name = vioser
             device_name = "VirtIO Serial Driver"
             virtio_ports = "vs"
             virtio_port_type = serialport
         - with_balloon:
+            no with_floopy
             driver_name = balloon
             device_name = "VirtIO Balloon Driver"
             balloon = balloon0

--- a/qemu/tests/single_driver_install.py
+++ b/qemu/tests/single_driver_install.py
@@ -87,11 +87,13 @@ def run(test, params, env):
         """
         guest_name = params["guest_name"]
         alias_map = params.get("guest_alias")
-        vol_virtio_key = "VolumeName like '%virtio-win%'"
+        vol_virtio_key = params.get("vol_virtio_key")
         vol_virtio = utils_misc.get_win_disk_vol(session, vol_virtio_key)
         logging.debug("vol_virtio is %s" % vol_virtio)
 
         if alias_map:
+            if params.get("run_with_floopy") == "yes":
+                alias_map = params.get("guest_alias_fl")
             guest_list = dict([x.split(":") for x in alias_map.split(",")])
             guest_name = guest_list[guest_name]
 
@@ -99,7 +101,11 @@ def run(test, params, env):
         # need udpate the path here.
         if driver_name == "vioser":
             driver_name = "vioserial"
-        driver_path = r"%s:\%s\%s" % (vol_virtio, driver_name, guest_name)
+        # For driver in virtio iso and floopy, the driver_path is not same
+        if vol_virtio == "A":
+            driver_path = r"%s:\%s" % (vol_virtio, guest_name)
+        else:
+            driver_path = r"%s:\%s\%s" % (vol_virtio, driver_name, guest_name)
         logging.debug("The driver which would be installed is %s" % driver_path)
 
         return driver_path


### PR DESCRIPTION
Attach a floopy disk to guest, and install the driver from it.

id: 1506891
Signed-off-by: peixiu <phou@redhat.com>