### PR TITLE
Disable ide in case "check_block_size.4096_4096"

### DIFF
--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -26,6 +26,7 @@
             only 4096_4096
     variants:
         - 4096_4096:
+            no ide
             need_install = no
             images += " stg"
             image_boot_stg = no


### PR DESCRIPTION
check_block_size.4096_4096:disable ide in this case,
for ide's logical_block_size must be 512.

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1509097