### PR TITLE
Reduce unattended import install to 3 minutes

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -144,7 +144,7 @@
             backup_image = no
             cdroms = ""
             floppy = ""
-            timeout = 180
+            install_timeout = 180
     variants:
         # Install guest from cdrom
         - cdrom:


### PR DESCRIPTION
The 'timeout' variable that was set had no effect, 'install_timeout' is
the one that should be used.