### PR TITLE
block_stream: Add monitor method check size for qemu2.10

### DIFF
--- a/qemu/tests/block_stream.py
+++ b/qemu/tests/block_stream.py
@@ -1,8 +1,9 @@
 import re
 import logging
 
-from autotest.client.shared import error, utils
+from avocado.utils import process
 
+from virttest import error_context
 from virttest import env_process, utils_misc
 
 from qemu.tests import blk_stream
@@ -11,16 +12,27 @@ from qemu.tests import blk_stream
 class BlockStreamTest(blk_stream.BlockStream):
 
     def get_image_size(self, image_file):
-        qemu_img = utils_misc.get_qemu_img_binary(self.params)
-        cmd = "%s info %s" % (qemu_img, image_file)
-        info = utils.system_output(cmd)
-        size = re.findall("(\d+) bytes", info)
+        try:
+            qemu_img = utils_misc.get_qemu_img_binary(self.params)
+            cmd = "%s info %s" % (qemu_img, image_file)
+            logging.info("Try to get image size via qemu-img info")
+            info = process.system_output(cmd)
+            size = int(re.findall("(\d+) bytes", info)[0])
+        except process.CmdError:
+            logging.info("qemu-img info failed(it happens because later qemu"
+                         " distributions prevent it access a running image.)."
+                         " Now get image size via qmp interface 'query-block'")
+            blocks_info = self.vm.monitor.info("block")
+            for block in blocks_info:
+                info = block["inserted"]
+                if image_file == info["file"]:
+                    size = info["image"]["virtual-size"]
         if size:
-            return int(size[0])
+            return size
         return 0
 
 
-@error.context_aware
+@error_context.context_aware
 def run(test, params, env):
     """
     Test block streaming functionality.
@@ -39,23 +51,23 @@ def run(test, params, env):
         stream_test.create_snapshots()
         backingfile = stream_test.get_backingfile()
         if not backingfile:
-            raise error.TestFail("Backing file is not available in the "
-                                 "backdrive image")
+            test.fail("Backing file is not available in the "
+                      "backdrive image")
         logging.info("Image file: %s" % stream_test.get_image_file())
         logging.info("Backing file: %s" % backingfile)
         stream_test.start()
         stream_test.wait_for_finished()
         backingfile = stream_test.get_backingfile()
         if backingfile:
-            raise error.TestFail("Backing file is still available in the "
-                                 "backdrive image")
+            test.fail("Backing file is still available in the "
+                      "backdrive image")
         target_file = stream_test.get_image_file()
         target_size = stream_test.get_image_size(target_file)
-        error.context("Compare image size", logging.info)
+        error_context.context("Compare image size", logging.info)
         if image_size < target_size:
-            raise error.TestFail("Compare %s image, size of %s increased"
-                                 "(%s -> %s)" % (image_file, target_file,
-                                                 image_size, target_size))
+            test.fail("Compare %s image, size of %s increased"
+                      "(%s -> %s)" % (image_file, target_file,
+                                      image_size, target_size))
         stream_test.verify_alive()
         stream_test.vm.destroy()
         vm_name = params["main_vm"]


### PR DESCRIPTION
qemu2.10 starts to prevent qemu-img access an operating image,
therefore it will prompt CmdError when check image size by qemu-img.
So check size via qmp monitor if catch such error.

id: 1510732
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>