### PR TITLE
Optimize function "get_match_cdrom" not to log mislead info

### DIFF
--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -366,7 +366,7 @@ def run(test, params, env):
         if serial_num_output:
             serial_cdrom = ""
             for line in serial_num_output.splitlines():
-                if utils_misc.find_substring(str(line), str(serial_num)):
+                if serial_num in line:
                     serial_cdrom = line.split(" ")[-1].split("/")[-1]
                     break
             if not serial_cdrom:


### PR DESCRIPTION
utils_misc.find_substring will logged every mismatch info. When
we call it in "get_match_cdrom", the mismatched info will be logged
until the matched cdrom found. This will cause misleading. So replace
it directly by re.

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1511747