### PR TITLE
usb.cfg: Add qemu-xhci support

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -39,11 +39,19 @@
             usb_max_port_usbtest = 6
             drive_format_stg = "usb2"
         - nec-xhci:
-            no RHEL.3
-            no RHEL.4
             no RHEL.5
             no Host_RHEL.m6
             usb_type_usbtest = nec-usb-xhci
+            usb_controller = xhci
+            usb_max_port_usbtest = 4
+            drive_format_stg = "usb3"
+            Host_RHEL:
+                no Win2000, WinXP, Win2003, WinVista, Win7, Win2008
+        - qemu-xhci:
+            no RHEL.5
+            no Host_RHEL.m6, Host_RHEL.m7.u0, Host_RHEL.m7.u1
+            no Host_RHEL.m7.u2, Host_RHEL.m7.u3
+            usb_type_usbtest = qemu-xhci
             usb_controller = xhci
             usb_max_port_usbtest = 4
             drive_format_stg = "usb3"

--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -55,11 +55,18 @@
             usb_controller = ehci
             usb_max_port_usbtest = 6
         - nec-xhci:
-            no RHEL.3
-            no RHEL.4
             no RHEL.5
             no Host_RHEL.m6
             usb_type_usbtest = nec-usb-xhci
+            usb_controller = xhci
+            usb_max_port_usbtest = 4
+            Host_RHEL:
+                no Win2000, WinXP, Win2003, WinVista, Win7, Win2008
+        - qemu-xhci:
+            no RHEL.5
+            no Host_RHEL.m6, Host_RHEL.m7.u0, Host_RHEL.m7.u1
+            no Host_RHEL.m7.u2, Host_RHEL.m7.u3
+            usb_type_usbtest = qemu-xhci
             usb_controller = xhci
             usb_max_port_usbtest = 4
             Host_RHEL:

--- a/qemu/tests/usb_common.py
+++ b/qemu/tests/usb_common.py
@@ -115,7 +115,7 @@ def verify_usb_device_in_guest(params, session, devs):
         # each dev must in the output
         for dev in devs:
             if dev[1] not in output:
-                logging.info("%s does not exist")
+                logging.info("%s does not exist" % dev[1])
                 return False
         # match number of devices
         dev_list = [dev[1] for dev in devs]


### PR DESCRIPTION
Added qemu-xhci on usb.cfg and usb_device_check.cfg.
Fixed a logging bug.

id: 1509825
Signed-off-by: Haotong Chen <hachen@redhat.com>