### PR TITLE
Make the pci_devices test to work again

### DIFF
--- a/qemu/tests/cfg/pci_devices.cfg
+++ b/qemu/tests/cfg/pci_devices.cfg
@@ -2,6 +2,7 @@
     type = pci_devices
     start_vm = no
     pci_controllers = ''
+    pci_controllers_autosort = "no"
     Linux:
         lspci_cmd = 'lspci -nn -m'
     variants:

--- a/qemu/tests/pci_devices.py
+++ b/qemu/tests/pci_devices.py
@@ -216,7 +216,7 @@ def add_device_usb(params, name_idxs, parent_bus, addr, device):
     params['usb_type_%s' % name] = device[1]
     if not params.get('reserved_slots_%s' % parent_bus):
         params['reserved_slots_%s' % parent_bus] = ""
-    params['reserved_slots_%s' % parent_bus] += " %02x-00" % addr
+    params['reserved_slots_%s' % parent_bus] += " 0x%x-0x0" % addr
     logging.debug("Add test device %s %s %s addr:%s", name, device[1],
                   parent_bus, addr)
     return params, name_idxs
@@ -263,7 +263,7 @@ def add_virtio_disk(params, name_idxs, parent_bus, addr):
     params['image_size_%s' % name] = '1M'
     if not params.get('reserved_slots_%s' % parent_bus):
         params['reserved_slots_%s' % parent_bus] = ""
-    params['reserved_slots_%s' % parent_bus] += " %02x-00" % addr
+    params['reserved_slots_%s' % parent_bus] += " 0x%x-0x0" % addr
     logging.debug("Add test device %s virtio_disk %s addr:%s", name,
                   parent_bus, addr)
     return params, name_idxs

--- a/qemu/tests/pci_devices.py
+++ b/qemu/tests/pci_devices.py
@@ -356,8 +356,8 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
 
     # PCI devices are initialized by firmware, which might require some time
-    # to setup. Wait 10s before getting the qtree.
-    time.sleep(10)
+    # to setup. Wait 5s before getting the qtree.
+    time.sleep(5)
     qtree = qemu_qtree.QtreeContainer()
 
     error.context("Verify qtree vs. qemu devices", logging.info)

--- a/qemu/tests/pci_devices.py
+++ b/qemu/tests/pci_devices.py
@@ -324,7 +324,7 @@ def run(test, params, env):
                     out += "->(test_devices)"
                     break
                 idx = names.get(device, 0) + 1
-                name = "pci_%s%d" % (device, idx)
+                name = "test_pci_%s%d" % (device, idx)
                 names[device] = idx
                 params, bus = add_bus(qdev, params, device, name, _lasts[_idx])
                 # we inserted a device, increase the upper bus first idx

--- a/qemu/tests/pci_devices.py
+++ b/qemu/tests/pci_devices.py
@@ -296,6 +296,8 @@ def run(test, params, env):
     env_process.preprocess_vm(test, params, env, params["main_vm"])
     vm = env.get_vm(params["main_vm"])
     qdev = vm.make_create_command()    # parse params into qdev
+    if isinstance(qdev, tuple):
+        qdev = qdev[0]
 
     error.context("Getting main PCI bus info")
 


### PR DESCRIPTION
The pci controllers handling changed significantly and the pci_devices test does not work anymore. This PR addresses all the issues needed for this test to run properly on Fedora.

Note: This test requires https://github.com/avocado-framework/avocado-vt/pull/1221 to work properly (it works without it, but one issue is not addressed)