### PR TITLE
multi_nics_stress.cfg: terminate the dhclient processs before runing next one

### DIFF
--- a/qemu/tests/cfg/multi_nics_stress.cfg
+++ b/qemu/tests/cfg/multi_nics_stress.cfg
@@ -23,4 +23,4 @@
         client_path_win = "c:\\"
         test_protocols = "TCP_STREAM TCP_MAERTS UDP_STREAM TCP_RR TCP_CRR UDP_RR"
     Linux:
-        dhcp_cmd = "for nic in `ls /sys/class/net|grep -v lo`;do arp -a|grep -v $nic && dhclient -v $nic;done"
+        dhcp_cmd = "for nic in `ls /sys/class/net|grep -v lo`;do arp -a|grep -v $nic && dhclient -r $nic && dhclient -v $nic;done"


### PR DESCRIPTION
ID: 1512404
In the previous shell command, the "dhclient process" will not be run
successfully, because there is already a active dhclient process. The
updated shell command will terminate the previous one before runing
next.

Signed-off-by: Zhengtong Liu <zhengtli@redhat.com>