### PR TITLE
device_option_check.blk_serial_check: change the disk letter of winutils disk

### DIFF
--- a/qemu/tests/cfg/device_option_check.cfg
+++ b/qemu/tests/cfg/device_option_check.cfg
@@ -64,7 +64,7 @@
             cmd = ls /dev/disk/by-id
             pattern = %s
             Windows:
-                cmd = D:\hddsn.exe C:
+                cmd = WINUTILS:\hddsn.exe C:
                 pattern = %s
             check_in_qtree = yes
             qtree_check_keyword = id


### PR DESCRIPTION
When the winutils disk letter happen to change in guest,
the "cmd = D:\hddsn.exe C:"  cannot be executed successfully.
Here changed it to "cmd = WIN_UTILS:\hddsn.exe C:",
and used the set_winutils_letter() to set the correct disk letter.

id:1511391

Signed-off-by: peixiu <phou@redhat.com>