### PR TITLE
drive_mirror: Add "force_share=True" for "qemu_img.compare_images"

### DIFF
--- a/qemu/tests/drive_mirror_complete.py
+++ b/qemu/tests/drive_mirror_complete.py
@@ -39,7 +39,7 @@ def run(test, params, env):
         if device_id != mirror_test.device:
             raise error.TestError("Mirrored image not being used by guest")
         error.context("Compare fully mirrored images", logging.info)
-        qemu_img.compare_images(source_image, target_image)
+        qemu_img.compare_images(source_image, target_image, force_share=True)
         mirror_test.vm.resume()
         if params.get("boot_target_image", "no") == "yes":
             mirror_test.vm.destroy()


### PR DESCRIPTION
To enable "-U" option for "qemu-img compare", avoid access error.
Depends on https://github.com/avocado-framework/avocado-vt/pull/1228

id: 1513863
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>