### PR TITLE
Add data-plane as a matrix for all block jobs

### DIFF
--- a/qemu/tests/cfg/block_commit.cfg
+++ b/qemu/tests/cfg/block_commit.cfg
@@ -19,6 +19,18 @@
     top_image = "images/sn3"
     expected_image_file = "images/sn1"
     variants:
+        - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
         - with_payload:
             type = block_commit_stress
             variants:

--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -22,6 +22,18 @@
     alive_check_cmd = dir
     tmp_dir = /tmp
     variants:
+        - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
         - simple_test:
             type = block_stream_simple
             variants:
@@ -89,15 +101,6 @@
             after_finished = "unload_stress reboot verify_alive"
             variants:
                 - @default:
-                - data_plane:
-                    only Host_RHEL.m7
-                    only virtio_blk virtio_scsi
-                    iothreads = iothread0
-                    virtio_blk:
-                        blk_extra_params_image1 = "iothread=${iothreads}"
-                    virtio_scsi:
-                        no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
-                        bus_extra_params_image1 = "iothread=${iothreads}"
                 - cancel_async:
                     wait_finished = no
                     cancel_timeout_image1 = 3

--- a/qemu/tests/cfg/block_stream_negative.cfg
+++ b/qemu/tests/cfg/block_stream_negative.cfg
@@ -17,6 +17,18 @@
     alive_check_cmd = dir
     tmp_dir = /tmp
     variants:
+        - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
         - simple_test:
             type = block_stream_negative
             variants:

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -35,6 +35,18 @@
     cancel_timeout = 5
     #For drive_mirror_complete, target image will not be boot by default, as boot_target_image=no
     variants:
+        - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
         - 2qcow2:
             image_format_target = "qcow2"
         - 2raw:

--- a/qemu/tests/cfg/drive_mirror_negative_tests.cfg
+++ b/qemu/tests/cfg/drive_mirror_negative_tests.cfg
@@ -33,6 +33,18 @@
     cancel_timeout = 5
     negative_test = yes
     variants:
+        - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
         - 2qcow2:
             image_format_target = "qcow2"
         - 2raw:

--- a/qemu/tests/cfg/live_backup.cfg
+++ b/qemu/tests/cfg/live_backup.cfg
@@ -20,6 +20,18 @@
     check_params = ""
     variants:
         - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
+        - @default:
             before_full_backup = "create_files reboot stop"
             after_incremental += " verify_md5s verify_efficiency"
             Linux:
@@ -38,12 +50,3 @@
                     granularity = 32768
                 - 131072:
                     granularity = 131072
-        - with_data_plane:
-            only Host_RHEL.m7
-            only virtio_blk virtio_scsi
-            iothreads = iothread0
-            virtio_blk:
-                blk_extra_params_image1 = "iothread=iothread0"
-            virtio_scsi:
-                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
-                bus_extra_params_image1 = "iothread=iothread0"

--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -14,6 +14,18 @@
     file_create = /var/tmp/file
     clean_cmd = rm -f
     variants:
+        - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
         - simple_test:
             type = live_snapshot_simple
             variants:
@@ -104,3 +116,10 @@
             force_create_image = yes
             force_create_image_image1 = no
             after_finished = "reboot verify_alive"
+            with_data_plane:
+                virtio_blk:
+                    blk_extra_params_sn1 = "iothread=iothread0"
+                    blk_extra_params_sn2 = "iothread=iothread1"
+                virtio_scsi:
+                    bus_extra_params_sn1 = "iothread=iothread0"
+                    bus_extra_params_sn2 = "iothread=iothread1"

--- a/qemu/tests/cfg/live_snapshot_chain.cfg
+++ b/qemu/tests/cfg/live_snapshot_chain.cfg
@@ -17,6 +17,18 @@
     pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
     post_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
     variants:
+        - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
         - pause:
             file_create =
             pre_snapshot_cmd = {monitor:stop}

--- a/qemu/tests/cfg/live_snapshot_negative.cfg
+++ b/qemu/tests/cfg/live_snapshot_negative.cfg
@@ -12,6 +12,18 @@
     file_create = /var/tmp/file
     clean_cmd = rm -f
     variants:
+        - @default:
+        - with_data_plane:
+            only Host_RHEL.m7
+            only virtio_blk virtio_scsi
+            #Add a redundant iothread for testing purpose
+            iothreads = "iothread0 iothread1"
+            virtio_blk:
+                blk_extra_params_image1 = "iothread=iothread0"
+            virtio_scsi:
+                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
+                bus_extra_params_image1 = "iothread=iothread0"
+    variants:
         - simple_test:
             type = live_snapshot_negative
             variants:


### PR DESCRIPTION
According to the test plan changed, add data-plane as a default matrix for all storage vm migration feature test.

id:  1516182
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>