### PR TITLE
smbios_table: Update function call as the definition be changed

### DIFF
--- a/qemu/tests/boot_with_machine_types.py
+++ b/qemu/tests/boot_with_machine_types.py
@@ -22,7 +22,7 @@ def run(test, params, env):
     machine_types = []
     machine_type_mapping = {"pc": ["i440FX", "RHEL 6"], "q35": ["Q35"], "pseries": ["pSeries"],
                             "arm64-pci:virt": ["ARM"], "arm64-mmio:virt": ["ARM"], "s390-ccw-virtio": ["S390"]}
-    for m_type, s_name in zip(*utils_misc.get_support_machine_type(qemu_binary)):
+    for m_type, s_name in zip(*utils_misc.get_support_machine_type(qemu_binary)[:2]):
         for item in machine_type_mapping[params["machine_type"]]:
             if item in s_name:
                 if "arm64" in params["machine_type"]:

--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -54,7 +54,7 @@ def run(test, params, env):
         support_machine_types.append(params.get("machine_type"))
     else:
         qemu_binary = utils_misc.get_qemu_binary(params)
-        tmp = utils_misc.get_support_machine_type(qemu_binary)
+        tmp = utils_misc.get_support_machine_type(qemu_binary, remove_alias=True)[:2]
         (support_machine_types, expect_system_versions) = tmp
         machine_type = params.get("machine_type", "")
         if ':' in machine_type:


### PR DESCRIPTION
1. The return value of utils_misc.get_support_machine_type has changed,update
   function call to match it.
2. Add "remove_alias = True" for smbios_table.
Depends on: https://github.com/avocado-framework/avocado-vt/pull/1218

id: 1510766
Signed-off-by: Yanan Fu <yfu@redhat.com>