### PR TITLE
Couple of fixes to make "valgrind_memalign" work

### DIFF
--- a/qemu/tests/cfg/valgrind_memalign.cfg
+++ b/qemu/tests/cfg/valgrind_memalign.cfg
@@ -9,6 +9,10 @@
     start_vm = no
     Ubuntu:
         valgrind_install_cmd = "apt-get install -y valgrind"
+    s390x:
+        # s390 firmware quits when no-bootable devices (unlike x86)
+        extra_params += " -no-shutdown"
+        expected_status = "paused (shutdown)"
     images = ""
     nics = ""
     serials = ""

--- a/qemu/tests/cfg/valgrind_memalign.cfg
+++ b/qemu/tests/cfg/valgrind_memalign.cfg
@@ -10,6 +10,8 @@
     Ubuntu:
         valgrind_install_cmd = "apt-get install -y valgrind"
     s390x:
+        # -cpu can't be set in TCG
+        cpu_model = ""
         # s390 firmware quits when no-bootable devices (unlike x86)
         extra_params += " -no-shutdown"
         expected_status = "paused (shutdown)"

--- a/qemu/tests/valgrind_memalign.py
+++ b/qemu/tests/valgrind_memalign.py
@@ -51,5 +51,6 @@ def run(test, params, env):
 
     error.context("Quit guest and check the process quit normally",
                   logging.info)
-    vm.destroy(gracefully=False)
+    vm.monitor.quit()
+    vm.wait_until_dead(5, 0.5, 0.5)
     vm.verify_userspace_crash()

--- a/qemu/tests/valgrind_memalign.py
+++ b/qemu/tests/valgrind_memalign.py
@@ -47,7 +47,7 @@ def run(test, params, env):
 
     time.sleep(interval)
     error.context("Verify guest status is running after cont", logging.info)
-    vm.verify_status("running")
+    vm.verify_status(params.get("expected_status", "running"))
 
     error.context("Quit guest and check the process quit normally",
                   logging.info)


### PR DESCRIPTION
This test depends on broken environment, where "vm.process" was not closed on "vm.shutdown". Let's fix that and tweak it to work properly on s390x.