### PR TITLE
Bunch of (not only) s390x fixes [v2]

### DIFF
--- a/qemu/tests/balloon_hotplug.py
+++ b/qemu/tests/balloon_hotplug.py
@@ -44,12 +44,13 @@ def run(test, params, env):
     err = ""
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
+    balloon_device = params.get("ballon_device", "virtio-balloon-pci")
 
     error_context.context("Hotplug and unplug balloon device in a loop",
                           logging.info)
     for i in xrange(int(params.get("balloon_repeats", 3))):
         vm.devices.set_dirty()
-        new_dev = qdevices.QDevice("virtio-balloon-pci",
+        new_dev = qdevices.QDevice(balloon_device,
                                    {'id': 'balloon%d' % idx},
                                    parent_bus={'aobject': 'pci.0'})
 

--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -264,9 +264,21 @@ class BlockCopy(object):
         blocks = self.vm.monitor.info("block")
         try:
             if isinstance(blocks, str):
+                # ide0-hd0: removable=1 locked=0 file=/tmp/test.img
                 image_regex = '%s.*\s+file=(\S*)' % self.device
                 image_file = re.findall(image_regex, blocks)
-                return image_file[0]
+                if image_file:
+                    return image_file[0]
+                # ide0-hd0 (#block184): a b c
+                # or
+                # ide0-hd0 (#block184): a b c (raw)
+                image_file = re.findall("%s[^:]+: ([^(]+)\(?" % self.device,
+                                        blocks)
+                if image_file:
+                    if image_file[0][-1] == ' ':
+                        return image_file[0][:-1]
+                    else:
+                        return image_file[0]
 
             for block in blocks:
                 if block['device'] == self.device:

--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -73,7 +73,7 @@
             balloon_type_evict = evict
             balloon_type_enlarge = enlarge
         - balloon_fix_value:
-            no ppc64 aarch64
+            only i386, x86_64
             only balloon_base
             test_tags = "evict_to_0.5 enlarge_to_0.75 evict_to_0.8"
             balloon_type_enlarge_to_0.75 = enlarge

--- a/qemu/tests/cfg/balloon_hotplug.cfg
+++ b/qemu/tests/cfg/balloon_hotplug.cfg
@@ -16,6 +16,9 @@
     test_tags = "evict enlarge"
     balloon_type_evict = evict
     balloon_type_enlarge = enlarge
+    balloon_device = virtio-balloon-pci
+    s390x:
+        balloon_device = virtio-balloon-ccw
     variants:
         - @default:
             balloon_repeats = 100

--- a/qemu/tests/cfg/floppy_test.cfg
+++ b/qemu/tests/cfg/floppy_test.cfg
@@ -1,7 +1,6 @@
 - floppy_test: install setup image_copy unattended_install.cdrom
     type = floppy
-    no pseries
-    no q35
+    only i440fx
     start_vm = no
     floppies = "fl"
     guest_floppy_path = "/dev/fd0"

--- a/qemu/tests/cfg/live_backup.cfg
+++ b/qemu/tests/cfg/live_backup.cfg
@@ -24,7 +24,7 @@
             after_incremental += " verify_md5s verify_efficiency"
             Linux:
                 create_cmd = "dd if=/dev/urandom of=FILE bs=128k count=100"
-                file_names = "/home/test"
+                file_names = "/home/test.img"
                 test_exists_cmd = "test -f FILE"
             Windows:
                 create_cmd = "D:\coreutils\DummyCMD.exe FILE 1073741824 1"

--- a/qemu/tests/cfg/live_snapshot_chain.cfg
+++ b/qemu/tests/cfg/live_snapshot_chain.cfg
@@ -38,6 +38,8 @@
         - long_chain:
             need_reboot = yes
             file_create = yes
+            # Check base, middle and last (set in code) images
             check_base_image_image1 = yes
+            check_base_image_sn32 = yes
             snapshot_chain = "image1"
             snapshot_num = 64

--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -48,6 +48,7 @@
         - all_drive_format_types:
             # virtio-scsi driver support from RHEL6.3
             no RHEL.3 RHEL.4 RHEL.5 RHEL.6.0 RHEL.6.1 RHEL.6.2
+            no s390x
             stg_image_num = 4
             stg_image_size = 100M
             stg_params = "drive_format:ide,scsi,virtio,scsi-hd,usb2"

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -9,7 +9,7 @@
     run_dhclient = no
     variants:
         - nic_8139:
-            no ppc64 ppc64le 
+            no ppc64, ppc64le, s390x
             pci_model = rtl8139
             match_string = "8139"
         - nic_virtio:
@@ -21,7 +21,7 @@
             s390x:
                 pci_model = virtio-net-ccw
         - nic_e1000:
-            no ppc64 ppc64le
+            no ppc64, ppc64le, s390x
             pci_model = e1000
             match_string = "Gigabit Ethernet Controller"
     variants:

--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -134,8 +134,8 @@
         - isa_serial:
             # Windows guests don't support isa serial, disable it directly.
             no Windows
-            # ppc64 and ppc64le platform doesn't support isa serial
-            no ppc64 ppc64le
+            # isa-serial is only supported on x86
+            only i386, x86_64
             gagent_serial_type = isa
             serials += " org.qemu.guest_agent.0"
             gagent_start_cmd = "pgrep qemu-ga || qemu-ga -d -m isa-serial -p /dev/ttyS1"

--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -1,6 +1,6 @@
 - seabios: install setup image_copy unattended_install.cdrom
     no Host_RHEL.m5
-    no ppc64 ppc64le aarch64
+    only i386, x86_64
     type = seabios
     start_vm = no
     restart_vm = no

--- a/qemu/tests/cfg/spice.cfg
+++ b/qemu/tests/cfg/spice.cfg
@@ -13,11 +13,11 @@
     virtio_port_name_prefix_virt-tests-vm1 = "com.redhat.spice."
   
     variants:
-        -RHEL.6.devel.x86_64:
+        - RHEL-6-devel-x86_64:
             image_name_vm2 = images/rhel6devel-64_client
-        -RHEL.6.devel.i386:
+        - RHEL-6-devel-i386:
             image_name_vm2 = images/rhel6devel-32_client
-        -RHEL.7.devel.x86_64:
+        - RHEL-7-devel-x86_64:
             image_name_vm2 = images/rhel7devel-64_client
     variants:
         - fullscreen_setup:

--- a/qemu/tests/cfg/unittest_kvmctl.cfg
+++ b/qemu/tests/cfg/unittest_kvmctl.cfg
@@ -1,5 +1,6 @@
 - unit_test_kvmctl:
     no JeOS
+    only i386, x86_64
     type = unittest_kvmctl
     vms = ''
     profilers = ''

--- a/qemu/tests/cfg/virtio_scsi_mq.cfg
+++ b/qemu/tests/cfg/virtio_scsi_mq.cfg
@@ -9,5 +9,5 @@
     start_vm = no
     image_size_extra_images = 512M
     q35:
-        system_image_drive_format = ahci
         dev_type = q35-pcihost
+    system_image_drive_format = virtio_blk

--- a/qemu/tests/cfg/virtio_scsi_mq.cfg
+++ b/qemu/tests/cfg/virtio_scsi_mq.cfg
@@ -8,6 +8,4 @@
     login_timeout = 240
     start_vm = no
     image_size_extra_images = 512M
-    q35:
-        dev_type = q35-pcihost
     system_image_drive_format = virtio_blk

--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -1665,7 +1665,7 @@ def run(test, params, env):
                 try:
                     out = process.system_output("cat /proc/%s/task/*/stat" %
                                                 pid)
-                except exceptions.CmdError:
+                except process.CmdError:
                     out = None
                 else:
                     break

--- a/qemu/tests/time_manage.py
+++ b/qemu/tests/time_manage.py
@@ -54,7 +54,7 @@ def run(test, params, env):
     curr_time = []
     timedrift = []
     totaldrift = []
-    vmnames = ["virt-tests-vm1"]
+    vmnames = [params["main_vm"]]
 
     # Run some load on the host
     logging.info("Starting load on host.")
@@ -86,8 +86,7 @@ def run(test, params, env):
         while itr <= int(params["max_itrs"]):
             for vmid, se in enumerate(sessions):
                 # Get the respective vm object
-                vmname = "virt-tests-vm%d" % (vmid + 1)
-                vm = env.get_vm(vmname)
+                vm = env.get_vm(vmnames[vmid])
                 # Run current iteration
                 logging.info(
                     "Rebooting:vm%d iteration %d " % ((vmid + 1), itr))

--- a/qemu/tests/virtio_scsi_mq.py
+++ b/qemu/tests/virtio_scsi_mq.py
@@ -65,7 +65,8 @@ def run(test, params, env):
     images_num = int(num_queues)
     extra_image_size = params.get("image_size_extra_images", "512M")
     system_image = params.get("images")
-    system_image_drive_format = params.get("system_image_drive_format", "ide")
+    system_image_drive_format = params.get("system_image_drive_format",
+                                           "virtio_blk")
     params["drive_format_%s" % system_image] = system_image_drive_format
 
     error.context("Boot up guest with block devcie with num_queues"


### PR DESCRIPTION
This is a follow-up of the https://github.com/autotest/tp-qemu/pull/1163 which got some acks and some nacks.

Changes:
* block_copy: Improve block regexp to work with recent qemu -> improved regexp to support spaces in filename
* Make sure images are removed in live_snapshot_chain -> reworked to not hide exceptions from test execution
* Turn the iscsi target into example only -> instead of commenting-out keep it and change the values to obviously dummy ones along with note to change it downstream
* Adjust config of nic_hotplug to work properly on s390x -> removed the double-fix

All but the changed commits were already acked by @luckyh so waiting for 2nd ack there and full 2 acks are required for the 4 patches mentioned above.