### PR TITLE
Bunch of (not only) s390x fixes [v3]

### DIFF
--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -76,9 +76,10 @@
         - boot_from_iscsi_device:
             start_vm = no
             dev_name = iscsi-dev
-            portal_ip = 10.66.90.100
-            initiator = "iqn.2010-07.com.redhat:kvmautotest"
-            target = "iqn.2001-05.com.equallogic:0-8a0906-db31f7d03-470263b05654c204-kvm-puyiqiao"
+            # Please update these to point to your iscsi server
+            portal_ip = 127.0.0.1
+            initiator = "iqn.2010-07.com.example:my_initiator"
+            target = "iqn.2001-05.com.mytarget:0-0a0000-000000000-0000000000000000-my-target"
             images = "stg"
             image_name_stg = "/dev/sdb"
             image_format_stg = ""

--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -287,7 +287,7 @@ def run(test, params, env):
                     out[i] = out[i][1:-1]
                 for _ in re.findall(re_dd, out[i])[1:-1]:
                     data += int(_[0])
-                    duration += float(_[1])
+                    duration += float(_[2])
                 out[i] = int(data / duration)
 
             # normalize each output according to cgroup_weights
@@ -359,8 +359,8 @@ def run(test, params, env):
         # ; true is necessarily when there is no dd present at the time
         kill_cmd = "rm -f /tmp/cgroup_lock; killall -9 dd; true"
         stat_cmd = "killall -SIGUSR1 dd; true"
-        re_dd = (r'(\d+) bytes \(\d+\.*\d* \w*\) copied, (\d+\.*\d*) s, '
-                 '\d+\.*\d* \w./s')
+        re_dd = (r'(\d+) bytes \(\d+\.*\d* \w*(, \d+\.*\d* \w*)?\) copied, '
+                 '(\d+\.*\d*) s, \d+\.*\d* \w./s')
         err = ""
         try:
             logging.info("Read test")
@@ -501,7 +501,7 @@ def run(test, params, env):
                     data = 0
                     for _ in re.findall(re_dd, out[i][j]):
                         data += int(_[0])
-                        duration += float(_[1])
+                        duration += float(_[2])
                     output.append(['PASS', j, 'vm%d' % i, speeds[i][j],
                                    int(data / duration)])
                     # Don't measure unlimited speeds
@@ -604,8 +604,8 @@ def run(test, params, env):
         # ; true is necessarily when there is no dd present at the time
         kill_cmd = "rm -f /tmp/cgroup_lock; killall -9 dd; true"
         stat_cmd = "killall -SIGUSR1 dd; true"
-        re_dd = (r'(\d+) bytes \(\d+\.*\d* \w*\) copied, (\d+\.*\d*) s, '
-                 '\d+\.*\d* \w./s')
+        re_dd = (r'(\d+) bytes \(\d+\.*\d* \w*(, \d+\.*\d* \w*)?\) copied, '
+                 '(\d+\.*\d*) s, \d+\.*\d* \w./s')
         err = ""
         try:
             logging.info("Read test")


### PR DESCRIPTION
The rest of the fixes from the big https://github.com/autotest/tp-qemu/pull/1170. The changes are:

* `Make sure images are removed in live_snapshot_chain` - reworked, 2 acks needed
* `Fix the usage of process in cgroup test` - separated the unrelated fixes, 2 acks needed
* `Improve "dd" regexp to cope with newer versions in cgroup test` - the separated part of the previous commit, 2 acks needed
* `Turn the iscsi target into example only` - Added missing `"`, acked by @clebergnu