### PR TITLE
generic.ioquit: fix cluster leak issue

### DIFF
--- a/generic/tests/cfg/ioquit.cfg
+++ b/generic/tests/cfg/ioquit.cfg
@@ -2,6 +2,9 @@
     virt_test_type = qemu libvirt
     only Linux
     type = ioquit
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
     background_cmd = "for i in 1 2 3 4; do (dd if=/dev/urandom of=/tmp/file bs=102400 count=10000000 &); done"
     check_cmd = ps -a | grep dd
     login_timeout = 360
+    image_restore_cmd = "qemu-img check -r leaks %s"

--- a/generic/tests/ioquit.py
+++ b/generic/tests/ioquit.py
@@ -2,10 +2,13 @@ import logging
 import time
 import random
 
-from autotest.client.shared import error
+from virttest import qemu_storage
+from virttest import data_dir
+from virttest import error_context
+from avocado.utils import process
 
 
-@error.context_aware
+@error_context.context_aware
 def run(test, params, env):
     """
     Emulate the poweroff under IO workload(dd so far) with signal SIGKILL.
@@ -14,6 +17,7 @@ def run(test, params, env):
     2) Add IO workload for guest OS
     3) Sleep for a random time
     4) Kill the VM
+    5) Check the image to verify if errors are found except some cluster leaks
 
     :param test: Kvm test object
     :param params: Dictionary with the test parameters.
@@ -26,16 +30,32 @@ def run(test, params, env):
     session2 = vm.wait_for_login(timeout=login_timeout)
 
     bg_cmd = params.get("background_cmd")
-    error.context("Add IO workload for guest OS.", logging.info)
+    error_context.context("Add IO workload for guest OS.", logging.info)
     session.cmd_output(bg_cmd, timeout=60)
 
-    error.context("Verify the background process is running")
+    error_context.context("Verify the background process is running")
     check_cmd = params.get("check_cmd")
     session2.cmd(check_cmd, timeout=360)
 
-    error.context("Sleep for a random time", logging.info)
+    error_context.context("Sleep for a random time", logging.info)
     time.sleep(random.randrange(30, 100))
     session2.cmd(check_cmd, timeout=360)
 
-    error.context("Kill the VM", logging.info)
+    error_context.context("Kill the VM", logging.info)
     vm.process.close()
+
+    error_context.context("Check img after kill VM", logging.info)
+    base_dir = data_dir.get_data_dir()
+    image_name = params.get("image_name")
+    image = qemu_storage.QemuImg(params, base_dir, image_name)
+    try:
+        image.check_image(params, base_dir)
+    except Exception as e:
+        if "Leaked clusters" not in e.message:
+            raise
+        error_context.context("Detected cluster leaks, try to repair it",
+                              logging.info)
+        restore_cmd = params.get("image_restore_cmd") % image.image_filename
+        cmd_status = process.system(restore_cmd)
+        if cmd_status:
+            test.fail("Failed to repair cluster leaks on the image")


### PR DESCRIPTION
Replace "vm.process.close()" by "vm.destroy()"

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1522616