### PR TITLE
s390x: add kernel update test case support

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -11,7 +11,7 @@
 - rh_kernel_update:
     only RHEL
     only Host_RHEL
-    only i386 x86_64 PAE ppc64 ppc64le aarch64
+    only i386 x86_64 PAE ppc64 ppc64le aarch64 s390x
     no RHEL.3.9
     type = rh_kernel_update
     start_vm = yes
@@ -35,6 +35,9 @@
     install_virtio = no
     verify_virtio = no
     virtio_drivers_list = "virtio virtio_ring virtio_pci"
+    s390x:
+        virtio_drivers_list = ""
+        update_kernel_cmd = "zipl"
     upgrade_pkgs = glibc
     kernel_deps_pkgs = dracut xfsprogs
     RHEL.6:
@@ -70,3 +73,6 @@
     aarch64:
         kernel_re = .*kernel-%s.el[^.]+\.aarch64.*
         knl_dbginfo_re = .*kernel-debuginfo-.*.el[^.]+\.aarch64.*
+    s390x:
+        kernel_re = .*kernel-%s.el[^.]+\.s390x.*
+        knl_dbginfo_re = .*kernel-debuginfo-.*.el[^.]+\.s390x.*

--- a/qemu/tests/rh_kernel_update.py
+++ b/qemu/tests/rh_kernel_update.py
@@ -387,6 +387,7 @@ def run(test, params, env):
     update_kernel_cmd = "grubby --update-kernel=%s " % kernel_path
     update_kernel_cmd += "".join(remove_args_list)
     update_kernel_cmd += '--args="%s"' % " ".join(args_added)
+    update_kernel_cmd = params.get("update_kernel_cmd", update_kernel_cmd)
     s, o = session.cmd_status_output(update_kernel_cmd)
     if s != 0:
         msg = "Fail to modify the kernel cmdline, guest output: '%s'" % o


### PR DESCRIPTION
ID: 1523604
Signed-off-by: Zhengtong Liu <zhengtli@redhat.com>

The kernel update test case was not enabled on s390x platform. this patch enabled it on s390x