### PR TITLE
qemu_option_check: add devices supported on s390x platform

### DIFF
--- a/qemu/tests/cfg/qemu_option_check.cfg
+++ b/qemu/tests/cfg/qemu_option_check.cfg
@@ -5,11 +5,13 @@
     variants:
         - virtio-net:
             device_name = virtio-net-pci
+            s390x:
+                device_name = virtio-net-ccw
         - e1000:
-            no ppc64,ppc64le
+            no ppc64,ppc64le,s390x
             device_name = e1000
         - rtl8139:
-            no ppc64,ppc64le
+            no ppc64,ppc64le,s390x
             device_name = rtl8139
         - spapr-vlan:
             only ppc64,ppc64le


### PR DESCRIPTION
ID: 1524251
disable the unsupported devices and add the supported for s390x platform
Signed-off-by: Zhengtong Liu <zhengtli@redhat.com>