### PR TITLE
Set context_aware in drive_mirror_stress

### DIFF
--- a/qemu/tests/drive_mirror_stress.py
+++ b/qemu/tests/drive_mirror_stress.py
@@ -75,6 +75,7 @@ class DriveMirrorStress(drive_mirror.DriveMirror):
             offset = _offset
 
 
+@error_context.context_aware
 def run(test, params, env):
     """
     drive_mirror_stress test:


### PR DESCRIPTION
The "drive_mirror_stress" uses "error_context" without setting
"context_aware" which leads to error. Let's set it.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>