### PR TITLE
virtio_console: Treat virtio-serial-* 

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -229,12 +229,12 @@
                             virtio_port_type_vs1 = serialport
                             virtio_port_params_vs1 = "nr=1"
                         - boot_too_much_ports:
-                            # arm doesn't use pci bus
-                            no aarch64
+                            # arm-mmio doesn't use pci bus
+                            no arm64-mmio
                             # max_ports extended in rhev7: "rhev7,lower_version"
                             max_ports_invalid = "512,32"
                             max_ports_valid = "511,31"
-                            extra_params = " -device virtio-serial-pci,max_ports=%s"
+                            extra_params = " -device %s,max_ports=%s"
                             start_vm = no
                             virtio_console_test = failed_boot
                             virtio_console_params = "maximum ports supported: %s"


### PR DESCRIPTION
The mmio-based arm requires virtio-serial-device and s390x machine
requires virtio-serial-ccw device.

This test also requires https://github.com/avocado-framework/avocado-vt/pull/1258 to properly define `virtio-serial-ccw` devices on the `avocado-vt` side.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>