### PR TITLE
balloon_stress: Update test_timeout to use default value

### DIFF
--- a/qemu/tests/cfg/balloon_stress.cfg
+++ b/qemu/tests/cfg/balloon_stress.cfg
@@ -27,4 +27,3 @@
     Linux:
         # Use a low stress to make sure guest can response during stress
         stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"
-        test_timeout = 1800


### PR DESCRIPTION
Current 1800s is not long enough to run 1000 times balloon on some hosts. Remove the config to use the default value in base.cfg.

ID: 1527381
Signed-off-by: Yumei Huang <yuhuang@redhat.com>