### PR TITLE
Netperf: add support with macvtap device.

### DIFF
--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -91,8 +91,9 @@ def run(test, params, env):
         error_context.context("Setup env for %s" % ip)
         ssh_cmd(session, "iptables -F", ignore_status=True)
         ssh_cmd(session, "service iptables stop", ignore_status=True)
-        ssh_cmd(session, "systemctl stop firewalld.service", ignore_status=True)
-        ssh_cmd(session, "echo 1 > /proc/sys/net/ipv4/conf/all/arp_ignore")
+        ssh_cmd(session, "systemctl stop firewalld.service",
+                ignore_status=True)
+        ssh_cmd(session, "echo 2 > /proc/sys/net/ipv4/conf/all/arp_ignore")
         ssh_cmd(session, "echo 0 > /sys/kernel/mm/ksm/run", ignore_status=True)
 
         pkg = params["netperf_pkg"]
@@ -120,11 +121,12 @@ def run(test, params, env):
             ssh_cmd(server_ctl, server_mtu_cmd % (ethname, mtu))
         elif params.get("os_type") == "windows":
             connection_id = utils_net.get_windows_nic_attribute(
-                            server_ctl, "macaddress", mac, "netconnectionid")
+                server_ctl, "macaddress", mac, "netconnectionid")
             ssh_cmd(server_ctl, server_mtu_cmd % (connection_id, mtu))
 
         error_context.context("Changing the MTU of client", logging.info)
-        ssh_cmd(client, client_mtu_cmd % (params.get("client_physical_nic"), mtu))
+        ssh_cmd(client, client_mtu_cmd
+                % (params.get("client_physical_nic"), mtu))
 
         netdst = params.get("netdst", "switch")
         host_bridges = utils_net.Bridge()
@@ -132,7 +134,10 @@ def run(test, params, env):
         if netdst in br_in_use:
             ifaces_in_use = host_bridges.list_iface()
             target_ifaces = list(ifaces_in_use + br_in_use)
-        error_context.context("Change all Bridge NICs MTU to %s" % mtu, logging.info)
+        if vm.virtnet[0].nettype == "macvtap":
+            target_ifaces.extend([vm.virtnet[0].netdst, vm.get_ifname(0)])
+        error_context.context("Change all Bridge NICs MTU to %s"
+                              % mtu, logging.info)
         for iface in target_ifaces:
             utils.run(host_mtu_cmd % (iface, mtu), ignore_status=False)
 
@@ -148,7 +153,17 @@ def run(test, params, env):
     vm.verify_alive()
     login_timeout = int(params.get("login_timeout", 360))
 
-    session = vm.wait_for_login(timeout=login_timeout)
+    server_ip = vm.wait_for_get_address(0, timeout=5)
+    if len(params.get("nics", "").split()) > 1:
+        vm.wait_for_serial_login(timeout=30, restart_network=True).close()
+        server_ctl = vm.wait_for_login(nic_index=1, timeout=login_timeout)
+        server_ctl_ip = vm.wait_for_get_address(1, timeout=5)
+        session = vm.wait_for_login(nic_index=1, timeout=30)
+    else:
+        server_ctl = vm.wait_for_login(timeout=login_timeout)
+        server_ctl_ip = server_ip
+        session = vm.wait_for_login(timeout=login_timeout)
+
     mac = vm.get_mac_address(0)
     queues = int(params.get("queues", 1))
     if queues > 1:
@@ -175,9 +190,6 @@ def run(test, params, env):
         utils_test.service_setup(vm, session, test.virtdir)
     session.close()
 
-    server_ip = vm.wait_for_get_address(0, timeout=5)
-    server_ctl = vm.wait_for_login(timeout=login_timeout)
-    server_ctl_ip = server_ip
     if (params.get("os_type") == "windows" and
             params.get("use_cygwin") == "yes"):
         cygwin_prompt = params.get("cygwin_prompt", r"\$\s+$")
@@ -189,7 +201,8 @@ def run(test, params, env):
         server_cyg = None
 
     if len(params.get("nics", "").split()) > 1:
-        vm.wait_for_login(nic_index=1, timeout=login_timeout, restart_network=True)
+        vm.wait_for_login(nic_index=1, timeout=login_timeout,
+                          restart_network=True)
         server_ctl_ip = vm.wait_for_get_address(1, timeout=5)
 
     logging.debug(commands.getoutput("numactl --hardware"))
@@ -255,7 +268,7 @@ def run(test, params, env):
     mtu = int(params.get("mtu", "1500"))
     mtu_set(mtu)
 
-    env.stop_tcpdump()
+    env.stop_ip_sniffing()
 
     error_context.context("Start netperf testing", logging.info)
     start_test(server_ip, server_ctl, host, clients, test.resultsdir,
@@ -278,7 +291,7 @@ def run(test, params, env):
         src = os.path.join(test.virtdir, params.get("log_guestinfo_script"))
         path = os.path.join(test.resultsdir, "systeminfo")
         destpath = params.get("log_guestinfo_path", "/tmp/log_guestinfo.sh")
-        vm.copy_files_to(src, destpath)
+        vm.copy_files_to(src, destpath, nic_index=1)
         logexec = params.get("log_guestinfo_exec", "bash")
         output = server_ctl.cmd_output("%s %s" % (logexec, destpath))
         logfile = open(path, "a+")
@@ -327,7 +340,7 @@ def start_test(server, server_ctl, host, clients, resultsdir, test_duration=60,
     test.write_test_keyval({'kvm-userspace-ver':
                             commands.getoutput(ver_cmd).strip()})
     test.write_test_keyval({'guest-kernel-ver': ssh_cmd(server_ctl,
-                                                        guest_ver_cmd).strip()})
+                            guest_ver_cmd).strip()})
     test.write_test_keyval({'session-length': test_duration})
 
     fd.write('### kvm-userspace-ver : %s\n' %
@@ -383,8 +396,9 @@ def start_test(server, server_ctl, host, clients, resultsdir, test_duration=60,
                 else:
                     nf_args = "-C -c -t %s -- -m %s" % (protocol, i)
 
-                ret = launch_client(j, server, server_ctl, host, clients, test_duration,
-                                    nf_args, netserver_port, params, server_cyg, test)
+                ret = launch_client(j, server, server_ctl, host, clients,
+                                    test_duration, nf_args, netserver_port,
+                                    params, server_cyg, test)
 
                 thu = float(ret['thu'])
                 cpu = 100 - float(ret['mpstat'].split()[mpstat_index])
@@ -475,28 +489,34 @@ def launch_client(sessions, server, server_ctl, host, clients, l, nf_args,
                     p_check_cmd = "dir %s" % cygwin_root
                     if not ("netserver.exe" in server_ctl.cmd(s_check_cmd) and
                             netperf_pack in server_ctl.cmd(p_check_cmd)):
-                        error_context.context("Install netserver in Windows guest cygwin",
-                                              logging.info)
-                        cmd = "xcopy %s %s /S /I /Y" % (netperf_src, cygwin_root)
+                        error_context.context(
+                            "Install netserver in Windows guest cygwin",
+                            logging.info)
+                        cmd = "xcopy %s %s /S /I /Y" % (
+                            netperf_src, cygwin_root)
                         server_ctl.cmd(cmd)
-                        server_cyg.cmd_output(netperf_install_cmd, timeout=timeout)
+                        server_cyg.cmd_output(
+                            netperf_install_cmd, timeout=timeout)
                         if "netserver.exe" not in server_ctl.cmd(s_check_cmd):
                             err_msg = "Install netserver cygwin failed"
                             test.error(err_msg)
-                        logging.info("Install netserver in cygwin successfully")
+                        logging.info(
+                            "Install netserver in cygwin successfully")
             else:
                 start_session = server_ctl
                 netserv_start_cmd = params.get("netserv_start_cmd") % cdrom_drv
                 logging.info("Start netserver without cygwin, cmd is: %s" %
                              netserv_start_cmd)
 
-            error_context.context("Start netserver on windows guest", logging.info)
+            error_context.context("Start netserver on windows guest",
+                                  logging.info)
             start_netserver_win(start_session, netserv_start_cmd, test)
 
         else:
             logging.info("Netserver start cmd is '%s'" % server_path)
             ssh_cmd(server_ctl, "pidof netserver || %s" % server_path)
-            ncpu = ssh_cmd(server_ctl, "cat /proc/cpuinfo |grep processor |wc -l")
+            ncpu = ssh_cmd(server_ctl,
+                           "cat /proc/cpuinfo |grep processor |wc -l")
             ncpu = re.findall(r"\d+", ncpu)[-1]
 
         logging.info("Netserver start successfully")
@@ -573,8 +593,8 @@ def launch_client(sessions, server, server_ctl, host, clients, l, nf_args,
         if numa_enable:
             n = abs(int(params.get("numa_node"))) - 1
             cmd += "numactl --cpunodebind=%s --membind=%s " % (n, n)
-        cmd += "/tmp/netperf_agent.py %d %s -D 1 -H %s -l %s %s" % (i,
-                                                                    client_path, server, int(l) * 1.5, nf_args)
+        cmd += "/tmp/netperf_agent.py %d %s -D 1 -H %s -l %s %s" % (
+            i, client_path, server, int(l) * 1.5, nf_args)
         cmd += " >> %s" % fname
         logging.info("Start netperf thread by cmd '%s'" % cmd)
         ssh_cmd(client_s, cmd)


### PR DESCRIPTION
1 Add jumbo setting for macvtap devices
2 Use second ethernet for login guest since host could not
communicate guest through first one which is attached from macvtap
3 fix no attribute 'stop_tcpdump' error

Signed-off-by: Wenli Quan <wquan@redhat.com>

ID: 1528209 1528203 1538502