### PR TITLE
balloon_stress.cfg: Add ratio paramter in cfg file

### DIFF
--- a/qemu/tests/cfg/balloon_stress.cfg
+++ b/qemu/tests/cfg/balloon_stress.cfg
@@ -24,6 +24,7 @@
         play_video_cmd = '"%s" "%s" /play /fullscreen'
         time_for_video = 1200
         guest_alias = "Win2008-sp2-32:2k8\x86,Win2008-sp2-64:2k8\amd64,Win2008-r2-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12\amd64"
+        ratio = 0.5
     Linux:
         # Use a low stress to make sure guest can response during stress
         stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"


### PR DESCRIPTION
get_memory_boundary function will calculate a min_size for balloon operation.
Default ratio value(0.1) is too small which lead to small min_size.Actuall
windows minimal mem increases if guest stress increase, sometimes it makes
balloon operation fail. Set ratio = 0.5 in the cfg file to avoid this issue.

Signed-off-by: Li Jin <lijin@redhat.com>

ID:1529225