### PR TITLE
Correct the volume label name to WIN_UTILS

### DIFF
--- a/qemu/tests/cfg/device_option_check.cfg
+++ b/qemu/tests/cfg/device_option_check.cfg
@@ -64,7 +64,7 @@
             cmd = ls /dev/disk/by-id
             pattern = %s
             Windows:
-                cmd = WINUTILS:\hddsn.exe C:
+                cmd = WIN_UTILS:\hddsn.exe C:
                 pattern = %s
             check_in_qtree = yes
             qtree_check_keyword = id


### PR DESCRIPTION
"cmd = WINUTILS:\hddsn.exe C:" is not match the lable name
in def set_winutils_letter, change it to WIN_UTILS.

id: 1527826

Signed-off-by: Peixiu Hou <phou@redhat.com>