### PR TITLE
s390x: add additional params for s390x plaform for pxe_boot testing

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -16,6 +16,9 @@
     image_verify_bootable = no
     kill_vm = yes
     kill_vm_gracefully = no
+    s390x:
+        extra_params += " -no-shutdown"
+        bootindex_nic1 = 0
     # pxe_boot does not work for macvtap backend, as pxe can't
     # capture the packet from the macvtap tap port, disable it
     # for macvtap temporarily, will fix it in the furture.


### PR DESCRIPTION
ID: 1532193
For s390x platform, If there is no bootindex set for the nic device, the
guest won't try to boot with it, and if there is no bootable device
found while booting, the qemu process will terminated if "-no-shutdown"
was not set

Signed-off-by: Zhengtong Liu <zhengtli@redhat.com>