### PR TITLE
boot_order_check: fix bug

### DIFF
--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -25,8 +25,6 @@
     image_size_stg2 = 2G
     force_create_image_stg2 = yes
     remove_image_stg2 = yes
-    # Char: '\b' (backspace)
-    backspace_char = '\x08'
     nic_addr_filter = "%s.*?Bus\s+\d+,\s+device\s+(\d+)"
     variants:
         - bootorder0:


### PR DESCRIPTION
In some hosts, guest got a key event from `wait_for_serial_login`, which cause grub process
waits for another key event to continue, and timeout will occur. It is redundant to login
serial console again, so use original `vm.serial_console` to fix this bug.

ID: 1481151
Signed-off-by: Sitong Liu <siliu@redhat.com>
  
  
  