### PR TITLE
qemu_guest_agent: Changing the way to download qemu-ga-win package from virtio-win iso

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -9,21 +9,23 @@
     gagent_status_cmd = "service qemu-guest-agent status"
     gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
     Windows:
+        gagent_src_type = url
+        cdroms += " virtio"
+        cdrom_virtio = isos/windows/virtio-win.iso
         ga_username = "Administrator"
-        deps = no
         i386:
             qemu_ga_pkg = qemu-ga-x86.msi
         x86_64:
             qemu_ga_pkg = qemu-ga-x64.msi
-        gagent_download_cmd = "wget https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-qemu-ga/${qemu_ga_pkg}  -P /tmp/"
-        gagent_install_cmd = "start /wait C:\qemu-ga\${qemu_ga_pkg}  /quiet"
-        gagent_uninstall_cmd = "start /wait msiexec /uninstall C:\qemu-ga\${qemu_ga_pkg} /quiet"
+        gagent_download_cmd = "wget https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-qemu-ga/${qemu_ga_pkg} -P /tmp/"
+        gagent_host_path = "/tmp/${qemu_ga_pkg}"
+        gagent_guest_dir = "C:\qemu-ga"
+        gagent_install_cmd = "start /wait %s /quiet"
+        gagent_uninstall_cmd = "start /wait msiexec /uninstall %s /quiet"
         gagent_start_cmd = "net start qemu-ga"
         gagent_stop_cmd = "net stop qemu-ga"
         gagent_status_cmd = sc query qemu-ga |findstr "RUNNING"
         gagent_pkg_check_cmd = wmic product get name |findstr "QEMU guest agent"
-        gagent_host_path = "/tmp/${qemu_ga_pkg}"
-        gagent_guest_dir = "C:\qemu-ga"
         gagent_remove_service_cmd = "net stop qemu-ga & del /f C:\qemu-ga\${qemu_ga_pkg} & echo done"
     RHEL.6:
         gagent_start_cmd = "service qemu-ga start"

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -15,7 +15,6 @@ from virttest import error_context
 from virttest import guest_agent
 from virttest import utils_misc
 from virttest import env_process
-from virttest import data_dir
 
 
 class BaseVirtTest(object):
@@ -77,6 +76,8 @@ class QemuGuestAgentTest(BaseVirtTest):
         self._open_session_list = []
         self.gagent = None
         self.vm = None
+        self.gagent_install_cmd = params.get("gagent_install_cmd")
+        self.gagent_uninstall_cmd = params.get("gagent_uninstall_cmd")
 
     def _get_session(self, params, vm):
         if not vm:
@@ -117,41 +118,29 @@ class QemuGuestAgentTest(BaseVirtTest):
         return s == 0
 
     @error_context.context_aware
-    def gagent_install(self, session, vm, *args):
-        if args and isinstance(args, tuple):
-            gagent_install_cmd = args[0]
-        else:
-            self.test.error("Missing config 'gagent_install_cmd'")
-
-        if not gagent_install_cmd:
-            self.test.error("Gagent_install_cmd's value is empty.")
-
+    def gagent_install(self, session, vm):
+        """
+        install qemu-ga pkg in guest.
+        :param session: use for sending cmd
+        :param vm: guest object.
+        """
         error_context.context("Try to install 'qemu-guest-agent' package.",
                               logging.info)
-        s, o = session.cmd_status_output(gagent_install_cmd)
+        s, o = session.cmd_status_output(self.gagent_install_cmd)
         if s:
             self.test.fail("Could not install qemu-guest-agent package"
                            " in VM '%s', detail: '%s'" % (vm.name, o))
 
     @error_context.context_aware
-    def gagent_uninstall(self, session, vm, *args):
+    def gagent_uninstall(self, session, vm):
         """
         uninstall qemu-ga pkg in guest.
         :param session: use for sending cmd
         :param vm: guest object.
-        :param args: Qemu-ga pkg uninstall cmd.
         """
-        if args and isinstance(args, tuple):
-            gagent_uninstall_cmd = args[0]
-        else:
-            self.test.error("Missing config 'gagent_uninstall_cmd'")
-
-        if not gagent_uninstall_cmd:
-            self.test.error("Gagent_uninstall_cmd's value is empty.")
-
         error_context.context("Try to uninstall 'qemu-guest-agent' package.",
                               logging.info)
-        s, o = session.cmd_status_output(gagent_uninstall_cmd)
+        s, o = session.cmd_status_output(self.gagent_uninstall_cmd)
         if s:
             self.test.fail("Could not uninstall qemu-guest-agent package "
                            "in VM '%s', detail: '%s'" % (vm.name, o))
@@ -237,7 +226,7 @@ class QemuGuestAgentTest(BaseVirtTest):
                 logging.info("qemu-ga is already installed.")
             else:
                 logging.info("qemu-ga is not installed.")
-                self.gagent_install(session, self.vm, *[params.get("gagent_install_cmd")])
+                self.gagent_install(session, self.vm)
 
             if self._check_ga_service(session, params.get("gagent_status_cmd")):
                 logging.info("qemu-ga service is already running.")
@@ -293,11 +282,11 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             error_context.context("Repeat: %s/%s" % (i + 1, repeats),
                                   logging.info)
             if self._check_ga_pkg(session, params.get("gagent_pkg_check_cmd")):
-                self.gagent_uninstall(session, self.vm, *[params.get("gagent_uninstall_cmd")])
-                self.gagent_install(session, self.vm, *[params.get("gagent_install_cmd")])
+                self.gagent_uninstall(session, self.vm)
+                self.gagent_install(session, self.vm)
             else:
-                self.gagent_install(session, self.vm, *[params.get("gagent_install_cmd")])
-                self.gagent_uninstall(session, self.vm, *[params.get("gagent_uninstall_cmd")])
+                self.gagent_install(session, self.vm)
+                self.gagent_uninstall(session, self.vm)
         session.close()
 
     @error_context.context_aware
@@ -905,27 +894,51 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
     """
 
     @error_context.context_aware
-    def setup_gagent_in_host(self, session, params, vm):
-        error_context.context("download qemu-ga.msi to host", logging.info)
-        deps = params["deps"]
-        gagent_download_cmd = params["gagent_download_cmd"]
-        if deps == "yes":
-            deps_dir = data_dir.get_deps_dir("windows_ga_install")
-            gagent_download_cmd = gagent_download_cmd % deps_dir
-        utils.run(gagent_download_cmd,
-                  float(params.get("login_timeout", 360)))
-        gagent_host_path = params["gagent_host_path"]
-        if not os.path.exists(gagent_host_path):
-            raise error.TestFail("qemu-ga install program is not exist, maybe "
-                                 "the program is not successfully downloaded ")
-        gagent_guest_dir = params["gagent_guest_dir"]
-#        gagent_remove_service_cmd = params["gagent_remove_service_cmd"]
-        s, o = session.cmd_status_output("mkdir %s" % gagent_guest_dir)
-        if bool(s) and str(s) != "1":
-            raise error.TestError("Could not create qemu-ga directory in "
-                                  "VM '%s', detail: '%s'" % (vm.name, o))
-        error_context.context("Copy qemu guest agent program to guest", logging.info)
-        vm.copy_files_to(gagent_host_path, gagent_guest_dir)
+    def get_qga_pkg_path(self, test, session, params, vm):
+        """
+        Get the qemu-ga pkg path which will be installed.
+        There are two methods to get qemu-ga pkg,one is download it
+        from fedora people website,and the other is from virtio-win iso.
+
+        :param test: kvm test object
+        :param session: VM session.
+        :param params: Dictionary with the test parameters
+        :param vm: Virtual machine object.
+        :return qemu_ga_pkg_path: Return the guest agent pkg path.
+        """
+        error_context.context("Get qemu-ga.msi path where it locate.", logging.info)
+        qemu_ga_pkg = params["qemu_ga_pkg"]
+        gagent_src_type = params.get("gagent_src_type", "url")
+
+        if gagent_src_type == "url":
+            gagent_host_path = params["gagent_host_path"]
+            gagent_guest_dir = params["gagent_guest_dir"]
+            gagent_download_cmd = params["gagent_download_cmd"]
+
+            error_context.context("Download qemu-ga.msi from website and copy "
+                                  "it to guest.", logging.info)
+            utils.run(gagent_download_cmd, float(params.get("login_timeout", 360)))
+            if not os.path.exists(gagent_host_path):
+                test.error("qemu-ga.msi is not exist, maybe it is not "
+                           "successfully downloaded ")
+            s, o = session.cmd_status_output("mkdir %s" % gagent_guest_dir)
+            if s and "already exists" not in o:
+                test.error("Could not create qemu-ga directory in "
+                           "VM '%s', detail: '%s'" % (vm.name, o))
+
+            error_context.context("Copy qemu-ga.msi to guest", logging.info)
+            vm.copy_files_to(gagent_host_path, gagent_guest_dir)
+            qemu_ga_pkg_path = r"%s\%s" % (gagent_guest_dir, qemu_ga_pkg)
+        elif gagent_src_type == "virtio-win":
+            vol_virtio_key = "VolumeName like '%virtio-win%'"
+            vol_virtio = utils_misc.get_win_disk_vol(session, vol_virtio_key)
+            qemu_ga_pkg_path = r"%s:\%s\%s" % (vol_virtio, "guest-agent", qemu_ga_pkg)
+        else:
+            test.error("Only support 'url' and 'virtio-win' method to "
+                       "download qga installer now.")
+
+        logging.info("The qemu-ga pkg which will be installed is %s" % qemu_ga_pkg_path)
+        return qemu_ga_pkg_path
 
     @error_context.context_aware
     def setup(self, test, params, env):
@@ -941,8 +954,10 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
                 logging.info("qemu-ga is already installed.")
             else:
                 logging.info("qemu-ga is not installed.")
-                self.setup_gagent_in_host(session, params, self.vm)
-                self.gagent_install(session, self.vm, *[params.get("gagent_install_cmd")])
+                qemu_ga_pkg_path = self.get_qga_pkg_path(test, session, params, self.vm)
+                self.gagent_install_cmd = params.get("gagent_install_cmd") % qemu_ga_pkg_path
+                self.gagent_uninstall_cmd = params.get("gagent_uninstall_cmd") % qemu_ga_pkg_path
+                self.gagent_install(session, self.vm)
 
             if self._check_ga_service(session, params.get("gagent_status_cmd")):
                 logging.info("qemu-ga service is already running.")


### PR DESCRIPTION
Qemu-ga-win pkg is not the latest one at present,need to get it from virtio-win iso.
BTW,optimize qemu-ga-instlall/uninstall function.

id: 1514340 

Signed-off-by: Xiaoling Gao <xiagao@redhat.com>