### PR TITLE
uttended_install.cfg: Specify cd_format here instead of in machine.cfg

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -119,6 +119,10 @@
     variants:
         # Additional iso with kickstart is attached into the guest
         - extra_cdrom_ks:
+            i440fx:
+                cd_format = ide
+            q35:
+                cd_format = ahci
             no WinXP Win2000 Win2003 WinVista
             unattended_delivery_method = cdrom
             cdroms += " unattended"
@@ -158,6 +162,10 @@
             # TODO: is this needed for both kvm and libvirt?
             # This option is only used in windows installation case,
             # since linux use kernel/initrd option of qemu.
+            i440fx:
+                cd_format = ide
+            q35:
+                cd_format = ahci
             boot_once = d
             medium = cdrom
             redirs += " unattended_install"


### PR DESCRIPTION
Move machine.cfg prior to subtests.cfg. Therefore remove
unattended_install..cdrom, unattended_install..extra_cdrom_ks
configuration from machine.cfg, it will not take effect after above
modification. Actually it is not proper to define such parameters
in machine.cfg, it should be defined here for itself.

id: 1537394
Signed-off-by: qizhu <qizhu@redhat.com>