### PR TITLE
Balloon check:Modify ballon min_size calculation formula

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -7,10 +7,6 @@
     balloon_dev_add_bus = yes
     iterations = 5
     free_mem_cmd = cat /proc/meminfo |grep MemFree
-    Linux:
-        ratio = 1
-    Windows:
-        ratio = 0.5
     variants:
         - balloon_base:
 

--- a/qemu/tests/cfg/balloon_hotplug.cfg
+++ b/qemu/tests/cfg/balloon_hotplug.cfg
@@ -8,10 +8,6 @@
     free_mem_cmd = cat /proc/meminfo |grep MemFree
     reboot_method = shell
     shutdown_method = shell
-    Linux:
-        ratio = 1
-    Windows:
-        ratio = 0.5
     run_sub_test_after_balloon = no
     test_tags = "evict enlarge"
     balloon_type_evict = evict

--- a/qemu/tests/cfg/balloon_illegal.cfg
+++ b/qemu/tests/cfg/balloon_illegal.cfg
@@ -6,10 +6,6 @@
     balloon_dev_devid = balloon0
     balloon_dev_add_bus = yes
     free_mem_cmd = cat /proc/meminfo | grep MemFree
-    Linux:
-        ratio = 1
-    Windows:
-        ratio = 0.5
     illegal_value_check = yes
     test_tags = "evict enlarge"
     balloon_type_evict = evict

--- a/qemu/tests/cfg/balloon_in_use.cfg
+++ b/qemu/tests/cfg/balloon_in_use.cfg
@@ -5,7 +5,6 @@
     balloon_dev_devid = balloon0
     balloon_dev_add_bus = yes
     repeat_times = 5
-    ratio = 0.5
     wait_bg_time = 720
     time_for_video = 600
     start_vm = yes

--- a/qemu/tests/cfg/balloon_service.cfg
+++ b/qemu/tests/cfg/balloon_service.cfg
@@ -25,7 +25,6 @@
     set_balloon_property = "guest-stats-polling-interval"
     get_balloon_property = "guest-stats"
     polling_sleep_time = 20
-    ratio = 0.1
     run_sub_test_after_balloon = no
     test_tags = "evict enlarge"
     balloon_type_evict = evict

--- a/qemu/tests/cfg/balloon_stress.cfg
+++ b/qemu/tests/cfg/balloon_stress.cfg
@@ -24,7 +24,6 @@
         play_video_cmd = '"%s" "%s" /play /fullscreen'
         time_for_video = 1200
         guest_alias = "Win2008-sp2-32:2k8\x86,Win2008-sp2-64:2k8\amd64,Win2008-r2-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12\amd64"
-        ratio = 0.5
     Linux:
         # Use a low stress to make sure guest can response during stress
         stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -43,7 +43,6 @@
             run_bgstress = balloon_check
             virtio_balloon_pause = 10.0
             free_mem_cmd = cat /proc/meminfo |grep MemFree
-            ratio = 0.5
             run_sub_test_after_balloon = no
             test_tags = "evict enlarge"
             balloon_type_evict = evict


### PR DESCRIPTION
1. When windows guest mem is small(e.g.1024M), calculated mem min_size will be larger than ori_mem if ratio=0.5, which will lead balloon cases fail.
2. When do balloon operation in linux guest, we should consider crashkernel value as well,leaving enough memory for guest to avoid guest OOM.
    
So modify the formula and leave a balloon buffer(300M in default) for guest min_sz.

ID:1529221,1538489

Signed-off-by: Li Jin <lijin@redhat.com>