### PR TITLE
balloon_in_use: Add linux guest support and fix migration timeout issue

### DIFF
--- a/qemu/tests/cfg/balloon_in_use.cfg
+++ b/qemu/tests/cfg/balloon_in_use.cfg
@@ -1,43 +1,49 @@
 - balloon_in_use:
     type = driver_in_use
-    only Windows
     balloon = balloon0
     balloon_dev_devid = balloon0
     balloon_dev_add_bus = yes
     repeat_times = 5
-    ratio = 0.5
     wait_bg_time = 720
-    time_for_video = 600
     start_vm = yes
     kill_vm_on_error = yes
-    check_guest_bsod = yes
     run_bgstress = balloon_stress
-    stress_test = win_video_play
     bg_stress_run_flag = balloon_test
     set_bg_stress_flag = yes
-    free_mem_cmd = wmic os get FreePhysicalMemory
-    default_memory = ${mem}
     session_cmd_timeout = 240
     balloon_timeout = 240
-    driver_name = "balloon.sys"
-    x86_64:
-        program_files = "%ProgramFiles(x86)%"
-    i386:
-        program_files = "%ProgramFiles%"
-    #Disable first startup guide for windows media player
-    wmplayer_reg_cmd = "reg add HKLM\SOFTWARE\Policies\Microsoft\WindowsMediaPlayer /v GroupPrivacyAcceptance  /t REG_DWORD /f /d 00000001"
-    wmplayer_path = "${program_files}\Windows Media Player\wmplayer.exe"
-    #Install kmplayer if wmplayer is not installed default
-    kmplayer_install_cmd = "start /wait WIN_UTILS:\kmplayer\%s\KMPlayer-setup.exe /SP- /VERYSILENT"
-    kmplayer_path = "${program_files}\KMPlayer\kmplayer.exe"
-    video_url = http://fileshare.com/Peppa_Pig_39_The_Tree_House.avi
-    play_video_cmd = '"%s" "%s" /play /fullscreen'
-    guest_alias = "Win2008-sp2-32:2k8\x86,Win2008-sp2-64:2k8\amd64,Win2008-r2-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12\amd64"
+    Windows:
+        x86_64:
+            program_files = "%ProgramFiles(x86)%"
+        i386:
+            program_files = "%ProgramFiles%"
+        stress_test = win_video_play
+        #Disable first startup guide for windows media player
+        wmplayer_reg_cmd = "reg add HKLM\SOFTWARE\Policies\Microsoft\WindowsMediaPlayer /v GroupPrivacyAcceptance  /t REG_DWORD /f /d 00000001"
+        wmplayer_path = "${program_files}\Windows Media Player\wmplayer.exe"
+        #Install kmplayer if wmplayer is not installed default
+        kmplayer_install_cmd = "start /wait WIN_UTILS:\kmplayer\%s\KMPlayer-setup.exe /SP- /VERYSILENT"
+        kmplayer_path = "${program_files}\KMPlayer\kmplayer.exe"
+        video_url = http://fileshare.com/Peppa_Pig_39_The_Tree_House.avi
+        play_video_cmd = '"%s" "%s" /play /fullscreen'
+        guest_alias = "Win2008-sp2-32:2k8\x86,Win2008-sp2-64:2k8\amd64,Win2008-r2-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12\amd64"
+        driver_name = "balloon.sys"
+        time_for_video = 600
+        free_mem_cmd = wmic os get FreePhysicalMemory
+        default_memory = ${mem}
+        check_guest_bsod = yes
+        migration_test_command = ver && vol
+    Linux:
+        # Use a low stress to make sure guest can response during stress
+        driver_name = "virtio_balloon"
+        stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"
+        migration_test_command = help
     variants:
         - before_bg_test:
             run_bg_flag = "before_bg_test"
         - during_bg_test:
             run_bg_flag = "during_bg_test"
+            repeat_times = 200
         - after_bg_test:
             run_bg_flag = "after_bg_test"
     variants:
@@ -61,4 +67,5 @@
         - with_live_migration:
             sub_test = migration
             suppress_exception = no
-            migration_test_command = ver && vol
+            mig_speed = 512M
+            pre_migrate = "mig_set_speed"


### PR DESCRIPTION
1).balloon_in_use only support windows guest before, add linux guest as well.
2).set mig_speed to 512M to avoid migration timeout issue.

ID:1483484,1517074

Signed-off-by: Li Jin <lijin@redhat.com>