### PR TITLE
Use the fio multiple device function to replace multiple thread

### DIFF
--- a/qemu/tests/cfg/fio_windows.cfg
+++ b/qemu/tests/cfg/fio_windows.cfg
@@ -8,8 +8,8 @@
     force_create_image_disk1 = yes
     disk_index = 1
     disk_letter = I
-    fio_file_name = "C\:\\fio_system_disk_test I\:\\fio_data_disk_test"
-    fio_log_file = "C:\fio_log_sys.txt C:\fio_log_data.txt"
+    fio_file_name = "C\:\\fio_system_disk_test:I\:\\fio_data_disk_test"
+    fio_log_file = "C:\fio_log.txt"
     cmd_timeout = 300
     i386, i686:
         install_path = "C:\Program Files\fio"
@@ -19,6 +19,6 @@
         install_cmd = 'msiexec /a DRIVE:\fio-x64.msi /qn TARGETDIR="${install_path}"'
     #config_cmd = 'setx -m path "%PATH%;${install_path}\fio;"'
     fio_cmd = '"${install_path}\fio\fio.exe" --rw=randrw --bs=4k --iodepth=4 --direct=1'
-    fio_cmd += ' --filename=%s --name=fiotest_%s --ioengine=windowsaio --thread --group_reporting'
-    fio_cmd += ' --numjobs=4 --size=1G --runtime=${cmd_timeout} > %s'
+    fio_cmd += ' --filename=${fio_file_name} --name=fiotest --ioengine=windowsaio --thread --group_reporting'
+    fio_cmd += ' --numjobs=4 --size=1G --runtime=${cmd_timeout} > ${fio_log_file}'
 

--- a/qemu/tests/fio_windows.py
+++ b/qemu/tests/fio_windows.py
@@ -21,10 +21,8 @@ def run(test, params, env):
     """
 
     install_path = params["install_path"].rstrip("\\")
-    fio_log_file = params.objects("fio_log_file")
-    fio_file_name = params.objects("fio_file_name")
-    fio_cmd_sys = params.get("fio_cmd") % (fio_file_name[0], "sys", fio_log_file[0])
-    fio_cmd_data = params.get("fio_cmd") % (fio_file_name[1], "data", fio_log_file[1])
+    fio_log_file = params.get("fio_log_file")
+    fio_cmd = params.get("fio_cmd")
     timeout = float(params.get("login_timeout", 360))
     cmd_timeout = int(params.get("cmd_timeout", "360"))
     check_installed_cmd = 'dir "%s"|findstr /I fio' % install_path
@@ -33,45 +31,35 @@ def run(test, params, env):
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
-    session_sys = vm.wait_for_login(timeout=timeout)
-    session_data = vm.wait_for_login(timeout=timeout)
+    session = vm.wait_for_login(timeout=timeout)
 
     error_context.context("Format disk", logging.info)
-    utils_misc.format_windows_disk(session_sys, params["disk_index"],
+    utils_misc.format_windows_disk(session, params["disk_index"],
                                    mountpoint=params["disk_letter"])
     try:
-        installed = session_sys.cmd_status(check_installed_cmd) == 0
+        installed = session.cmd_status(check_installed_cmd) == 0
         if not installed:
-            dst = r"%s:\\" % utils_misc.get_winutils_vol(session_sys)
+            dst = r"%s:\\" % utils_misc.get_winutils_vol(session)
 
             error_context.context("Install fio in guest", logging.info)
             install_cmd = params["install_cmd"]
             install_cmd = re.sub(r"DRIVE:\\+", dst, install_cmd)
-            session_sys.cmd(install_cmd, timeout=180)
+            session.cmd(install_cmd, timeout=180)
             time.sleep(30)
             config_cmd = params.get("config_cmd")
             if config_cmd:
-                session_sys.cmd(config_cmd)
+                session.cmd(config_cmd)
 
         error_context.context("Start fio in guest.", logging.info)
-        # FIXME:Here use the timeout=(cmd_timeout*2)
-        # Will determine a better specific calculation later
-        fio_thread_data = utils_misc.InterruptedThread(session_data.cmd_status_output,
-                                                       (fio_cmd_data, (cmd_timeout*2)))
-        fio_thread_data.start()
-        status_sys, output_sys = session_sys.cmd_status_output(fio_cmd_sys,
-                                                               timeout=(cmd_timeout*2))
-        status_data, output_data = fio_thread_data.join()
-        if status_sys or status_data:
-            test.error("Failed to run fio, output: %s\n%s" % (output_sys, output_data))
+        status, output = session.cmd_status_output(fio_cmd, timeout=(cmd_timeout*2))
+        if status:
+            test.error("Failed to run fio, output: %s" % output)
 
     finally:
         error_context.context("Copy fio log from guest to host.", logging.info)
         try:
-            vm.copy_files_from(fio_log_file[0], test.resultsdir)
-            vm.copy_files_from(fio_log_file[1], test.resultsdir)
+            vm.copy_files_from(fio_log_file, test.resultsdir)
         except Exception, err:
             logging.warn("Log file copy failed: %s" % err)
-        session_data.close()
-        if session_sys:
-            session_sys.close()
+        if session:
+            session.close()


### PR DESCRIPTION
Fio has multiple device function, it allows fio running
on multiple disks at the same time. Here use this way to catch
run fio on system and data disks at the same time.

id:1520254

Signed-off-by: Peixiu Hou <phou@redhat.com>