### PR TITLE
balloon_check: Modify linux guest balloon min_size to avoid guest OOM

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -193,9 +193,8 @@ class BallooningTest(MemoryBaseTest):
             self.wait_for_balloon_complete(balloon_timeout)
             self.ori_gmem = self.get_memory_status()
         else:
-            vm_total = self.get_memory_status()
             vm_mem_free = self.get_free_mem()
-            used_size = vm_total - vm_mem_free + 16
+            used_size = self.ori_mem - vm_mem_free + 300
         if balloon_type == "enlarge":
             min_size = self.current_mmem
         elif balloon_type == "evict":


### PR DESCRIPTION
When do balloon operation, we should consider crashkernel value as well, leave enough memory for guest to avoid OOM.
Using MemTotal(which does not include crashkernel value) to calculate used_size is risky, it leads to too small balloon value. Using ori_mem in qemu cli is much more accurate.

ID:1538489

Signed-off-by: Li Jin <lijin@redhat.com>