### PR TITLE
block_resize: only virtio driver needs to be verified in windows

### DIFF
--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -58,7 +58,7 @@ def run(test, params, env):
     timeout = float(params.get("login_timeout", 240))
     driver_name = params.get("driver_name")
 
-    if params.get("os_type") == "windows":
+    if params.get("os_type") == "windows" and driver_name:
         utils_test.qemu.setup_win_driver_verifier(driver_name, vm, timeout)
 
     session = vm.wait_for_login(timeout=timeout)


### PR DESCRIPTION
Only virtio driver needs to be checked in windows, no need
to do it with ide driver.

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1541271