### PR TITLE
balloon_boot_in_pause: Fix login error since vm boot in pause status

### DIFF
--- a/qemu/tests/balloon_boot_in_pause.py
+++ b/qemu/tests/balloon_boot_in_pause.py
@@ -46,7 +46,7 @@ class BallooningTestPause(BallooningTest):
                             abs(gmem - self.old_gmem) - changed_mem) > 100):
             self.error_report(step, abs(self.old_mmem - changed_mem),
                               mmem, gmem)
-            raise exceptions.TestFail("Balloon test failed %s" % step)
+            self.test.fail("Balloon test failed %s" % step)
         return (mmem, gmem)
 
     @error_context.context_aware
@@ -64,24 +64,22 @@ class BallooningTestPause(BallooningTest):
             if self.vm.monitor.verify_status('paused'):
                 # Make sure memory not changed before the guest resumed
                 if self.get_ballooned_memory() != self.ori_mem:
-                    raise exceptions.TestFail("Memory changed before guest "
-                                              "resumed")
+                    self.test.fail("Memory changed before guest resumed")
 
                 logging.info("Resume the guest")
                 self.vm.resume()
             elif new_mem == self.get_ballooned_memory():
                 pass
             else:
-                raise exceptions.TestFail("Balloon memory fail with error"
-                                          " message: %s" % e)
+                self.test.fail("Balloon memory fail with error message:%s" % e)
         compare_mem = new_mem
         balloon_timeout = float(self.params.get("balloon_timeout", 240))
         status = utils_misc.wait_for((lambda: compare_mem ==
                                       self.get_ballooned_memory()),
                                      balloon_timeout)
         if status is None:
-            raise exceptions.TestFail("Failed to balloon memory to expect"
-                                      " value during %ss" % balloon_timeout)
+            self.test.fail("Failed to balloon memory to expect value during "
+                           "%ss" % balloon_timeout)
 
     def get_memory_boundary(self):
         """
@@ -226,8 +224,8 @@ def run(test, params, env):
         output = utils_misc.wait_for(_memory_check_after_sub_test, timeout,
                                      sleep_before_check, 5, msg)
         if output is None:
-            raise exceptions.TestFail("Check memory status failed after "
-                                      "subtest after %s seconds" % timeout)
+            test.fail("Check memory status failed after subtest "
+                      "after %s seconds" % timeout)
 
     error_context.context("Reset guest memory to original one after all the "
                           "test", logging.info)

--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -23,21 +23,22 @@ class BallooningTest(MemoryBaseTest):
         super(BallooningTest, self).__init__(test, params, env)
 
         self.vm = env.get_vm(params["main_vm"])
-        self.session = self.get_session(self.vm)
-        self.params["balloon_test_setup_ready"] = False
-        if self.params.get('os_type') == 'windows':
-            sleep_time = 180
-        else:
-            sleep_time = 90
-        logging.info("Waiting %d seconds for guest's applications up" % sleep_time)
-        time.sleep(sleep_time)
-        self.params["balloon_test_setup_ready"] = True
+        if params.get("paused_after_start_vm") != "yes":
+            self.params["balloon_test_setup_ready"] = False
+            if self.params.get('os_type') == 'windows':
+                sleep_time = 180
+            else:
+                sleep_time = 90
+            logging.info("Waiting %d seconds for guest's "
+                         "applications up" % sleep_time)
+            time.sleep(sleep_time)
+            self.params["balloon_test_setup_ready"] = True
+            self.ori_gmem = self.get_memory_status()
+            self.current_gmem = self.ori_gmem
         self.ori_mem = self.get_vm_mem(self.vm)
         self.current_mmem = self.get_ballooned_memory()
         if self.current_mmem != self.ori_mem:
             self.balloon_memory(self.ori_mem)
-        self.ori_gmem = self.get_memory_status()
-        self.current_gmem = self.ori_gmem
         self.current_mmem = self.ori_mem
 
     def get_ballooned_memory(self):


### PR DESCRIPTION
Guest boot in pause status in this case, super(BallooningTestPause, self).__init__ () will always fail since it will try to get guest ip address and login.

ID: 1517601
Signed-off-by: Yumei Huang <yuhuang@redhat.com>