### PR TITLE
balloon_small:Reset memory size to very small during runtime

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -112,6 +112,7 @@ class BallooningTest(MemoryBaseTest):
         elif new_mem == 0:
             compare_mem = self.current_mmem
         elif new_mem <= 100:
+            self._balloon_post_action()
             self.current_mmem = self.get_ballooned_memory()
             compare_mem = self.current_mmem
         else:
@@ -156,7 +157,7 @@ class BallooningTest(MemoryBaseTest):
             qemu_quit_after_test = 0
         return qemu_quit_after_test
 
-    def _mem_state(self):
+    def _mem_state(self, threshold):
         """
         A generator to get guest memory until it does not change
         """
@@ -165,7 +166,7 @@ class BallooningTest(MemoryBaseTest):
         while True:
             yield stable
             cur_mem = self.get_memory_status()
-            stable = abs(cur_mem - ori_mem) < 100
+            stable = abs(cur_mem - ori_mem) < threshold
             ori_mem = cur_mem
 
     def wait_for_balloon_complete(self, timeout):
@@ -173,8 +174,10 @@ class BallooningTest(MemoryBaseTest):
         Wait until guest memory don't change
         """
         logging.info("Wait until guest memory don't change")
-        is_stable = self._mem_state()
-        utils_misc.wait_for(lambda: next(is_stable), timeout, step=10.0)
+        threshold = int(self.params.get("guest_stable_threshold", 100))
+        is_stable = self._mem_state(threshold)
+        utils_misc.wait_for(lambda: next(is_stable), timeout,
+                            step=float(self.params.get("guest_check_step", 10.0)))
 
     def get_memory_boundary(self, balloon_type=''):
         """
@@ -308,12 +311,24 @@ class BallooningTest(MemoryBaseTest):
         """
         pass
 
+    def _balloon_post_action(self):
+        """
+        Wait for guest memory goes into stable status
+        """
+        pass
+
 
 class BallooningTestWin(BallooningTest):
 
     """
     Windows memory ballooning test
     """
+    def _balloon_post_action(self):
+        """
+        Wait for guest memory goes into stable status
+        """
+        balloon_timeout = float(self.params.get("balloon_timeout", 240))
+        self.wait_for_balloon_complete(balloon_timeout)
 
     def error_report(self, step, expect_value, monitor_value, guest_value):
         """
@@ -489,6 +504,8 @@ def run(test, params, env):
             balloon_type = params_tag['balloon_type']
             min_sz, max_sz = balloon_test.get_memory_boundary(balloon_type)
             expect_mem = int(random.uniform(min_sz, max_sz))
+            if params_tag.get('minimum_value_check', 'no') == 'yes':
+                expect_mem = int(min_sz)
 
         quit_after_test = balloon_test.run_ballooning_test(expect_mem, tag)
         if quit_after_test:

--- a/qemu/tests/cfg/balloon_minimum.cfg
+++ b/qemu/tests/cfg/balloon_minimum.cfg
@@ -1,0 +1,27 @@
+- balloon_minimum: install setup image_copy unattended_install.cdrom
+    virt_test_type = qemu
+    no Win2000, Fedora.8, Fedora.9, Fedora.10, RHEL.3, RHEL.4
+    type = balloon_check
+    balloon = balloon0
+    balloon_dev_devid = balloon0
+    balloon_dev_add_bus = yes
+    minimum_value_check = yes
+    balloon_type = evict
+    test_tags = "evict"
+    kill_vm_on_error = yes
+    variants:
+        - negative:
+            only Windows
+            backup_image_before_testing = yes
+            restore_image_after_testing = yes
+            expect_memory = 10
+            balloon_timeout = 900
+            guest_check_step = 60.0
+            guest_stable_threshold = 25
+            check_guest_bsod = yes
+        - boundary:
+            run_sub_test_after_balloon = yes
+            sub_test_after_balloon_evict = "boot"
+            Windows:
+                guest_compare_threshold = 300
+            reboot_method = shell


### PR DESCRIPTION
1. Set very small value(10M) to windows guest, guest memory will keep still at a minimal working value.
2. Set a minimal boudary memory value to guests, guests can work normally even after reboot.

ID:1542296

Signed-off-by: Li Jin <lijin@redhat.com>