### PR TITLE
Add hotunplug virtio scsi controller and add multi storage hotplug/unplug

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -16,8 +16,8 @@
     kill_vm_on_error = yes
 
     Windows:
-        disk_index = "1 2"
-        disk_letter = "I J"
+        disk_index = "1 2 3"
+        disk_letter = "I J K"
         disk_op_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 125M -g 512M -M -i 0"
         disk_op_cmd += " -i 1 -b %s:\iozone_test -f %s:\testfile"
 
@@ -26,14 +26,18 @@
             blk_num = 1
             repeat_times = 3
         - multi_pci:
-            blk_num = 2
+            blk_num = 3
             repeat_times = 3
-            images += " stg1"
+            images += " stg1 stg2"
             boot_drive_stg1 = no
+            boot_drive_stg2 = no
             image_name_stg1 = images/storage1
-            image_size_stg1 = 1G
+            image_name_stg2 = images/storage2
+            image_size_equal = 1G
             remove_image_stg1 = yes
+            remove_image_stg2 = yes
             force_create_image_stg1 = yes
+            force_create_image_stg2 = yes
 
     variants:
         - @default:
@@ -67,6 +71,7 @@
             repeat_times = 1
             boot_drive_stg0 = yes
             boot_drive_stg1 = yes
+            boot_drive_stg2 = yes
             need_plug = no
 
     variants:
@@ -75,11 +80,13 @@
             img_format_type = qcow2
             image_format_stg0 = qcow2
             image_format_stg1 = qcow2
+            image_format_stg2 = qcow2
         - fmt_raw:
             image_extra_params = ""
             img_format_type = raw
             image_format_stg0 = raw
             image_format_stg1 = raw
+            image_format_stg2 = raw
 
     variants:
         - block_virtio:
@@ -88,17 +95,18 @@
                 pci_type = virtio-blk-ccw
             drive_format_stg0 = virtio
             drive_format_stg1 = virtio
+            drive_format_stg2 = virtio
             get_disk_pattern = "^/dev/vd[a-z]*$"
         - block_scsi:
             pci_type = scsi-hd
             drive_format_stg0 = scsi-hd
             drive_format_stg1 = scsi-hd
+            drive_format_stg2 = scsi-hd
             get_disk_pattern = "^/dev/sd[a-z]*$"
-            virtio_blk:
-                need_controller = yes
-                controller_model = virtio-scsi-pci
-                s390x:
-                    controller_model = virtio-scsi-ccw
+            need_controller = yes
+            controller_model = virtio-scsi-pci
+            s390x:
+                controller_model = virtio-scsi-ccw
 
     variants:
         - @default:


### PR DESCRIPTION
1. Original code only have hotplug virtio scsi controller,
but have not hotunplug virtio scsi controller function.
It's a basic requirement of hotunplug cases.
2. And also update the code to match the requirement of the
case "hotplug/unplug multi storage".

id: 1520877, 1542350, 1231141

Signed-off-by: Peixiu Hou <phou@redhat.com>