### PR TITLE
unattended_install: Specify cd_format when install Windows guest

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -119,13 +119,14 @@
     variants:
         # Additional iso with kickstart is attached into the guest
         - extra_cdrom_ks:
-            i440fx:
-                cd_format = ide
-            q35:
-                cd_format = ahci
             no WinXP Win2000 Win2003 WinVista
             unattended_delivery_method = cdrom
             cdroms += " unattended"
+            Windows:
+                i440fx:
+                    cd_format_unattended = ide
+                q35:
+                    cd_format_unattended = ahci
             drive_index_unattended = 1
             drive_index_cd1 = 2
         # Kickstart is packed into the installation iso
@@ -162,10 +163,13 @@
             # TODO: is this needed for both kvm and libvirt?
             # This option is only used in windows installation case,
             # since linux use kernel/initrd option of qemu.
-            i440fx:
-                cd_format = ide
-            q35:
-                cd_format = ahci
+            Windows:
+                i440fx:
+                    cd_format_cd1 = ide
+                    cd_format_winutils = ide
+                q35:
+                    cd_format_cd1 = ahci
+                    cd_format_winutils = ahci
             boot_once = d
             medium = cdrom
             redirs += " unattended_install"

--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -14,14 +14,23 @@
     image_verify_bootable = no
     force_create_image_stg = yes
     drive_serial_stg = "TARGET_DISK0"
-    cdroms += " unattended"
-    unattended_delivery_method = cdrom
     chk_phy_blk_cmd = "cat /sys/block/%s/queue/physical_block_size"
     chk_log_blk_cmd = "cat /sys/block/%s/queue/logical_block_size"
     chk_blks_cmd_windows = "powershell "get-disk|format-list""
     variants:
         - extra_cdrom_ks:
             no 4096_4096
+            cdroms += " unattended"
+            unattended_delivery_method = cdrom
+            Windows:
+                i440fx:
+                    cd_format_cd1 = ide
+                    cd_format_winutils = ide
+                    cd_format_unattended = ide
+                q35:
+                    cd_format_cd1 = ahci
+                    cd_format_winutils = ahci
+                    cd_format_unattended = ahci
         - base:
             only 4096_4096
     variants:


### PR DESCRIPTION
For windows guest, virtio driver is needed if drive format is blk and scsi.
To aviod vm can not identify cdrom as no driver, specify cd_format to ide.
This issue is introduced by avocado-vt commit 164dc1ff7fd39f30a7fb3ec54ad14858614ce907.

id: 1542520
Signed-off-by: Yanan Fu <yfu@redhat.com>