### PR TITLE
qemu_guest_agent:Make guest-fsfreeze-freeze/thaw work in windows guest

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -8,6 +8,7 @@
     gagent_stop_cmd = "service qemu-guest-agent stop"
     gagent_status_cmd = "service qemu-guest-agent status"
     gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
+    gagent_fs_test_cmd = "echo foo > /tmp/foo"
     Windows:
         ga_username = "Administrator"
         deps = no
@@ -25,6 +26,7 @@
         gagent_host_path = "/tmp/${qemu_ga_pkg}"
         gagent_guest_dir = "C:\qemu-ga"
         gagent_remove_service_cmd = "net stop qemu-ga & del /f C:\qemu-ga\${qemu_ga_pkg} & echo done"
+        gagent_fs_test_cmd = "echo foo > C:\foo.txt"
     RHEL.6:
         gagent_start_cmd = "service qemu-ga start"
         gagent_stop_cmd = "service qemu-ga stop"
@@ -103,10 +105,7 @@
             no Windows
             gagent_check_type = get_interfaces
         - check_fsfreeze:
-            # fsfreeze series commands can't run on windows guest.
-            no Windows
             gagent_check_type = fsfreeze
-            gagent_fs_test_cmd = "rm -f /tmp/foo; echo foo > /tmp/foo"
         - check_snapshot:
             # fsfreeze series commands can't run on windows guest.
             type = qemu_guest_agent_snapshot


### PR DESCRIPTION
1.make guest-fsfreeze-freeze/thaw work in windows guest.
2.add check steps after thaw fs in guest.
3.fix bug about 'thread._local' object has no attribute 'contexts'

id: 1508306 , 1543259 , 1508356
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>