### PR TITLE
qemu.tests.block_hotplug: make the condition detection of vm.is_dead() more robust.

### DIFF
--- a/qemu/tests/block_hotplug.py
+++ b/qemu/tests/block_hotplug.py
@@ -210,7 +210,7 @@ def run(test, params, env):
             error_context.context(context_msg % (sub_type, "after hotplug"),
                                   logging.info)
             utils_test.run_virt_sub_test(test, params, env, sub_type)
-            if vm.is_dead():
+            if sub_type == "shutdown" and vm.is_dead():
                 return
 
         sub_type = params.get("sub_type_before_unplug")


### PR DESCRIPTION
If the vm is truly crash/dead, original code will return directly, which is not expected. Only for screnaio 'shutdown' could return directly, others should prompt guest dead error info which is already added in the framework.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1511837