### PR TITLE
block_hotplug: set "only one_pci" for with_block_resize

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -61,6 +61,7 @@
             reboot_method = system_reset
         - with_block_resize:
             only with_plug
+            only one_pci
             sub_type_after_plug = block_resize
             blk_extra_params_stg0 += " serial=TARGET_DISK0"
             block_size_cmd = "fdisk -l | grep {0}"


### PR DESCRIPTION
block_resize.py only support extend/shrink on one data disk.
To keep consistency, set "only one_pci" in block_hotplug.cfg
for with_block_resize.

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1549976