### PR TITLE
block_hotplug_negative: set image_format for hotplug block device

### DIFF
--- a/qemu/tests/block_hotplug_negative.py
+++ b/qemu/tests/block_hotplug_negative.py
@@ -48,52 +48,50 @@ def run(test, params, env):
         drive.hotplug(vm.monitor)
 
     img_list = params.get("images").split()
-    img_format_type = params.get("img_format_type", "qcow2")
+    img_format_type = params["image_format"]
     pci_type = params.get("pci_type", "virtio-blk-pci")
-    blk_num = int(params.get("blk_num", 1))
     add_block_device = True
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
 
     error_context.context("Hotplug block device", logging.info)
-    for num in xrange(blk_num):
-        device = qdevices.QDevice(pci_type)
-        drive = qdevices.QRHDrive("block%d" % num)
-        drive.set_param("file", find_image(img_list[num + 1]))
-        drive.set_param("format", img_format_type)
-        drive_id = drive.get_param("id")
-        drive.hotplug(vm.monitor)
-        #add controller if needed
-        if params.get("need_controller", "no") == "yes":
-            controller_model = params.get("controller_model")
-            controller = qdevices.QDevice(controller_model)
-            bus_extra_param = params.get("bus_extra_params_%s" % img_list[num + 1])
-            if bus_extra_param:
-                key, value = bus_extra_param.split("=")
-                qdevice_params = {key: value}
-                controller.params.update(qdevice_params)
-            try:
-                controller.hotplug(vm.monitor)
-            except Exception, e:
-                if "QMP command 'device_add' failed" in str(e):
-                    logging.info("Failed to add controller with invalid params")
-                    drive_unplug_plug(drive, vm)
-                    add_block_device = False
+    device = qdevices.QDevice(pci_type)
+    drive = qdevices.QRHDrive("hotadd_block")
+    drive.set_param("file", find_image(img_list[1]))
+    drive.set_param("format", img_format_type)
+    drive_id = drive.get_param("id")
+    drive.hotplug(vm.monitor)
+    #add controller if needed
+    if params.get("need_controller", "no") == "yes":
+        controller_model = params.get("controller_model")
+        controller = qdevices.QDevice(controller_model)
+        bus_extra_param = params.get("bus_extra_params_%s" % img_list[1])
+        if bus_extra_param:
+            key, value = bus_extra_param.split("=")
+            qdevice_params = {key: value}
+            controller.params.update(qdevice_params)
+        try:
+            controller.hotplug(vm.monitor)
+        except Exception, e:
+            if "QMP command 'device_add' failed" in str(e):
+                logging.info("Failed to add controller with invalid params")
+                drive_unplug_plug(drive, vm)
+                add_block_device = False
 
-        if add_block_device:
-            device.set_param("drive", drive_id)
-            device.set_param("id", "block%d" % num)
-            blk_extra_param = params.get("blk_extra_params_%s" % img_list[num + 1])
-            if blk_extra_param:
-                key, value = blk_extra_param.split("=")
-                device.set_param(key, value)
-            try:
-                device.hotplug(vm.monitor)
-            except Exception, e:
-                if "QMP command 'device_add' failed" in str(e):
-                    logging.info("Failed to add block with invalid params")
-                    drive_unplug_plug(drive, vm)
+    if add_block_device:
+        device.set_param("drive", drive_id)
+        device.set_param("id", "hotadd_block")
+        blk_extra_param = params.get("blk_extra_params_%s" % img_list[1])
+        if blk_extra_param:
+            key, value = blk_extra_param.split("=")
+            device.set_param(key, value)
+        try:
+            device.hotplug(vm.monitor)
+        except Exception, e:
+            if "QMP command 'device_add' failed" in str(e):
+                logging.info("Failed to add block with invalid params")
+                drive_unplug_plug(drive, vm)
 
     error_context.context("Check vm is alive after drive unplug/hotplug test", logging.info)
     session = vm.wait_for_login()


### PR DESCRIPTION
Default image_format for hotplug device is "qcow2",
but for raw image, it should be raw, so error occurs.
Correct it.

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1550397