### PR TITLE
balloon_check: Send stable signal when guest memory reach stable state

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -24,12 +24,14 @@ class BallooningTest(MemoryBaseTest):
 
         self.vm = env.get_vm(params["main_vm"])
         self.session = self.get_session(self.vm)
+        self.env["balloon_test_setup_ready"] = False
         if self.params.get('os_type') == 'windows':
             sleep_time = 180
         else:
             sleep_time = 90
         logging.info("Waiting %d seconds for guest's applications up" % sleep_time)
         time.sleep(sleep_time)
+        self.env["balloon_test_setup_ready"] = True
         self.ori_mem = self.get_vm_mem(self.vm)
         self.current_mmem = self.get_ballooned_memory()
         if self.current_mmem != self.ori_mem:

--- a/qemu/tests/cfg/balloon_in_use.cfg
+++ b/qemu/tests/cfg/balloon_in_use.cfg
@@ -12,6 +12,7 @@
     set_bg_stress_flag = yes
     session_cmd_timeout = 240
     balloon_timeout = 240
+    check_setup_events = balloon_test_setup_ready
     Windows:
         x86_64:
             program_files = "%ProgramFiles(x86)%"

--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -102,6 +102,7 @@
             run_bgstress = balloon_stress
             bg_stress_run_flag = balloon_test
             set_bg_stress_flag = yes
+            check_setup_events = balloon_test_setup_ready
             wait_bg_time = 180
             free_mem_cmd = wmic os get FreePhysicalMemory
             session_cmd_timeout = 240

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -66,6 +66,13 @@ def run(test, params, env):
                 utils_test.run_virt_sub_test, (test, params, env),
                 {"sub_type": bg_stress_test})
             stress_thread.start()
+
+        for event in params.get("check_setup_events", "").strip().split():
+            if not utils_misc.wait_for(lambda: env.get(event),
+                                       240, 0, 1):
+                test.error("Background test not in ready state since haven't "
+                           "received event %s" % event)
+
         if not utils_misc.wait_for(lambda: check_bg_running(target_process),
                                    120, 0, 1):
             raise exceptions.TestFail("Backgroud test %s is not "


### PR DESCRIPTION
It will takes 90/180 seconds for guests getting to stable state in balloon_check, it should send signal when it's ready so that other operation can start after that.
driver_in_use should start background test only when guest memory get to stable state to avoid bg_test check failure.

ID:1550805

Signed-off-by: Li Jin <lijin@redhat.com>