### PR TITLE
nfs_corrupt: add space check for nfs and change timeo for mount

### DIFF
--- a/generic/tests/nfs_corrupt.py
+++ b/generic/tests/nfs_corrupt.py
@@ -2,13 +2,19 @@ import os
 import re
 import logging
 
-from autotest.client.shared import error
 from autotest.client import utils
 from autotest.client import os_dep
 
 from virttest import utils_misc
 from virttest import utils_net
 from virttest import env_process
+from virttest import error_context
+
+
+class NFSCorruptError(Exception):
+
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
 
 
 class NFSCorruptConfig(object):
@@ -22,6 +28,7 @@ class NFSCorruptConfig(object):
         self.mnt_dir = os.path.join(test.tmpdir, "mnt_dir")
         self.chk_re = params.get("nfs_stat_chk_re", "running")
         self.nfs_ip = ip
+        self.required_size = params.object_params("stg").get("image_size")
 
         cmd_list = self._get_service_cmds()
         self.start_cmd = cmd_list[0]
@@ -29,12 +36,13 @@ class NFSCorruptConfig(object):
         self.restart_cmd = cmd_list[2]
         self.status_cmd = cmd_list[3]
 
-    @error.context_aware
+    @error_context.context_aware
     def _get_service_cmds(self):
         """
         Figure out the commands used to control the NFS service.
         """
-        error.context("Finding out appropriate commands to handle NFS service")
+        error_context.context("Finding out commands to handle NFS service",
+                              logging.info)
         service = os_dep.command("service")
         try:
             systemctl = os_dep.command("systemctl")
@@ -49,7 +57,7 @@ class NFSCorruptConfig(object):
             elif os.path.isfile(service_file):
                 service_name = "nfs-server"
             else:
-                raise error.TestError("Files %s and %s absent, don't know "
+                raise NFSCorruptError("Files %s and %s absent, don't know "
                                       "how to set up NFS for this host" %
                                       (init_script, service_file))
             start_cmd = "%s start %s.service" % (systemctl, service_name)
@@ -64,20 +72,32 @@ class NFSCorruptConfig(object):
 
         return [start_cmd, stop_cmd, restart_cmd, status_cmd]
 
-    @error.context_aware
+    @error_context.context_aware
     def setup(self, force_start=False):
         """
         Setup test NFS share.
 
         :param force_start: Whether to make NFS service start anyway.
         """
-        error.context("Setting up test NFS share")
+        error_context.context("Setting up test NFS share", logging.info)
 
         for d in [self.nfs_dir, self.mnt_dir]:
             try:
                 os.makedirs(d)
             except OSError:
                 pass
+
+        error_context.context("Checking available space to export",
+                              logging.info)
+        stat = os.statvfs(self.nfs_dir)
+        free = str(stat.f_bsize * stat.f_bfree) + 'B'
+        available_size = float(utils_misc.normalize_data_size(free,
+                                                              order_magnitude="M"))
+        required_size = float(utils_misc.normalize_data_size(self.required_size,
+                                                             order_magnitude="M"))
+        if available_size < required_size:
+            raise NFSCorruptError("Space available: %fM, space needed: %fM"
+                                  % (available_size, required_size))
 
         if force_start:
             self.start_service()
@@ -87,12 +107,12 @@ class NFSCorruptConfig(object):
 
         utils.run("exportfs %s:%s -o rw,no_root_squash" %
                   (self.nfs_ip, self.nfs_dir))
-        utils.run("mount %s:%s %s -o rw,soft,timeo=1,retrans=1,vers=3" %
+        utils.run("mount %s:%s %s -o rw,soft,timeo=30,retrans=1,vers=3" %
                   (self.nfs_ip, self.nfs_dir, self.mnt_dir))
 
-    @error.context_aware
+    @error_context.context_aware
     def cleanup(self, force_stop=False):
-        error.context("Cleaning up test NFS share")
+        error_context.context("Cleaning up test NFS share", logging.info)
         utils.run("umount %s" % self.mnt_dir)
         utils.run("exportfs -u %s:%s" % (self.nfs_ip, self.nfs_dir))
         if force_stop:
@@ -130,7 +150,7 @@ class NFSCorruptConfig(object):
             return False
 
 
-@error.context_aware
+@error_context.context_aware
 def run(test, params, env):
     """
     Test if VM paused when image NFS shutdown, the drive option 'werror' should
@@ -187,17 +207,20 @@ def run(test, params, env):
         else:
             return True
 
-    error.context("Setup NFS Server on local host", logging.info)
+    error_context.context("Setup NFS Server on local host", logging.info)
     host_ip = utils_net.get_host_ip_address(params)
-    config = NFSCorruptConfig(test, params, host_ip)
-    config.setup()
+    try:
+        config = NFSCorruptConfig(test, params, host_ip)
+        config.setup()
+    except NFSCorruptError as e:
+        test.error(str(e))
     image_name = os.path.join(config.mnt_dir, "nfs_corrupt")
     params["image_name_stg"] = image_name
     params["force_create_image_stg"] = "yes"
     params["create_image_stg"] = "yes"
     stg_params = params.object_params("stg")
 
-    error.context("Boot vm with image on NFS server", logging.info)
+    error_context.context("Boot vm with image on NFS server", logging.info)
     env_process.preprocess_image(test, stg_params, image_name)
 
     vm = env.get_vm(params["main_vm"])
@@ -207,7 +230,7 @@ def run(test, params, env):
     nfs_devname = get_nfs_devname(params, session)
 
     # Write disk on NFS server
-    error.context("Write disk that image on NFS", logging.info)
+    error_context.context("Write disk that image on NFS", logging.info)
     write_disk_cmd = "dd if=/dev/urandom of=%s" % nfs_devname
     session.sendline(write_disk_cmd)
     try:
@@ -217,7 +240,8 @@ def run(test, params, env):
         pass
 
     try:
-        error.context("Make sure guest is running before test")
+        error_context.context("Make sure guest is running before test",
+                              logging.info)
         vm.resume()
         vm.verify_status("running")
 
@@ -232,16 +256,16 @@ def run(test, params, env):
             cmd += " --dport 2049"
             cmd += " -j REJECT"
 
-            error.context("Reject NFS connection on host", logging.info)
+            error_context.context("Reject NFS connection on host", logging.info)
             utils.system(cmd)
 
-            error.context("Check if VM status is 'paused'", logging.info)
+            error_context.context("Check if VM status is 'paused'", logging.info)
             if not utils_misc.wait_for(
                 lambda: check_vm_status(vm, "paused"),
                     int(params.get('wait_paused_timeout', 120))):
-                raise error.TestError("Guest is not paused after stop NFS")
+                test.error("Guest is not paused after stop NFS")
         finally:
-            error.context("Accept NFS connection on host")
+            error_context.context("Accept NFS connection on host", logging.info)
             cmd = "iptables"
             cmd += " -t filter"
             cmd += " -D INPUT"
@@ -254,12 +278,12 @@ def run(test, params, env):
 
             utils.system(cmd)
 
-        error.context("Continue guest")
+        error_context.context("Continue guest", logging.info)
         vm.resume()
 
-        error.context("Check if VM status is 'running'")
+        error_context.context("Check if VM status is 'running'", logging.info)
         if not utils_misc.wait_for(lambda: check_vm_status(vm, "running"), 20):
-            raise error.TestError("Guest does not restore to 'running' status")
+            test.error("Guest does not restore to 'running' status")
 
     finally:
         session.close()


### PR DESCRIPTION
id: 1475777
Add check for NFS to ensure that its exported size should be large enough to hold the data image created, which will be used as destination for dd test in NFS corrupt. Also change the timeout of NFS soft mount to increase the wait time.

Signed-off-by: lolyu <lolyu@redhat.com>