### PR TITLE
generic.tests.lvm: don't remove image_stg1 and image_stg2 before lvm clean

### DIFF
--- a/generic/tests/cfg/lvm.cfg
+++ b/generic/tests/cfg/lvm.cfg
@@ -11,6 +11,8 @@
     image_cluster_size_stg2 = 65536
     image_size_stg2 = 1G
     image_format_stg2 = qcow2
+    remove_image_stg1 = no
+    remove_image_stg2 = no
     guest_testdir = /mnt
     post_command_noncritical = no
     clean = no


### PR DESCRIPTION
ID: 1542384
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>