### PR TITLE
kdump: Change Kdump variable name

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -57,7 +57,7 @@
                     netperf_test_duration = 360
                     netperf_para_sessions = 2
                     test_protocols = TCP_STREAM
-                    check_cmd = "ps -C netperf"
+                    kdump_check_cmd = "ps -C netperf"
                     RHEL.4:
                         netperf_link = netperf-2.4.5.tar.bz2
                 - io_stress:
@@ -68,7 +68,7 @@
                     install_cmd = "tar -xzvf ${tmp_dir}/stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install"
                     app_check_cmd = "stress --help"
                     start_cmd = "stress --cpu 4 --io 4 --vm 2 --vm-bytes 256M --quiet &"
-                    check_cmd = "pidof -s stress"
+                    kdump_check_cmd = "pidof -s stress"
         - with_ssh:
             # Note: This is a existed bug 737786#c13 for RHEl6
             no RHEL.5

--- a/qemu/tests/kdump_with_stress.py
+++ b/qemu/tests/kdump_with_stress.py
@@ -84,7 +84,7 @@ def run(test, params, env):
         """
         Check stress app really run in background.
         """
-        cmd = params.get("check_cmd")
+        cmd = params.get("kdump_check_cmd")
         status = session.cmd_status(cmd, timeout=120)
         return status == 0
 


### PR DESCRIPTION
kdump.cfg variable name check_cmd conflict with guest-os/Linux.cfg line 140
ID: 1543768
Signed-off-by: Chunyu Liao cliao@redhat.com