### PR TITLE
macvtap_mac_change: Adjust test steps according to test plan

### DIFF
--- a/generic/tests/mac_change.py
+++ b/generic/tests/mac_change.py
@@ -160,7 +160,10 @@ def run(test, params, env):
                                       logging.info)
                 utils_test.run_file_transfer(test, params, env)
         else:
-            check_guest_mac(test, new_mac, vm)
+            if params.get("ctrl_mac_addr") == "off":
+                check_guest_mac(test, old_mac, vm)
+            else:
+                check_guest_mac(test, new_mac, vm)
     finally:
         if os_type == "windows":
             clean_cmd_pattern = params.get("clean_cmd")


### PR DESCRIPTION
macvtap_mac_change: Adjust test steps according to test plan

1. in RHEL guest with virtio1.0, when set ctrl_mac_addr=off, mac can be changed to new one in guest but display the old one while 'info network'
2. in RHEL guest with virtio1.0, when set ctrl_mac_addr=on, mac can be changed to new ones both in guest and 'info network'

id: 1486119
Signed-off-by: Xiyue Wang <xiywang@redhat.com>