### PR TITLE
Rewrite clock test in autotest

### DIFF
--- a/generic/deps/monotonic_time/Makefile
+++ b/generic/deps/monotonic_time/Makefile
@@ -1,0 +1,23 @@
+CC=	cc
+
+CFLAGS=	-O -std=gnu99 -Wall
+LIBS=	-lpthread -lrt
+
+PROG=	time_test
+
+SRCS=	time_test.c cpuset.c threads.c logging.c
+HDRS=	spinlock.h cpuset.h threads.h logging.h
+OBJS=	$(SRCS:.c=.o)
+
+all:	$(PROG)
+
+$(PROG):	$(OBJS)
+	$(CC) $(LDFLAGS) -o $(PROG) $(OBJS) $(LIBS)
+
+$(OBJS):	$(HDRS)
+
+clean:
+	-rm -f $(OBJS)
+
+clobber:	clean
+	-rm -f $(PROG)

--- a/generic/deps/monotonic_time/cpuset.c
+++ b/generic/deps/monotonic_time/cpuset.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ * Author: md@google.com (Michael Davidson)
+ */
+#define _GNU_SOURCE	/* for cpu_set macros */
+
+#include <sched.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "cpuset.h"
+#include "logging.h"
+
+/*
+ * Return the number of cpus in a cpu_set
+ */
+int count_cpus(const cpu_set_t *cpus)
+{
+	int	count	= 0;
+	int	cpu;
+
+	for (cpu = 0; cpu < CPU_SETSIZE; cpu++)
+		if (CPU_ISSET(cpu, cpus))
+			++count;
+
+	return count;
+}
+
+/*
+ * Parse a string containing a comma separated list of ranges
+ * of cpu numbers such as: "0,2,4-7" into a cpu_set_t.
+ */
+int parse_cpu_set(const char *s, cpu_set_t *cpus)
+{
+	CPU_ZERO(cpus);
+
+	while (*s) {
+		char	*next;
+		int	cpu;
+		int	start, end;
+
+		start = end = (int)strtol(s, &next, 0);
+		if (s == next)
+			break;
+		s = next;
+
+		if (*s == '-') {
+			++s;
+			end = (int)strtol(s, &next, 0);
+			if (s == next)
+				break;
+			s = next;
+		}
+
+		if (*s == ',')
+			++s;
+
+		if (start < 0 || start >= CPU_SETSIZE) {
+			ERROR(0, "bad cpu number '%d' in cpu set", start);
+			return 1;
+		}
+
+		if (end < 0 || end >= CPU_SETSIZE) {
+			ERROR(0, "bad cpu number '%d' in cpu set", end);
+			return 1;
+		}
+
+		if (end < start) {
+			ERROR(0, "bad range '%d-%d' in cpu set", start, end);
+			return 1;
+		}
+
+		for (cpu = start; cpu <= end; ++cpu)
+			CPU_SET(cpu, cpus);
+
+	}
+
+	if (*s) {
+		ERROR(0, "unexpected character '%c' in cpu set", *s);
+		return 1;
+	}
+
+	return 0;
+}
+
+
+static int show_range(char *buf, size_t len, const char *prefix,
+			int start, int end)
+{
+	int	n;
+
+	if (start == end)
+		n = snprintf(buf, len, "%s%d", prefix, start);
+	else
+		n = snprintf(buf, len, "%s%d-%d", prefix, start, end);
+
+	if (n < len)
+		return n;
+
+	return -1;
+}
+
+/*
+ * Turn a cpu_set_t into a human readable string containing a
+ * comma separated list of ranges of cpu numbers.
+ *
+ * Returns the number of bytes written to the buffer,
+ * not including the terminating '\0' character,
+ * or -1 if there was not enough space in the  buffer.
+ */
+int show_cpu_set(char *buf, size_t len, const cpu_set_t *cpus)
+{
+	char	*bufp	= buf;
+	int	start	= -1;
+	int	end	= -1;
+	char	*sep	= "";
+	int	cpu;
+
+	for (cpu = 0; cpu < CPU_SETSIZE; cpu++) {
+		if (CPU_ISSET(cpu, cpus)) {
+			if (start < 0)
+				start = cpu;
+			end = cpu;
+		} else if (start >= 0) {
+			int	n;
+			if ((n = show_range(bufp, len, sep, start, end)) < 0)
+				return -1;
+			len -= n;
+			bufp += n;
+			sep = ",";
+			start = end = -1;
+		}
+	}
+
+	if (start >= 0) {
+		int	n;
+		if ((n = show_range(bufp, len, sep, start, end)) < 0)
+			return -1;
+		bufp += n;
+	}
+
+	return bufp - buf;
+}

--- a/generic/deps/monotonic_time/cpuset.h
+++ b/generic/deps/monotonic_time/cpuset.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ * Author: md@google.com (Michael Davidson)
+ */
+
+#ifndef CPUSET_H_
+#define CPUSET_H_
+
+#define _GNU_SOURCE	/* for cpu_set macros */
+
+#include <sched.h>
+
+int count_cpus(const cpu_set_t *cpus);
+int parse_cpu_set(const char *s, cpu_set_t *cpus);
+int show_cpu_set(char *buf, size_t len, const cpu_set_t *cpus);
+
+#endif	/* CPUSET_H_ */

--- a/generic/deps/monotonic_time/logging.c
+++ b/generic/deps/monotonic_time/logging.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ *
+ * Author: md@google.com (Michael Davidson)
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "logging.h"
+
+
+static FILE		*log_fp		= NULL;
+static const char	*program	= "";
+static int		debug		= 0;
+
+
+void set_log_file(FILE *fp)
+{
+	log_fp = fp;
+}
+
+void set_program_name(const char *name)
+{
+	program = name;
+}
+
+void set_debug_level(int level)
+{
+	debug = level;
+}
+
+void msg(enum msg_type msg_type, int data, const char *fmt, ...)
+{
+	va_list		ap;
+	int		err	= 0;
+	const char	*type 	= NULL;
+
+	/*
+	 * default is to log to stdout
+	 */
+	if (!log_fp)
+		log_fp = stdout;
+
+	switch (msg_type) {
+		case MSG_DEBUG:
+			if (data > debug)
+				return;
+			type = "DEBUG";
+			break;
+		case MSG_INFO:
+			type = "INFO";
+			break;
+		case MSG_WARN:
+			type = "WARN";
+			break;
+		case MSG_ERROR:
+			type = "ERROR";
+			err = data;
+			break;
+		case MSG_FATAL:
+			type = "FATAL";
+			err = data;
+			break;
+	}
+
+	va_start(ap, fmt);
+
+	if (type)
+		fprintf(log_fp, "%s: ", type);
+
+	if (program)
+		fprintf(log_fp, "%s: ", program);
+
+	vfprintf(log_fp, fmt, ap);
+
+	if (err) {
+		fprintf(log_fp, ": %s\n", strerror(err));
+	} else {
+		fputc('\n', log_fp);
+	}
+
+	va_end(ap);
+
+	if (msg_type == MSG_FATAL)
+		exit(EXIT_FAILURE);
+}

--- a/generic/deps/monotonic_time/logging.h
+++ b/generic/deps/monotonic_time/logging.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ *
+ * Author: md@google.com (Michael Davidson)
+ */
+
+#ifndef LOGGING_H_
+#define LOGGING_H_
+
+enum msg_type {
+	MSG_DEBUG,
+	MSG_INFO,
+	MSG_WARN,
+	MSG_ERROR,
+	MSG_FATAL,
+};
+
+void msg(enum msg_type, int data, const char *fmt, ...);
+
+#define	DEBUG(level, fmt, args...)	msg(MSG_DEBUG, level, fmt, ##args)
+#define	INFO(fmt, args...)		msg(MSG_INFO, 0, fmt, ##args)
+#define	WARN(err, fmt, args...)		msg(MSG_WARN, err, fmt, ##args)
+#define	ERROR(err, fmt, args...)	msg(MSG_ERROR, err, fmt, ##args)
+#define	FATAL(err, fmt, args...)	msg(MSG_FATAL, err, fmt, ##args)
+
+extern void set_program_name(const char *name);
+extern void set_debug_level(int level);
+extern void set_log_file(FILE *fp);
+
+#endif /* LOGGING_H_ */

--- a/generic/deps/monotonic_time/spinlock.h
+++ b/generic/deps/monotonic_time/spinlock.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ * Author: md@google.com (Michael Davidson)
+ *
+ * Based on time-warp-test.c, which is:
+ * Copyright (C) 2005, Ingo Molnar
+ */
+
+#ifndef SPINLOCK_H_
+#define	SPINLOCK_H_
+
+typedef unsigned long spinlock_t;
+
+static inline void spin_lock(spinlock_t *lock)
+{
+	__asm__ __volatile__(
+		"1: rep; nop\n"
+		" lock; btsl $0,%0\n"
+		"jc 1b\n"
+			     : "=m"(*lock) : : "memory");
+}
+
+static inline void spin_unlock(spinlock_t *lock)
+{
+	__asm__ __volatile__("movl $0,%0; rep; nop" : "=m"(*lock) :: "memory");
+}
+
+#endif	/* SPINLOCK_H_ */

--- a/generic/deps/monotonic_time/threads.c
+++ b/generic/deps/monotonic_time/threads.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ * Author: md@google.com (Michael Davidson)
+ */
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <sched.h>
+#include <pthread.h>
+
+#include "logging.h"
+#include "threads.h"
+
+#define MAX_CPUS	CPU_SETSIZE
+#define	MAX_THREADS	MAX_CPUS
+
+typedef struct thread {
+	pthread_t	thread;
+	cpu_set_t	cpus;
+	thread_func_t	func;
+	void		*arg;
+} thread_t;
+
+static thread_t	threads[MAX_THREADS];
+static int	num_threads;
+
+
+/*
+ * Helper function to run a thread on a specific set of CPUs.
+ */
+static void *run_thread(void *arg)
+{
+	thread_t	*thread = arg;
+	void		*result;
+
+	if (sched_setaffinity(0, sizeof thread->cpus, &thread->cpus) < 0)
+		WARN(errno, "sched_setaffinity() failed");
+
+	result = thread->func(thread->arg);
+
+	return result;
+}
+
+
+/*
+ * Create a set of threads each of which is bound to one of
+ * the CPUs specified by cpus.
+ * Returns the number of threads created.
+ */
+int create_per_cpu_threads(cpu_set_t *cpus, thread_func_t func, void *arg)
+{
+	int	cpu;
+
+	for (cpu = 0; cpu < MAX_CPUS; cpu++) {
+		int		err;
+		thread_t	*thread;
+		if (!CPU_ISSET(cpu, cpus))
+			continue;
+		if (num_threads >= MAX_THREADS)
+			break;
+
+		thread		= &threads[num_threads++];
+		thread->func	= func;
+		thread->arg	= arg;
+		CPU_ZERO(&thread->cpus);
+		CPU_SET(cpu, &thread->cpus);
+
+		err = pthread_create(&thread->thread, NULL, run_thread, thread);
+		if (err) {
+			WARN(err, "pthread_create() failed");
+			--num_threads;
+			break;
+		}
+	}
+
+	return num_threads;
+}
+
+
+/*
+ * Create nthreads threads.
+ * Returns the number of threads created.
+ */
+int create_threads(int nthreads, thread_func_t func, void *arg)
+{
+	if (nthreads > MAX_THREADS)
+		nthreads = MAX_THREADS;
+
+	while (--nthreads >= 0) {
+		int		err;
+		thread_t	*thread;
+
+		thread		= &threads[num_threads++];
+		thread->func	= func;
+		thread->arg	= arg;
+		CPU_ZERO(&thread->cpus);
+
+		err = pthread_create(&thread->thread, NULL, func, arg);
+		if (err) {
+			WARN(err, "pthread_create() failed");
+			--num_threads;
+			break;
+		}
+	}
+
+	return num_threads;
+}
+
+
+/*
+ * Join with the set of previsouly created threads.
+ */
+void join_threads(void)
+{
+	while (num_threads > 0)
+		pthread_join(threads[--num_threads].thread, NULL);
+}

--- a/generic/deps/monotonic_time/threads.h
+++ b/generic/deps/monotonic_time/threads.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ * Author: md@google.com (Michael Davidson)
+ */
+
+#ifndef THREADS_H_
+#define THREADS_H_
+
+typedef void  *(*thread_func_t)(void *);
+
+int create_threads(int num_threads, thread_func_t func, void *arg);
+int create_per_cpu_threads(cpu_set_t *cpus, thread_func_t func, void *arg);
+void join_threads(void);
+
+#endif /* THREADS_H_ */

--- a/generic/deps/monotonic_time/time_test.c
+++ b/generic/deps/monotonic_time/time_test.c
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ * Author: md@google.com (Michael Davidson)
+ *
+ * Based on time-warp-test.c, which is:
+ * Copyright (C) 2005, Ingo Molnar
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <pthread.h>
+#include <getopt.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+#include "cpuset.h"
+#include "spinlock.h"
+#include "threads.h"
+#include "logging.h"
+
+
+char	*program	= "";
+long	duration	= 0;
+long	threshold	= 0;
+int	verbose		= 0;
+
+const char optstring[] = "c:d:ht:v";
+
+struct option options[] = {
+	{ "cpus",	required_argument,	0, 	'c'	},
+	{ "duration",	required_argument,	0,	'd'	},
+	{ "help",	no_argument,		0, 	'h'	},
+	{ "threshold",	required_argument,	0, 	't'	},
+	{ "verbose",	no_argument,		0, 	'v'	},
+	{ 0,	0,	0,	0 }
+};
+
+
+void usage(void)
+{
+	printf("usage: %s [-hv] [-c <cpu_set>] [-d duration] [-t threshold] "
+		"tsc|gtod|clock", program);
+}
+
+
+const char help_text[] =
+"check time sources for monotonicity across multiple CPUs\n"
+"  -c,--cpus        set of cpus to test (default: all)\n"
+"  -d,--duration    test duration in seconds (default: infinite)\n"
+"  -t,--threshold   error threshold (default: 0)\n"
+"  -v,--verbose     verbose output\n"
+"  tsc              test the TSC\n"
+"  gtod             test gettimeofday()\n"
+"  clock            test CLOCK_MONOTONIC\n";
+
+
+void help(void)
+{
+	usage();
+	printf("%s", help_text);
+}
+
+
+/*
+ * get the TSC as 64 bit value with CPU clock frequency resolution
+ */
+#if defined(__x86_64__)
+static inline uint64_t rdtsc(void)
+{
+	uint32_t	tsc_lo, tsc_hi;
+	__asm__ __volatile__("rdtsc" : "=a" (tsc_lo), "=d" (tsc_hi));
+	return ((uint64_t)tsc_hi << 32) | tsc_lo;
+}
+#elif defined(__i386__)
+static inline uint64_t rdtsc(void)
+{
+	uint64_t	tsc;
+	__asm__ __volatile__("rdtsc" : "=A" (tsc));
+	return tsc;
+}
+#else
+#error "rdtsc() not implemented for this architecture"
+#endif
+
+
+static inline uint64_t rdtsc_mfence(void)
+{
+	__asm__ __volatile__("mfence" ::: "memory");
+	return rdtsc();
+}
+
+
+static inline uint64_t rdtsc_lfence(void)
+{
+	__asm__ __volatile__("lfence" ::: "memory");
+	return rdtsc();
+}
+
+
+/*
+ * get result from gettimeofday() as a 64 bit value
+ * with microsecond resolution
+ */
+static inline uint64_t rdgtod(void)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	return (uint64_t)tv.tv_sec * 1000000 + tv.tv_usec;
+}
+
+
+/*
+ * get result from clock_gettime(CLOCK_MONOTONIC) as a 64 bit value
+ * with nanosecond resolution
+ */
+static inline uint64_t rdclock(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000 + ts.tv_nsec;
+}
+
+
+/*
+ * test data
+ */
+typedef struct test_info {
+	const char	*name;		/* test name			*/
+	void		(*func)(struct test_info *);	/* the test	*/
+	spinlock_t	lock;
+	uint64_t	last;		/* last time value		*/
+	long		loops;		/* # of test loop iterations	*/
+	long		warps;		/* # of backward time jumps	*/
+	int64_t		worst;		/* worst backward time jump	*/
+	uint64_t	start;		/* test start time		*/
+	int		done;		/* flag to stop test		*/
+} test_info_t;
+
+
+void show_warps(struct test_info *test)
+{
+	INFO("new %s-warp maximum: %9"PRId64, test->name, test->worst);
+}
+
+
+#define	DEFINE_TEST(_name)				\
+							\
+void _name##_test(struct test_info *test)		\
+{							\
+	uint64_t t0, t1;				\
+	int64_t delta;					\
+							\
+	spin_lock(&test->lock);				\
+	t1 = rd##_name();				\
+	t0 = test->last;				\
+	test->last = rd##_name();			\
+	test->loops++;					\
+	spin_unlock(&test->lock);			\
+							\
+	delta = t1 - t0;				\
+	if (delta < 0 && delta < -threshold) {		\
+		spin_lock(&test->lock);			\
+		++test->warps;				\
+		if (delta < test->worst) {		\
+			test->worst = delta;		\
+			show_warps(test);		\
+		}					\
+		spin_unlock(&test->lock);		\
+	}						\
+	if (!((unsigned long)t0 & 31))			\
+		asm volatile ("rep; nop");		\
+}							\
+							\
+struct test_info _name##_test_info = {			\
+	.name = #_name,					\
+	.func = _name##_test,				\
+}
+
+DEFINE_TEST(tsc);
+DEFINE_TEST(tsc_lfence);
+DEFINE_TEST(tsc_mfence);
+DEFINE_TEST(gtod);
+DEFINE_TEST(clock);
+
+struct test_info *tests[] = {
+	&tsc_test_info,
+	&tsc_lfence_test_info,
+	&tsc_mfence_test_info,
+	&gtod_test_info,
+	&clock_test_info,
+	NULL
+};
+
+
+void show_progress(struct test_info *test)
+{
+	static int	count;
+	const char	progress[] = "\\|/-";
+	uint64_t	elapsed = rdgtod() - test->start;
+
+        printf(" | %.2f us, %s-warps:%ld %c\r",
+                        (double)elapsed/(double)test->loops,
+			test->name,
+                        test->warps,
+			progress[++count & 3]);
+	fflush(stdout);
+}
+
+
+void *test_loop(void *arg)
+{
+	struct test_info *test = arg;
+
+	while (! test->done)
+		(*test->func)(test);
+
+	return NULL;
+}
+
+
+int run_test(cpu_set_t *cpus, long duration, struct test_info *test)
+{
+	int		errs;
+	int		ncpus;
+	int		nthreads;
+	struct timespec ts		= { .tv_sec = 0, .tv_nsec = 200000000 };
+	struct timespec	*timeout	= (verbose || duration) ? &ts : NULL;
+	sigset_t	signals;
+
+	/*
+	 * Make sure that SIG_INT is blocked so we can
+	 * wait for it in the main test loop below.
+	 */
+	sigemptyset(&signals);
+	sigaddset(&signals, SIGINT);
+	sigprocmask(SIG_BLOCK, &signals, NULL);
+
+	/*
+	 * test start time
+	 */
+	test->start = rdgtod();
+
+	/*
+     * create the threads
+     */
+	ncpus = count_cpus(cpus);
+	nthreads = create_per_cpu_threads(cpus, test_loop, test);
+	if (nthreads != ncpus) {
+		ERROR(0, "failed to create threads: expected %d, got %d",
+			ncpus, nthreads);
+		if (nthreads) {
+			test->done = 1;
+			join_threads();
+		}
+		return 1;
+	}
+
+	if (duration) {
+		INFO("running %s test on %d cpus for %ld seconds",
+			 test->name, ncpus, duration);
+	} else {
+		INFO("running %s test on %d cpus", test->name, ncpus);
+	}
+
+	/*
+     * wait for a signal
+     */
+	while (sigtimedwait(&signals, NULL, timeout) < 0) {
+		if (duration  && rdgtod() > test->start + duration * 1000000)
+			break;
+
+		if (verbose)
+			show_progress(test);
+	}
+
+	/*
+	 * tell the test threads that we are done and wait for them to exit
+	 */
+	test->done = 1;
+
+	join_threads();
+
+	errs = (test->warps != 0);
+
+	if (!errs)
+		printf("PASS:\n");
+	else
+		printf("FAIL: %s-worst-warp=%"PRId64"\n",
+			test->name, test->worst);
+
+	return errs;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+	int		c;
+	cpu_set_t	cpus;
+	int		errs;
+	int		i;
+	test_info_t	*test;
+	const char	*testname;
+	extern int	opterr;
+	extern int	optind;
+	extern char	*optarg;
+
+	if ((program = strrchr(argv[0], '/')) != NULL)
+		++program;
+	else
+		program = argv[0];
+	set_program_name(program);
+
+	/*
+	 * default to checking all cpus
+	 */
+	for (c = 0; c < CPU_SETSIZE; c++) {
+		CPU_SET(c, &cpus);
+	}
+
+	opterr = 0;
+	errs = 0;
+	while ((c = getopt_long(argc, argv, optstring, options, NULL)) != EOF) {
+		switch (c) {
+			case 'c':
+				if (parse_cpu_set(optarg, &cpus) != 0)
+					++errs;
+				break;
+			case 'd':
+				duration = strtol(optarg, NULL, 0);
+				break;
+			case 'h':
+				help();
+				exit(0);
+			case 't':
+				threshold = strtol(optarg, NULL, 0);
+				break;
+			case 'v':
+				++verbose;
+				break;
+			default:
+				ERROR(0, "unknown option '%c'", c);
+				++errs;
+				break;
+		}
+	}
+
+	if (errs || optind != argc-1) {
+		usage();
+		exit(1);
+	}
+
+	testname = argv[optind];
+	for (i = 0; (test = tests[i]) != NULL; i++) {
+		if (strcmp(testname, test->name) == 0)
+			break;
+	}
+
+	if (!test) {
+		ERROR(0, "unknown test '%s'\n", testname);
+		usage();
+		exit(1);
+	}
+
+	/*
+	 * limit the set of CPUs to the ones that are currently available
+	 * (Note that on some kernel versions sched_setaffinity() will fail
+	 * if you specify CPUs that are not currently online so we ignore
+	 * the return value and hope for the best)
+	 */
+	sched_setaffinity(0, sizeof cpus, &cpus);
+	if (sched_getaffinity(0, sizeof cpus, &cpus) < 0) {
+		ERROR(errno, "sched_getaffinity() failed");
+		exit(1);
+	}
+
+	return run_test(&cpus, duration, test);
+}

--- a/generic/deps/rtc/Makefile
+++ b/generic/deps/rtc/Makefile
@@ -1,0 +1,19 @@
+CC=		cc
+CFLAGS=	        -O -Wall -Wstrict-prototypes
+
+PROGS=		rtctest
+
+SRCS=		rtctest.c
+OBJS=		${SRCS:.c=.o}
+
+
+all:		$(PROGS)
+
+rtctest:	$(OBJS)
+		$(CC) $(LDFLAGS) -o rtctest $(OBJS)
+
+clean:
+		-rm -f $(OBJS)
+
+clobber:	clean
+		-rm -f $(PROGS)

--- a/generic/deps/rtc/rtctest.c
+++ b/generic/deps/rtc/rtctest.c
@@ -1,0 +1,406 @@
+/*
+ *      Real Time Clock Driver Test/Example Program
+ *
+ *      Compile with:
+ *		     gcc -s -Wall -Wstrict-prototypes rtctest.c -o rtctest
+ *
+ *      Copyright (C) 1996, Paul Gortmaker.
+ *
+ *      Released under the GNU General Public License, version 2,
+ *      included herein by reference.
+ *
+ */
+
+#include <stdio.h>
+#include <linux/rtc.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#ifndef ARRAY_SIZE
+# define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#endif
+
+/*
+ * This expects the new RTC class driver framework, working with
+ * clocks that will often not be clones of what the PC-AT had.
+ * Use the command line to specify another RTC if you need one.
+ */
+static const char default_rtc[] = "/dev/rtc0";
+static int maxfreq = 64;
+
+static struct rtc_time cutoff_dates[] = {
+	{
+		.tm_year = 70, /* 1970 -1900 */
+		.tm_mday = 1,
+	},
+	/* signed time_t 19/01/2038 3:14:08 */
+	{
+		.tm_year = 138,
+		.tm_mday = 19,
+	},
+	{
+		.tm_year = 138,
+		.tm_mday = 20,
+	},
+	{
+		.tm_year = 199, /* 2099 -1900 */
+		.tm_mday = 1,
+	},
+	{
+		.tm_year = 200, /* 2100 -1900 */
+		.tm_mday = 1,
+	},
+	/* unsigned time_t 07/02/2106 7:28:15*/
+	{
+		.tm_year = 205,
+		.tm_mon = 1,
+		.tm_mday = 7,
+	},
+	{
+		.tm_year = 206,
+		.tm_mon = 1,
+		.tm_mday = 8,
+	},
+	/* signed time on 64bit in nanoseconds 12/04/2262 01:47:16*/
+	{
+		.tm_year = 362,
+		.tm_mon = 3,
+		.tm_mday = 12,
+	},
+	{
+		.tm_year = 362, /* 2262 -1900 */
+		.tm_mon = 3,
+		.tm_mday = 13,
+	},
+};
+
+static int compare_dates(struct rtc_time *a, struct rtc_time *b)
+{
+	if (a->tm_year != b->tm_year ||
+	    a->tm_mon != b->tm_mon ||
+	    a->tm_mday != b->tm_mday ||
+	    a->tm_hour != b->tm_hour ||
+	    a->tm_min != b->tm_min ||
+	    ((b->tm_sec - a->tm_sec) > 1))
+		return 1;
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	int i, fd, retval, irqcount = 0, dangerous = 0;
+	unsigned long tmp, data;
+	struct rtc_time rtc_tm;
+	const char *rtc = default_rtc;
+	struct timeval start, end, diff;
+
+	switch (argc) {
+	case 4:
+		if (*argv[2] == 'd')
+			dangerous = 1;
+	case 3:
+		maxfreq = atoi(argv[2]);
+	case 2:
+		rtc = argv[1];
+		/* FALLTHROUGH */
+	case 1:
+		break;
+	default:
+		fprintf(stderr, "usage:  rtctest [rtcdev] [maxfreq] [d]\n");
+		return 1;
+	}
+
+	fd = open(rtc, O_RDONLY);
+
+	if (fd ==  -1) {
+		perror(rtc);
+		exit(errno);
+	}
+
+	fprintf(stderr, "\n\t\t\tRTC Driver Test Example.\n\n");
+
+	/* Turn on update interrupts (one per second) */
+	retval = ioctl(fd, RTC_UIE_ON, 0);
+	if (retval == -1) {
+		if (errno == EINVAL) {
+			fprintf(stderr,
+				"\n...Update IRQs not supported.\n");
+			goto test_READ;
+		}
+		perror("RTC_UIE_ON ioctl");
+		exit(errno);
+	}
+
+	fprintf(stderr, "Counting 5 update (1/sec) interrupts from reading %s:",
+			rtc);
+	fflush(stderr);
+	for (i=1; i<6; i++) {
+		/* This read will block */
+		retval = read(fd, &data, sizeof(unsigned long));
+		if (retval == -1) {
+			perror("read");
+			exit(errno);
+		}
+		fprintf(stderr, " %d",i);
+		fflush(stderr);
+		irqcount++;
+	}
+
+	fprintf(stderr, "\nAgain, from using select(2) on /dev/rtc:");
+	fflush(stderr);
+	for (i=1; i<6; i++) {
+		struct timeval tv = {5, 0};     /* 5 second timeout on select */
+		fd_set readfds;
+
+		FD_ZERO(&readfds);
+		FD_SET(fd, &readfds);
+		/* The select will wait until an RTC interrupt happens. */
+		retval = select(fd+1, &readfds, NULL, NULL, &tv);
+		if (retval == -1) {
+		        perror("select");
+		        exit(errno);
+		}
+		/* This read won't block unlike the select-less case above. */
+		retval = read(fd, &data, sizeof(unsigned long));
+		if (retval == -1) {
+		        perror("read");
+		        exit(errno);
+		}
+		fprintf(stderr, " %d",i);
+		fflush(stderr);
+		irqcount++;
+	}
+
+	/* Turn off update interrupts */
+	retval = ioctl(fd, RTC_UIE_OFF, 0);
+	if (retval == -1) {
+		perror("RTC_UIE_OFF ioctl");
+		exit(errno);
+	}
+
+test_READ:
+	/* Read the RTC time/date */
+	retval = ioctl(fd, RTC_RD_TIME, &rtc_tm);
+	if (retval == -1) {
+		perror("RTC_RD_TIME ioctl");
+		exit(errno);
+	}
+
+	fprintf(stderr, "\n\nCurrent RTC date/time is %d-%d-%d, %02d:%02d:%02d.\n",
+		rtc_tm.tm_mday, rtc_tm.tm_mon + 1, rtc_tm.tm_year + 1900,
+		rtc_tm.tm_hour, rtc_tm.tm_min, rtc_tm.tm_sec);
+
+	/* Set the alarm to 5 sec in the future, and check for rollover */
+	rtc_tm.tm_sec += 5;
+	if (rtc_tm.tm_sec >= 60) {
+		rtc_tm.tm_sec %= 60;
+		rtc_tm.tm_min++;
+	}
+	if (rtc_tm.tm_min == 60) {
+		rtc_tm.tm_min = 0;
+		rtc_tm.tm_hour++;
+	}
+	if (rtc_tm.tm_hour == 24)
+		rtc_tm.tm_hour = 0;
+
+	retval = ioctl(fd, RTC_ALM_SET, &rtc_tm);
+	if (retval == -1) {
+		if (errno == EINVAL) {
+			fprintf(stderr,
+				"\n...Alarm IRQs not supported.\n");
+			goto test_PIE;
+		}
+
+		perror("RTC_ALM_SET ioctl");
+		exit(errno);
+	}
+
+	/* Read the current alarm settings */
+	retval = ioctl(fd, RTC_ALM_READ, &rtc_tm);
+	if (retval == -1) {
+		if (errno == EINVAL) {
+			fprintf(stderr,
+					"\n...EINVAL reading current alarm setting.\n");
+			goto test_PIE;
+		}
+		perror("RTC_ALM_READ ioctl");
+		exit(errno);
+	}
+
+	fprintf(stderr, "Alarm time now set to %02d:%02d:%02d.\n",
+		rtc_tm.tm_hour, rtc_tm.tm_min, rtc_tm.tm_sec);
+
+	/* Enable alarm interrupts */
+	retval = ioctl(fd, RTC_AIE_ON, 0);
+	if (retval == -1) {
+		if (errno == EINVAL || errno == EIO) {
+			fprintf(stderr,
+				"\n...Alarm IRQs not supported.\n");
+			goto test_PIE;
+		}
+
+		perror("RTC_AIE_ON ioctl");
+		exit(errno);
+	}
+
+	fprintf(stderr, "Waiting 5 seconds for alarm...");
+	fflush(stderr);
+	/* This blocks until the alarm ring causes an interrupt */
+	retval = read(fd, &data, sizeof(unsigned long));
+	if (retval == -1) {
+		perror("read");
+		exit(errno);
+	}
+	irqcount++;
+	fprintf(stderr, " okay. Alarm rang.\n");
+
+	/* Disable alarm interrupts */
+	retval = ioctl(fd, RTC_AIE_OFF, 0);
+	if (retval == -1) {
+		perror("RTC_AIE_OFF ioctl");
+		exit(errno);
+	}
+
+test_PIE:
+	/* Read periodic IRQ rate */
+	retval = ioctl(fd, RTC_IRQP_READ, &tmp);
+	if (retval == -1) {
+		/* not all RTCs support periodic IRQs */
+		if (errno == EINVAL) {
+			fprintf(stderr, "\nNo periodic IRQ support\n");
+			goto test_DATE;
+		}
+		perror("RTC_IRQP_READ ioctl");
+		exit(errno);
+	}
+	fprintf(stderr, "\nPeriodic IRQ rate is %ldHz.\n", tmp);
+
+	fprintf(stderr, "Counting 20 interrupts at:");
+	fflush(stderr);
+
+	/* The frequencies 128Hz, 256Hz, ... 8192Hz are only allowed for root. */
+	for (tmp=2; tmp<=maxfreq; tmp*=2) {
+
+		retval = ioctl(fd, RTC_IRQP_SET, tmp);
+		if (retval == -1) {
+			/* not all RTCs can change their periodic IRQ rate */
+			if (errno == EINVAL) {
+				fprintf(stderr,
+					"\n...Periodic IRQ rate is fixed\n");
+				goto test_DATE;
+			}
+			perror("RTC_IRQP_SET ioctl");
+			exit(errno);
+		}
+
+		fprintf(stderr, "\n%ldHz:\t", tmp);
+		fflush(stderr);
+
+		/* Enable periodic interrupts */
+		retval = ioctl(fd, RTC_PIE_ON, 0);
+		if (retval == -1) {
+			perror("RTC_PIE_ON ioctl");
+			exit(errno);
+		}
+
+		for (i=1; i<21; i++) {
+			gettimeofday(&start, NULL);
+			/* This blocks */
+			retval = read(fd, &data, sizeof(unsigned long));
+			if (retval == -1) {
+				perror("read");
+				exit(errno);
+			}
+			gettimeofday(&end, NULL);
+			timersub(&end, &start, &diff);
+			if (diff.tv_sec > 0 ||
+			    diff.tv_usec > ((1000000L / tmp) * 1.10)) {
+				fprintf(stderr, "\nPIE delta error: %ld.%06ld should be close to 0.%06ld\n",
+				       diff.tv_sec, diff.tv_usec,
+				       (1000000L / tmp));
+				fflush(stdout);
+				exit(-1);
+			}
+
+			fprintf(stderr, " %d",i);
+			fflush(stderr);
+			irqcount++;
+		}
+
+		/* Disable periodic interrupts */
+		retval = ioctl(fd, RTC_PIE_OFF, 0);
+		if (retval == -1) {
+			perror("RTC_PIE_OFF ioctl");
+			exit(errno);
+		}
+	}
+
+test_DATE:
+	if (!dangerous)
+		goto done;
+
+	fprintf(stderr, "\nTesting problematic dates\n");
+
+	for (i = 0; i < ARRAY_SIZE(cutoff_dates); i++) {
+		struct rtc_time current;
+
+		/* Write the new date in RTC */
+		retval = ioctl(fd, RTC_SET_TIME, &cutoff_dates[i]);
+		if (retval == -1) {
+			perror("RTC_SET_TIME ioctl");
+			close(fd);
+			exit(errno);
+		}
+
+		/* Read back */
+		retval = ioctl(fd, RTC_RD_TIME, &current);
+		if (retval == -1) {
+			perror("RTC_RD_TIME ioctl");
+			exit(errno);
+		}
+
+		if(compare_dates(&cutoff_dates[i], &current)) {
+			fprintf(stderr,"Setting date %d failed\n",
+			        cutoff_dates[i].tm_year + 1900);
+			goto done;
+		}
+
+		cutoff_dates[i].tm_sec += 5;
+
+		/* Write the new alarm in RTC */
+		retval = ioctl(fd, RTC_ALM_SET, &cutoff_dates[i]);
+		if (retval == -1) {
+			perror("RTC_ALM_SET ioctl");
+			close(fd);
+			exit(errno);
+		}
+
+		/* Read back */
+		retval = ioctl(fd, RTC_ALM_READ, &current);
+		if (retval == -1) {
+			perror("RTC_ALM_READ ioctl");
+			exit(errno);
+		}
+
+		if(compare_dates(&cutoff_dates[i], &current)) {
+			fprintf(stderr,"Setting alarm %d failed\n",
+			        cutoff_dates[i].tm_year + 1900);
+			goto done;
+		}
+
+		fprintf(stderr, "Setting year %d is OK \n",
+			cutoff_dates[i].tm_year + 1900);
+	}
+done:
+	fprintf(stderr, "\n\n\t\t\t *** Test complete ***\n");
+
+	close(fd);
+
+	return 0;
+}

--- a/generic/deps/tsc/Makefile
+++ b/generic/deps/tsc/Makefile
@@ -1,0 +1,20 @@
+CC=		cc
+CFLAGS=		-O
+LIBS=		-lpthread
+
+PROGS=		checktsc
+
+SRCS=		checktsc.c
+OBJS=		${SRCS:.c=.o}
+
+
+all:		$(PROGS)
+
+checktsc:	$(OBJS)
+		$(CC) $(LDFLAGS) -o checktsc $(OBJS) $(LIBS)
+
+clean:
+		-rm -f $(OBJS)
+
+clobber:	clean
+		-rm -f $(PROGS)

--- a/generic/deps/tsc/README
+++ b/generic/deps/tsc/README
@@ -1,0 +1,18 @@
+checktsc is a user space program that checks TSC synchronization
+between pairs of CPUs on an SMP system using a technique borrowed
+from the Linux 2.6.18 kernel.
+
+The test passes if all TSCs are within +/- "threshold" clock cycles
+of each other. The default value of "threshold" is 500 clock cycles
+and can be changed using the --threshold option.
+
+Default behaviour is to check all of the CPUs on a system and to
+report the observed difference in TSC values between each pair of CPUs.
+The --cpus option can be used to specify a subset of the CPUs to test.
+
+When run with the --silent option the test produces no output (other
+than for catastrophic errors) and success or failure is indicated by
+a 0 or 1 exit status from the program.
+
+Author: md@google.com
+License: GPL

--- a/generic/deps/tsc/checktsc.c
+++ b/generic/deps/tsc/checktsc.c
@@ -1,0 +1,405 @@
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include <getopt.h>
+#include <pthread.h>
+#include <errno.h>
+#include "sched.h"
+
+
+#define MAX_CPUS		32
+#define	DEFAULT_THRESHOLD	500	/* default maximum TSC skew	*/
+
+
+char	*program;
+long	threshold	= DEFAULT_THRESHOLD;
+int	silent		= 0;
+int	verbose		= 0;
+
+
+struct option options[] = {
+	{ "cpus",	required_argument,	0, 	'c'	},
+	{ "help",	no_argument,		0, 	'h'	},
+	{ "silent",	no_argument,		0, 	's'	},
+	{ "threshold",	required_argument,	0, 	't'	},
+	{ "verbose",	no_argument,		0, 	'v'	},
+	{ 0,	0,	0,	0 }
+};
+
+
+void usage(void)
+{
+	printf("usage: %s [-hsv] [-c <cpu_set>] [-t threshold]\n", program);
+}
+
+
+void help(void)
+{
+	usage();
+	printf("check TSC synchronization between CPUs\n");
+	printf("  -c,--cpus        set of cpus to test (default: all)\n");
+	printf("  -h,--help        show this message\n");
+	printf("  -s,--silent      no output if test is successful\n");
+	printf("  -t,--threshold   TSC skew threshold (default: %d cycles)\n",
+		DEFAULT_THRESHOLD);
+	printf("  -v,--verbose     verbose output\n");
+}
+
+
+void error(int err, const char *fmt, ...)
+{
+	va_list	ap;
+
+	fprintf(stderr, "%s: ", program);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+
+	if (err)
+		fprintf(stderr, ": %s\n", strerror(err));
+	putc('\n', stderr);
+}
+
+
+/*
+ * parse a string containing a comma separated list of ranges
+ * of cpu numbers such as: "0,2,4-7" into a cpu_set_t
+ */
+int parse_cpu_set(const char *s, cpu_set_t *cpus)
+{
+	CPU_ZERO(cpus);
+
+	while (*s) {
+		char	*next;
+		int	cpu;
+		int	start, end;
+
+		start = end = (int)strtol(s, &next, 0);
+		if (s == next)
+			break;
+		s = next;
+
+		if (*s == '-') {
+			++s;
+			end = (int)strtol(s, &next, 0);
+			if (s == next)
+				break;
+			s = next;
+		}
+
+		if (*s == ',')
+			++s;
+
+		if (start < 0 || start >= CPU_SETSIZE) {
+			error(0, "bad cpu number '%d' in cpu set", start);
+			return 1;
+		}
+
+		if (end < 0 || end >= CPU_SETSIZE) {
+			error(0, "bad cpu number '%d' in cpu set", end);
+			return 1;
+		}
+
+		if (end < start) {
+			error(0, "bad cpu range '%d-%d' in cpu set",
+				start, end);
+			return 1;
+		}
+
+		for (cpu = start; cpu <= end; ++cpu)
+			CPU_SET(cpu, cpus);
+
+	}
+
+	if (*s) {
+		error(0, "unexpected character '%c' in cpu set", *s);
+		return 1;
+	}
+
+	return 0;
+}
+
+
+#define	CACHE_LINE_SIZE	256
+typedef union state {
+	int	state;
+	char	pad[CACHE_LINE_SIZE];
+} state_t;
+
+#define barrier()	__asm__ __volatile__("" : : : "memory")
+
+static void inline set_state(state_t *s, int v)
+{
+	s->state = v;
+}
+
+static void inline wait_for_state(state_t *s, int v)
+{
+	while (s->state != v)
+		barrier();
+}
+
+#if defined(__x86_64__)
+static inline uint64_t rdtsc(void)
+{
+	uint32_t	tsc_lo, tsc_hi;
+
+	__asm__ __volatile__("rdtsc" : "=a" (tsc_lo), "=d" (tsc_hi));
+
+	return ((uint64_t)tsc_hi << 32) | tsc_lo;
+}
+#elif defined(__i386__)
+static inline uint64_t rdtsc(void)
+{
+	uint64_t	tsc;
+
+	__asm__ __volatile__("rdtsc" : "=A" (tsc));
+
+	return tsc;
+}
+#elif defined(__powerpc64__)
+static inline uint64_t rdtsc(void)
+{
+	uint64_t	tb;
+
+	__asm__ __volatile__("mfspr %0,268" : "=r"(tb));
+
+	return tb;
+}
+#elif defined(__s390x__)
+static inline uint64_t rdtsc(void)
+{
+	uint64_t clk;
+
+	__asm__ __volatile__("stck %0" : : "Q"(clk) : "memory");
+
+	return clk;
+}
+#else
+#error Unsupported architecture
+#endif
+
+#define	READY	1
+#define	DONE	2
+#define	ERROR	3
+
+state_t		master;
+state_t		slave;
+
+int64_t		slave_tsc;
+int		slave_cpu;
+
+
+int set_cpu_affinity(int cpu)
+{
+	cpu_set_t cpus;
+
+	CPU_ZERO(&cpus);
+	CPU_SET(cpu, &cpus);
+	if (sched_setaffinity(0, sizeof cpus, &cpus) < 0) {
+		error(errno, "sched_setaffinity() failed for CPU %d", cpu);
+		return -1;
+	}
+	return 0;
+}
+
+#define NUM_ITERS	10
+
+int64_t
+tsc_delta(int cpu_a, int cpu_b)
+{
+	uint64_t	best_t0	= 0;
+	uint64_t	best_t1	= ~0ULL;
+	uint64_t	best_tm	= 0;
+	int64_t		delta;
+	uint64_t	t0, t1, tm;
+	int		i;
+
+	if (verbose)
+		printf("CPU %d - CPU %d\n", cpu_a, cpu_b);
+
+	if (set_cpu_affinity(cpu_a) < 0)
+		return -1;
+
+	slave_cpu = cpu_b;
+
+	for (i = 0; i < NUM_ITERS; i++) {
+
+		set_state(&master, READY);
+
+		wait_for_state(&slave, READY);
+
+		t0 = rdtsc();
+		set_state(&master, DONE);
+		wait_for_state(&slave, DONE);
+		t1 = rdtsc();
+
+		if ((t1 - t0) < (best_t1 - best_t0)) {
+			best_t0 = t0;
+			best_t1 = t1;
+			best_tm = slave_tsc;
+		}
+		if (verbose)
+			printf("loop %2d: roundtrip = %5Ld\n", i, t1 - t0);
+	}
+
+	delta = (best_t0/2 + best_t1/2 + (best_t0 & best_t1 & 1)) - best_tm;
+
+	if (!silent)
+		printf("CPU %d - CPU %d = % 5Ld\n", cpu_a, cpu_b, delta);
+
+	return delta;
+}
+
+
+void *
+slave_thread(void *arg)
+{
+	int	current_cpu = -1;
+
+	for(;;) {
+
+		wait_for_state(&master, READY);
+
+		if (slave_cpu < 0) {
+			return NULL;
+		}
+
+		if (slave_cpu != current_cpu) {
+
+			if (set_cpu_affinity(slave_cpu) < 0) {
+				set_state(&slave, ERROR);
+				return NULL;
+			}
+
+			current_cpu = slave_cpu;
+		}
+
+		set_state(&slave, READY);
+
+		wait_for_state(&master, DONE);
+
+		slave_tsc = rdtsc();
+
+		set_state(&slave, DONE);
+	}
+	return NULL;
+}
+
+
+int
+check_tsc(cpu_set_t *cpus)
+{
+	int		cpu_a, cpu_b;
+	int64_t		delta;
+	int		err	= 0;
+	pthread_t	thread;
+
+	if ((err = pthread_create(&thread, NULL, slave_thread, NULL))) {
+		error(err, "pthread_create_failed");
+		return -1;
+	}
+
+
+	for (cpu_a = 0; cpu_a < MAX_CPUS; cpu_a++) {
+		if (!CPU_ISSET(cpu_a, cpus))
+			continue;
+
+		for (cpu_b = 0; cpu_b < MAX_CPUS; cpu_b++) {
+			if (!CPU_ISSET(cpu_b, cpus) || cpu_a == cpu_b)
+				continue;
+
+			delta = tsc_delta(cpu_a, cpu_b);
+
+			if (llabs(delta) > threshold) {
+				++err;
+			}
+		}
+	}
+
+	/*
+	 * tell the slave thread to exit
+	 */
+	slave_cpu = -1;
+	set_state(&master, READY);
+
+	pthread_join(thread, NULL);
+
+	return err;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+	int		c;
+	cpu_set_t	cpus;
+	int		errs	= 0;
+	extern int	optind;
+	extern char	*optarg;
+
+	if ((program = strrchr(argv[0], '/')) != NULL)
+		++program;
+	else
+		program = argv[0];
+
+	/*
+	 * default to checking all cpus
+	 */
+	for (c = 0; c < MAX_CPUS; c++) {
+		CPU_SET(c, &cpus);
+	}
+
+	while ((c = getopt_long(argc, argv, "c:hst:v", options, NULL)) != EOF) {
+		switch (c) {
+			case 'c':
+				if (parse_cpu_set(optarg, &cpus) != 0)
+					++errs;
+				break;
+			case 'h':
+				help();
+				exit(0);
+			case 's':
+				++silent;
+				break;
+			case 't':
+				threshold = strtol(optarg, NULL, 0);
+				break;
+			case 'v':
+				++verbose;
+				break;
+			default:
+				++errs;
+				break;
+		}
+	}
+
+	if (errs || optind < argc) {
+		usage();
+		exit(1);
+	}
+
+	/*
+	 * limit the set of CPUs to the ones that are currently available
+	 * (Note that on some kernel versions sched_setaffinity() will fail
+	 * if you specify CPUs that are not currently online so we ignore
+	 * the return value and hope for the best)
+	 */
+	sched_setaffinity(0, sizeof cpus, &cpus);
+	if (sched_getaffinity(0, sizeof cpus, &cpus) < 0) {
+		error(errno, "sched_getaffinity() failed");
+		exit(1);
+	}
+
+	errs = check_tsc(&cpus);
+
+	if (!silent) {
+		printf("%s\n", errs ? "FAIL" : "PASS");
+	}
+
+	return errs ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/generic/deps/tsc/sched.h
+++ b/generic/deps/tsc/sched.h
@@ -1,0 +1,47 @@
+#include <sched.h>
+/*
+ * if we have an ancient sched.h we need to provide
+ * definitions for cpu_set_t and associated macros
+ */
+#if !defined __cpu_set_t_defined
+# define __cpu_set_t_defined
+/* Size definition for CPU sets.  */
+# define __CPU_SETSIZE	1024
+# define __NCPUBITS	(8 * sizeof (__cpu_mask))
+
+/* Type for array elements in 'cpu_set'.  */
+typedef unsigned long int __cpu_mask;
+
+/* Basic access functions.  */
+# define __CPUELT(cpu)	((cpu) / __NCPUBITS)
+# define __CPUMASK(cpu)	((__cpu_mask) 1 << ((cpu) % __NCPUBITS))
+
+/* Data structure to describe CPU mask.  */
+typedef struct
+{
+  __cpu_mask __bits[__CPU_SETSIZE / __NCPUBITS];
+} cpu_set_t;
+
+/* Access functions for CPU masks.  */
+# define __CPU_ZERO(cpusetp) \
+  do {									      \
+    unsigned int __i;							      \
+    cpu_set_t *__arr = (cpusetp);					      \
+    for (__i = 0; __i < sizeof (cpu_set_t) / sizeof (__cpu_mask); ++__i)      \
+      __arr->__bits[__i] = 0;						      \
+  } while (0)
+# define __CPU_SET(cpu, cpusetp) \
+  ((cpusetp)->__bits[__CPUELT (cpu)] |= __CPUMASK (cpu))
+# define __CPU_CLR(cpu, cpusetp) \
+  ((cpusetp)->__bits[__CPUELT (cpu)] &= ~__CPUMASK (cpu))
+# define __CPU_ISSET(cpu, cpusetp) \
+  (((cpusetp)->__bits[__CPUELT (cpu)] & __CPUMASK (cpu)) != 0)
+
+/* Access macros for `cpu_set'.  */
+#define CPU_SETSIZE __CPU_SETSIZE
+#define CPU_SET(cpu, cpusetp)	__CPU_SET (cpu, cpusetp)
+#define CPU_CLR(cpu, cpusetp)	__CPU_CLR (cpu, cpusetp)
+#define CPU_ISSET(cpu, cpusetp)	__CPU_ISSET (cpu, cpusetp)
+#define CPU_ZERO(cpusetp)	__CPU_ZERO (cpusetp)
+
+#endif

--- a/generic/tests/cfg/timerclock.cfg
+++ b/generic/tests/cfg/timerclock.cfg
@@ -6,3 +6,5 @@
             type = monotonic_time
         - rtc:
             type = rtc
+        - tsc:
+            type = tsc

--- a/generic/tests/cfg/timerclock.cfg
+++ b/generic/tests/cfg/timerclock.cfg
@@ -8,3 +8,5 @@
             type = rtc
         - tsc:
             type = tsc
+        - hwclock:
+            type = hwclock

--- a/generic/tests/cfg/timerclock.cfg
+++ b/generic/tests/cfg/timerclock.cfg
@@ -4,3 +4,5 @@
     variants:
         - monotonic_time:
             type = monotonic_time
+        - rtc:
+            type = rtc

--- a/generic/tests/cfg/timerclock.cfg
+++ b/generic/tests/cfg/timerclock.cfg
@@ -1,0 +1,6 @@
+- timerclock:
+    only Linux
+    virt_test_type = qemu
+    variants:
+        - monotonic_time:
+            type = monotonic_time

--- a/generic/tests/hwclock.py
+++ b/generic/tests/hwclock.py
@@ -1,0 +1,25 @@
+import re
+import logging
+
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Check hwclock can be set and read successfully.
+
+    :param test: kvm test object.
+    :param params: Dictionary with test parameters.
+    :param env: Dictionary with the test environment.
+    """
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=240)
+
+    logging.info("Setting hwclock to 2/2/80 03:04:00")
+    session.cmd('/sbin/hwclock --set --date "2/2/80 03:04:00"')
+    date = session.cmd_output('LC_ALL=C /sbin/hwclock')
+    if not re.match('Sat *Feb *2 *03:04:.. 1980', date):
+        test.fail("Fail to set hwclock back to the 80s."
+                  "Output of hwclock is '%s'" % date)

--- a/generic/tests/monotonic_time.py
+++ b/generic/tests/monotonic_time.py
@@ -1,0 +1,97 @@
+import os
+import logging
+
+from inspect import ismethod
+
+from virttest import data_dir
+from virttest import error_context
+
+
+class TimeClientTest(object):
+    def __init__(self, test, params, env, test_name):
+        self.test = test
+        self.vm = env.get_vm(params["main_vm"])
+        self.session = self.vm.wait_for_login()
+        self.host_dir = os.path.join(data_dir.get_deps_dir(), test_name)
+        self.src_dir = os.path.join("/tmp/", test_name)
+
+    def setUp(self):
+        logging.info("Copy files to guest")
+        self.vm.copy_files_to(self.host_dir, os.path.dirname(self.src_dir))
+        self.session.cmd("cd %s && make clobber && make" % self.src_dir)
+
+    def runTest(self):
+        for attr in dir(self):
+            if not attr.startswith("test_"):
+                continue
+            func = getattr(self, attr)
+            if ismethod(func):
+                func()
+
+    def cleanUp(self):
+        self.session.cmd("rm -rf %s" % self.src_dir)
+        self.session.close()
+
+
+class MonotonicTime(TimeClientTest):
+    def _test(self, test_type=None, duration=300, threshold=None):
+        """
+        :params test_type: Test gettimeofday(), TSC or
+                           clock_gettime(CLOCK_MONOTONIC).
+        :params duration: Tests run for 'duration' seconds and check that
+                          the selected time interface does not go backwards
+                          by more than 'threshold'.
+        :params threshold: Same resolution as clock source.
+        """
+        if not test_type:
+            self.test.error('missing test type')
+        logging.info("Test type: %s" % test_type)
+        timeout = float(duration) + 100.0
+
+        cmd = self.src_dir + '/time_test'
+        cmd += ' --duration ' + str(duration)
+        if threshold:
+            cmd += ' --threshold ' + str(threshold)
+        cmd += ' ' + test_type
+
+        (exit_status, stdout) = self.session.cmd_status_output(cmd, timeout=timeout)
+        logging.info('Time test command exit status: %s',
+                     exit_status)
+        if exit_status != 0:
+            for line in stdout.splitlines():
+                if line.startswith('ERROR:'):
+                    self.test.error(line)
+                if line.startswith('FAIL:'):
+                    self.test.fail(line)
+            self.test.error('unknown test failure')
+
+    def test_Gtod(self):
+        self._test(test_type='gtod', threshold=0)
+
+    def test_Tsc(self):
+        self._test(test_type='tsc', threshold=0)
+
+    def test_Clock(self):
+        self._test(test_type='clock', threshold=0)
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Check various time interfaces:
+      gettimeofday()
+      clock_gettime(CLOCK_MONTONIC)
+      TSC
+    for monotonicity.
+
+    Based on time-warp-test.c by Ingo Molnar.
+
+    :param test: kvm test object.
+    :param params: Dictionary with test parameters.
+    :param env: Dictionary with the test environment.
+    """
+
+    monotonic_test = MonotonicTime(test, params, env, 'monotonic_time')
+    monotonic_test.setUp()
+    monotonic_test.runTest()
+    monotonic_test.cleanUp()

--- a/generic/tests/rtc.py
+++ b/generic/tests/rtc.py
@@ -1,0 +1,39 @@
+from virttest import error_context
+
+from generic.tests.monotonic_time import TimeClientTest
+
+
+class RtcTest(TimeClientTest):
+    def __init__(self, test, params, env, test_name, rtc_path):
+        super(RtcTest, self).__init__(test, params, env, test_name)
+        self.def_rtc = rtc_path
+        self.maxfreq = 64
+
+    def _test(self):
+        if self.session.cmd_status("ls %s" % self.def_rtc):
+            self.test.cancel("RTC device %s does not exist" % self.def_rtc)
+        (exit_status, output) = self.session.cmd_status_output("cd %s && ./rtctest %s %s" %
+                                                               (self.src_dir, self.def_rtc,
+                                                                self.maxfreq), timeout=240)
+        if exit_status != 0:
+            self.test.fail("Test fail on RTC device, output: %s" % output)
+
+    def test_RTC(self):
+        self._test()
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    A simple test of realtime clock driver, does the functional test of
+    interrupt, alarm and requested frequency.
+
+    :param test: kvm test object.
+    :param params: Dictionary with test parameters.
+    :param env: Dictionary with the test environment.
+    """
+
+    rtc_test = RtcTest(test, params, env, 'rtc', '/dev/rtc0')
+    rtc_test.setUp()
+    rtc_test.runTest()
+    rtc_test.cleanUp()

--- a/generic/tests/tsc.py
+++ b/generic/tests/tsc.py
@@ -1,0 +1,61 @@
+import re
+import logging
+
+from virttest import error_context
+
+from generic.tests.monotonic_time import TimeClientTest
+
+
+class TscTest(TimeClientTest):
+    def __init__(self, test, params, env, test_name):
+        super(TscTest, self).__init__(test, params, env, test_name)
+        self.args = '-t 650'
+
+    def _test(self):
+        cmd = self.src_dir + '/checktsc '
+        cmd += self.args
+
+        (exit_status, result) = self.session.cmd_status_output(cmd)
+
+        if exit_status != 0:
+            logging.error("Program checktsc exit status is %s", exit_status)
+            default_fail = ("UNKNOWN FAILURE: rc=%d from %s" % (exit_status, cmd))
+
+            if exit_status == 1:
+                if result.strip('\n').endswith('FAIL'):
+                    max_delta = 0
+                    reason = ''
+                    threshold = int(self.args.split()[1])
+                    latencies = re.findall("CPU \d+ - CPU \d+ =\s+-*\d+",
+                                           result)
+                    for ln in latencies:
+                        cur_delta = int(ln.split('=', 2)[1])
+                        if abs(cur_delta) > max_delta:
+                            max_delta = abs(cur_delta)
+                            reason = ln
+                    if max_delta > threshold:
+                        reason = "Latency %s exceeds threshold %d" % (reason, threshold)
+                        self.test.fail(reason)
+
+            self.test.error(default_fail)
+
+    def test_TSC(self):
+        self._test()
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Checktsc is a user space program that checks TSC synchronization
+    between pairs of CPUs on an SMP system using a technique borrowed
+    from the Linux 2.6.18 kernel.
+
+    :param test: kvm test object.
+    :param params: Dictionary with test parameters.
+    :param env: Dictionary with the test environment.
+    """
+
+    tsc_test = TscTest(test, params, env, 'tsc')
+    tsc_test.setUp()
+    tsc_test.runTest()
+    tsc_test.cleanUp()


### PR DESCRIPTION
Since these four cases are still used in our test, rewrite them to avocado.

ID: 1556861
Signed-off-by: Sitong Liu siliu@redhat.com