### PR TITLE
balloon_check: Use params instead of env to save balloon ready event

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -24,14 +24,14 @@ class BallooningTest(MemoryBaseTest):
 
         self.vm = env.get_vm(params["main_vm"])
         self.session = self.get_session(self.vm)
-        self.env["balloon_test_setup_ready"] = False
+        self.params["balloon_test_setup_ready"] = False
         if self.params.get('os_type') == 'windows':
             sleep_time = 180
         else:
             sleep_time = 90
         logging.info("Waiting %d seconds for guest's applications up" % sleep_time)
         time.sleep(sleep_time)
-        self.env["balloon_test_setup_ready"] = True
+        self.params["balloon_test_setup_ready"] = True
         self.ori_mem = self.get_vm_mem(self.vm)
         self.current_mmem = self.get_ballooned_memory()
         if self.current_mmem != self.ori_mem:

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -68,10 +68,12 @@ def run(test, params, env):
             stress_thread.start()
 
         for event in params.get("check_setup_events", "").strip().split():
-            if not utils_misc.wait_for(lambda: env.get(event),
+            if not utils_misc.wait_for(lambda: params.get(event),
                                        240, 0, 1):
                 test.error("Background test not in ready state since haven't "
                            "received event %s" % event)
+            # Clear event
+            params[event] = False
 
         if not utils_misc.wait_for(lambda: check_bg_running(target_process),
                                    120, 0, 1):


### PR DESCRIPTION
env["balloon_test_setup_ready"] value will keep available between cases which lead to following two cases fail if run them together with other balloon cases:
 - balloon_in_use..during_bg_test
 - driver_load_stress.with_balloon.during_bg_test

ID:1558323

Signed-off-by: Li Jin <lijin@redhat.com>