### PR TITLE
kdump: fix guest can not do kdump over ssh

### DIFF
--- a/generic/tests/kdump.py
+++ b/generic/tests/kdump.py
@@ -1,16 +1,15 @@
 import logging
 import os
 
-from autotest.client import utils
-from autotest.client.shared import error
-
+from avocado.utils import process
 from virttest import utils_conn
 from virttest import utils_misc
 from virttest import utils_net
+from virttest import error_context
 
 
-@error.context_aware
-def preprocess_kdump(vm, timeout):
+@error_context.context_aware
+def preprocess_kdump(test, vm, timeout):
     """
     Backup /etc/kdump.conf file before trigger crash.
 
@@ -26,21 +25,23 @@ def preprocess_kdump(vm, timeout):
     status, output = session.cmd_status_output(cp_kdumpcf_cmd)
     if status != 0:
         logging.error(output)
-        raise error.TestError("Fail to backup the kdump.conf")
+        test.error("Fail to backup the kdump.conf")
 
     session.close()
 
 
-@error.context_aware
-def postprocess_kdump(vm, timeout):
+@error_context.context_aware
+def postprocess_kdump(test, vm, timeout):
     """
     Restore /etc/kdump.conf file after trigger crash.
 
     :param timeout: Timeout in seconds
     """
     kdump_cfg_path = vm.params.get("kdump_cfg_path", "/etc/kdump.conf")
-    restore_kdumpcf_cmd = "/bin/cp -f %s-bk %s" % (kdump_cfg_path, kdump_cfg_path)
-    restore_kdumpcf_cmd = vm.params.get("restore_kdumpcf_cmd", restore_kdumpcf_cmd)
+    restore_kdumpcf_cmd = ("/bin/cp -f %s-bk %s" %
+                           (kdump_cfg_path, kdump_cfg_path))
+    restore_kdumpcf_cmd = vm.params.get("restore_kdumpcf_cmd",
+                                        restore_kdumpcf_cmd)
 
     session = vm.wait_for_login(timeout=timeout)
 
@@ -48,12 +49,12 @@ def postprocess_kdump(vm, timeout):
     status, output = session.cmd_status_output(restore_kdumpcf_cmd)
     if status != 0:
         logging.error(output)
-        raise error.TestError("Fail to restore the kdump.conf")
+        test.error("Fail to restore the kdump.conf")
 
     session.close()
 
 
-@error.context_aware
+@error_context.context_aware
 def kdump_enable(vm, vm_name, crash_kernel_prob_cmd,
                  kernel_param_cmd, kdump_enable_cmd, timeout):
     """
@@ -72,25 +73,28 @@ def kdump_enable(vm, vm_name, crash_kernel_prob_cmd,
     kdump_propagate_cmd = vm.params.get("kdump_propagate_cmd")
     kdump_enable_timeout = int(vm.params.get("kdump_enable_timeout", 360))
 
-    error.context("Try to log into guest '%s'." % vm_name, logging.info)
+    error_context.context("Try to log into guest '%s'." % vm_name,
+                          logging.info)
     session = vm.wait_for_login(timeout=timeout)
 
-    error.context("Checking the existence of crash kernel in %s" %
-                  vm_name, logging.info)
+    error_context.context("Checking the existence of crash kernel in %s" %
+                          vm_name, logging.info)
     try:
         session.cmd(crash_kernel_prob_cmd)
     except Exception:
-        error.context("Crash kernel is not loaded. Trying to load it",
-                      logging.info)
+        error_context.context("Crash kernel is not loaded. Trying to load it",
+                              logging.info)
         session.cmd(kernel_param_cmd)
         session = vm.reboot(session, timeout=timeout)
 
     if kdump_config:
         if kdump_method == "ssh":
-            host_ip = utils_net.get_ip_address_by_interface(vm.params.get('netdst'))
+            host_ip = utils_net.get_ip_address_by_interface(
+                vm.params.get('netdst'))
             kdump_config = kdump_config % (host_ip, vmcore_path)
 
-        error.context("Configuring the Core Collector...", logging.info)
+        error_context.context("Configuring the Core Collector...",
+                              logging.info)
 
         session.cmd("cat /dev/null > %s" % kdump_cfg_path)
         for config_line in kdump_config.split(";"):
@@ -98,37 +102,20 @@ def kdump_enable(vm, vm_name, crash_kernel_prob_cmd,
             config_con = config_line.strip()
             session.cmd(config_cmd % (config_con, kdump_cfg_path))
 
-    if kdump_method == "ssh":
-        host_pwd = vm.params.get("host_pwd", "redhat")
-        guest_pwd = vm.params.get("guest_pwd", "redhat")
-        guest_ip = vm.get_address()
-
-        error.context("Setup ssh login without password...", logging.info)
-        session.cmd("rm -rf /root/.ssh/*")
-
-        ssh_connection = utils_conn.SSHConnection(server_ip=host_ip,
-                                                  server_pwd=host_pwd,
-                                                  client_ip=guest_ip,
-                                                  client_pwd=guest_pwd)
-        try:
-            ssh_connection.conn_check()
-        except utils_conn.ConnectionError:
-            ssh_connection.conn_setup()
-            ssh_connection.conn_check()
-
         logging.info("Trying to propagate with command '%s'" %
                      kdump_propagate_cmd)
         session.cmd(kdump_propagate_cmd, timeout=120)
 
-    error.context("Enabling kdump service...", logging.info)
+    error_context.context("Enabling kdump service...",
+                          logging.info)
     # the initrd may be rebuilt here so we need to wait a little more
     session.cmd(kdump_enable_cmd, timeout=kdump_enable_timeout)
 
     return session
 
 
-@error.context_aware
-def crash_test(vm, vcpu, crash_cmd, timeout):
+@error_context.context_aware
+def crash_test(test, vm, vcpu, crash_cmd, timeout):
     """
     Trigger a crash dump through sysrq-trigger
 
@@ -142,6 +129,7 @@ def crash_test(vm, vcpu, crash_cmd, timeout):
     vmcore_rm_cmd = vmcore_rm_cmd % vmcore_path
     kdump_restart_cmd = vm.params.get("kdump_restart_cmd",
                                       "service kdump restart")
+    kdump_propagate_cmd = vm.params.get("kdump_propagate_cmd")
     kdump_status_cmd = vm.params.get("kdump_status_cmd",
                                      "systemctl status kdump.service")
 
@@ -149,7 +137,11 @@ def crash_test(vm, vcpu, crash_cmd, timeout):
 
     logging.info("Delete the vmcore file.")
     if kdump_method == "ssh":
-        utils.run(vmcore_rm_cmd)
+        session.cmd("rm -rf /root/.ssh/kdump*")
+        logging.info("Trying to propagate with command '%s'" %
+                     kdump_propagate_cmd)
+        session.cmd(kdump_propagate_cmd, timeout=120) 
+        process.run(vmcore_rm_cmd, shell=True)
     else:
         session.cmd_output(vmcore_rm_cmd)
 
@@ -169,11 +161,11 @@ def crash_test(vm, vcpu, crash_cmd, timeout):
             logging.info("Triggering crash on vcpu %d ...", vcpu)
             session.sendline("taskset -c %d %s" % (vcpu, crash_cmd))
     except Exception:
-        postprocess_kdump(vm, timeout)
+        postprocess_kdump(test, vm, timeout)
 
 
-@error.context_aware
-def check_vmcore(vm, session, timeout):
+@error_context.context_aware
+def check_vmcore(test, vm, session, timeout):
     """
     Check the vmcore file after triggering a crash
 
@@ -185,27 +177,28 @@ def check_vmcore(vm, session, timeout):
     vmcore_chk_cmd = vmcore_chk_cmd % vmcore_path
 
     if not utils_misc.wait_for(lambda: not session.is_responsive(), 240, 0, 1):
-        raise error.TestFail("Could not trigger crash.")
+        test.fail("Could not trigger crash.")
 
-    error.context("Waiting for kernel crash dump to complete", logging.info)
+    error_context.context("Waiting for kernel crash dump to complete",
+                          logging.info)
     session = vm.wait_for_login(timeout=timeout)
 
-    error.context("Probing vmcore file...", logging.info)
+    error_context.context("Probing vmcore file...", logging.info)
     try:
         if vm.params.get("kdump_method") == "ssh":
             logging.info("Checking vmcore file on host")
-            utils.run(vmcore_chk_cmd)
+            process.run(vmcore_chk_cmd, shell=True)
         else:
             logging.info("Checking vmcore file on guest")
             session.cmd(vmcore_chk_cmd)
     except Exception:
-        postprocess_kdump(vm, timeout)
-        raise error.TestFail("Could not found vmcore file.")
+        postprocess_kdump(test, vm, timeout)
+        test.fail("Could not found vmcore file.")
 
     logging.info("Found vmcore.")
 
 
-@error.context_aware
+@error_context.context_aware
 def run(test, params, env):
     """
     KVM kdump test:
@@ -241,19 +234,45 @@ def run(test, params, env):
             vm.verify_alive()
             vm_list.append(vm)
 
-            preprocess_kdump(vm, timeout)
+            preprocess_kdump(test, vm, timeout)
             vm.copy_files_from(kdump_cfg_path,
                                os.path.join(test.debugdir,
                                             "kdump.conf-%s" % vm_name))
 
-            session = kdump_enable(vm, vm_name, crash_kernel_prob_cmd,
-                                   kernel_param_cmd, kdump_enable_cmd, timeout)
+            kdump_method = vm.params.get("kdump_method", "basic")
+            vmcore_path = vm.params.get("vmcore_path", "/var/crash")
+            kdump_config = vm.params.get("kdump_config")
 
-            session_list.append(session)
+            if kdump_method == "ssh":
+                host_pwd = vm.params.get("host_pwd", "redhat")
+                guest_pwd = vm.params.get("guest_pwd", "redhat")
+                host_ip = utils_net.get_ip_address_by_interface(
+                    vm.params.get('netdst'))
+                guest_ip = vm.get_address()
+                session = vm.wait_for_login(timeout=timeout)
+
+                error_context.context("Setup ssh login without password...",
+                                      logging.info)
+                session.cmd("rm -rf /root/.ssh/*")
+
+                ssh_connection = utils_conn.SSHConnection(server_ip=host_ip,
+                                                          server_pwd=host_pwd,
+                                                          client_ip=guest_ip,
+                                                          client_pwd=guest_pwd)
+                try:
+                    ssh_connection.conn_check()
+                except utils_conn.ConnectionError:
+                    ssh_connection.conn_setup()
+                    ssh_connection.conn_check()
+
+                session = kdump_enable(vm, vm_name, crash_kernel_prob_cmd,
+                                       kernel_param_cmd, kdump_enable_cmd, timeout)
+
+                session_list.append(session)
 
         for vm in vm_list:
-            error.context("Kdump Testing, force the Linux kernel to crash",
-                          logging.info)
+            error_context.context("Kdump Testing, force the Linux kernel"
+                                  " to crash", logging.info)
             crash_cmd = params.get("crash_cmd", "echo c > /proc/sysrq-trigger")
 
             session = vm.wait_for_login(timeout=timeout)
@@ -261,20 +280,22 @@ def run(test, params, env):
                                os.path.join(test.debugdir,
                                             "kdump.conf-%s-test" % vm.name))
             if crash_cmd == "nmi":
-                crash_test(vm, None, crash_cmd, timeout)
+                crash_test(test, vm, None, crash_cmd, timeout)
+                error_context.context("Check the vmcore file after triggering"
+                                      " a crash", logging.info)
+                check_vmcore(test, vm, session, crash_timeout)
             else:
                 # trigger crash for each vcpu
                 nvcpu = int(params.get("smp", 1))
                 for i in range(nvcpu):
-                    crash_test(vm, i, crash_cmd, timeout)
+                    crash_test(test, vm, i, crash_cmd, timeout)
+                    error_context.context("Check the vmcore file after triggering"
+                                          " a crash", logging.info)
+                    check_vmcore(test, vm, session, crash_timeout)
 
-        for i in range(len(vm_list)):
-            error.context("Check the vmcore file after triggering a crash",
-                          logging.info)
-            check_vmcore(vm_list[i], session_list[i], crash_timeout)
     finally:
         for s in session_list:
             s.close()
         for vm in vm_list:
-            postprocess_kdump(vm, timeout)
+            postprocess_kdump(test, vm, timeout)
             vm.destroy()


### PR DESCRIPTION
 Change location of SSH connection setup;
 Add check core dump for each panic;

bug id: 1543770

Signed-off-by: Chunyu Liao cliao@redhat.com

