### PR TITLE
block_resize: add block resize test for system disk and add iozone test after block resize

### DIFF
--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -7,6 +7,165 @@ from virttest import utils_misc
 from virttest import utils_test
 from virttest import storage
 from virttest import data_dir
+from virttest.utils_windows import drive
+
+
+def get_block_size(test, session, block_cmd, block_pattern):
+    """
+    Get the disk size inside guest.
+
+    param block_cmd: run block_cmd command to get detail disk size info.
+    param block_pattern: use this pattern to filter the needed.
+
+    param return: return current block size.
+    """
+    output = session.cmd_output(block_cmd)
+    block_size = re.findall(block_pattern, output)
+    if block_size:
+        if not re.search("[a-zA-Z]", block_size[0]):
+            return int(block_size[0])
+        else:
+            return float(utils_misc.normalize_data_size(block_size[0],
+                                                        order_magnitude="B"))
+    else:
+        test.error("Can not find the block size for the device."
+                   " The output of command is: %s" % output)
+
+
+def compare_block_size(test, session, params, expected_size, current_size):
+    """
+    Compare the current block size with the expected size.
+
+    param expected_size: the expected size after block resize.
+    param current_size: the size from guest after block resize.
+    """
+    accept_ratio = float(params.get("accept_ratio", 0))
+    if (current_size <= expected_size and
+            current_size >= expected_size * (1 - accept_ratio)):
+        logging.info("Block Resizing Finished !!! \n"
+                     "Current size %s is same as the expected %s",
+                     current_size, expected_size)
+        return True
+    else:
+        test.fail("Block size get from guest is not same as expected.\n"
+                  "Reported: %s\nExpect: %s\n" % (current_size, expected_size))
+    return
+
+
+def get_drive_path_linux(test, session, params, data_image):
+    """
+    Get the drive id in linux guest.
+
+    param data_image: data image name, like image1 or stg.
+    param return: return drive path, like /dev/sda or /dev/sdb.
+    """
+    pattern = r"(serial|wwn)=(\w+)"
+    match = re.search(pattern, params["blk_extra_params_%s" % data_image], re.M)
+    if match:
+        drive_id = match.group(2)
+    else:
+        test.fail("No available tag to get drive id")
+    drive_path = utils_misc.get_linux_drive_path(session, drive_id)
+    if not drive_path:
+        test.error("Failed to get '%s' drive path" % data_image)
+    return drive_path
+
+
+def block_resize_enlarge(vm, session, params, device, block_size):
+    """
+    Enlarge the disk image of device to expected block_size.
+
+    param device: enlarge device.
+    param block_size: enlarge device to block_size.
+    """
+    logging.info("Enlarge disk size to %s in monitor"
+                 % block_size, logging.info)
+    vm.monitor.block_resize(device, block_size)
+    if params.get("os_type") == "windows":
+        drive.extend_shrink_disk(session, params["disk_index"],
+                                 params["disk_letter"],
+                                 operation="extend")
+
+
+def block_resize_shrink(vm, session, params, device, old_disk_size, shrunk_size):
+    """
+    Shrink the disk image of device to expected block_size.
+
+    param device: shrink device.
+    param old_disk_size: the size before shrink.
+    param shrunk_size: want to shrink size, after shrunk, the disk size
+    should equal to "old_disk_size - shrunk_size".
+
+    param return: return the block_size: "old_disk_size-shrunk_size".
+    """
+    if params.get("os_type") == "windows":
+        shrunk_size = drive.extend_shrink_disk(session,
+                                               params["disk_index"],
+                                               params["disk_letter"],
+                                               operation="shrink")
+        shrunk_size = float(utils_misc.normalize_data_size("%sM" % shrunk_size,
+                                                           order_magnitude="B"))
+    block_size = old_disk_size - int(shrunk_size)
+    logging.info("Shrink disk size to %s in monitor"
+                 % block_size, logging.info)
+    vm.monitor.block_resize(device, block_size)
+    return block_size
+
+
+def refresh_disk_after_resize(vm, session, params):
+    """
+    Rescan disk in windows or linux guest.
+    In linux guest, after block_resize:
+    need to rescan for virtio-scsi disk(no need reboot),
+    need to reboot for virtio-blk disk(no need rescan).
+    In windows guest, agter block_resize:
+    need to rescan for both virtio-scsi and virtio-blk disk.
+    """
+    if params.get("guest_prepare_cmd"):
+        session.cmd(params.get("guest_prepare_cmd"))
+    if params.get("need_reboot", "no") == "yes":
+        session = vm.reboot(session=session)
+    if params.get("os_type") == "windows":
+        drive.rescan_disk(session)
+
+
+def block_resize_restore(vm, session, params, current_size, device,
+                         original_size, accept_ratio):
+    """
+    Restore the disk image to the original size.
+
+    After disk is shrunk, the disk size is less than the original size,
+    especially for system disk, the lower size system disk may affect
+    other tests running, so restore it to the original size.
+
+    param device: restore device.
+    param current_size: the disk current size.
+    param original_size: the disk original_size.
+    param accept_ratio: an accepted ratio.
+
+    """
+    if (current_size < original_size and
+            current_size > original_size*(1-accept_ratio)):
+        logging.info("Restore the disk to original size.")
+        block_resize_enlarge(vm, session, params, device, original_size)
+
+
+def iozone_test(test, session, iozone_cmd, disk_letter, iozone_timeout=360):
+    """
+    Run iozone_test on disk.
+
+    param iozone_cmd: iozone command.
+    param disk_letter: which disk will be test.
+    param iozone_timeout: timeout for iozone running.
+
+    """
+    iozone_cmd = utils_misc.set_winutils_letter(session, iozone_cmd)
+    logging.info("Running IOzone command on guest, timeout %ss"
+                 % iozone_timeout, logging.info)
+    status, results = session.cmd_status_output(cmd=iozone_cmd,
+                                                timeout=iozone_timeout)
+    if status != 0:
+        test.fail("iozone test failed: %s" % results)
 
 
 @error.context_aware
@@ -17,157 +176,74 @@ def run(test, params, env):
     1) Start guest with data image and check the data image size.
     2) Enlarge(or Decrease) the data image and check it in guest.
 
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
+    :param test: QEMU test object.
+    :param params: Dictionary with the test parameters.
     :param env: Dictionary with test environment.
     """
-    def get_block_size(session, block_cmd, block_pattern):
-        """
-        Get block size inside guest.
-        """
-        output = session.cmd_output(block_cmd)
-        block_size = re.findall(block_pattern, output)
-        if block_size:
-            if not re.search("[a-zA-Z]", block_size[0]):
-                return int(block_size[0])
-            else:
-                return float(utils_misc.normalize_data_size(block_size[0],
-                                                            order_magnitude="B"))
-        else:
-            raise error.TestError("Can not find the block size for the"
-                                  " deivce. The output of command"
-                                  " is: %s" % output)
-
-    def compare_block_size(session, block_cmd, block_pattern):
-        """
-        Compare the current block size with the expected size.
-        """
-        global current_size
-        current_size = get_block_size(session,
-                                      block_size_cmd, block_size_pattern)
-        if (current_size <= block_size and
-                current_size >= block_size * (1 - accept_ratio)):
-            logging.info("Block Resizing Finished !!! \n"
-                         "Current size %s is same as the expected %s",
-                         current_size, block_size)
-            return True
-        return
-
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     timeout = float(params.get("login_timeout", 240))
     driver_name = params.get("driver_name")
 
-    if params.get("os_type") == "windows" and driver_name:
-        utils_test.qemu.setup_win_driver_verifier(driver_name, vm, timeout)
-
     session = vm.wait_for_login(timeout=timeout)
+    pattern = params.get("block_size_pattern")
+    block_size_cmd = params["block_size_cmd"]
+    accept_ratio = float(params.get("accept_ratio", 0))
     data_image = params.get("images").split()[-1]
     data_image_params = params.object_params(data_image)
-    data_image_size = data_image_params.get("image_size")
-    data_image_size = float(utils_misc.normalize_data_size(data_image_size,
-                                                           order_magnitude="B"))
     data_image_filename = storage.get_image_filename(data_image_params,
                                                      data_dir.get_data_dir())
     data_image_dev = vm.get_block({'file': data_image_filename})
-
+    block_virtual_size = vm.monitor.get_block_virtual_size({'device': data_image_dev})
+    disk_change_ratio = params.get("disk_change_ratio")
+    block_resize_type = params["block_resize_type"]
     drive_path = ""
+
     if params.get("os_type") == 'linux':
-        pattern = r"(serial|wwn)=(\w+)"
-        match = re.search(pattern, params["blk_extra_params_%s"
-                          % data_image], re.M)
-        if match:
-            drive_id = match.group(2)
-        else:
-            test.fail("No available tag to get drive id")
-        drive_path = utils_misc.get_linux_drive_path(session, drive_id)
-        if not drive_path:
-            raise error.TestError("Failed to get '%s' drive path"
-                                  % data_image)
+        drive_path = get_drive_path_linux(test, session, params, data_image)
+        block_size_cmd = params["block_size_cmd"].format(drive_path)
 
-    block_size_cmd = params["block_size_cmd"].format(drive_path)
-    block_size_pattern = params.get("block_size_pattern")
-    need_reboot = params.get("need_reboot", "no") == "yes"
-    accept_ratio = float(params.get("accept_ratio", 0))
+    if params.get("os_type") == "windows" and driver_name:
+        utils_test.qemu.setup_win_driver_verifier(driver_name, vm, timeout)
+        if params.get("format_disk", "no") == "yes":
+            error.context("Format disk", logging.info)
+            utils_misc.format_windows_disk(session, params["disk_index"],
+                                           mountpoint=params["disk_letter"])
 
-    error.context("Check image size in guest", logging.info)
-    block_size = get_block_size(session, block_size_cmd, block_size_pattern)
-    if (block_size > data_image_size or
-            block_size < data_image_size * (1 - accept_ratio)):
-        raise error.TestError("Image size from guest and image not match"
-                              "Block size get from guest: %s \n"
-                              "Image size get from image: %s \n"
-                              % (block_size, data_image_size))
+    error.context("Check image size before disk resize", logging.info)
+    guest_disk_size = get_block_size(test, session, block_size_cmd, pattern)
 
-    if params.get("guest_prepare_cmd"):
-        session.cmd(params.get("guest_prepare_cmd"))
+    for type in block_resize_type.strip().split():
+        if (guest_disk_size > block_virtual_size or
+                guest_disk_size < block_virtual_size * (1-accept_ratio)):
+            raise error.TestError("Image size from guest and image not match\n"
+                                  "Block size get from guest: %s \n"
+                                  "Image size get from image: %s \n"
+                                  % (guest_disk_size, block_virtual_size))
+        if type == "enlarge":
+            enlarge_size = int(int(block_virtual_size) * float(disk_change_ratio))
+            block_size = int(block_virtual_size) + enlarge_size
+            block_resize_enlarge(vm, session, params, data_image_dev, block_size)
+        elif type == "shrink":
+            old_virtual_size = block_size
+            shrunk_size = block_virtual_size * float(disk_change_ratio)
+            block_size = block_resize_shrink(vm, session, params, data_image_dev,
+                                             old_virtual_size, shrunk_size)
+        refresh_disk_after_resize(session, params)
+        new_disk_size = get_block_size(test, session, block_size_cmd, pattern)
 
-    if params.get("format_disk", "no") == "yes":
-        error.context("Format disk", logging.info)
-        utils_misc.format_windows_disk(session, params["disk_index"],
-                                       mountpoint=params["disk_letter"])
-
-    disk_update_cmd = params.get("disk_update_cmd")
-    if disk_update_cmd:
-        disk_update_cmd = disk_update_cmd.split("::")
-
-    disk_rescan_cmd = params.get("disk_rescan_cmd")
-
-    block_size = data_image_size
-    disk_change_ratio = params["disk_change_ratio"]
-    for index, ratio in enumerate(disk_change_ratio.strip().split()):
-        old_block_size = block_size
-        block_size = int(int(data_image_size) * float(ratio))
-
-        if block_size == old_block_size:
-            logging.warn("Block size is not changed in round %s."
-                         " Just skip it" % index)
-            continue
-
-        if disk_update_cmd:
-            if "DISK_CHANGE_SIZE" in disk_update_cmd[index]:
-                disk_unit = params.get("disk_unit", "M")
-                size = abs(block_size - old_block_size)
-                change_size = utils_misc.normalize_data_size("%sB" % size,
-                                                             disk_unit)
-                disk_update_cmd[index] = re.sub("DISK_CHANGE_SIZE",
-                                                change_size.split(".")[0],
-                                                disk_update_cmd[index])
-
-        # So far only virtio drivers support online auto block size change in
-        # linux guest. So we need manully update the the disk or even reboot
-        # guest to get the right block size after change it from monitor.
-
-        # We need shrink the disk in guest first, than in monitor
-        if block_size < old_block_size and disk_update_cmd:
-            error.context("Shrink disk size to %s in guest"
-                          % block_size, logging.info)
-            session.cmd(disk_update_cmd[index])
-
-        error.context("Change disk size to %s in monitor"
-                      % block_size, logging.info)
-        vm.monitor.block_resize(data_image_dev, block_size)
-
-        if need_reboot:
-            session = vm.reboot(session=session)
-        elif disk_rescan_cmd:
-            error.context("Rescan disk", logging.info)
-            session.cmd(disk_rescan_cmd)
-
-        # We need expand disk in monitor first than extend it in guest
-        if block_size > old_block_size and disk_update_cmd:
-            error.context("Extend disk to %s in guest"
-                          % block_size, logging.info)
-            session.cmd(disk_update_cmd[index])
-
-        global current_size
-        current_size = 0
         if not utils_misc.wait_for(lambda: compare_block_size
-                                   (session, block_size_cmd,
-                                    block_size_pattern),
+                                   (test, session, params, block_size,
+                                    new_disk_size),
                                    20, 0, 1, "Block Resizing"):
             raise error.TestFail("Block size get from guest is not"
                                  "the same as expected \n"
                                  "Reported: %s\n"
-                                 "Expect: %s\n" % (current_size,
+                                 "Expect: %s\n" % (new_disk_size,
                                                    block_size))
+        if params.get("iozone_test") == "yes":
+            iozone_test(test, session, params.get("iozone_cmd"),
+                        params["disk_letter"])
+        block_resize_restore(vm, session, params, new_disk_size, data_image_dev,
+                             block_virtual_size, accept_ratio)
+    session.close()

--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -4,42 +4,56 @@
     no RHEL.4
     only qcow2 raw
     type = block_resize
-    images += " stg"
-    image_size_stg = 10G
-    image_name_stg = images/stg
-    create_image_stg = yes
-    force_create_image_stg = yes
-    image_snapshot_image1 = yes
-    blk_extra_params_stg = "serial=TARGET_DISK0"
-    Host_RHEL.m6..ide:
-        blk_extra_params_stg = "wwn=0x5000123456789abc"
     block_size_cmd = "fdisk -l | grep {0}"
     block_size_pattern = ",\s+(\d+\s+b)ytes"
-    disk_change_ratio = "1.5 0.5"
+    disk_change_ratio = "0.5"
     guest_prepare_cmd = ""
-    Windows:
-        block_size_cmd = wmic diskdrive get size, index
-        disk_index = 1
-        disk_letter = I
-        format_disk = yes
-        block_size_pattern = "1\s+(\d+)"
-        accept_ratio = 0.005
-        disk_update_cmd = "echo rescan > cmd"
-        disk_update_cmd += " && echo select disk 1 >> cmd"
-        disk_update_cmd += " && echo select partition 1 >> cmd"
-        disk_update_cmd += " && echo extend >> cmd"
-        disk_update_cmd += " && echo exit >> cmd"
-        disk_update_cmd += " && diskpart /s cmd"
-        # "::" is used to separate the commands as it is not used in both Linux and Windows
-        disk_update_cmd += "::"
-        disk_update_cmd += "echo select disk 1 > cmd"
-        disk_update_cmd += " && echo select partition 1 >> cmd"
-        disk_update_cmd += " && echo shrink desired=DISK_CHANGE_SIZE >> cmd"
-        disk_update_cmd += " && echo exit >> cmd && diskpart /s cmd"
-        disk_unit = M
-        disk_rescan_cmd = "echo rescan > cmd"
-        disk_rescan_cmd += " && echo exit >> cmd"
-        disk_rescan_cmd += " && diskpart /s cmd"
+    variants:
+        - with_system_disk:
+            qcow2:
+                block_resize_type = "enlarge"
+            raw:
+                block_resize_type = "enlarge shrink"
+            blk_extra_params_image1 = "serial=TARGET_DISK0"
+            Host_RHEL.m6..ide:
+                blk_extra_params_image1 = "wwn=0x5000123456789abc"
+            backup_image_before_testing = yes
+            restore_image_after_testing = yes
+            Windows:
+                accept_ratio = 0.005
+                disk_index = 0
+                disk_letter = C
+                block_size_pattern = "${disk_index}\s+(\d+)"
+                block_size_cmd = wmic diskdrive get size, index
+        - with_data_disk:
+            images += " stg"
+            image_size_stg = 10G
+            image_name_stg = images/stg
+            create_image_stg = yes
+            remove_image_stg = yes
+            force_create_image_stg = yes
+            image_snapshot_image = yes
+            blk_extra_params_stg = "serial=TARGET_DISK0"
+            Host_RHEL.m6..ide:
+                blk_extra_params_stg = "wwn=0x5000123456789abc"
+            Windows:
+                accept_ratio = 0.005
+                block_size_cmd = wmic diskdrive get size, index
+                disk_index = 1
+                disk_letter = I
+                format_disk = yes
+                block_size_pattern = "${disk_index}\s+(\d+)"
+            variants:
+                - fmt_qcow2:
+                    image_extra_params = ""
+                    image_format_type = qcow2
+                    image_format_stg = qcow2
+                    block_resize_type = "enlarge"
+                - fmt_raw:
+                    image_extra_params = ""
+                    image_format_type = raw
+                    image_format_stg = raw
+                    block_resize_type = "enlarge shrink"
     ide:
         # TODO this is bug that ide not support qcow2 format block resize
         # recently. Will remove this line when the bug fixed.
@@ -53,10 +67,6 @@
         driver_name = vioscsi
         Linux:
             guest_prepare_cmd = "echo 1 > /sys/block/sda/device/rescan"
-    qcow2:
-        disk_change_ratio = 1.5
-    raw:
-        disk_change_ratio = 1.5 0.5
     RHEL.5:
         need_reboot = yes
     variants:
@@ -70,3 +80,13 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_stg = "iothread=${iothreads}"
+    variants:
+        - @default:
+        - iozone_test:
+            # Here only add windows iozone test part.
+            # For linux iozone test, will be developed by other colleague later,
+            # When it be finished, will update the code.
+            only Windows
+            iozone_test = "yes"
+            iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 1G"
+            iozone_cmd += " -M -b iozone.xls -f ${disk_letter}:\testfile"


### PR DESCRIPTION
1. Add block resize test for system disk(both linux and windows).
2. Add iozone test after block resize(only for windows).
3. Add block_resize_enlarge, block_resize_shrink, block_resize_restore function.
4. Take some codes out and put them in new function:
   rescan_disk_after_resize and get_drive_path_linux.
5. Add 2 differ image type for block resize.with data disk, when the system disk is qcow2, according to original code, the data disk also is qcow2 type, qcow2 not support shrink, so the shrink function will not be tested.  Here do a different with qcow2 and raw  will add a case  that system disk is qcow2 type but the data disk is raw type, thus, the shrink scenario can be covered at this time.

id: 1411207 1390485  1552433 1552432
Signed-off-by: Peixiu Hou <phou@redhat.com>