### PR TITLE
Update threshold of memory_hotplug tests on ppc

### DIFF
--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -15,6 +15,11 @@
     no RHEL.5 RHEL.6
     no Windows..i386
     no WinXP Win2000 Win2003 WinVista
+    # Notes:
+    #    The threshold on ppc was confirmed with developer
+    #    since crashkernel size is much bigger than x86
+    ppc64,ppc64le:
+        threshold = 0.15
     sub_test_wait_time = 0
     variants numa_nodes:
         - one:


### PR DESCRIPTION
ID: 1558339
As power guest's crashkernel size is much bigger than x86's,which makes some memory_hotplug test cases fail just because of an improper one.It's necessary for us to change a proper one.I've already confirmed threshold with ppc developer and I've been told it was reasonable on ppc.Thanks
Signed-off-by: mdeng@redhat.com <mdeng@redhat.com>