### PR TITLE
usb: Refine test cases in the config file

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -12,38 +12,50 @@
         - piix3-uhci:
             usb_type_usbtest = piix3-usb-uhci
             usb_controller = uhci
-            usb_max_port_usbtest = 2
+            max_ports_usbtest = 2
             drive_format_stg = "usb1"
             no ppc64 ppc64le
         - piix4-uhci:
             usb_type_usbtest = piix4-usb-uhci
             usb_controller = uhci
-            usb_max_port_usbtest = 2
+            max_ports_usbtest = 2
             drive_format_stg = "usb1"
             no ppc64 ppc64le
         - ich9-uhci:
             usb_type_usbtest = ich9-usb-uhci6
             usb_controller = uhci
-            usb_max_port_usbtest = 2
+            max_ports_usbtest = 2
             drive_format_stg = "usb1"
             no ppc64 ppc64le
             no Host_RHEL.m6
         - ich9-ehci:
-            usb_type_usbtest = ich9-usb-ehci1
             usb_controller = ehci
-            usb_max_port_usbtest = 6
+            max_ports = 6
             drive_format_stg = "usb2"
+            no ppc64 ppc64le
+            # Use ich9-usb-ehci2 for usb_hotplug..usb_negative_test and
+            # usb_multi_disk test since ich9-usb-ehci1 is specified to
+            # be used as companion controller in avocado-vt
+            variants:
+                - @ich9-ehci1:
+                    no usb_hotplug..usb_negative_test, usb_multi_disk
+                    usb_type_usbtest = ich9-usb-ehci1
+                - ich9-ehci2:
+                    only usb_hotplug..usb_negative_test, usb_multi_disk
+                    usb_type = ich9-usb-ehci2
         - usb-ehci:
             usb_type_usbtest = usb-ehci
+            usb_type = usb-ehci
             usb_controller = ehci
-            usb_max_port_usbtest = 6
+            max_ports = 6
             drive_format_stg = "usb2"
         - nec-xhci:
             no RHEL.5
             no Host_RHEL.m6
             usb_type_usbtest = nec-usb-xhci
+            usb_type = nec-usb-xhci
             usb_controller = xhci
-            usb_max_port_usbtest = 4
+            max_ports = 4
             drive_format_stg = "usb3"
             Host_RHEL:
                 no Win2000, WinXP, Win2003, WinVista, Win7, Win2008
@@ -51,9 +63,10 @@
             no RHEL.5
             no Host_RHEL.m6, Host_RHEL.m7.u0, Host_RHEL.m7.u1
             no Host_RHEL.m7.u2, Host_RHEL.m7.u3
-            usb_type_usbtest = qemu-xhci
+            usb_type_usbtest = nec-usb-xhci
+            usb_type = qemu-xhci
             usb_controller = xhci
-            usb_max_port_usbtest = 4
+            max_ports = 4
             drive_format_stg = "usb3"
             Host_RHEL:
                 no Win2000, WinXP, Win2003, WinVista, Win7, Win2008
@@ -96,7 +109,7 @@
         - usb_kbd:
             Host_RHEL.m6:
                 no usb-ehci
-            only usb_boot, usb_reboot, usb_hotplug
+            only usb_reboot, usb_hotplug
             usb_type = "usb-kbd"
             info_usb_name = "QEMU USB Keyboard"
             vendor_id = "0627"
@@ -106,7 +119,7 @@
         - usb_mouse:
             Host_RHEL.m6:
                 no usb-ehci
-            only usb_boot, usb_reboot, usb_hotplug
+            only usb_reboot, usb_hotplug
             usb_type = "usb-mouse"
             info_usb_name = "QEMU USB Mouse"
             vendor_id = "0627"
@@ -116,7 +129,7 @@
         - usb_tablet:
             Host_RHEL.m6:
                 no usb-ehci
-            only usb_boot, usb_reboot, usb_hotplug
+            only usb_reboot, usb_hotplug
             usb_type = "usb-tablet"
             info_usb_name = "QEMU USB Tablet"
             vendor_id = "0627"
@@ -189,18 +202,19 @@
             variants:
                 - usb_normal_test:
                 - usb_negative_test:
-                    only ehci
+                    only ich9-ehci
                     only usb_hub
                     only without_usb_hub
                     # Note: This is a workaround for the multifunction
                     # code in qemu_vm module.
-                    usb_type_usbtest = usb-ehci
+                    usb_type_usbtest = ich9-usb-ehci2
                     usb_negative_test = "yes"
                     usb_reply_msg = "Warning: speed mismatch trying to attach usb device"
             variants:
                 - usb_one_time:
                     usb_repeat_times = 1
                 - usb_multi_times:
+                    no usb_negative_test
                     usb_repeat_times = 5000
         - usb_storage:
             type = usb_storage
@@ -280,12 +294,16 @@
                 - usb_one_time:
                     usb_repeat_times = 1
                 - usb_multi_times:
+                    no usb_negative_test
                     usb_repeat_times = 5000
         - usb_multi_disk:
-            only ehci
+            no piix3-uhci, piix4-uhci, ich9-uhci
+            Host_RHEL.m6:
+                no usb-ehci
             type = multi_disk
             cmd_timeout = 1000
-            black_list = "C: D:"
+            black_list = C: S:
+            cdroms = ""
             start_vm = no
             kill_vm = yes
             create_image = yes
@@ -299,18 +317,17 @@
             stg_image_boot = no
             stg_image_format = qcow2
             stg_assign_index = yes
-            stg_drive_format = usb2
-            usbs = usb1
-            # Override global config for the usb1.
-            usb_type_usb1 = usb-ehci
-            usb_type = usb-ehci
-            usb_max_port_usb1 = 6
-            usb_max_port = 6
             usb_devices = ""
             variants:
                 - one_disk_repeat:
                     stg_image_num = 1
                     n_repeat = 10
                 - max_disk:
-                    usbs += " usb2 usb3 usb4"
                     stg_image_num = 24
+                    usb-ehci, ich9-ehci:
+                        stg_drive_format = usb2
+                        # Add multi usb controllers
+                        usbs = "usbdisk1 usbdisk2 usbdisk3 usbdisk4"
+                    nec-xhci, qemu-xhci:
+                        stg_drive_format = usb3
+                        usbs = "usbdisk1 usbdisk2 usbdisk3 usbdisk4 usbdisk5 usbdisk6"


### PR DESCRIPTION
1. Replace parameter 'usb_max_port*' to the correct one 'max_ports*'.
2. Add 'no ppc64 ppc64le' in 'ich9-ehci' part.
3. Delete usb_boot test for usb_kbd, usb_mouse and usb_tablet part
   since it's covered by cases in usb_device_check.cfg.
4. Correct usb controllers to be 'only usb-ehci, ich9-ehci' in
   usb_hotplug..usb_negative_test part.
5. Delete usb_hotplug.usb_multi_times.usb_negative_test and
   usb_host.usb_multi_times.usb_negative_test cases, since they are
   meaningless.
6. Add/delete lines to make usb_multi_disk part work.

ID: 1411609, 1560843
Signed-off-by: Nini Gu <ngu@redhat.com>