### PR TITLE
qemu.migrate: Quote the paths in gzip command

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -27,8 +27,8 @@
             variants:
                 - @default_exec:
                 - gzip_exec:
-                    migration_exec_cmd_src = "gzip -c > %s"
-                    migration_exec_cmd_dst = "gzip -c -d %s"
+                    migration_exec_cmd_src = "gzip -c > '%s'"
+                    migration_exec_cmd_dst = "gzip -c -d '%s'"
         - fd:
             migration_protocol = "fd"
         - mig_cancel:


### PR DESCRIPTION
The path in gzip command might contain spaces or "weird" characters.
Migrate command already uses double-quotes so let's use the single
quotes to avoid the need to escape characters in the src/dst path.

Tested with:

    exec:gzip -c > '/var/tmp/avocado_u8sHJg/avocado_job_OHWFL5/1-\
    functional_rpm_dvd type_specific.io-github-autotest-qemu.migrate\
    .with_reboot.exec.gzip_exec;-e630/migrateE8PDpZ/migrate_file'

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>