### PR TITLE
qemu.pci_devices: Remove default usb devices and controllers

### DIFF
--- a/qemu/tests/cfg/pci_devices.cfg
+++ b/qemu/tests/cfg/pci_devices.cfg
@@ -3,6 +3,8 @@
     start_vm = no
     pci_controllers = ''
     pci_controllers_autosort = "no"
+    usbs = ''
+    usb_devices = ''
     Linux:
         lspci_cmd = 'lspci -nn -m'
     variants:


### PR DESCRIPTION
The default usb-controller breaks the pci_device..max_devices variants
because it occupies the 1d.0 slot. We don't really need any additional
usb devices so let's just remove them for this test.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>