### PR TITLE
pvpanic.py: add trigger crash cases for pvpanic

### DIFF
--- a/qemu/tests/cfg/pvpanic_basic.cfg
+++ b/qemu/tests/cfg/pvpanic_basic.cfg
@@ -8,12 +8,39 @@
     backup_image_before_testing = yes
     restore_image_after_testing = yes
     set_kdump_cmd = "systemctl disable kdump.service && systemctl stop kdump.service"
-    set_panic_cmd = "echo 1 > /proc/sys/kernel/unknown_nmi_panic"
     RHEL.6:
         set_kdump_cmd = "chkconfig kdump off && service kdump stop"
     Windows:
         no Host_RHEL.m6
-        set_panic_cmd = 'wmic class stdregprov call SetDwordValue hDefKey="&h80000002" sSubKeyName="SYSTEM\CurrentControlSet\Control\CrashControl" sValueName="NMICrashDump" uValue=1'
+        crash_key1 = "ctrl_r"
+        crash_key2 = "scroll_lock"
     variants:
         - nmi:
             crash_method = nmi
+            Linux:
+                set_panic_cmd = "echo 1 > /proc/sys/kernel/unknown_nmi_panic"
+            Windows:        
+                set_panic_cmd = 'wmic class stdregprov call SetDwordValue hDefKey="&h80000002" sSubKeyName="SYSTEM\CurrentControlSet\Control\CrashControl" sValueName="NMICrashDump" uValue=1'
+        - usb_keyboard:
+            only Windows
+            crash_method = usb_keyboard
+            usb_devices += " kb1"
+            usb_type_kb1 = "usb-kbd"
+            set_panic_cmd = 'wmic class stdregprov call SetDwordValue hDefKey="&h80000002" sSubKeyName="SYSTEM\CurrentControlSet\Services\kbdhid\Parameters" sValueName="CrashOnCtrlScroll" uValue=1'
+            # There is no inbox usb3.0 driver on Win2008, Win2008R2 and Win7, so run with usb2.0 instead.
+            Win7, Win2008:
+                usb_type = ich9-usb-ehci1
+                usb_type_usb1 = ich9-usb-ehci1
+                usb_controller = ehci
+        - ps2_keyboard:
+            only Windows
+            del usb_devices
+            crash_method = ps2_keyboard
+            set_panic_cmd = 'wmic class stdregprov call SetDwordValue hDefKey="&h80000002" sSubKeyName="SYSTEM\CurrentControlSet\Services\i8042prt\Parameters" sValueName="CrashOnCtrlScroll" uValue=1'
+        - notmyfault_app:
+            only Windows
+            crash_method = notmyfault_app
+            i386:
+                notmyfault_cmd = "WIN_UTILS:\notmyfault.exe /bugcheck %#04x /accepteula"
+            x86_64:
+                notmyfault_cmd = "WIN_UTILS:\notmyfault64.exe /bugcheck %#04x /accepteula"


### PR DESCRIPTION
Add ps2_keyboard, usb_keyboard and notmyfault_app method to trigger
a crash.

Signed-off-by: Yu Wang <wyu@redhat.com>

id: 1542783 1542785  1542786