### PR TITLE
linux_stress: To replace stress test in autotest_control

### DIFF
--- a/generic/tests/cfg/linux_stress.cfg
+++ b/generic/tests/cfg/linux_stress.cfg
@@ -1,0 +1,6 @@
+- linux_stress:
+    only Linux
+    type = linux_stress
+    stress_time = 60
+    # Please specify below params for stress test, or use default value as shown
+    # download_url = http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz

--- a/generic/tests/cfg/linux_stress.cfg
+++ b/generic/tests/cfg/linux_stress.cfg
@@ -1,6 +1,6 @@
 - linux_stress:
     only Linux
     type = linux_stress
-    stress_time = 60
+    stress_duration = 60
     # Please specify below params for stress test, or use default value as shown
     # download_url = http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz

--- a/generic/tests/linux_stress.py
+++ b/generic/tests/linux_stress.py
@@ -1,0 +1,31 @@
+import time
+
+from virttest import utils_test
+
+
+def run(test, params, env):
+    """
+    General stress test for linux:
+       1). Install stress if need
+       2). Start stress process
+       3). If no stress_time defined, keep stress until test_timeout;
+       otherwise execute below steps after sleeping stress_time long
+       4). Stop stress process
+       5). Uninstall stress
+       6). Verify guest kernel crash
+
+    :param test: kvm test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    vm = env.get_vm(params['main_vm'])
+    vm.verify_alive()
+    stress = utils_test.VMStress(vm, 'stress')
+    stress.load_stress_tool()
+    stress_time = int(params.get('stress_time'))
+    if stress_time:
+        time.sleep(stress_time)
+        stress.unload_stress()
+        stress.clean()
+        vm.verify_kernel_crash()

--- a/generic/tests/linux_stress.py
+++ b/generic/tests/linux_stress.py
@@ -23,9 +23,15 @@ def run(test, params, env):
     vm.verify_alive()
     stress = utils_test.VMStress(vm, 'stress')
     stress.load_stress_tool()
-    stress_time = int(params.get('stress_time'))
-    if stress_time:
-        time.sleep(stress_time)
+    stress_duration = int(params.get('stress_duration', 0))
+    # NOTE: stress_duration = 0 ONLY for some legacy test cases using
+    # autotest stress.control as their sub test.
+    # Please DO define stress_duration to make sure the clean action
+    # being performed, if your case can not be controlled by time,
+    # use utils_test.VMStress() directly
+
+    if stress_duration:
+        time.sleep(stress_duration)
         stress.unload_stress()
         stress.clean()
         vm.verify_kernel_crash()

--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -163,8 +163,7 @@
                 i386, i686:
                     install_path = "C:\Program Files\JAM Software\HeavyLoad"
             Linux:
-                sub_type = autotest_control
-                test_control_file = stress.control
+                sub_type = linux_stress
                 test_timeout = 1800
     variants stage:
         - before:

--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -85,10 +85,7 @@
                 i386, i686:
                     install_path = "C:\Program Files\JAM Software\HeavyLoad"
             Linux:
-                stress_test = autotest_control
-                test_control_file = stress.control
-                # Use a low stress to make sure guest can response during stress
-                control_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"
+                stress_test = linux_stress
                 test_timeout = 1800
                 check_cmd = 'pgrep stress'
                 stop_cmd = "killall -g stress"
@@ -128,7 +125,6 @@
                         create_command = "dd if=/dev/urandom of=FILE bs=128k count=100"
                         file_names = "/home/live_snapshot_base /home/live_snapshot_sn1"
                         test_exists_cmd = "test -f FILE"
-                        control_args = "--cpu 1 --vm 1 --vm-bytes 16M"
                         sync_cmd = "sync"
         - transaction:
             type = live_snapshot_transaction


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/1467

id: 1552382
Signed-off-by: qizhu <qizhu@redhat.com>