### PR TITLE
nmi_bsod_catch: disable pvpanic

### DIFF
--- a/qemu/tests/cfg/nmi_bsod_catch.cfg
+++ b/qemu/tests/cfg/nmi_bsod_catch.cfg
@@ -2,6 +2,7 @@
     type = nmi_bsod_catch
     only Windows
     mem_fixed = 2048
+    enable_pvpanic = no
     config_cmds = config_cmd1, config_cmd2, config_cmd3, config_cmd4, config_cmd5, config_cmd6
     # enable AutoReboot, guest will reboot after finishing create dump file.
     config_cmd1 = reg add HKLM\System\CurrentControlSet\Control\CrashControl /v AutoReboot /d 1 /t REG_DWORD /f


### PR DESCRIPTION
nmi_bsod_catch.cfg: disable pvpanic

this case needs system reboot after panic.
open pvpanic system will shutdown after panic.

bug id: 1560457
Signed-off-by: Chunyu Liao  cliao@redhat.com