### PR TITLE
balloon_in_use: Correct balloon driver name

### DIFF
--- a/qemu/tests/cfg/balloon_in_use.cfg
+++ b/qemu/tests/cfg/balloon_in_use.cfg
@@ -28,7 +28,7 @@
         video_url = http://fileshare.com/Peppa_Pig_39_The_Tree_House.avi
         play_video_cmd = '"%s" "%s" /play /fullscreen'
         guest_alias = "Win2008-sp2-32:2k8\x86,Win2008-sp2-64:2k8\amd64,Win2008-r2-64:2k8\amd64,Win2012-64:2k12\amd64,Win2012-64r2:2k12\amd64"
-        driver_name = "balloon.sys"
+        driver_name = "balloon"
         time_for_video = 600
         free_mem_cmd = wmic os get FreePhysicalMemory
         default_memory = ${mem}


### PR DESCRIPTION
Correct balloon driver's name from "balloon.sys" to "balloon" which is used in windrv_check_running_verifier() function.

ID:1562739

Signed-off-by: Li Jin <lijin@redhat.com>