### PR TITLE
Add 2M hugepage size tests for P9 

### DIFF
--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -78,7 +78,6 @@
                     # default pagesize is 2M, 2G guest memory need to allocate
                     # in hugepage, so page nubmer is:
                     #    target_hugepages = (size_mem / page_size) * 2 + 10
-                    only i386, x86_64
                     target_hugepages = 2058
                     expected_hugepage_size = 2048
                 - 16M_hugepage:


### PR DESCRIPTION
ID: 1563481
It is because 2M size is default hugepage size on Power9 and we need to adjust it accordingly
Signed-off-by: mdeng@redhat.com <mdeng@redhat.com>