### PR TITLE
qemu_disk_img.commmit: Update configurations for the case

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -42,6 +42,8 @@
                 - writeback:
                     cache_mode = writeback
                 - unsafe:
+                    Host_RHEL.m6:
+                        no commit
                     cache_mode = unsafe
                 - directsync:
                     cache_mode = directsync
@@ -122,6 +124,8 @@
             image_chain += " sn1"
             image_name_sn1 = "images/sn1"
             image_format_sn1 = "qcow2"
+            backup_image_before_testing = yes
+            restore_image_after_testing = yes
         - info:
             type = qemu_disk_img_info
             guest_file_name_image1 = "${tmp_dir}/test.img"


### PR DESCRIPTION
1. Skip commit test with unsafe mode on RHEL-6 host.
2. Backup image and restore image for commit test to avoid
interference in later cases.

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1565424
