### PR TITLE
Netperf: add tries parameter to repeat sub tests

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -6,6 +6,11 @@
     setup_ksm = no
     take_regular_screendumps = no
     store_vm_register = no
+    # sometimes since vm performance issue or processors could not handle
+    # at same time with mis-config sessions number, it may not all clients
+    # up at same times, please modify tires parameter to repeat sub tests
+    # to increase the successful probalility
+    tries = 5
     # Please update following comments params when you need special cfg for
     # your test nic cards
     # nic1 is for control, nic2 is for data connection
@@ -64,6 +69,8 @@
     log_hostinfo_script = scripts/rh_perf_log_hostinfo_script.sh
     host_tuned_profile = "tuned-adm profile virtual-host"
     client_tuned_profile = "tuned-adm profile virtual-host"
+    client_kill_linux = "killall netperf"
+    client_kill_windows = "taskkill /F /IM netperf*"
     # Now the get status functions are implemented for RHEL and Fedora guests.
     # Not test with other guests, please set this depends on your guest os
     # environment.


### PR DESCRIPTION
1. sometimes since vm performance issue or processors could not handle
at same time with mis-config sessions number, it may not all clients
up at same times, we can modify tries  parameters to repeat sub tests
to increase the successful probalility.
2.add function stop_netperf_clients() to use correct kill command
    according to linux or windows system

Signed-off-by: Wenli Quan <wquan@redhat.com>

ID: 1315167 1408744