### PR TITLE
Python 3: [generic] replaced foo.func_name

### DIFF
--- a/generic/tests/ethtool.py
+++ b/generic/tests/ethtool.py
@@ -253,7 +253,7 @@ def run(test, params, env):
                 logging.error(e_msg)
                 failed_tests.append(e_msg)
 
-            txt = "Run callback function %s" % callback.func_name
+            txt = "Run callback function %s" % callback.__name__
             error_context.context(txt, logging.info)
 
             # Some older kernel versions split packets by GSO
@@ -269,7 +269,7 @@ def run(test, params, env):
                 e_msg = "Failed to disable %s" % f_type
                 logging.error(e_msg)
                 failed_tests.append(e_msg)
-            txt = "Run callback function %s" % callback.func_name
+            txt = "Run callback function %s" % callback.__name__
             error_context.context(txt, logging.info)
             if not callback(status="off"):
                 e_msg = "Callback failed after disabling %s" % f_type


### PR DESCRIPTION
Python 3 dese not support `foo.fucn_name`,
using `foo.__name__` instead.

Signed-off-by: Haotong Chen <hachen@redhat.com>