### PR TITLE
Replace test.srcdir with test.workdir

### DIFF
--- a/generic/tests/build.py
+++ b/generic/tests/build.py
@@ -9,8 +9,8 @@ def run(test, params, env):
     :param params: Dictionary with test parameters.
     :param env: Test environment.
     """
-    srcdir = params.get("srcdir", test.srcdir)
-    params["srcdir"] = srcdir
+    workdir = params.get("workdir", test.workdir)
+    params["workdir"] = workdir
 
     # Flag if a installer minor failure occurred
     minor_failure = False

--- a/openvswitch/tests/ovs_basic.py
+++ b/openvswitch/tests/ovs_basic.py
@@ -71,7 +71,7 @@ class InfrastructureInit(MiniSubtest):
                                           self.ovs)
 
         logging.debug(self.ovs.status())
-        self.host = ovs_utils.Machine(src=test.srcdir)
+        self.host = ovs_utils.Machine(src=test.workdir)
         self.mvms = [ovs_utils.Machine(vm) for vm in self.vms]
         self.machines = [self.host] + self.mvms
 

--- a/qemu/tests/qemu_iotests.py
+++ b/qemu/tests/qemu_iotests.py
@@ -28,7 +28,7 @@ def run(test, params, env):
     commit = params.get("qemu_io_commit", None)
     base_uri = params.get("qemu_io_base_uri", None)
     iotests_dir = params.get("qemu_iotests_dir", "tests/qemu-iotests")
-    destination_dir = os.path.join(test.srcdir, "qemu_io_tests")
+    destination_dir = os.path.join(test.workdir, "qemu_io_tests")
     git.get_repo(uri=uri, branch=branch, lbranch=lbranch, commit=commit,
                  destination_dir=destination_dir, base_uri=base_uri)
 

--- a/qemu/tests/unittest_kvmctl.py
+++ b/qemu/tests/unittest_kvmctl.py
@@ -14,8 +14,8 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
     case = params["case"]
-    srcdir = params.get("srcdir", test.srcdir)
-    unit_dir = os.path.join(srcdir, "kvm_userspace", "kvm", "user")
+    workdir = params.get("workdir", test.workdir)
+    unit_dir = os.path.join(workdir, "kvm_userspace", "kvm", "user")
     if not os.path.isdir(unit_dir):
         os.makedirs(unit_dir)
     os.chdir(unit_dir)


### PR DESCRIPTION
The test's "srcdir" property is deprecated and is planned to be
removed no later than May 11 2018. So replaced test.srcdir with
test.workdir.
Also changed variable name accordingly.

Please refer to:
https://github.com/avocado-framework/avocado/pull/2509

Signed-off-by: Haotong Chen <hachen@redhat.com>

id: 1568659