### PR TITLE
block_hotplug: Modify the repeat time and add limited condition for with_shutdown case

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -24,10 +24,10 @@
     variants:
         - one_pci:
             blk_num = 1
-            repeat_times = 3
+            repeat_times = 1
         - multi_pci:
             blk_num = 2
-            repeat_times = 3
+            repeat_times = 1
             images += " stg1"
             boot_drive_stg1 = no
             image_name_stg1 = images/storage1
@@ -38,7 +38,7 @@
     variants:
         - @default:
         - with_repetition:
-            repeat_times = 300
+            repeat_times = 100
         - with_reboot:
             sub_type_after_plug = boot
             sub_type_after_unplug = boot
@@ -46,6 +46,7 @@
         - with_shutdown:
             variants:
                 - after_plug:
+                    only with_plug
                     sub_type_after_plug = shutdown
                 - after_unplug:
                     sub_type_after_unplug = shutdown


### PR DESCRIPTION
1. Modify the repeat time from 300 to 100 about with_repetition test.
   Repeat 300 times takes too long time.
2. Modify the repeat time from 3 to 1 about not repetition test.
   Repeat hotplug and unplug can be covered by with_repetition test.
3. Limited the with_shutdown.after_plug only with_plug,
   When test without_plug, this case is no needed.

id: 1572160
Signed-off-by: Peixiu Hou <phou@redhat.com>