### PR TITLE
Python 3: drop usage of iter.next()

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -174,7 +174,7 @@ class BallooningTest(MemoryBaseTest):
         """
         logging.info("Wait until guest memory don't change")
         is_stable = self._mem_state()
-        utils_misc.wait_for(is_stable.next, timeout, step=10.0)
+        utils_misc.wait_for(lambda: next(is_stable), timeout, step=10.0)
 
     def get_memory_boundary(self, balloon_type=''):
         """


### PR DESCRIPTION
To support both Python 3 and 2, use `next(iter)` or `iter.__next__()`

Signed-off-by: Haotong Chen <hachen@redhat.com>