### PR TITLE
Netperf: variants jumbo is duplicated with jumbo.py case

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -125,7 +125,7 @@
                     netserv_start_cmd = netserver
                     netperf_install_cmd = cd netperf-2.6.0; ./configure --enable-burst --enable-demo=yes; make; make install
     variants:
-        - jumbo:
+        - with_jumbo:
             mtu = 9000
             # please config physical nic name of client for jumbo frame case by uncommenting it
             # client_physical_nic = <your_client_physical_nic>


### PR DESCRIPTION
variants jumbo is duplicated with jumbo.py, so replace it with
with_jumbo.

Signed-off-by: Wenli Quan <wquan@redhat.com>

ID: 1528148 