### PR TITLE
virtio_scsi_mq: Update the num_queues

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_mq.cfg
+++ b/qemu/tests/cfg/virtio_scsi_mq.cfg
@@ -11,6 +11,8 @@
     system_image_drive_format = virtio
     bootindex_image1 = 0
     irq_regex = "virtio\d+-request"
+    num_queues_min = 4
+    num_queues_max = 8
     ppc64le,ppc64:
         system_image_drive_format = scsi-hd
         scsi_hba_image1 = spapr-vscsi

--- a/qemu/tests/virtio_scsi_mq.py
+++ b/qemu/tests/virtio_scsi_mq.py
@@ -59,9 +59,13 @@ def run(test, params, env):
 
     timeout = float(params.get("login_timeout", 240))
     host_cpu_num = utils_cpu.online_cpus_count()
-    while host_cpu_num:
-        num_queues = str(host_cpu_num)
-        host_cpu_num &= host_cpu_num - 1
+    if host_cpu_num < int(params.get("num_queues_min")):
+        logging.debug("Host cpus is %s" % host_cpu_num)
+        test.cancel("Can not run since required minimum cpus is %s."
+                    % params.get("num_queues_min"))
+    if host_cpu_num > int(params.get("num_queues_max")):
+        host_cpu_num = int(params.get("num_queues_max"))
+    num_queues = str(host_cpu_num)
     params['smp'] = num_queues
     params['num_queues'] = num_queues
     images_num = int(num_queues)


### PR DESCRIPTION
Update the num_queues appropriately,
since cpus will be greater on host that spent more time on dd testing.

Signed-off-by: Yongxue Hong <yhong@redhat.com>

ID : 1567877