### PR TITLE
system_reset_bootable: Use fractional random sleeps

### DIFF
--- a/qemu/tests/system_reset_bootable.py
+++ b/qemu/tests/system_reset_bootable.py
@@ -51,7 +51,7 @@ def run(test, params, env):
 
         interval_tmp = interval
         if params.get("fixed_interval", "yes") != "yes":
-            interval_tmp = random.randint(0, interval)
+            interval_tmp = random.randint(0, interval * 1000) / 1000.0
 
         logging.debug("Reset the system by monitor cmd"
                       " after %ssecs" % interval_tmp)


### PR DESCRIPTION
system_reset_bootable picks random times to sleep for between
reboot iterations.
Prior to this patch it used integers, and so always waited for
whole numbers of seconds.  This causes a problem where there's
a sub-second failure window during which a reboot would fail.
Depending on the system, qemu version and luck, the window could
completely miss the failure (reliably), and a small change
(such as a slightly different qemu build or host system) could
move the failure window within a second-boundary that would be caught.
This results in blaming the change rather than the original
fault.

Solve this by moving to random fractional values, at millisecond
resolution; there's probably more than a ms slop in the system
anyway.

Signed-off-by: Dr. David Alan Gilbert <dgilbert@redhat.com>