### PR TITLE
timedrift: Fix the CmdError of restore_cpu_affinity()

### DIFF
--- a/qemu/tests/timedrift.py
+++ b/qemu/tests/timedrift.py
@@ -59,7 +59,8 @@ def run(test, params, env):
         :param prev_masks: A dict containing TIDs as keys and masks as values.
         """
         for tid, mask in prev_masks.items():
-            process.system("taskset -p %s %s" % (mask, tid), verbose=False)
+            process.system("taskset -p %s %s" % (mask, tid), verbose=False,
+                           ignore_status=True)
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()


### PR DESCRIPTION
When restoring the configurations of cpu affinity, some threads
would be no long existed, so need to ignore the errors emitted
by this operation.

Signed-off-by: Xu Han <xuhan@redhat.com>