### PR TITLE
migrate: Set "max_vms" to allow "hugepage" testing

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -7,6 +7,7 @@
     kill_vm_on_error = yes
     iterations = 2
     used_mem = 1024
+    max_vms = 2
     mig_timeout = 3600
     ping_pong = 1
     # you can uncomment the following line to enable the state
@@ -87,6 +88,7 @@
                 - read_only_dest:
                     test_type = test_read_only_dest
                     only exec
+                    max_vms = 3
                     vms = "virt_test_vm1_guest virt_test_vm2_data_server"
                     start_vm_vm1_guest = no
                     read_only_timeout = 480
@@ -105,6 +107,7 @@
             requires_root = yes
             master_images_clone = "image1"
             type = migration_with_dst_problem
+            max_vms = 3
             vms = "vm1 virt_test_vm2_data_server"
 
             copy_block_size = 100M


### PR DESCRIPTION
The migrate jobs usually define 1 vms, but during the migration 2 vms
might be live, which might affect the number of required memory for
hugepages. Let's use the "max_vms" parameter, which is considered on
hugepage setup, to reflect the reality.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>