### PR TITLE
virtio-win driver signtool check Test

### DIFF
--- a/qemu/tests/cfg/virtio_driver_sign_check.cfg
+++ b/qemu/tests/cfg/virtio_driver_sign_check.cfg
@@ -1,16 +1,42 @@
 - virtio_driver_sign_check:
     virt_test_type = qemu
-    only Win7.x86_64
-    # This script only need run once for every virtio driver version.
-    # So need not add to our testing loop.
+    only Windows
     type = virtio_driver_sign_check
-    cdroms += " sdk virtio"
-    cdrom_virtio = isos/windows/virtio-win.iso
-    cdrom_sdk = isos/windows/GRMSDKX_EN_DVD.iso
-    floppies = "fl"
-    floppy_name = images/win7-64/virtio-win.vfd
-    list_files_cmd = dir /s /b %s | find "%s"
-    winsdk_au3 = autoit/winsdk.au3
-    signtool_install = "D:\autoit3.exe c:\winsdk.au3"
-    signtool_cmd = "c:\Program Files\Microsoft SDKs\Windows\v7.0\Bin\signtool.exe" verify /v /kp /c %s %s
-    drive_list = F: A:
+    signtool_path_key = "HLK"
+    Win2008..sp2:
+        # windows 2008 not support virtio input device
+        no with_vioinput
+        signtool_path_key = "WLK"
+    Win2008..r2, Win7, Win8, Win2012:
+        signtool_path_key = "HCK"
+    signtool_cmd = "WIN_UTILS:\signtool\Signtool_%%PROCESSOR_ARCHITECTURE%%_${signtool_path_key}.exe" verify /v /kp /c %s %s
+    variants:
+        - virtio_win_iso_media:
+            virtio_win_media_type = iso
+            cdroms += " virtio"
+        - virtio_win_vfd_media:
+            only with_vioscsi, with_viostor, with_netkvm
+            virtio_win_media_type = vfd
+            floppies = "virtio"
+            i386:
+                floppy_name_virtio = isos/windows/virtio-win_x86.vfd
+            x86_64:
+                floppy_name_virtio = isos/windows/virtio-win_amd64.vfd
+            floppy_readonly_virtio = yes
+    variants:
+        - with_balloon:
+            tested_driver = "Balloon"
+        - with_pvpanic:
+            tested_driver = "pvpanic"
+        - with_viorng:
+            tested_driver = "viorng"
+        - with_vioser:
+            tested_driver = "vioserial"
+        - with_vioinput:
+            tested_driver = "vioinput"
+        - with_netkvm:
+            tested_driver = "NetKVM"
+        - with_vioscsi:
+            tested_driver = "vioscsi"
+        - with_viostor:
+            tested_driver = "viostor"


### PR DESCRIPTION
1. Boot a guest with latest virtio-win.iso and virtio-win.vfd.
2. Run signtool.exe to verify each driver '.sys', '.inf' and 'Wdf'file.

id: 1375853
Signed-off-by: Peixiu Hou <phou@redhat.com>