### PR TITLE
smbios_table: make uuid check case insensitive

### DIFF
--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -99,6 +99,11 @@ def run(test, params, env):
                 if smbios_get_para == notset_output:
                     smbios_get_para = default_key_para
 
+                # make UUID check case insensitive
+                if key == "UUID":
+                    smbios_set_para = smbios_set_para.lower()
+                    smbios_get_para = smbios_get_para.lower()
+
                 if (smbios_set_para not in smbios_get_para):
                     e_msg = ("%s.%s mismatch, Set '%s' but guest is : '%s'"
                              % (sm_type, key, smbios_set_para,


### PR DESCRIPTION
When `uuid = random`, avocado-vt will generate a uuid through
`/proc/sys/kernel/random/uuid`. This uuid contains digits and
lower letters. It will be passed to qemu cmdline as a option.

eg: -smbios type=1,manufacturer='Dell Inc.',product='PowerEdge R430',
uuid='4c4c4544-0050-4610-804c-b9c04f584d32',serial='9PFLXM2',
version='Not Specified',family='VIRT',sku='KVM' \

However, the guest uuid obtained from
`dmidecode -t 1 | grep UUID | sed 's/^.*://g'` contains digits
and capital letters, which causes mismatch for the verification.

id: 1585588

Signed-off-by: Haotong Chen <hachen@redhat.com>