### PR TITLE
block_hotplug: Use the correct 'blk_extra_params' separator

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -64,7 +64,7 @@
             only with_plug
             only one_pci
             sub_type_after_plug = block_resize
-            blk_extra_params_stg0 += " serial=TARGET_DISK0"
+            blk_extra_params_stg0 += ",serial=TARGET_DISK0"
             block_size_cmd = "fdisk -l | grep {0}"
             block_size_pattern = ",\s+(\d+\s+b)ytes"
             disk_change_ratio = "1.5 0.5"


### PR DESCRIPTION
The 'blk_extra_params' uses ',' as separator and not ' '. Using ' '
leads to ' serial' instead of 'serial' being passed as an argument.

Theoretically I could just use '=' without any separator, but in order
to keep '+=' I decided to simply add the separator here. Empty inputs
are automatically skipped on parsing.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>