### PR TITLE
Postcopy

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -13,6 +13,27 @@
     # check
     # vmstate_check = yes
     variants:
+        - @default:
+        - with_post_copy:
+            migrate_inner_funcs = [('postcopy', 70)]
+            migrate_capabilities = "{'postcopy-ram': 'on'}"
+            mig_speed = 1b
+            pre_migrate = "mig_set_speed"
+            only tcp,unix
+            # Needs us to dupe the stuff over (or make it common) from
+            # migration.py to all other migration_*.py tests
+            no with_reboot
+            no with_speed_measurement
+            no with_file_transfer
+            no after_vm_paused
+            no mig_dest_problem
+            no after_extensive_io
+            no with_autotest
+            no with_stress
+            no between_vhost_novhost
+            no with_netperf
+
+    variants:
         - x-rdma:
             migration_protocol = "x-rdma"
         - rdma:

--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -4,6 +4,7 @@ import types
 import re
 
 import aexpect
+import ast
 
 from virttest import utils_misc
 from virttest import utils_test
@@ -206,6 +207,9 @@ def run(test, params, env):
                     guest_stress_deamon, ())
                 deamon_thread.start()
 
+            capabilities = ast.literal_eval(params.get("migrate_capabilities", "{}"))
+            inner_funcs = ast.literal_eval(params.get("migrate_inner_funcs", "[]"))
+
             # Migrate the VM
             ping_pong = params.get("ping_pong", 1)
             for i in range(int(ping_pong)):
@@ -216,7 +220,10 @@ def run(test, params, env):
                 vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay,
                            offline, check,
                            migration_exec_cmd_src=mig_exec_cmd_src,
-                           migration_exec_cmd_dst=mig_exec_cmd_dst, env=env)
+                           migration_exec_cmd_dst=mig_exec_cmd_dst,
+                           migrate_capabilities=capabilities,
+                           mig_inner_funcs=inner_funcs,
+                           env=env)
 
             # Set deamon thread action to stop after migrate
             params["action"] = "stop"


### PR DESCRIPTION
Now the avocado changes have gone in, it's time for the tp changes.
With this we get a simple 'migrate.default.tcp.with_post_copy' that normally does a handful of postcopy requests.