### PR TITLE
usb.usb_multi_disk: fix the absent of param file_system

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -300,6 +300,8 @@
             no piix3-uhci, piix4-uhci, ich9-uhci
             Host_RHEL.m6:
                 no usb-ehci
+            Linux:
+                file_system = "ext4"
             type = multi_disk
             cmd_timeout = 1000
             black_list = C: S:


### PR DESCRIPTION
Fix below issue:
```
13:02:16 ERROR|   File "/var/lib/avocado/data/avocado-vt/test-providers.d/downloads/io-github-autotest-qemu/qemu/tests/multi_disk.py", line 227, in run
13:02:16 ERROR|     file_system = [_.strip() for _ in params.get("file_system").split()]
13:02:16 ERROR| AttributeError: 'NoneType' object has no attribute 'split'
```
id: 1588919
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>