### PR TITLE
Fixup: Update test cases to reflect recent lib changes

### DIFF
--- a/generic/tests/linux_stress.py
+++ b/generic/tests/linux_stress.py
@@ -21,7 +21,7 @@ def run(test, params, env):
 
     vm = env.get_vm(params['main_vm'])
     vm.verify_alive()
-    stress = utils_test.VMStress(vm, 'stress')
+    stress = utils_test.VMStress(vm, 'stress', params)
     stress.load_stress_tool()
     stress_duration = int(params.get('stress_duration', 0))
     # NOTE: stress_duration = 0 ONLY for some legacy test cases using

--- a/qemu/tests/balloon_stress.py
+++ b/qemu/tests/balloon_stress.py
@@ -31,7 +31,7 @@ def run(test, params, env):
                 utils_test.run_virt_sub_test(test, params, env,
                                              params.get("stress_test"))
             else:
-                stress_bg = utils_test.VMStress(vm, "stress")
+                stress_bg = utils_test.VMStress(vm, "stress", params)
                 stress_bg.load_stress_tool()
 
     error_context.context("Boot guest with balloon device", logging.info)


### PR DESCRIPTION
Due to recent change in utils_test relating to VMStress, couple of qemu tests
were failing. This patch fixes up 2 qemu testcases.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>