### PR TITLE
boot_with_different_vectors: remove set mq operation in test steps

### DIFF
--- a/qemu/tests/cfg/boot_with_different_vectors.cfg
+++ b/qemu/tests/cfg/boot_with_different_vectors.cfg
@@ -2,6 +2,7 @@
     only Linux
     only virtio_net
     no RHEL.3 RHEL.4 RHEL.5 RHEL.6
+    no RHEL.7.0 RHEL.7.1 RHEL.7.2 RHEL.7.3 RHEL.7.4
     no Host_RHEL.m5, Host_RHEL.m6
     queues = 4
     vectors_list = 0 1 2 3 4 5 6 7 8 9 10 11 -1


### PR DESCRIPTION
1. MQ will be set automatically according to cmd line configuration
in qemu. This behavior is introduced by an RFE bug.
2. virtio[x]-interrupt match string modified

id: 1576643

Signed-off-by: Xiyue Wang <xiywang@redhat.com>