### PR TITLE
Python 3: fix a process issue

### DIFF
--- a/qemu/tests/vhost_with_cgroup.py
+++ b/qemu/tests/vhost_with_cgroup.py
@@ -54,9 +54,10 @@ def run(test, params, env):
     assign_vm_into_cgroup(vm, cgroup, 0)
 
     vhost_pids = process.system_output("pidof vhost-%s" % vm.get_pid(),
-                                       shell=True)
+                                       shell=True,
+                                       ignore_status=True).decode()
     if not vhost_pids:
-        test.error("Vhost process not exise")
+        test.error("Vhost process does not exist")
     logging.info("Vhost have started with pid %s" % vhost_pids)
     for vhost_pid in vhost_pids.strip().split():
         cgroup.set_cgroup(int(vhost_pid))


### PR DESCRIPTION
porcess.system_output needs to set ignore_status=True
and decode the return value for later usage.

Signed-off-by: Haotong Chen <hachen@redhat.com>