### PR TITLE
openflow_acl_test.accessed_deny_all_target.telnet: telnelserver is deprecated in Win10,Win2016,Win2019

### DIFF
--- a/qemu/tests/cfg/openflow_acl_test.cfg
+++ b/qemu/tests/cfg/openflow_acl_test.cfg
@@ -70,8 +70,12 @@
             Windows:
                  quit_cmd = quit
                  copy_scripts = telnet.py wait_for_quit.py
-            del stop_cmd_windows
+            stop_cmd_windows = net stop telnet
             setup_targets = virt-tests-vm1 virt-tests-vm2 localhost
+            Win10,Win2016,Win2019:
+                 setup_cmd_windows = start /w pkgmgr /iu:TelnetClient
+                 setup_targets = virt-tests-vm1 localhost
+                 stop_cmd_windows =
     variants:
         - access_deny_all_target:
             acl_disabled = yes
@@ -110,6 +114,9 @@
             extra_target = localhost
             ftp, website:
                 setup_targets = virt-tests-vm1
+            Win10..telnet,Win2016..telnet,Win2019..telnet:
+                vms = virt-tests-vm1
+                extra_target =
         - accessed_deny_special_target:
             access_targets = virt-tests-vm1
             deny_target = virt-tests-vm2

--- a/qemu/tests/openflow_acl_test.py
+++ b/qemu/tests/openflow_acl_test.py
@@ -83,13 +83,14 @@ def run(test, params, env):
                         stat = 1
                         out_err = "Failed to login %s " % atgt
                         out_err += "from %s, err: %s" % (asys, err.output)
-                    try:
-                        out += remote_login(access_cmd, ssh_src_ip,
-                                            target_vm, params, host_ip)
-                    except remote.LoginError as err:
-                        stat += 1
-                        out_err += "Failed to login %s " % asys
-                        out_err += "from %s, err: %s" % (atgt, err.output)
+                    if "TelnetServer" in params.get("setup_cmd_windows"):
+                        try:
+                            out += remote_login(access_cmd, ssh_src_ip,
+                                                target_vm, params, host_ip)
+                        except remote.LoginError as err:
+                            stat += 1
+                            out_err += "Failed to login %s " % asys
+                            out_err += "from %s, err: %s" % (atgt, err.output)
                     if out_err:
                         out = out_err
                 else:


### PR DESCRIPTION
1. Telnelserver is deprecated in Win10,Win2016,Win2019, remove it in
setup_cmd and tests when Win vm as telnetserver.
2. the default bridge name is atbr0

Signed-off-by: WenliQuan <wquan@redhat.com>

id: 1467827