### PR TITLE
rh_qemu_iotests: Specify the path for binary QEMU_NBD_PROG

### DIFF
--- a/qemu/tests/rh_qemu_iotests.py
+++ b/qemu/tests/rh_qemu_iotests.py
@@ -100,6 +100,7 @@ def run(test, params, env):
         os.environ["QEMU_PROG"] = utils_misc.get_qemu_binary(params)
         os.environ["QEMU_IMG_PROG"] = utils_misc.get_qemu_img_binary(params)
         os.environ["QEMU_IO_PROG"] = utils_misc.get_qemu_io_binary(params)
+        os.environ["QEMU_NBD_PROG"] = utils_misc.get_binary('qemu-nbd', params)
         os.chdir(os.path.join(qemu_src_dir, iotests_root))
         cmd = './check'
         if extra_options:


### PR DESCRIPTION
Since qemu-2.12, qemu-iotests requires tester to specify the path
for qemu, qemu-img, qemu-io, and qemu-nbd. Or the test suit will
show a warning message and terminate the tests.

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1582035