### PR TITLE
fillup_disk: Update method of fill up disk

### DIFF
--- a/generic/tests/fillup_disk.py
+++ b/generic/tests/fillup_disk.py
@@ -1,15 +1,54 @@
 import logging
+import re
 
 from virttest import error_context
+
+
+def fill_partitions(test, params, session, partition, deeply=False):
+    """
+    Fill up the specified partitions.
+    :param test: QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param session: ShellSession object.
+    :param partition: Specified partition,
+    :param deeply: fill up partition with block size of 512b.
+    """
+    fillup_cmd = params["fillup_cmd"]
+    clean_cmd = params["clean_cmd"]
+    fillup_timeout = int(params["fillup_timeout"])
+    fillup_size = int(params["fillup_size"])
+    prefix = re.search(r'%s/.*\*$', clean_cmd).group().lstrip('%s/').rstrip('*')
+    number = 0
+
+    info = "Start shallow filling the %s partition." % partition
+    if deeply:
+        info = "Start deep filling the %s partition with 512b." % partition
+    error_context.context(info, logging.info)
+
+    while 1:
+        # As we want to test the backing file, so bypass the cache
+        cmd = fillup_cmd % (partition, number, fillup_size)
+        if deeply:
+            cmd = 'dd if=/dev/zero of=%s/%s512b bs=512b oflag=direct' \
+                  % (partition, prefix)
+        logging.debug(cmd)
+        s, o = session.cmd_status_output(cmd, timeout=fillup_timeout)
+        if "No space left on device" in o:
+            if not deeply:
+                fill_partitions(test, params, session, partition, True)
+            break
+        elif s != 0:
+            test.fail("Command dd failed to execute: %s" % o)
+        number += 1
 
 
 @error_context.context_aware
 def run(test, params, env):
     """
-    Fileup disk test:
-    Purpose to expand the qcow2 file to its max size.
+    Fill up disk test:
+    Purpose to expand the qcow2 file to its max size by filling partitions.
     Suggest to test rebooting vm after this test.
-    1). Fillup guest disk (root mount point) using dd if=/dev/zero.
+    1). Fill up guest disk (root mount point) using dd if=/dev/zero.
     2). Clean up big files in guest with rm command.
 
 
@@ -22,37 +61,53 @@ def run(test, params, env):
     login_timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=login_timeout)
     session2 = vm.wait_for_serial_login(timeout=login_timeout)
+    filled_partition = params.get("guest_testdir")
 
-    fillup_timeout = int(params.get("fillup_timeout"))
-    fillup_size = int(params.get("fillup_size"))
-    fill_dir = params.get("guest_testdir", "/tmp")
-    filled = False
-    number = 0
+    logging.debug('Check info of parttions: ')
+    parts_info = session.cmd_output('lsblk')
+    logging.debug(parts_info)
+    all_partitions = [str(mp.split()[-1]) for mp in parts_info.splitlines()
+                      if re.search(r'\d+\s+(lvm|part)\s+/', mp)]
 
     try:
-        error_context.context("Start filling the disk in %s" % fill_dir,
-                              logging.info)
-        cmd = params.get("fillup_cmd")
-        while not filled:
-            # As we want to test the backing file, so bypass the cache
-            tmp_cmd = cmd % (fill_dir, number, fillup_size)
-            logging.debug(tmp_cmd)
-            s, o = session.cmd_status_output(tmp_cmd, timeout=fillup_timeout)
-            if "No space left on device" in o:
-                logging.debug("Successfully filled up the disk")
-                filled = True
-            elif s != 0:
-                test.fail("Command dd failed to execute: %s" % o)
-            number += 1
+        if not filled_partition:
+            # fill up all the partitions exclude [SWAP].
+            for partition in all_partitions:
+                fill_partitions(test, params, session, partition)
+        else:
+            # fill up the specify partition for other cases,such as lvm.lvm_fill.
+            fill_partitions(test, params, session, filled_partition)
+        logging.debug("Successfully filled up the disk")
     finally:
+        logging.debug('Check capacity of disk:')
+        cap_info = session.cmd_output('df -h')
+        logging.debug(cap_info)
+
         error_context.context("Cleaning the temporary files...", logging.info)
         try:
-            clean_cmd = params.get("clean_cmd") % fill_dir
-            session2.cmd(clean_cmd, ignore_all_errors=True)
+            if not filled_partition:
+                for partition in all_partitions:
+                    clean_cmd = params["clean_cmd"] % partition
+                    session2.cmd(clean_cmd, ignore_all_errors=True)
+            else:
+                clean_cmd = params["clean_cmd"] % filled_partition
+                session2.cmd(clean_cmd, ignore_all_errors=True)
         finally:
-            show_fillup_dir_cmd = params.get("show_fillup_dir_cmd") % fill_dir
-            output = session2.cmd(show_fillup_dir_cmd, ignore_all_errors=True)
-            logging.debug("The fill_up dir shows:\n %s", output)
+            if not filled_partition:
+                for partition in all_partitions:
+                    show_fillup_dir_cmd = params["show_fillup_dir_cmd"] \
+                                          % partition
+                    output = session2.cmd(show_fillup_dir_cmd,
+                                          ignore_all_errors=True)
+                    logging.debug("The fill up %s partition shows:\n %s"
+                                  % (partition, output))
+            else:
+                show_fillup_dir_cmd = params["show_fillup_dir_cmd"] \
+                                      % filled_partition
+                output = session2.cmd(show_fillup_dir_cmd,
+                                      ignore_all_errors=True)
+                logging.debug("The fill up %s partition shows:\n %s"
+                              % (filled_partition, output))
             if session:
                 session.close()
             if session2:


### PR DESCRIPTION
1. Fill up disk by writing specified partitions.
2. Add a deep method of filling which write block
   size of 512b to partitions, so that write full
   as much as possible.

Signed-off-by: Yongxue Hong <yhong@redhat.com>

ID: 1579571