### PR TITLE
boot_from_device: update the check policy for some un-bootable devices

### DIFF
--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -35,6 +35,7 @@
             image_size_stg = 100M
             create_image_stg = yes
             remove_image_stg = yes
+            is_bootable = no
             variants:
                 - with_new_device:
                     bootindex_stg = 0
@@ -49,7 +50,7 @@
                 - with_local_device:
                     bootindex_image1 = 0
                 - with_new_device:
-                    images = " stg"
+                    images += " stg"
                     image_name_stg = "images/scsidevice"
                     image_format_stg = "qcow2"
                     drive_format_stg = scsi-hd
@@ -57,6 +58,8 @@
                     create_image_stg = yes
                     remove_image_stg = yes
                     bootindex_stg = 0
+                    bootindex_image1 = 1
+                    is_bootable = no
                 - with_specify_device:
                     boot_device = "virtio-scsi Drive"
         - boot_from_scsi_cdrom:
@@ -67,6 +70,7 @@
             cd_format = scsi-cd
             boot_entry_info = "Booting from DVD/CD..."
             boot_fail_info = "Boot failed: Could not read from CDROM"
+            is_bootable = no
             variants:
                 - with_local_iso:
                     bootindex_test = 0
@@ -84,6 +88,7 @@
             image_name_stg = "/dev/sdb"
             image_format_stg = ""
             drive_format_stg = scsi-block
+            is_bootable = no
             variants:
                 - with_remote_stg:
                     bootindex_stg = 0


### PR DESCRIPTION
  For some un-bootable devices like 'usb-stg/scsi-cd/scsi-hd' in 'boot_from_usb_stg', 'boot_from_scsi_cdrom', and 'boot_from_scsi_hd.with_new_device', 'Boot failed' is reasonable.

ID: 1458551

Signed-off-by: ybduan <yduan@redhat.com>