### PR TITLE
balloon_check: Set "gcompare_threshold" to int type

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -72,7 +72,7 @@ class BallooningTest(MemoryBaseTest):
         error_context.context("Check memory status %s" % step, logging.info)
         mmem = self.get_ballooned_memory()
         gmem = self.get_memory_status()
-        gcompare_threshold = self.params.get("guest_compare_threshold", 100)
+        gcompare_threshold = int(self.params.get("guest_compare_threshold", 100))
         # for windows illegal test:set windows guest balloon in (1,100),free memory will less than 50M
         if ballooned_mem >= self.ori_mem - 100:
             timeout = float(self.params.get("login_timeout", 600))


### PR DESCRIPTION
Can not compare "int" with "str".
id: 1602224
Signed-off-by: Yanan Fu <yfu@redhat.com>