### PR TITLE
block_hotplug: Reduce calling of wait_for_login method.

### DIFF
--- a/qemu/tests/block_hotplug.py
+++ b/qemu/tests/block_hotplug.py
@@ -128,6 +128,7 @@ def run(test, params, env):
                     if status:
                         test.fail("Check for block device failed."
                                   "Output: %s" % output)
+                session.close()
 
                 devs = [dev for dev in devs if not isinstance(dev, qdevices.QDrive)]
                 device_list.extend(devs)


### PR DESCRIPTION
Fix up the filedescriptor out of range in select()
by reducing to call the wait_for_login.

Signed-off-by: Yongxue Hong <yhong@redhat.com>

ID: 1598700