### PR TITLE
Python3: fix filter and map related bug

### DIFF
--- a/multi_host_migration/tests/migration_multi_host_auto_converge.py
+++ b/multi_host_migration/tests/migration_multi_host_auto_converge.py
@@ -150,14 +150,14 @@ def run(test, params, env):
             for index, line in enumerate(output):
                 if sar_cpu_str in line:
                     cpu_average = output[index + 1].split()[2:]
-                    cpu_average = map(float, cpu_average)
+                    cpu_average = list(map(float, cpu_average))
                 if sar_memory_str in line:
                     memory_average_raw = output[index + 1].split()
                     memory_average = []
                     for j in range(len(memory_average_raw)):
                         if j in [3, 7]:
                             memory_average.append(memory_average_raw[j])
-                    memory_average = map(float, memory_average)
+                    memory_average = list(map(float, memory_average))
                     break
             all_items = set(vars())
             interested_items = set(["cpu_average", "memory_average"])

--- a/qemu/deps/win_driver_install/win_driver_install.py
+++ b/qemu/deps/win_driver_install/win_driver_install.py
@@ -88,7 +88,8 @@ def get_inf_files(driver_path, driver_name):
     inf_files = []
     for root, dirs, files in os.walk(driver_path):
         files_path = map(lambda x: os.path.join(root, x), files)
-        inf_files += filter(lambda x: x.lower().endswith(inf_name), files_path)
+        inf_files += list(
+            filter(lambda x: x.lower().endswith(inf_name), files_path))
     return inf_files
 
 
@@ -107,7 +108,8 @@ def uninstall_driver(driver_name):
         sys.exit(1)
     logger.info("Uninstall driver !")
     inf_files = get_inf_files(driver_store, driver_name)
-    map(lambda x: cmd_output(uninstall_driver_cmd % x), inf_files)
+    for ini_file in inf_files:
+        cmd_output(uninstall_driver_cmd % ini_file)
 
 
 def get_current_driver_ver(device_name):

--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -488,12 +488,14 @@ class BlockCopy(object):
         """
         Create files and record m5 values of them.
         """
-        file_names = self.params["file_names"]
-        map(self.create_file, file_names.split())
+        file_names = self.params["file_names"].split()
+        for name in file_names:
+            self.create_file(name)
 
     def verify_md5s(self):
         """
         Check if the md5 values matches the record ones.
         """
-        file_names = self.params["file_names"]
-        map(self.verify_md5, file_names.split())
+        file_names = self.params["file_names"].split()
+        for name in file_names:
+            self.verify_md5(name)

--- a/qemu/tests/block_stream_drop_backingfile.py
+++ b/qemu/tests/block_stream_drop_backingfile.py
@@ -108,4 +108,5 @@ def run(test, params, env):
         session = vm.reboot(session=session, timeout=timeout)
         session.cmd(alive_check_cmd)
     finally:
-        map(lambda x: process.system("rm -rf %s" % x), snapshots)
+        for sn in snapshots:
+            process.system("rm -rf %s" % sn)

--- a/qemu/tests/cpuid.py
+++ b/qemu/tests/cpuid.py
@@ -205,15 +205,12 @@ def run(test, params, env):
 
     def cpuid_to_vendor(cpuid_dump, idx):
         dst = []
-        map(lambda i:
-            dst.append((chr(cpuid_dump[idx, 0, 'ebx'] >> (8 * i) & 0xff))),
-            range(0, 4))
-        map(lambda i:
-            dst.append((chr(cpuid_dump[idx, 0, 'edx'] >> (8 * i) & 0xff))),
-            range(0, 4))
-        map(lambda i:
-            dst.append((chr(cpuid_dump[idx, 0, 'ecx'] >> (8 * i) & 0xff))),
-            range(0, 4))
+        for i in range(0, 4):
+            dst.append((chr(cpuid_dump[idx, 0, 'ebx'] >> (8 * i) & 0xff)))
+        for i in range(0, 4):
+            dst.append((chr(cpuid_dump[idx, 0, 'edx'] >> (8 * i) & 0xff)))
+        for i in range(0, 4):
+            dst.append((chr(cpuid_dump[idx, 0, 'ecx'] >> (8 * i) & 0xff)))
         return ''.join(dst)
 
     def default_vendor(self):

--- a/qemu/tests/hotplug_mem.py
+++ b/qemu/tests/hotplug_mem.py
@@ -45,7 +45,8 @@ class MemoryHotplugSimple(MemoryHotplugTest):
             mem_devs = mem_devs_post - mem_devs_origin
             vm, operation = pre_vm, "unplug"
         func = getattr(self, "%s_memory" % operation)
-        map(lambda x: func(vm, x), mem_devs)
+        for mem_dev in mem_devs:
+            func(vm, mem_dev)
 
     def get_mem_by_name(self, vm, name):
         """

--- a/qemu/tests/live_snapshot_integrity.py
+++ b/qemu/tests/live_snapshot_integrity.py
@@ -34,6 +34,7 @@ def run(test, params, env):
         format_postfix = ".%s" % params["image_format"]
         snapshot = stress_test.snapshot_file.replace(format_postfix, '')
         stress_test.reopen(snapshot)
-        map(stress_test.verify_md5, file_names)
+        for name in file_names:
+            stress_test.verify_md5(name)
     finally:
         stress_test.clean()

--- a/qemu/tests/timedrift_adjust_time.py
+++ b/qemu/tests/timedrift_adjust_time.py
@@ -72,7 +72,8 @@ class TimedriftTest(object):
         """
         logging.info("Close useless session after test")
         open_sessions = [s for s in self.open_sessions if s]
-        return map(lambda x: x.close(), open_sessions)
+        for session in open_sessions:
+            session.close()
 
     def execute(self, cmd, session=None):
         """


### PR DESCRIPTION
`filter` and `map` on Python3 returns an object, without iteration
the call back function will not be executed.

Signed-off-by: Xu Han <xuhan@redhat.com>