### PR TITLE
balloon_in_use: extend timeout value for checking "check_setup_events"

### DIFF
--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -68,7 +68,7 @@ def run(test, params, env):
 
         for event in params.get("check_setup_events", "").strip().split():
             if not utils_misc.wait_for(lambda: params.get(event),
-                                       240, 0, 1):
+                                       600, 0, 1):
                 test.error("Background test not in ready state since haven't "
                            "received event %s" % event)
             # Clear event


### PR DESCRIPTION
qemu.windrv_check_running_verifier() functions is introduced in balloon_stress case, it takes at most another 360 seconds. So need to extend timeout value for check_setup_events.

ID:1605051

Signed-off-by: Li Jin <lijin@redhat.com>