### PR TITLE
Decode Binary data to Text

### DIFF
--- a/qemu/tests/enospc.py
+++ b/qemu/tests/enospc.py
@@ -56,7 +56,7 @@ class EnospcConfig(object):
             # it with the raw file as quickly as possible
             l_result = process.run("losetup -f")
             process.run("losetup -f %s" % self.raw_file_path)
-            self.loopback = l_result.stdout.strip()
+            self.loopback = l_result.stdout.decode().strip()
             # Add the loopback device configured to the list of pvs
             # recognized by LVM
             process.run("pvcreate %s" % self.loopback)
@@ -85,11 +85,11 @@ class EnospcConfig(object):
             time.sleep(2)
         l_result = process.run("lvdisplay")
         # Let's remove all volumes inside the volume group created
-        if self.lvtest_name in l_result.stdout:
+        if self.lvtest_name in l_result.stdout.decode():
             process.run("lvremove -f %s" % self.lvtest_device)
         # Now, removing the volume group itself
         v_result = process.run("vgdisplay")
-        if self.vgtest_name in v_result.stdout:
+        if self.vgtest_name in v_result.stdout.decode():
             process.run("vgremove -f %s" % self.vgtest_name)
         # Now, if we can, let's remove the physical volume from lvm list
         if self.loopback:
@@ -97,7 +97,7 @@ class EnospcConfig(object):
             if self.loopback in p_result.stdout:
                 process.run("pvremove -f %s" % self.loopback)
         l_result = process.run('losetup -a')
-        if self.loopback and (self.loopback in l_result.stdout):
+        if self.loopback and (self.loopback in l_result.stdout.decode()):
             try:
                 process.run("losetup -d %s" % self.loopback)
             except process.CmdError:
@@ -169,7 +169,7 @@ def run(test, params, env):
             try:
                 process.run("lvextend -L +200M %s" % logical_volume)
             except process.CmdError as e:
-                logging.debug(e.result.stdout)
+                logging.debug(e.result.stdout.decode())
             error_context.context("Continue paused guest", logging.info)
             vm.resume()
         elif not vm.monitor.verify_status("running"):

--- a/qemu/tests/qemu_img.py
+++ b/qemu/tests/qemu_img.py
@@ -75,7 +75,7 @@ def run(test, params, env):
         try:
             output = process.system_output(cmd, verbose=False).decode()
         except process.CmdError as err:
-            result_stderr = err.result.stderr
+            result_stderr = err.result.stderr.decode()
             if "does not support checks" in result_stderr:
                 return (True, "")
             else:
@@ -304,7 +304,8 @@ def run(test, params, env):
         try:
             output = process.system_output(cmd).decode()
         except process.CmdError as err:
-            logging.error("Get info of image '%s' failed: %s", img, str(err))
+            logging.error("Get info of image '%s' failed: %s",
+                          img, err.result.stderr.decode())
             return None
 
         if not sub_info:
@@ -516,7 +517,7 @@ def run(test, params, env):
         :param cmd: qemu-img base command.
         """
         if 'rebase' not in process.system_output(cmd + ' --help',
-                                                 ignore_status=True):
+                                                 ignore_status=True).decode():
             test.cancel("Current kvm user space version does not"
                         " support 'rebase' subcommand")
         sn_fmt = params.get("snapshot_format", "qcow2")

--- a/qemu/tests/rebase_negative_test.py
+++ b/qemu/tests/rebase_negative_test.py
@@ -47,7 +47,7 @@ def run(test, params, env):
                 msg = "Fail to trigger negative image('%s') rebase" % image
                 test.fail(msg)
         except process.CmdError as err:
-            output = err.result.stderr
+            output = err.result.stderr.decode()
             logging.info("Rebase image('%s') failed: %s." %
                          (image, output))
             if negtive_test == "no":


### PR DESCRIPTION
In Python 2, the str type was used for two different kinds of values:
text and bytes, whereas in Python 3, these are separate and incompatible
types.
e.g.

TypeError: a bytes-like object is required, not 'str'
\>>> 'abc' in b'abcd'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
\>>> type(b'abcd')
<class 'bytes'>

More background on this can be seen in
  https://www.redhat.com/archives/avocado-devel/2018-April/msg00002.html

This patch helps to decode the binary data into a text string.

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1610167