### PR TITLE
rng_stress: Fix bugs of pre_cmd and post_cmd

### DIFF
--- a/qemu/tests/cfg/rng_stress.cfg
+++ b/qemu/tests/cfg/rng_stress.cfg
@@ -35,6 +35,6 @@
             rng_egd:
                  backend_rng1 = rng-egd
         - one_device:
-            pre_cmd = "while true; do dd if=/dev/random of=/dev/null bs=1024 count=10; done &"
-            post_cmd = kill -9 `ps -a -o ppid,comm | grep dd | awk '{print $1}'`
-            ignore_status = True
+            pre_cmd = "dd if=/dev/random of=/dev/null &"
+            post_cmd = "pkill dd"
+            ignore_status = yes

--- a/qemu/tests/rng_stress.py
+++ b/qemu/tests/rng_stress.py
@@ -54,7 +54,8 @@ def run(test, params, env):
 
     if params.get("pre_cmd"):
         error_context.context("Fetch data from host", logging.info)
-        process.system(params.get("pre_cmd"), shell=True)
+        process.system(params.get("pre_cmd"), shell=True,
+                       ignore_bg_processes=True)
 
     error_context.context("Read rng device in guest", logging.info)
     utils_test.run_virt_sub_test(test, params, env, sub_test)
@@ -82,7 +83,7 @@ def run(test, params, env):
         while time.time() < end_time:
             s = process.system(
                 params.get("post_cmd"),
-                ignore_status=params.get("ignore_status", "False"),
+                ignore_status=(params.get("ignore_status") == "yes"),
                 shell=True)
             if s == 0:
                 break


### PR DESCRIPTION
1. avoid getting stuck when pre_cmd is running in background
2. correct the value of param `ignore_status` for post_cmd

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1588412