### PR TITLE
Use "six.string_types" instead of "str"

### DIFF
--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -2,6 +2,7 @@ import logging
 import os
 import threading
 import re
+import six
 import time
 
 from avocado.utils import process
@@ -23,7 +24,7 @@ def format_result(result, base="12", fbase="5"):
     :param base: the length of converted string
     :param fbase: the decimal digit for float
     """
-    if isinstance(result, str):
+    if isinstance(result, six.string_types):
         value = "%" + base + "s"
     elif isinstance(result, int):
         value = "%" + base + "d"

--- a/generic/tests/pktgen_perf.py
+++ b/generic/tests/pktgen_perf.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import six
 import aexpect
 import functools
 
@@ -23,7 +24,7 @@ def format_result(result, base="12", fbase="2"):
     :param base: the length of converted string
     :param fbase: the decimal digit for float
     """
-    if isinstance(result, str):
+    if isinstance(result, six.string_types):
         value = "%" + base + "s"
     elif isinstance(result, int):
         value = "%" + base + "d"

--- a/multi_host_migration/tests/migration_multi_host_firewall_block.py
+++ b/multi_host_migration/tests/migration_multi_host_firewall_block.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import six
 import time
 from autotest.client.shared import error
 from autotest.client import utils
@@ -39,12 +40,12 @@ def run(test, params, env):
             if (vm.params["display"] == "spice" and
                     vm.get_spice_var("spice_seamless_migration") == "on"):
                 s = vm.monitor.info("spice")
-                if isinstance(s, str):
+                if isinstance(s, six.string_types):
                     ret = "migrated: true" in s
                 else:
                     ret = s.get("migrated") == "true"
             o = vm.monitor.info("migrate")
-            if isinstance(o, str):
+            if isinstance(o, six.string_types):
                 return ret and ("status: active" not in o)
             else:
                 return ret and (o.get("status") != "active")
@@ -93,7 +94,7 @@ def run(test, params, env):
             else:
                 for _ in range(self.mig_fir_timeout):
                     state = vm.monitor.info("migrate")
-                    if type(state) is str:
+                    if isinstance(state, six.string_types):
                         if "failed" in state:
                             break
                     else:

--- a/multi_host_migration/tests/migration_multi_host_with_speed_measurement.py
+++ b/multi_host_migration/tests/migration_multi_host_with_speed_measurement.py
@@ -3,6 +3,7 @@ import re
 import logging
 import time
 import socket
+import six
 from autotest.client.shared import error, utils
 from autotest.client.shared.barrier import listen_server
 from autotest.client.shared.syncdata import SyncData
@@ -61,7 +62,7 @@ def run(test, params, env):
                            " filling its memory.")
             fail_msg = ("Could not determine the transferred memory from"
                         " monitor data: %s" % o)
-            if isinstance(o, str):
+            if isinstance(o, six.string_types):
                 if "status: active" not in o:
                     raise error.TestWarn(warning_msg)
                 try:

--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -1,6 +1,7 @@
 import re
 import time
 import random
+import six
 import logging
 
 from avocado.utils import process
@@ -261,7 +262,7 @@ class BlockCopy(object):
         """
         blocks = self.vm.monitor.info("block")
         try:
-            if isinstance(blocks, str):
+            if isinstance(blocks, six.string_types):
                 # ide0-hd0: removable=1 locked=0 file=/tmp/test.img
                 image_regex = r'%s.*\s+file=(\S*)' % self.device
                 image_file = re.findall(image_regex, blocks)

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -202,7 +202,7 @@ def run(test, params, env):
         """
         blocks = vm.monitor.info("block")
         cdfile = None
-        if isinstance(blocks, str):
+        if isinstance(blocks, six.string_types):
             tmp_re_str = r'%s: .*file=(\S*) ' % qemu_cdrom_device
             file_list = re.findall(tmp_re_str, blocks)
             if file_list:
@@ -230,7 +230,7 @@ def run(test, params, env):
         is_open, checked = (None, False)
 
         blocks = vm.monitor.info("block")
-        if isinstance(blocks, str):
+        if isinstance(blocks, six.string_types):
             for block in blocks.splitlines():
                 if qemu_cdrom_device in block:
                     if "tray-open=1" in block:
@@ -307,7 +307,7 @@ def run(test, params, env):
         """
         error_context.context("Check cdrom state of locing.")
         blocks = vm.monitor.info("block")
-        if isinstance(blocks, str):
+        if isinstance(blocks, six.string_types):
             for block in blocks.splitlines():
                 if cdrom in block:
                     if "locked=1" in block:
@@ -435,7 +435,7 @@ def run(test, params, env):
         """
         device = None
         blocks = vm.monitor.info("block")
-        if isinstance(blocks, str):
+        if isinstance(blocks, six.string_types):
             for block in blocks.strip().split('\n'):
                 if 'not inserted' in block:
                     device = block.split(':')[0]

--- a/qemu/tests/cdrom_block_size_check.py
+++ b/qemu/tests/cdrom_block_size_check.py
@@ -1,6 +1,7 @@
 import re
 import logging
 import os
+import six
 
 from avocado.utils import process
 
@@ -63,7 +64,7 @@ def run(test, params, env):
         """
         device = None
         blocks = vm.monitor.info("block")
-        if isinstance(blocks, str):
+        if isinstance(blocks, six.string_types):
             for block in blocks.strip().split('\n'):
                 if 'not inserted' in block:
                     device = block.split(':')[0]

--- a/qemu/tests/change_media.py
+++ b/qemu/tests/change_media.py
@@ -1,4 +1,5 @@
 import re
+import six
 import logging
 
 from virttest import error_context
@@ -29,7 +30,7 @@ def run(test, params, env):
     def check_block_locked(block_name):
         blocks_info = monitor.info("block")
 
-        if isinstance(blocks_info, str):
+        if isinstance(blocks_info, six.string_types):
             lock_str = "locked=1"
             for block in blocks_info.splitlines():
                 if block_name in block and lock_str in block:

--- a/qemu/tests/fio_perf.py
+++ b/qemu/tests/fio_perf.py
@@ -1,5 +1,6 @@
 import os
 import re
+import six
 import time
 import threading
 import logging
@@ -18,7 +19,7 @@ def format_result(result, base="12", fbase="2"):
     :param base: the length of converted string
     :param fbase: the decimal digit for float
     """
-    if isinstance(result, str):
+    if isinstance(result, six.string_types):
         value = "%" + base + "s"
     elif isinstance(result, int):
         value = "%" + base + "d"

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -1,5 +1,6 @@
 import os
 import re
+import six
 import logging
 import time
 
@@ -93,7 +94,7 @@ def run(test, params, env):
                            " filling its memory.")
             fail_msg = ("Could not determine the transferred memory from"
                         " monitor data: %s" % o)
-            if isinstance(o, str):
+            if isinstance(o, six.string_types):
                 if "status: active" not in o:
                     test.error(warning_msg)
                 try:

--- a/qemu/tests/pci_devices.py
+++ b/qemu/tests/pci_devices.py
@@ -7,6 +7,7 @@ This is a virt-test test for testing PCI devices in various PCI setups
 import logging
 import random
 import re
+import six
 import time
 
 from virttest import env_process
@@ -41,7 +42,7 @@ def process_qdev(qdev):
     qdev_devices_noid = []
     for bus in qdev.get_buses({'type': ('PCI', 'PCIE')}):
         for device in bus:
-            if isinstance(device, str):
+            if isinstance(device, six.string_types):
                 logging.error("Not a device %s (bus %s)", device, bus)
                 continue
             dev_id = device.get_param('id')

--- a/qemu/tests/performance.py
+++ b/qemu/tests/performance.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import shelve
+import six
 import threading
 try:
     from queue import Queue
@@ -251,7 +252,7 @@ def format_result(result, base="20", fbase="2"):
     :param base: the length of converted string
     :param fbase: the decimal digit for float
     """
-    if isinstance(result, str):
+    if isinstance(result, six.string_types):
         value = "%" + base + "s"
     elif isinstance(result, int):
         value = "%" + base + "d"


### PR DESCRIPTION
With the py3k changes some returns are not strings, but decoded
unicodes. Currently this mainly breaks monitor returns, where human
monitor gets recognized as qmp one. Let's use "six.string_types" that
provides the right string types for given python version.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>