### PR TITLE
Drop the package virttest.staging.backports

### DIFF
--- a/qemu/tests/sr_iov_irqbalance.py
+++ b/qemu/tests/sr_iov_irqbalance.py
@@ -7,9 +7,6 @@ from virttest import utils_test
 from virttest import utils_net
 from virttest import utils_misc
 
-# The backports module will take care of using the builtin if available
-from virttest.staging.backports import bin
-
 
 @error_context.context_aware
 def get_first_network_devname(test, session, nic_interface_filter):


### PR DESCRIPTION
Since legacy python (2.4-2.6) is no longer supported by avocado-vt,
now it is the time to drop the package `virttest.staging.backports`
as it is used for backward compatibility.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1607758