### PR TITLE
hwclock: make an ability to define custom pattern

### DIFF
--- a/generic/tests/hwclock.py
+++ b/generic/tests/hwclock.py
@@ -14,12 +14,13 @@ def run(test, params, env):
     :param env: Dictionary with the test environment.
     """
     vm = env.get_vm(params["main_vm"])
+    date_pattern = params.get("date_pattern", 'Sat *Feb *2 *03:04:.. 1980')
     vm.verify_alive()
     session = vm.wait_for_login(timeout=240)
 
     logging.info("Setting hwclock to 2/2/80 03:04:00")
     session.cmd('/sbin/hwclock --set --date "2/2/80 03:04:00"')
     date = session.cmd_output('LC_ALL=C /sbin/hwclock')
-    if not re.match('Sat *Feb *2 *03:04:.. 1980', date):
+    if not re.match(date_pattern, date):
         test.fail("Fail to set hwclock back to the 80s."
                   "Output of hwclock is '%s'" % date)


### PR DESCRIPTION
hwclock test fails on JeOS, Fedora etc with default pattern,
make an ability to define custom date pattern for other OSes