### PR TITLE
Extend linux stress to support multivm with multi stress tools

### DIFF
--- a/generic/tests/cfg/linux_stress.cfg
+++ b/generic/tests/cfg/linux_stress.cfg
@@ -1,6 +1,27 @@
 - linux_stress:
     only Linux
     type = linux_stress
-    stress_duration = 60
-    # Please specify below params for stress test, or use default value as shown
-    # download_url = http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz
+    stress_shell_timeout = 1200
+    stress_wait_for_timeout = 60
+    stress_duration = 10
+    variants:
+        - @default:
+            stress_duration = 60
+        - stressapptest:
+            #all vms in this variant will run stressapptest
+            stress_type = "stressapptest"
+            stress_cmds_stressapptest = "stressapptest"
+            make_cmds_stressapptest = "./configure && make && make install"
+            uninstall_cmds_stressapptest = "./configure && make && make uninstall"
+            download_url_stressapptest = "https://github.com/stressapptest/stressapptest.git"
+            download_type_stressapptest = "git"
+            stressapptest_args = "-s 100 -M 256 -m 8 -W"
+        - stress-ng:
+            #all vms in this variant will run default stress apart from vm2 which runs stress-ng
+            stress_type_vm2 = "stress-ng"
+            stress_cmds_stress-ng_vm2 = "stress-ng"
+            make_cmds_stress-ng_vm2 = "rm -rf /usr/bin/stress-ng && make && cp stress-ng /usr/bin && rm -rf /tmp/stress-*"
+            uninstall_cmds_stress-ng_vm2 = "rm -rf /usr/bin/stress-ng && make clean"
+            download_url_stress-ng_vm2 = "https://github.com/ColinIanKing/stress-ng.git"
+            download_type_stress-ng = "git"
+            stress-ng_args_vm2 = "--timer 32 --timer-freq 1000000"

--- a/generic/tests/linux_stress.py
+++ b/generic/tests/linux_stress.py
@@ -1,4 +1,7 @@
 import time
+import logging
+
+from avocado.core import exceptions
 
 from virttest import utils_test
 
@@ -19,19 +22,47 @@ def run(test, params, env):
     :param env: Dictionary with test environment
     """
 
-    vm = env.get_vm(params['main_vm'])
-    vm.verify_alive()
-    stress = utils_test.VMStress(vm, 'stress', params)
-    stress.load_stress_tool()
-    stress_duration = int(params.get('stress_duration', 0))
+    stress_duration = int(params.get("stress_duration", "0"))
     # NOTE: stress_duration = 0 ONLY for some legacy test cases using
     # autotest stress.control as their sub test.
     # Please DO define stress_duration to make sure the clean action
     # being performed, if your case can not be controlled by time,
     # use utils_test.VMStress() directly
+    stress_type = params.get("stress_type", "stress")
+    vms = env.get_all_vms()
+    up_time = {}
+    error = False
+    stress_server = {}
+
+    for vm in vms:
+        try:
+            up_time[vm.name] = vm.uptime()
+            stress_server[vm.name] = utils_test.VMStress(vm, stress_type, params)
+            stress_server[vm.name].load_stress_tool()
+        except exceptions.TestError as err_msg:
+            error = True
+            logging.error(err_msg)
 
     if stress_duration:
         time.sleep(stress_duration)
-        stress.unload_stress()
-        stress.clean()
-        vm.verify_kernel_crash()
+
+    for vm in vms:
+        try:
+            s_ping, o_ping = utils_test.ping(vm.get_address(), count=5, timeout=20)
+            if s_ping != 0:
+                error = True
+                logging.error("%s seem to have gone out of network", vm.name)
+                continue
+            uptime = vm.uptime()
+            if up_time[vm.name] > uptime:
+                error = True
+                logging.error("%s seem to have rebooted during the stress run", vm.name)
+            stress_server[vm.name].unload_stress()
+            stress_server[vm.name].clean()
+            vm.verify_dmesg()
+        except exceptions.TestError as err_msg:
+            error = True
+            logging.error(err_msg)
+
+    if error:
+        test.fail("Run failed: see error messages above")


### PR DESCRIPTION
Existing linux stress was supporting single vm with single stress
tool. This commit extends that testcase to now support multiple
guests running same/different stress tools inside for given duration

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>