### PR TITLE
Remove "virtio_console..check_zero_sym"

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -30,9 +30,6 @@
                     variants:
                         - open:
                            virtio_console_test = open
-                        - check_zero_sym:
-                            only Linux
-                            virtio_console_test = check_zero_sym
                         - multi_open:
                             virtio_console_test = multi_open
                         - close:

--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -79,19 +79,6 @@ def run(test, params, env):
         port.open()
         virtio_test.cleanup(vm, guest_worker)
 
-    def test_check_zero_sym():
-        """
-        Check if port /dev/vport0p0 was created.
-        :param cfg: virtio_console_params - which type of virtio port to test
-        :param cfg: virtio_port_spread - how many devices per virt pci (0=all)
-        """
-        if params.get('virtio_console_params') == 'serialport':
-            vm, guest_worker = virtio_test.get_vm_with_worker(no_serialports=1)
-        else:
-            vm, guest_worker = virtio_test.get_vm_with_worker(no_consoles=1)
-        guest_worker.cmd("virt.check_zero_sym()", 10)
-        virtio_test.cleanup(vm, guest_worker)
-
     def test_multi_open():
         """
         Try to open the same port twice.


### PR DESCRIPTION
This test used a wrong assumption that this symlink must always
exists, but it doesn't have to be there when other virtio device
is present. Let's just rely only on the "_get_port_status" test
which makes sure the number of symlinks correspondent to number
of devices.

Relates to: https://github.com/avocado-framework/avocado-vt/issues/1736