### PR TITLE
timedrift_check_after_load_vm: add case

### DIFF
--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -1,8 +1,16 @@
 - check_clock_offset:
     rtc_clock = host
     rtc_base = utc
-    rtc_drift = slew
+    i386, x86_64:
+        rtc_drift = slew
     requires_root = yes
+    ntp_server = "clock.redhat.com"
+    ntp_cmd = "(systemctl stop chronyd || service ntpdate stop)"
+    ntp_cmd += " && chronyd -q 'server clock.redhat.com iburst'"
+    ntp_query_cmd = "chronyd -Q 'server clock.redhat.com iburst'"
+    Windows:
+        ntp_cmd = "sc start w32time && ping -n 6 -w 1000 127.0.0.1>nul && w32tm /config /manualpeerlist:${ntp_server} /syncfromflags:manual /update"
+        ntp_query_cmd = "w32tm /stripchart /computer:${ntp_server} /samples:1 /dataonly"
     variants:
         - with_syscall:
             type = timedrift_check_with_syscall
@@ -25,8 +33,6 @@
                 - bsod:
                     only Windows
                     nmi_cmd = "monitor:inject-nmi"
-                    ntp_cmd = "sc start w32time && ping -n 6 -w 1000 127.0.0.1>nul && w32tm /config /manualpeerlist:${ntp_server} /syncfromflags:manual /update"
-                    ntp_query_cmd = "w32tm /stripchart /computer:${ntp_server} /samples:1 /dataonly"
                 - hang:
                     kill_vm = yes
                     # Notes:
@@ -65,3 +71,34 @@
             clock_sync_command = "(systemctl stop chronyd || service ntpdate stop)"
             clock_sync_command += " && chronyd -q 'server clock.redhat.com iburst'"
             drift_threshold = 3
+        - after_load_vm:
+            only i386 x86_64 ppc64le ppc64
+            only Linux
+            type = timedrift_check_after_load_vm
+            start_vm = no
+            clocksource = "kvm-clock"
+            ppc64le,ppc64:
+                clocksource = "timebase"
+            gagent_name = "org.qemu.guest_agent.0"
+            gagent_install_cmd = "yum install -y qemu-guest-agent"
+            gagent_start_cmd = "systemctl start qemu-guest-agent"
+            gagent_stop_cmd = "systemctl stop qemu-guest-agent"
+            gagent_status_cmd = "systemctl status qemu-guest-agent"
+            RHEL.6:
+                gagent_start_cmd = "service qemu-guest-agent start"
+                gagent_stop_cmd = "service qemu-guest-agent stop"
+                gagent_status_cmd = "service qemu-guest-agent status"
+            gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
+            gagent_serial_type = virtio
+            virtio_ports += " org.qemu.guest_agent.0"
+            virtio_port_type_org.qemu.guest_agent.0 = "serialport"
+            qmp_savevm_cmd = "savevm tag=sn1"
+            qmp_loadvm_cmd = "loadvm tag=sn1"
+            i386, x86_64:
+                qmp_rtc_reset_cmd = "rtc-reset-reinjection"
+                check_mod_cmd = "cat /sys/module/kvm/parameters/kvmclock_periodic_sync"
+            # The expected time dirft is 3 seconds.
+            expected_time_drift = 3
+            # Check time drift after 10/20/30 minutes.
+            sleep_time = 600
+            sleep_iteration_times = 3

--- a/qemu/tests/timedrift_check_after_load_vm.py
+++ b/qemu/tests/timedrift_check_after_load_vm.py
@@ -1,0 +1,167 @@
+import re
+import time
+import logging
+
+from avocado.utils import process
+from virttest import env_process
+from virttest import error_context
+from virttest import arch
+
+from qemu.tests.qemu_guest_agent import QemuGuestAgentTest
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Clock check after savevm/loadvm
+
+    1. Load kvm module with "kvmclock_periodic_sync=N"
+    2. Stop chronyd service and sync time with ntp server on host
+    3. Boot vm and check current clocksource in vm
+    4. Stop chronyd service and sync time with ntp server on vm
+    5. Run samevm and loadvm with qmp monitor
+    6. Run 'guest-set-time' with qemu-guest-agent
+    7. Run 'rtc-reset-reinjection' with qmp monitor
+    8. Query time offset with ntp server on vm,
+       it should be less than 3 seconds
+
+    :param test: Kvm test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _load_kvm_module_with_kvmclock_periodic_sync(module_param):
+        """
+        Load kvm module with kvmclock_periodic_sync=N/Y
+
+       :params module_param: the value of kvmclock_periodic_sync
+       """
+        error_context.context("Load kvm module with kvmclock_periodic_sync=%s"
+                              % module_param, logging.info)
+        check_modules = arch.get_kvm_module_list()
+        error_context.context("check_module: '%s'" % check_modules, logging.info)
+        check_modules.reverse()
+        for module in check_modules:
+            rm_mod_cmd = "modprobe -r %s" % module
+            process.system(rm_mod_cmd, shell=True)
+        check_modules.reverse()
+        for module in check_modules:
+            load_mod_cmd = "modprobe %s" % module
+            if module == "kvm":
+                load_mod_cmd = "%s kvmclock_periodic_sync=%s" % (load_mod_cmd, module_param)
+            process.system(load_mod_cmd, shell=True)
+        check_mod_cmd = params["check_mod_cmd"]
+        if process.system_output(check_mod_cmd).decode() != module_param:
+            test.error("Cannot load kvm module with kvmclock_periodic_sync=%s"
+                       % module_param)
+
+    def setup():
+        """
+        On host, load kvm module with "kvmclock_periodic_sync=N"
+        sync time with ntp server and boot the guest
+        """
+        if arch.ARCH not in ('ppc64', 'ppc64le'):
+            _load_kvm_module_with_kvmclock_periodic_sync("N")
+        error_context.context("Sync host time with ntp server", logging.info)
+        ntp_cmd = params.get("ntp_cmd")
+        status = process.system(ntp_cmd, shell=True)
+        if status != 0:
+            test.cancel("Fail to sync host time with ntp server.")
+
+        error_context.context("Boot the guest", logging.info)
+        params["start_vm"] = "yes"
+        vm = env.get_vm(params["main_vm"])
+        env_process.preprocess_vm(test, params, env, vm.name)
+        vm.verify_alive()
+        return vm
+
+    def cleanup():
+        """
+        Close session and load kvm module with "kvmclock_periodic_sync=Y"
+        """
+        if session:
+            session.close()
+        env.unregister_vm(vm.name)
+        vm.destroy(gracefully=False, free_mac_addresses=True)
+        if arch.ARCH not in ('ppc64', 'ppc64le'):
+            _load_kvm_module_with_kvmclock_periodic_sync("Y")
+
+    def setup_gagent():
+        """
+        Execute guest agent command 'guest-set-time' in host side.
+        """
+        gagent_test = QemuGuestAgentTest(test, params, env)
+        gagent_test.initialize(test, params, env)
+        gagent_test.setup(test, params, env)
+        return gagent_test
+
+    def run_qmp_cmd(qmp_port, qmp_cmd):
+        """
+        Run a qmp command
+
+        :params qmp_port: the guest qmp port to send qmp command
+        :params qmp_cmd: qmp command
+        """
+        output = qmp_port.send_args_cmd(qmp_cmd)
+        logging.info("QMP command: '%s' \n Output: '%s'" % (qmp_cmd, output))
+
+    def query_ntp_time():
+        """
+        On guest, query clock offset
+        """
+        ntp_query_cmd = params["ntp_query_cmd"]
+        output = session.cmd_output_safe(ntp_query_cmd)
+        error_context.context("Verify guest time offset", logging.info)
+        offset = float(re.findall(r"[+|-]*\s*(\d+\.\d+)\s*sec", output)[-1])
+        error_context.context("offset: '%.2f'" % offset, logging.info)
+        exptected_time_drift = params.get("expected_time_drift", 3)
+        if offset > float(exptected_time_drift):
+            test.fail("After loadvm, the time drift of guest is too large.")
+
+    vm = setup()
+    session = vm.wait_for_login()
+    try:
+        error_context.context("Check the clocksource currently in use",
+                              logging.info)
+        clocksource = params.get("clocksource", "kvm-clock")
+        clocksource_cmd = "cat /sys/devices/system/clocksource/clocksource0"
+        clocksource_cmd += "/current_clocksource"
+        currentsource = session.cmd_output_safe(clocksource_cmd)
+        if clocksource not in currentsource:
+            test.cancel("Mismatch clocksource, current clocksource: %s",
+                        currentsource)
+        error_context.context("Stop chronyd and sync guest time with ntp server",
+                              logging.info)
+        ntp_cmd = params.get("ntp_cmd")
+        status, output = session.cmd_status_output(ntp_cmd)
+        if status != 0:
+            test.error("Failed to sync guest time with ntp server.")
+        error_context.context("Setup qemu-guest-agent in guest", logging.info)
+        gagent = setup_gagent()
+
+        qmp_ports = vm.get_monitors_by_type('qmp')
+        if qmp_ports:
+            qmp_port = qmp_ports[0]
+        else:
+            test.cancel("Incorrect configuration, no QMP monitor found.")
+        error_context.context("Save/load VM", logging.info)
+        qmp_savevm_cmd = params["qmp_savevm_cmd"]
+        run_qmp_cmd(qmp_port, qmp_savevm_cmd)
+        qmp_loadvm_cmd = params["qmp_loadvm_cmd"]
+        run_qmp_cmd(qmp_port, qmp_loadvm_cmd)
+
+        error_context.context("Execute 'guest-set-time' in qmp monitor")
+        gagent.gagent.set_time()
+
+        error_context.context("Execute 'rtc-reset-reinjection' in qmp"
+                              " monitor, not for power platform", logging.info)
+        if arch.ARCH not in ('ppc64', 'ppc64le'):
+            qmp_rtc_reset_cmd = params["qmp_rtc_reset_cmd"]
+            run_qmp_cmd(qmp_port, qmp_rtc_reset_cmd)
+
+        sleep_time = int(params.get("sleep_time", "600"))
+        sleep_iteration_times = int(params.get("sleep_iteration_times", "3"))
+        for i in range(1, sleep_iteration_times + 1):
+            time.sleep(sleep_time)
+            query_ntp_time()
+    finally:
+        cleanup()


### PR DESCRIPTION
Add case for checking time drift after savevm and loadvm
ID: 1468147
Signed-off-by: Sitong Liu <siliu@redhat.com>

P.S. This patch is from closed patch #1095 , reopen it.