### PR TITLE
pxe_query_cpus: An enhancement to the test

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -25,10 +25,6 @@
     no macvtap
     variants:
         - @default:
-        - etherboot:
-            # etherboot pkg only in RHEL.5 Host
-            only Host_RHEL.m5
-            pre_command = "alternatives --display qemu-pxe-roms |grep -q etherboot && alternatives --set 'qemu-pxe-roms' /usr/share/etherboot || true"
         - gpxe:
             only Host_RHEL.m6
             pre_command = "alternatives --display qemu-pxe-roms |grep -q gpxe || alternatives --install /usr/share/qemu-pxe-roms qemu-pxe-roms /usr/share/gpxe 1; alternatives --set 'qemu-pxe-roms' /usr/share/gpxe"
@@ -36,8 +32,6 @@
             only Host_RHEL.m7
             pre_command = "alternatives --display qemu-pxe-roms |grep -q ipxe || alternatives --install /usr/share/qemu-pxe-roms qemu-pxe-roms /usr/share/ipxe 1; alternatives --set 'qemu-pxe-roms' /usr/share/ipxe"
         - with_query_cpus:
-            # EPT/NPT not support by kvm module in RHEL.5 Host
-            no Host_RHEL.m5
             type = pxe_query_cpus
             start_vm = no
             restart_vm = no

--- a/qemu/tests/pxe_query_cpus.py
+++ b/qemu/tests/pxe_query_cpus.py
@@ -2,13 +2,36 @@ import os
 import time
 import logging
 
+import aexpect
 from avocado.utils import process
 
 from virttest import error_context
-from virttest import utils_test
 from virttest import utils_misc
 from virttest import qemu_monitor
 from virttest import env_process
+
+
+@error_context.context_aware
+def _capture_tftp(test, vm, timeout):
+    error_context.context("Snoop packet in the tap device", logging.info)
+    output = aexpect.run_fg("tcpdump -nli %s" % vm.get_ifname(),
+                            logging.debug, "(pxe capture) ", timeout)[1]
+
+    error_context.context("Analyzing the tcpdump result", logging.info)
+    if "tftp" not in output:
+        test.fail("Couldn't find any TFTP packets after %s seconds" % timeout)
+    logging.info("Found TFTP packet")
+
+
+def _kill_vms(params, env):
+    for vm in env.get_all_vms():
+        if vm:
+            vm.destroy()
+            env.unregister_vm(vm.name)
+
+    qemu_bin = os.path.basename(params["qemu_binary"])
+    process.run("killall -g %s" % qemu_bin, ignore_status=True)
+    time.sleep(5)
 
 
 @error_context.context_aware
@@ -24,51 +47,38 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    def stopVMS(params, env):
-        """
-        Kill all VMS for relaod kvm_intel/kvm_amd module;
-        """
-        for vm in env.get_all_vms():
-            if vm:
-                vm.destroy()
-                env.unregister_vm(vm.name)
-
-        qemu_bin = os.path.basename(params["qemu_binary"])
-        process.run("killall -g %s" % qemu_bin, ignore_status=True)
-        time.sleep(5)
-
-    enable_mmu_cmd = None
-    check_mmu_cmd = None
     restore_mmu_cmd = None
-    error_context.context("Enable ept(npt)", logging.info)
+    pxe_timeout = int(params.get("pxe_timeout", 60))
+
+    error_context.context("Enable ept/npt", logging.info)
     try:
         flag = list(filter(lambda x: x in utils_misc.get_cpu_flags(),
                            ['ept', 'npt']))[0]
     except IndexError:
-        logging.warn("Host doesn't support ept(npt)")
+        logging.info("Host doesn't support ept/npt, skip the configuration")
     else:
         enable_mmu_cmd = params["enable_mmu_cmd_%s" % flag]
         check_mmu_cmd = params["check_mmu_cmd_%s" % flag]
+        restore_mmu_cmd = params["restore_mmu_cmd_%s" % flag]
         status = process.system(check_mmu_cmd, timeout=120, ignore_status=True,
                                 shell=True)
         if status != 0:
-            stopVMS(params, env)
+            _kill_vms(params, env)
             process.run(enable_mmu_cmd, shell=True)
-            restore_mmu_cmd = params["restore_mmu_cmd_%s" % flag]
 
     params["start_vm"] = "yes"
     params["kvm_vm"] = "yes"
     params["paused_after_start_vm"] = "yes"
 
+    error_context.context("Try to boot from NIC", logging.info)
     env_process.preprocess_vm(test, params, env, params["main_vm"])
-    bg = utils_misc.InterruptedThread(utils_test.run_virt_sub_test,
-                                      args=(test, params, env,),
-                                      kwargs={"sub_type": "pxe_boot"})
+    vm = env.get_vm(params["main_vm"])
+    bg = utils_misc.InterruptedThread(_capture_tftp, (test, vm, pxe_timeout))
+
     count = 0
     try:
         bg.start()
         error_context.context("Query cpus in loop", logging.info)
-        vm = env.get_vm(params["main_vm"])
         vm.resume()
         while True:
             count += 1
@@ -83,5 +93,5 @@ def run(test, params, env):
     finally:
         bg.join()
         if restore_mmu_cmd:
-            stopVMS(params, env)
+            _kill_vms(params, env)
             process.run(restore_mmu_cmd, shell=True)


### PR DESCRIPTION
The test would call `pxe_boot` and run parallelly, and that would
result in error which was caused by race conditions. The patch
attends to fix this issue by making the script indenpendent.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1548954