### PR TITLE
data_plane: change cd_format as scsi-cd is not supported by data plane

### DIFF
--- a/qemu/tests/cfg/block_commit.cfg
+++ b/qemu/tests/cfg/block_commit.cfg
@@ -30,6 +30,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - with_payload:
             type = block_commit_stress

--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -141,3 +141,8 @@
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=${iothreads}"
                 bus_extra_params_stg0 = "iothread=${iothreads}"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci

--- a/qemu/tests/cfg/block_hotplug_negative.cfg
+++ b/qemu/tests/cfg/block_hotplug_negative.cfg
@@ -27,3 +27,8 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=${iothreads}"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci

--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -70,3 +70,8 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_stg = "iothread=${iothreads}"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci

--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -46,6 +46,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - simple_test:
             type = block_stream_simple

--- a/qemu/tests/cfg/block_stream_negative.cfg
+++ b/qemu/tests/cfg/block_stream_negative.cfg
@@ -28,6 +28,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - simple_test:
             type = block_stream_negative

--- a/qemu/tests/cfg/data_plane_boot.cfg
+++ b/qemu/tests/cfg/data_plane_boot.cfg
@@ -8,6 +8,11 @@
     virtio_scsi:
         no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
         bus_extra_params_image1 = "iothread=${iothreads}"
+        Windows:
+            i440fx:
+                cd_format_cd1 = ide
+            q35:
+                cd_format_cd1 = ahci
     variants:
         - snapshot:
             type = boot

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -46,6 +46,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - 2qcow2:
             image_format_target = "qcow2"

--- a/qemu/tests/cfg/drive_mirror_negative_tests.cfg
+++ b/qemu/tests/cfg/drive_mirror_negative_tests.cfg
@@ -44,6 +44,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - 2qcow2:
             image_format_target = "qcow2"

--- a/qemu/tests/cfg/live_backup.cfg
+++ b/qemu/tests/cfg/live_backup.cfg
@@ -30,6 +30,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - @default:
             before_full_backup = "create_files reboot stop"

--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -25,6 +25,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - simple_test:
             type = live_snapshot_simple

--- a/qemu/tests/cfg/live_snapshot_chain.cfg
+++ b/qemu/tests/cfg/live_snapshot_chain.cfg
@@ -26,6 +26,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - pause:
             file_create =

--- a/qemu/tests/cfg/live_snapshot_negative.cfg
+++ b/qemu/tests/cfg/live_snapshot_negative.cfg
@@ -23,6 +23,11 @@
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                 bus_extra_params_image1 = "iothread=iothread0"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci
     variants:
         - simple_test:
             type = live_snapshot_negative


### PR DESCRIPTION
"scsi-cd" is not supported by data plane (id:1378816), so replace it with "ide" for i440fx and "ahci" for q35

id: 1630176
Signed-off-by: Yanan Fu <yfu@redhat.com>