### PR TITLE
watchdog: fix python3 encoding issue

### DIFF
--- a/qemu/tests/watchdog.py
+++ b/qemu/tests/watchdog.py
@@ -146,7 +146,7 @@ def run(test, params, env):
         error_context.context("Checking whether or not the host support"
                               " WDT '%s'" % watchdog_device_type, logging.info)
         watchdog_device = process.system_output("%s 2>&1" % qemu_cmd,
-                                                shell=True)
+                                                shell=True).decode()
         if watchdog_device:
             if re.findall(watchdog_device_type, watchdog_device, re.I):
                 logging.info("The host support '%s' type watchdog device" %


### PR DESCRIPTION
As python3 only use unicode string. This patch covert bytes string
to unicode string.

ID:1630779

Signed-off-by: Xiangchun Fu <xfu@redhat.com>
