### PR TITLE
rng_module_rhel8: virtio_rng module becomes builtin in RHEL8

### DIFF
--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -27,6 +27,7 @@
             driver_load_cmd = modprobe virtio_balloon
 
         - with_viorng:
+            no RHEL.8
             virtio_rngs += " rng0"
             backend_rng0 = rng-random
             backend_type = passthrough

--- a/qemu/tests/cfg/rng_driver_load.cfg
+++ b/qemu/tests/cfg/rng_driver_load.cfg
@@ -1,6 +1,7 @@
 - rng_driver_load:
     only Linux
     no no_virtio_rng
+    no RHEL.8
     start_vm = yes
     login_timeout = 240
     image_snapshot = yes


### PR DESCRIPTION
Drop load/unload virtio_rng module cases for RHEL8 guest

ID: 1630794

Signed-off-by: ybduan <yduan@redhat.com>