### PR TITLE
virtio_console.cfg: set monitor_type to human

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -10,6 +10,7 @@
     virtio_port_type_vc3 = "console"
     virtio_port_type_vc4 = "console"
     virtio_console_test_time = 60
+    monitor_type = human
     variants:
         # Dummy and debug scripts.
         # You have to remove "no virtio_console" to be able to run those tests


### PR DESCRIPTION
The code in virtio console test assumes HMP is used, but it doesn't
set monitor_type in its cfg file (note that parameter defaults to QMP
in virt-test). The change fixs it.