### PR TITLE
rh_kernel_update: Fix a param assignment bug

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -39,14 +39,14 @@
         pkg_arch = aarch64
     s390x:
         pkg_arch = s390x
-    s390x:
-        virtio_drivers_list = ""
-        update_kernel_cmd = "zipl"
     args_removed = "rhgb quiet"
     args_added = "console=ttyS0,115200 console=tty0"
     install_virtio = no
     verify_virtio = no
     virtio_drivers_list = "virtio virtio_ring virtio_pci"
+    s390x:
+        virtio_drivers_list = ""
+        update_kernel_cmd = "zipl"
     ignore_deps = yes
     install_debuginfo = no
     install_pkg_timeout = 600


### PR DESCRIPTION
Fix a param assignment bug that would lead a failure of virtio
module check on s390x.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1632994