### PR TITLE
virtio_console: Fix device_del and device_add arguments

### DIFF
--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -605,10 +605,13 @@ def run(test, params, env):
             # when replugging port from pci to different pci. We should
             # either use symlinks (as in Windows) or replug with the busname
             port = ports[port_idx]
-            vm.monitor.cmd('device_del %s' % port.qemu_id)
+            vm.monitor.cmd('device_del', args={'id': '%s' % port.qemu_id})
             time.sleep(intr_time)
-            vm.monitor.cmd('device_add %s,id=%s,chardev=dev%s,name=%s'
-                           % (device, port.qemu_id, port.qemu_id, port.name))
+            vm.monitor.cmd('device_add',
+                           args={'driver': '%s' % device,
+                                 'id': '%s' % port.qemu_id,
+                                 'chardev': '%s' % port.chardev_id,
+                                 'name': '%s' % port.name})
 
         def _serialport_send_replug():
             """ hepler for executing replug of the sender port """


### PR DESCRIPTION
monitor_type parameter in virt-test defaults to QMP, but Virtio console
test code assumes guest has HMPs. The change fixes the issue by modifying
the test to use QMPMonitor cmd() API. An alternative option would be
keeping the test code unchanged but modifying its cfg to use HMP, but
that doesn't seem to be robust because HumanMonitor cmd() method can't
detect command error.

Note that the code change depends on avocado-vt PR #1768 (it doesn't have
to be so, but it's convenient to get chardev backend device id there).