### PR TITLE
optmize block_hotplug_negative to support raw disk's hotplug

### DIFF
--- a/qemu/tests/block_hotplug_negative.py
+++ b/qemu/tests/block_hotplug_negative.py
@@ -1,10 +1,7 @@
 import logging
 import time
 
-from virttest import data_dir
-from virttest import storage
 from virttest import error_context
-from virttest.qemu_devices import qdevices
 
 
 @error_context.context_aware
@@ -14,26 +11,15 @@ def run(test, params, env):
 
     1) Boot up guest without block device.
     2) Hotplug a drive
-    2) Hoplug block device with invalid blk params.
-    3) Unplug the drive
-    4) Hotplug the drive again
-    5) Check vm is alive after drive unplug/hotplug
+    3) Hotplug block device with invalid blk params.
+    4) Unplug the drive
+    5) Hotplug the drive again
+    6) Check vm is alive after drive unplug/hotplug
 
     :param test:   QEMU test object.
     :param params: Dictionary with the test parameters.
     :param env:    Dictionary with test environment.
     """
-    def find_image(image_name):
-        """
-        Find the path of the iamge.
-
-        :param image_name: name of image.
-        :return mage_filename: filename of image.
-        """
-        image_params = params.object_params(image_name)
-        image_filename = storage.get_image_filename(image_params, data_dir.get_data_dir())
-        return image_filename
-
     def drive_unplug_plug(drive, vm):
         """
         Unplug drive then replug it.
@@ -47,55 +33,30 @@ def run(test, params, env):
         error_context.context("Hotplug the drive", logging.info)
         drive.hotplug(vm.monitor)
 
-    img_list = params.get("images").split()
-    img_format_type = params.get("img_format_type", "qcow2")
-    pci_type = params.get("pci_type", "virtio-blk-pci")
-    blk_num = int(params.get("blk_num", 1))
-    add_block_device = True
-
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
 
     error_context.context("Hotplug block device", logging.info)
-    for num in range(blk_num):
-        device = qdevices.QDevice(pci_type)
-        drive = qdevices.QRHDrive("block%d" % num)
-        drive.set_param("file", find_image(img_list[num + 1]))
-        drive.set_param("format", img_format_type)
-        drive_id = drive.get_param("id")
-        drive.hotplug(vm.monitor)
-        #add controller if needed
-        if params.get("need_controller", "no") == "yes":
-            controller_model = params.get("controller_model")
-            controller = qdevices.QDevice(controller_model)
-            bus_extra_param = params.get("bus_extra_params_%s" % img_list[num + 1])
-            if bus_extra_param:
-                key, value = bus_extra_param.split("=")
-                qdevice_params = {key: value}
-                controller.params.update(qdevice_params)
-            try:
-                controller.hotplug(vm.monitor)
-            except Exception as e:
-                if "QMP command 'device_add' failed" in str(e):
-                    logging.info("Failed to add controller with invalid params")
+    img_list = params.get("images").split()
+    image_name = img_list[-1]
+    image_params = params.object_params(image_name)
+    devs = vm.devices.images_define_by_params(image_name,
+                                              image_params, 'disk')
+    drive = devs[-2]
+    for dev in devs:
+        try:
+            ret = vm.devices.simple_hotplug(dev, vm.monitor)
+        except Exception as e:
+            if "QMP command 'device_add' failed" in str(e):
+                logging.info("Failed to hotplug device with invalid params")
+                try:
                     drive_unplug_plug(drive, vm)
-                    add_block_device = False
+                except Exception as e:
+                    test.fail("Failed to hotplug/unplug drive with error:"
+                              "%s") % e
 
-        if add_block_device:
-            device.set_param("drive", drive_id)
-            device.set_param("id", "block%d" % num)
-            blk_extra_param = params.get("blk_extra_params_%s" % img_list[num + 1])
-            if blk_extra_param:
-                key, value = blk_extra_param.split("=")
-                device.set_param(key, value)
-            try:
-                device.hotplug(vm.monitor)
-            except Exception as e:
-                if "QMP command 'device_add' failed" in str(e):
-                    logging.info("Failed to add block with invalid params")
-                    drive_unplug_plug(drive, vm)
-
-    error_context.context("Check vm is alive after drive unplug/hotplug test", logging.info)
+    error_context.context("Check vm is alive after drive unplug/hotplug test",
+                          logging.info)
     session = vm.wait_for_login()
     if not session.is_responsive():
         session.close()

--- a/qemu/tests/cfg/block_hotplug_negative.cfg
+++ b/qemu/tests/cfg/block_hotplug_negative.cfg
@@ -14,16 +14,21 @@
     remove_image_stg0 = yes
     force_create_image_stg0 = yes
     kill_vm_on_error = yes
-    blk_num = 1
     blk_extra_params_stg0 = "invalid_param=on"
 
     variants:
         - @default:
         - data_plane:
             no Host_RHEL.m6
+            only virtio_blk, virtio_scsi
             iothreads = iothread0
             virtio_blk:
                 blk_extra_params_image1 = "iothread=${iothreads}"
             virtio_scsi:
                 no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
-                bus_extra_params_image1 = "iothread=${iothreads}"
+                bus_extra_params = "iothread=${iothreads}"
+                Windows:
+                    i440fx:
+                        cd_format_cd1 = ide
+                    q35:
+                        cd_format_cd1 = ahci


### PR DESCRIPTION
block_hotplug_negative: replace hotplug process defination by
images_define_by_params()

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1550397