### PR TITLE
single_driver_install: Remove workaround

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -50,10 +50,6 @@
                 backend_type = passthrough
                 filename_passthrough = /dev/random
         - with_viostor:
-            # For latest windows guests, changing system disk driver between
-            # virtio_blk and virt_scsi will cause BSOD "INACCESSABLE_DEVICE".
-            # Do a workaround here to avoid such scenario.
-            no virtio_scsi
             driver_name = viostor
             device_name = "Red Hat VirtIO SCSI controller"
             device_hwid = '"PCI\VEN_1AF4&DEV_1001" "PCI\VEN_1AF4&DEV_1042"'
@@ -67,10 +63,6 @@
             force_create_image_stg = yes
             remove_image_stg = yes
         - with_vioscsi:
-            # For latest windows guests, changing system disk driver between
-            # virtio_blk and virt_scsi will cause BSOD "INACCESSABLE_DEVICE".
-            # Do a workaround here to avoid such scenario.
-            no virtio_blk
             driver_name = vioscsi
             device_name = "Red Hat VirtIO SCSI pass-through controller"
             device_hwid = '"PCI\VEN_1AF4&DEV_1004" "PCI\VEN_1AF4&DEV_1048"'


### PR DESCRIPTION
Since now we use different name for system disk between virtio-scsi
and virtio-blk, it has less chance to trigger the BSOD error, so we
can remove the previous workaround.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1608673