### PR TITLE
Re-write code logic of checking results of network mq change

### DIFF
--- a/qemu/tests/pktgen.py
+++ b/qemu/tests/pktgen.py
@@ -34,7 +34,7 @@ def run(test, params, env):
     external_host = params.get("external_host")
     if not external_host:
         get_host_cmd = "ip route | awk '/default/ {print $3}'"
-        external_host = process.system_output(get_host_cmd, shell=True)
+        external_host = process.system_output(get_host_cmd, shell=True).decode()
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     session = vm.wait_for_login(timeout=login_timeout)


### PR DESCRIPTION
1. Deprecate 'status' as a result condition for mq change function
2. Fix an function parameter error with using decode()

ID: 1626881
Signed-off-by: Pei Zhang <pezhang@redhat.com>