### PR TITLE
single_driver_install: No need to switch system to ide when install storage drivers

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -53,9 +53,6 @@
             driver_name = viostor
             device_name = "Red Hat VirtIO SCSI controller"
             device_hwid = '"PCI\VEN_1AF4&DEV_1001" "PCI\VEN_1AF4&DEV_1042"'
-            drive_format_image1 = ide
-            q35:
-                drive_format_image1 = ahci
             images += " stg"
             image_name_stg = "images/storage"
             image_size_stg = 4G
@@ -66,9 +63,6 @@
             driver_name = vioscsi
             device_name = "Red Hat VirtIO SCSI pass-through controller"
             device_hwid = '"PCI\VEN_1AF4&DEV_1004" "PCI\VEN_1AF4&DEV_1048"'
-            drive_format_image1 = ide
-            q35:
-                drive_format_image1 = ahci
             images += " stg"
             image_name_stg = "images/storage"
             image_size_stg = 4G


### PR DESCRIPTION
When install vioscsi and viostor drivers, switching system to ide then install another driver, then switch it back will cause windows crash.

ID:1638181

Signed-off-by: Li Jin <lijin@redhat.com>