### PR TITLE
Update iperf2 version and fix bug

### DIFF
--- a/qemu/tests/cfg/multicast_iperf.cfg
+++ b/qemu/tests/cfg/multicast_iperf.cfg
@@ -1,10 +1,10 @@
 - multicast_iperf: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu
     type = multicast_iperf
-    win_iperf_url = https://nocweboldcst.ucf.edu/files/iperf.exe
-    linux_iperf_url = http://sourceforge.net/projects/iperf/files/iperf-2.0.5.tar.gz
-    iperf_version = 2.0.5
-    linux_install_cmd = tar zxvf %s > /dev/null ; cd iperf-%s; ./configure > /dev/null; make >/dev/null; make install >/dev/null
+    win_iperf_url = https://sourceforge.net/projects/iperf2/files/iperf-2.0.12-win.exe
+    linux_iperf_url = https://sourceforge.net/projects/iperf2/files/iperf-2.0.12.tar.gz
+    iperf_version = 2.0.12
+    linux_install_cmd = tar zxvf %s > /dev/null ; cd iperf-%s; ./configure > /dev/null; make > /dev/null; make install > /dev/null
     linux_app_check_cmd = "iperf --version"
     linux_app_check_exit_status = 1
     transfer_timeout = 100

--- a/qemu/tests/multicast_iperf.py
+++ b/qemu/tests/multicast_iperf.py
@@ -44,7 +44,7 @@ def run(test, params, env):
     os_type = params.get("os_type")
     win_iperf_url = params.get("win_iperf_url")
     linux_iperf_url = params.get("linux_iperf_url")
-    iperf_version = params.get("iperf_version", "2.0.5")
+    iperf_version = params.get("iperf_version", "2.0.12")
     transfer_timeout = int(params.get("transfer_timeout", 360))
     login_timeout = int(params.get("login_timeout", 360))
 
@@ -146,7 +146,7 @@ def run(test, params, env):
 
         error_context.context("Test finish, check the result", logging.info)
         process.system("pkill -2 iperf")
-        t.join()
+        t.join(timeout=60)
 
     finally:
         if _process_is_alive("iperf"):


### PR DESCRIPTION
ID: 1638723

- Update iperf2 version to iperf-2.0.12
- Add parameter "timeout" into `t.join()`

Additional info:

**Add parameter "timeout"  to fix another bug.**
When interrupting iperf, if the client task in the guest is not 
completed, the host iperf server will wait threads to complete. So add 
it to avoid unexpected situations, otherwise the job will always hang.

Signed-off-by: Yihuang Yu <yihyu@redhat.com>