### PR TITLE
nic_hotplug: python3 compatible, add e1000e, remove e1000

### DIFF
--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -11,19 +11,21 @@
         - nic_8139:
             no ppc64, ppc64le, s390x
             pci_model = rtl8139
-            match_string = "8139"
         - nic_virtio:
             #TODO: Confirm this works with libvirt
             pci_model = virtio-net-pci
-            match_string = "Virtio network device"
             Host_RHEL.m5:
                 pci_model = virtio
             s390x:
                 pci_model = virtio-net-ccw
         - nic_e1000:
             no ppc64, ppc64le, s390x
+            RHEL:
+                only RHEL.6 RHEL.7
             pci_model = e1000
-            match_string = "Gigabit Ethernet Controller"
+        - nic_e1000e:
+            no ppc64, ppc64le, s390x
+            pci_model = e1000e
     variants:
         - one_pci:
             pci_num = 1

--- a/qemu/tests/nic_hotplug.py
+++ b/qemu/tests/nic_hotplug.py
@@ -74,7 +74,7 @@ def run(test, params, env):
         if nic_ip:
             return nic_ip
         cached_ip = vm.address_cache.get(nic["mac"])
-        arps = process.system_output("arp -aen")
+        arps = process.system_output("arp -aen").decode()
         logging.debug("Can't get IP address:")
         logging.debug("\tCached IP: %s", cached_ip)
         logging.debug("\tARP table: %s", arps)


### PR DESCRIPTION
1. fix python3 compatible issue
2. add e1000e variant
3. remove e1000 for RHEL8 guest
4. remove useless parameter match_string in cfg file

id: 1644717

Signed-off-by: Xiyue Wang <xiywang@redhat.com>