### PR TITLE
guest_test: Allow 'killall x' failed per it sometimes not processed

### DIFF
--- a/generic/tests/cfg/guest_test.cfg
+++ b/generic/tests/cfg/guest_test.cfg
@@ -42,5 +42,6 @@
             pre_command = "echo 'dd if=/dev/zero of=/home/bigfile bs=1M count=2048 && "
             pre_command += "\cp -f /home/{bigfile,bigfile.bak} && "
             pre_command += "\rm -f /home/{bigfile,bigfile.bak} && "
-            pre_command += "killall dhclient && dhclient -v && ifconfig -a' > ${guest_script}"
+            pre_command += "(! pgrep dhclient || killall dhclient) && "
+            pre_command += "dhclient -v && ifconfig -a' > ${guest_script}"
             post_command = "\rm -f ${guest_script}"


### PR DESCRIPTION
dhclient is not started by default on new system, so 'killall x' will fail and cause the script fails, so replace '&&' with ';' to allow it not processed and execute later command directly

id: 1645453
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>