### PR TITLE
iozone_windows: Delete "mem=2048" from iozone_windows.cfg

### DIFF
--- a/generic/tests/cfg/iozone_windows.cfg
+++ b/generic/tests/cfg/iozone_windows.cfg
@@ -7,7 +7,6 @@
     iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 4G -M -b iozone.xls -f ${disk_letter}:\testfile"
     iozone_timeout = 10800
     post_result = yes
-    mem = 2048
     variants:
         - aio_native:
             image_aio = native


### PR DESCRIPTION
iozone_windows cfg set mem=2048 before, but when the guest
min memory large then 2G, like win2016 need min memory 4G,
the job will be canceled.
It's better that let the guest use automatic allocation mem value.

id: 1633895
Signed-off-by: Peixiu Hou <phou@redhat.com>