### PR TITLE
live_snapshot_chain: Flush data to disk before running system_reset

### DIFF
--- a/qemu/tests/cfg/live_snapshot_chain.cfg
+++ b/qemu/tests/cfg/live_snapshot_chain.cfg
@@ -14,6 +14,11 @@
     check_alive_cmd = "ls"
     kill_vm = yes
     remove_snapshot_images = yes
+    Windows:
+        x86_64:
+            sync_bin = WIN_UTILS:\Sync\sync64.exe /accepteula
+        i386, i686:
+            sync_bin = WIN_UTILS:\Sync\sync.exe /accepteula
     variants:
         - @default:
         - with_data_plane:


### PR DESCRIPTION
QMP command 'system_reset' is issued after creating files in the guest. The
command has an effect similar to the physical reset button on a PC. But
filesystems may be left in an unclean state which causes the loss of data. Run
the command "sync" to flush the data to disk.

Signed-off-by: Ping Li <pingl@redhat.com>

ID: 1642032