### PR TITLE
pci_hotplug: set monitor type to HMP

### DIFF
--- a/qemu/tests/cfg/pci_hotplug.cfg
+++ b/qemu/tests/cfg/pci_hotplug.cfg
@@ -6,6 +6,7 @@
     repeat_times = 1
     wait_secs_for_hook_up = 3
     hotplug_timeout = 360
+    monitor_type = human
     variants:
         - with_reboot:
             sub_type_after_unplug = boot


### PR DESCRIPTION
The test depends on "drive_add" command, which is only available in HMP.
Since virttest's monitor_type defaults to "qmp", the test should set the
parameter explicitly.

Signed-off-by: Huan Xiong <huan.xiong@hxt-semitech.com>