### PR TITLE
dd_test: remove destroy vm operation

### DIFF
--- a/generic/tests/dd_test.py
+++ b/generic/tests/dd_test.py
@@ -169,4 +169,3 @@ def run(test, params, env):
         for dev_id in dev_partitioned:
             utils_disk.clean_partition_linux(session, dev_id)
         session.close()
-        vm.destroy(gracefully=True)


### PR DESCRIPTION
1. vm.destroy is not a mandatory step when dd_test is executed directly.
2. If dd_test is called as subtest in some other tests,
   caller's following steps may be interrupted
   for vm has been destroyed.

ID: 1650421

Signed-off-by: ybduan <yduan@redhat.com>