### PR TITLE
boot_with_different_vectors: cannot find a str in session.cmd_output

### DIFF
--- a/qemu/tests/boot_with_different_vectors.py
+++ b/qemu/tests/boot_with_different_vectors.py
@@ -79,10 +79,11 @@ def run(test, params, env):
         error_context.context("Check the cpu interrupt of virito",
                               logging.info)
         cmd = "cat /proc/interrupts |grep virtio"
-        output = session.cmd_output(cmd)
+        output = session.cmd_output(cmd).strip()
         vectors = int(vectors)
         if vectors == 0 or vectors == 1:
-            if "IO-APIC-fasteoi" not in output:
+            if not (re.findall("IO-APIC", output) and
+                    re.findall("fasteoi", output)):
                 msg = "Could not find IO-APIC-fasteoi interrupt"
                 msg += " when vectors = %d" % vectors
                 test.fail(msg)


### PR DESCRIPTION
should use findall to find a str in the output of session.cmd_output

id: 1646772

Signed-off-by: Xiyue Wang <xiywang@redhat.com>