### PR TITLE
hotplug_mem: Fix timeout issue for some cases 

### DIFF
--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -138,7 +138,6 @@
             reboot_method = system_reset
             sleep_before_reset = 0
         - guest_reboot:
-            sub_test_wait_time = 2
             sub_type = boot
             reboot_method = shell
             kill_vm_on_error = yes


### PR DESCRIPTION
1. add wait_for_login at the beginning to wait guest boot up before
doing test
2. for guest_reboot and vm_system_reset cases, wait a few seconds
to make sure sub test run in correct order and avoid timeout issue

ID: 1649970
Signed-off-by: Yumei Huang <yuhuang@redhat.com>