### PR TITLE
qemu_guest_agent:q35 support for qemu_guest_agent_hotplug

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent_hotplug.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent_hotplug.cfg
@@ -10,7 +10,12 @@
     gagent_status_cmd = "service qemu-guest-agent status"
     gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
     gagent_check_type = sync
-    extra_params += "-device virtio-serial-pci,id=virtio-serial0,bus=pci.0"
+    extra_params = "-device virtio-serial-pci,id=virtio-serial0,bus=pci.0"
+    q35:
+        # temporary workaround since currently no virtio-serial-pci bus object provided in the framework
+        pci_controllers += " pcie_root_port_qga"
+        type_pcie_root_port_qga = "pcie-root-port"
+        extra_params = "-device virtio-serial-pci,id=virtio-serial0,bus=pcie_root_port_qga"
     backend_char_plug = "socket"
     id_char_plug = "serial0"
     dev_driver = "virtserialport"


### PR DESCRIPTION
The existed parameter only support pc machine type,should support q35 as well.
id: 1653167
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>