### PR TITLE
qemu..smbios: q35 and py3 fixes

### DIFF
--- a/qemu/tests/cfg/smbios.cfg
+++ b/qemu/tests/cfg/smbios.cfg
@@ -5,6 +5,10 @@
     type = smbios_table
     requires_root = yes
     start_vm = no
+    # Remove extra pci_controllers as they only make sense for q35 but we
+    # might be booting i440fx machines as well which would require PCIE
+    # bridge
+    pcie_extra_root_port = 0
     SKU_System = "KVM"
     Family_System = "VIRT"
     dmikeyword_Bios =  Vendor Version Date

--- a/qemu/tests/cfg/smbios.cfg
+++ b/qemu/tests/cfg/smbios.cfg
@@ -18,6 +18,9 @@
     # Different systems may have different outputs for the item that is not set
     # Please update these parameters based on your guest os system
     notset_output = "Not Specified"
+    # RHEL uses different entries
+    Host_RHEL:
+        smbios_system_version = rhel
     variants:
         - type0:
             smbios_type = Bios

--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -5,6 +5,7 @@ from avocado.utils import process
 from virttest import error_context
 from virttest import env_process
 from virttest import utils_misc
+from virttest.compat_52lts import decode_to_text
 
 
 @error_context.context_aware
@@ -39,8 +40,8 @@ def run(test, params, env):
             dmidecode_key = dmidecode_key.split()
             for key in dmidecode_key:
                 cmd = (dmidecode_exp % (smbios_type_number, key))
-                default_key_para = process.system_output(
-                    cmd, shell=True).strip()
+                default_key_para = decode_to_text(process.system_output(
+                    cmd, shell=True).strip())
                 smbios_key_para_set = params.object_params(sm_type).get(key,
                                                                         default_key_para)
                 smbios += ",%s='%s'" % (key.lower(), smbios_key_para_set)
@@ -87,8 +88,8 @@ def run(test, params, env):
             for key in dmidecode_key:
                 cmd = (dmidecode_exp % (smbios_type_number, key))
                 smbios_get_para = session.cmd(cmd).strip()
-                default_key_para = process.system_output(
-                    cmd, shell=True).strip()
+                default_key_para = decode_to_text(process.system_output(
+                                                  cmd, shell=True).strip())
                 if params.get("smbios_type_disable", "no") == "no":
                     smbios_set_para = params.object_params(sm_type).get(key,
                                                                         default_key_para)

--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -66,6 +66,8 @@ def run(test, params, env):
 
     failures = []
     for m_type in support_machine_types:
+        if m_type in ("isapc", "xenfv", "xenpv"):
+            continue
         params["machine_type"] = m_type
         params["start_vm"] = "yes"
 


### PR DESCRIPTION
This contains some config tweaks to allow running this test under q35 profile, then some py3 fixes and adjustment to avoid booting unwanted upstream targets.

@KarMez-Redhat, @wainersm, @yashkmankad: this should help you with your CI.