### PR TITLE
generic..ioquit: Adjust reading Exception to py3

### DIFF
--- a/generic/tests/ioquit.py
+++ b/generic/tests/ioquit.py
@@ -6,6 +6,7 @@ import six
 from virttest import qemu_storage
 from virttest import data_dir
 from virttest import error_context
+from virttest import utils_misc
 from avocado.utils import process
 
 
@@ -43,8 +44,7 @@ def run(test, params, env):
     session2.cmd(check_cmd, timeout=360)
 
     error_context.context("Kill the VM", logging.info)
-    vm.process.close()
-
+    utils_misc.kill_process_tree(vm.process.get_pid(), wait=60)
     error_context.context("Check img after kill VM", logging.info)
     base_dir = data_dir.get_data_dir()
     image_name = params.get("image_name")

--- a/generic/tests/ioquit.py
+++ b/generic/tests/ioquit.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import random
+import six
 
 from virttest import qemu_storage
 from virttest import data_dir
@@ -50,8 +51,8 @@ def run(test, params, env):
     image = qemu_storage.QemuImg(params, base_dir, image_name)
     try:
         image.check_image(params, base_dir)
-    except Exception as e:
-        if "Leaked clusters" not in e.message:
+    except Exception as exc:
+        if "Leaked clusters" not in six.text_type(exc):
             raise
         error_context.context("Detected cluster leaks, try to repair it",
                               logging.info)


### PR DESCRIPTION
The first commit fixes py2/py3 compatibility issue and the second one uses https://github.com/avocado-framework/avocado/pull/2924 to avoid write-lock issues on recent qemu. The problem is that `aexpect.close()` kills the `sh` underneath, which is suppose to destroy the `qemu` process as well. And it does, but especially after extensive io usage it takes time resulting in failed tests due to `qemu-img` being unable to obtain write lock.