### PR TITLE
balloon_disable/balloon_stop_continue: remove -balloon usage

### DIFF
--- a/qemu/tests/cfg/balloon_disable.cfg
+++ b/qemu/tests/cfg/balloon_disable.cfg
@@ -4,3 +4,4 @@
     no RHEL.4.9
     type = balloon_disable
     extra_params += " -balloon none"
+    required_qemu = [, 3.1.0)

--- a/qemu/tests/cfg/balloon_stop_continue.cfg
+++ b/qemu/tests/cfg/balloon_stop_continue.cfg
@@ -1,5 +1,7 @@
 - balloon_stop_continue: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu
     type = balloon_stop_continue
-    extra_params += " -balloon virtio"
+    balloon = balloon0
+    balloon_dev_devid = balloon0
+    balloon_dev_add_bus = yes
     repeat_timeout = 360


### PR DESCRIPTION
Since -balloon is no longer supported by qemu3.1, update cases accordingly.
ID: 1655410
Signed-off-by: Yumei Huang <yuhuang@redhat.com>