### PR TITLE
boot_from_device: re-factor boot_from_device

### DIFF
--- a/qemu/tests/boot_from_device.py
+++ b/qemu/tests/boot_from_device.py
@@ -1,14 +1,11 @@
 import os
 import re
-import time
 import logging
 
 from avocado.utils import process
 
 from virttest import error_context
 from virttest import utils_misc
-from virttest import data_dir
-from virttest import qemu_storage
 from virttest import env_process
 
 
@@ -16,160 +13,83 @@ from virttest import env_process
 def run(test, params, env):
     """
     QEMU boot from device:
-
-    1) Start guest from device(hd/usb/scsi-hd)
+    1) Start guest from device
+       ide-hd/virtio-blk/scsi-hd/usb-storage
+       ide-cd/scsi-cd
     2) Check the boot result
-    3) Log into the guest if it's up
-    4) Shutdown the guest if it's up
 
     :param test: QEMU test object
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
 
-    def create_cdroms():
+    def create_cdroms(cdrom_test):
         """
         Create 'test' cdrom with one file on it
         """
-
         logging.info("creating test cdrom")
-        cdrom_test = params.get("cdrom_test")
-        cdrom_test = utils_misc.get_path(data_dir.get_data_dir(), cdrom_test)
         process.run("dd if=/dev/urandom of=test bs=10M count=1")
         process.run("mkisofs -o %s test" % cdrom_test)
         process.run("rm -f test")
 
-    def cleanup_cdroms():
+    def cleanup_cdroms(cdrom_test):
         """
         Removes created cdrom
         """
-
         logging.info("cleaning up temp cdrom images")
-        cdrom_test = utils_misc.get_path(
-            data_dir.get_data_dir(), params.get("cdrom_test"))
         os.remove(cdrom_test)
 
-    def preprocess_remote_storage():
+    def boot_check(info):
         """
-        Prepare remote ISCSI storage for block image, and login session for
-        iscsi device.
+        boot info check
         """
-        image_name = params.get("images").split()[0]
-        base_dir = params.get("images_base_dir", data_dir.get_data_dir())
-        iscsidevice = qemu_storage.Iscsidev(params, base_dir, image_name)
-        iscsidevice.setup()
-
-    def postprocess_remote_storage():
-        """
-        Logout from target.
-        """
-        image_name = params.get("images").split()[0]
-        base_dir = params.get("images_base_dir", data_dir.get_data_dir())
-        iscsidevice = qemu_storage.Iscsidev(params, base_dir, image_name)
-        iscsidevice.cleanup()
-
-    def cleanup(dev_name):
-        if dev_name == "scsi-cd":
-            cleanup_cdroms()
-        elif dev_name == "iscsi-dev":
-            postprocess_remote_storage()
-
-    def check_boot_result(boot_entry_info, boot_fail_info, device_name):
-        """
-        Check boot result, and logout from iscsi device if boot from iscsi.
-        """
-
-        logging.info("Wait for display and check boot info.")
-        start = time.time()
-        while True:
-            try:
-                output = vm.serial_console.get_stripped_output()
-            except ValueError:
-                output = vm.serial_console.get_output()
-            if boot_fail_info in output:
-                test.fail("Could not boot from"
-                          " '%s'" % device_name)
-            elif boot_entry_info in output:
-                break
-            if time.time() > start + timeout:
-                test.fail("No device for boot after %s" % timeout)
-            time.sleep(1)
-        logging.info("Try to boot from '%s'" % device_name)
-        try:
-            if dev_name == "hard-drive" or (dev_name == "scsi-hd" and not
-                                            params.get("image_name_stg")):
-                error_context.context("Log into the guest to verify it's up",
-                                      logging.info)
-                session = vm.wait_for_login(timeout=timeout)
-                session.close()
-                vm.destroy()
-                return
-        finally:
-            cleanup(device_name)
+        return re.search(info, vm.serial_console.get_stripped_output(), re.S)
 
     timeout = int(params.get("login_timeout", 360))
-    boot_menu_key = params.get("boot_menu_key", 'f12')
-    boot_menu_hint = params.get("boot_menu_hint")
-    boot_entry_info = params.get("boot_entry_info")
-    boot_fail_info = params.get("boot_fail_info")
-    boot_device = params.get("boot_device")
+    boot_menu_key = params.get("boot_menu_key", 'esc')
+    boot_menu_hint = params["boot_menu_hint"]
+    boot_entry_info = params["boot_entry_info"]
+    boot_dev = params.get("boot_dev")
     dev_name = params.get("dev_name")
-    if dev_name == "scsi-cd":
-        create_cdroms()
+
+    if dev_name == "cdrom":
+        cdrom_test = params["cdrom_test"]
+        create_cdroms(cdrom_test)
         params["start_vm"] = "yes"
         env_process.preprocess_vm(test, params, env, params.get("main_vm"))
-        vm = env.get_vm(params["main_vm"])
-        vm.verify_alive()
-    elif dev_name == "iscsi-dev":
-        preprocess_remote_storage()
-        params["start_vm"] = "yes"
-        env_process.preprocess_vm(test, params, env, params.get("main_vm"))
-        vm = env.get_vm(params["main_vm"])
-        vm.verify_alive()
-    else:
-        vm = env.get_vm(params["main_vm"])
-        vm.verify_alive()
-    if boot_device:
-        match = False
-        start = time.time()
-        console_str = ""
-        while True:
-            try:
-                output = vm.serial_console.get_stripped_output()
-            except ValueError:
-                output = vm.serial_console.get_output()
-            console_str += output
-            match = re.search(boot_menu_hint, output)
-            if match or time.time() > start + timeout:
-                break
-            time.sleep(1)
-        if not match:
-            cleanup(dev_name)
-            test.fail("Could not get boot menu message. "
-                      "Excepted Result: '%s', Actual result: '%s'"
-                      % (boot_menu_hint, console_str))
 
-        # Send boot menu key in monitor.
-        vm.send_key(boot_menu_key)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
 
-        try:
+    try:
+        if boot_dev:
+            if not utils_misc.wait_for(lambda: boot_check(boot_menu_hint),
+                                       timeout, 1):
+                test.fail("Could not get boot menu message")
+
+            # Send boot menu key in monitor.
+            vm.send_key(boot_menu_key)
+
             output = vm.serial_console.get_stripped_output()
-        except ValueError:
-            output = vm.serial_console.get_output()
-        boot_list = re.findall(r"^\d+\. (.*)\s", output, re.M)
+            boot_list = re.findall(r"^\d+\. (.*)\s", output, re.M)
+            if not boot_list:
+                test.fail("Could not get boot entries list")
+            logging.info("Got boot menu entries: '%s'", boot_list)
 
-        if not boot_list:
-            cleanup(dev_name)
-            test.fail("Could not get boot entries list.")
+            for i, v in enumerate(boot_list, start=1):
+                if re.search(boot_dev, v, re.I):
+                    msg = "Start guest from boot entry '%s'" % boot_dev
+                    error_context.context(msg, logging.info)
+                    vm.send_key(str(i))
+                    break
+            else:
+                msg = "Could not get boot entry match pattern '%s'" % boot_dev
+                test.fail(msg)
 
-        logging.info("Got boot menu entries: '%s'", boot_list)
-        for i, v in enumerate(boot_list, start=1):
-            if re.search(boot_device, v, re.I):
-                logging.info("Start guest from boot entry '%s'" % boot_device)
-                vm.send_key(str(i))
-                break
-        else:
-            test.fail("Could not get any boot entry match "
-                      "pattern '%s'" % boot_device)
-
-    check_boot_result(boot_entry_info, boot_fail_info, dev_name)
+        error_context.context("Check boot result", logging.info)
+        if not utils_misc.wait_for(lambda: boot_check(boot_entry_info),
+                                   timeout, 1):
+            test.fail("Could not boot from '%s'" % dev_name)
+    finally:
+        if dev_name == "cdrom":
+            cleanup_cdroms(cdrom_test)

--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -1,92 +1,81 @@
 - boot_from_device:
     no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
+    virt_test_type = qemu
     type = boot_from_device
     boot_menu = on
     enable_sga = yes
-    image_boot = no
-    virt_test_type = qemu
-    boot_menu_key = "f12"
-    Host_RHEL.m7:
-        boot_menu_key = "esc"
+    boot_menu_key = "esc"
+    Host_RHEL.m6:
+        boot_menu_key = "f12"
     boot_menu_hint = "Press .*(F12|ESC) for boot menu"
     boot_entry_info = "Booting from Hard Disk..."
-    boot_fail_info = "Boot failed: not a bootable disk"
+    images = "stg"
+    image_name_stg = "images/stg"
+    image_size_stg = 100M
+    force_create_image_stg = yes
+    remove_image_stg = yes
     variants:
-        - boot_from_hard_drive:
-            dev_name = hard-drive
-            bootindex_image1 = 0
-        - boot_from_usb_stg:
+        - cdrom:
+            cdroms = "test"
+            cdrom_test = "/tmp/test.iso"
+            boot_entry_info = "Booting from DVD/CD..."
+            start_vm = no
+            dev_name = cdrom
             variants:
-                - usb-ehci:
+                - with_bootindex:
+                    bootindex_test = 0
+                - with_specify_device:
+                    boot_dev = "DVD/CD"
+            variants:
+                - ide_cd:
+                    no q35
+                    cd_format_test = ide
+                - scsi_cd:
+                    cd_format_test = scsi-cd
+        - ide_disk:
+            no q35
+            drive_format_stg = ide
+            dev_name = ide_disk
+            variants:
+                - with_bootindex:
+                    bootindex_stg = 0
+                - with_specify_device:
+                    boot_dev = "ata"
+        - virtio_blk_disk:
+            drive_format_stg = virtio
+            dev_name = virtio_blk
+            variants:
+                - with_bootindex:
+                    bootindex_stg = 0
+                - with_specify_device:
+                    boot_dev = "Virtio disk"
+        - scsi_hd_disk:
+            drive_format_stg = scsi-hd
+            dev_name = scsi_hd
+            variants:
+                - with_bootindex:
+                    bootindex_stg = 0
+                - with_specify_device:
+                    boot_dev = "virtio-scsi Drive"
+        - usb_storage_disk:
+            dev_name = usb_storage
+            usb_devices = ""
+            usbs = usb1
+            variants:
+                - with_bootindex:
+                    bootindex_stg = 0
+                - with_specify_device:
+                    boot_dev = "USB MSC Drive"
+            variants:
+                - usb_uhci:
+                    usb_type_usb1 = ich9-usb-uhci1
+                    drive_format_stg = "usb1"
+                - usb_ehci:
                     usb_type_usb1 = usb-ehci
                     drive_format_stg = "usb2"
-                - nec-xhci:
+                - usb_xhci:
                     no RHEL.3, RHEL.4, RHEL.5
                     no Win2000, WinXP, Win2003, WinVista
                     no Host_RHEL.m6
                     usb_type_usb1 = nec-usb-xhci
-                    drive_format_stg = "usb3" 
-            dev_name = usb-storage
-            usb_devices = ""
-            usbs = usb1
-            images += " stg"
-            image_name_stg = "images/usbdevice"
-            image_format_stg = "qcow2"
-            image_size_stg = 100M
-            create_image_stg = yes
-            remove_image_stg = yes
-            variants:
-                - with_new_device:
-                    bootindex_stg = 0
-                    bootindex_image1 = 1
-                - with_specify_device:
-                    # Specify the boot device name which you want to test here.
-                    boot_device = "USB MSC Drive"
-        - boot_from_scsi_hd:
-            dev_name = scsi-hd
-            drive_format_image1 = scsi-hd
-            variants:
-                - with_local_device:
-                    bootindex_image1 = 0
-                - with_new_device:
-                    images = " stg"
-                    image_name_stg = "images/scsidevice"
-                    image_format_stg = "qcow2"
-                    drive_format_stg = scsi-hd
-                    image_size_stg = 1G
-                    create_image_stg = yes
-                    remove_image_stg = yes
-                    bootindex_stg = 0
-                - with_specify_device:
-                    boot_device = "virtio-scsi Drive"
-        - boot_from_scsi_cdrom:
-            start_vm = no
-            dev_name = scsi-cd
-            cdroms = "test"
-            cdrom_test = /tmp/test.iso
-            cd_format = scsi-cd
-            boot_entry_info = "Booting from DVD/CD..."
-            boot_fail_info = "Boot failed: Could not read from CDROM"
-            variants:
-                - with_local_iso:
-                    bootindex_test = 0
-                    bootindex_image1 = 1
-                - with_specify_device:
-                    boot_device = "DVD/CD"
-        - boot_from_iscsi_device:
-            start_vm = no
-            dev_name = iscsi-dev
-            # Please update these to point to your iscsi server
-            portal_ip = 127.0.0.1
-            initiator = "iqn.2010-07.com.example:my_initiator"
-            target = "iqn.2001-05.com.mytarget:0-0a0000-000000000-0000000000000000-my-target"
-            images = "stg"
-            image_name_stg = "/dev/sdb"
-            image_format_stg = ""
-            drive_format_stg = scsi-block
-            variants:
-                - with_remote_stg:
-                    bootindex_stg = 0
-                - with_specify_device:
-                    boot_device = "virtio-scsi Drive"
-
+                    drive_format_stg = "usb3"

--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -30,6 +30,8 @@
                 - ide_cd:
                     no q35
                     cd_format_test = ide
+                - ahci_cd:
+                    cd_format_test = ahci
                 - scsi_cd:
                     cd_format_test = scsi-cd
         - ide_disk:
@@ -41,6 +43,14 @@
                     bootindex_stg = 0
                 - with_specify_device:
                     boot_dev = "ata"
+        - ahci_disk:
+            drive_format_stg = ahci
+            dev_name = ahci_disk
+            variants:
+                - with_bootindex:
+                    bootindex_stg = 0
+                - with_specify_device:
+                    boot_dev = "AHCI"
         - virtio_blk_disk:
             drive_format_stg = virtio
             dev_name = virtio_blk


### PR DESCRIPTION
No need to login and verify guest up, also mixed usage of bootable
and unbootable devices looks messy. Change all test cases to use
new created unbootable image.
Booting from iscsi is not so related with seabios and it needs extra
preparation steps. So remove boot_from_iscsi_device.

Categorize booting from cdroms:
    ide-cd/scsi-cd
Categorize booting from disks:
    ide-hd/virtio-blk/scsi-hd/usb-storage

ID: 1656723

Signed-off-by: ybduan <yduan@redhat.com>