### PR TITLE
boot_with_different_vectors: Support Power8/9

### DIFF
--- a/qemu/tests/cfg/boot_with_different_vectors.cfg
+++ b/qemu/tests/cfg/boot_with_different_vectors.cfg
@@ -19,3 +19,5 @@
     netperf_para_sessions = 6
     test_protocol = TCP_STREAM
     enable_msix_vectors = yes
+    msi_check_cmd = "lspci -vvv -s %s | grep MSI"
+    irq_check_cmd = "cat /proc/interrupts | grep virtio"


### PR DESCRIPTION
Add support for "XICS" and "XIVE" interrupt controller type.

ID: 1646772

Signed-off-by: Yihuang Yu <yihyu@redhat.com>