### PR TITLE
block_discard: correct scsi-hd to scsi-block for pass-through scsi disk

### DIFF
--- a/qemu/tests/cfg/block_discard.cfg
+++ b/qemu/tests/cfg/block_discard.cfg
@@ -5,6 +5,7 @@
     type = block_discard
     start_vm = no
     kill_vm = yes
+    drive_format_scsi_debug = scsi-block
     disk_size = 1024
     # image size 1G, support WRITE SAME(16) and UNMAP
     pre_command = "modprobe -r scsi_debug; modprobe scsi_debug dev_size_mb=${disk_size} lbpws=1"


### PR DESCRIPTION
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1659926