### PR TITLE
tp-qemu: Add case WMI_facility_test for windows guests

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_mq.cfg
+++ b/qemu/tests/cfg/virtio_scsi_mq.cfg
@@ -1,7 +1,6 @@
 - virtio_scsi_mq: install setup image_copy unattended_install.cdrom
     type = virtio_scsi_mq
     only virtio_scsi
-    only RHEL
     no RHEL.3 RHEL.4 RHEL.5 RHEL.6
     no Host_RHEL.m5 Host_RHEL.m6
     kill_vm_on_error = yes
@@ -14,3 +13,14 @@
     ppc64le,ppc64:
         system_image_drive_format = scsi-hd
         scsi_hba_image1 = spapr-vscsi
+    variants:
+        - @default:
+            only RHEL
+        - wmi_facility_check:
+            only Windows
+            # As WinXP, Win2003, Win2008, Win7 not support multi queue. So don't test them.
+            no WinXP Win2003 Win2008 Win7
+            system_image_drive_format = scsi-hd
+            driver_name = vioscsi
+            pattern = "instance\.QueuesCount=(\d+)"
+            wmi_check_cmd = "WIN_UTILS:\vioscsi.vbs && timeout 5 && type vioscsi.log"


### PR DESCRIPTION
step1: boot guest vm up with num_queues
step2: enable vioscsi.sys verifier in guest
step3: run wmi check command
step4: check instance.QueuesCount value as expected

id: 1564837
Signed-off-by: Peixiu Hou <phou@redhat.com>