### PR TITLE
jumbo: remove redundant ports in ovs bridge and fix python3 issue

### DIFF
--- a/generic/tests/cfg/jumbo.cfg
+++ b/generic/tests/cfg/jumbo.cfg
@@ -5,6 +5,7 @@
     requires_root = yes
     type = jumbo
     mtu = 9000
+    start_vm = no
     rtl8139, spapr-vlan:
         mtu = 1500
     e1000:

--- a/generic/tests/ethtool.py
+++ b/generic/tests/ethtool.py
@@ -53,7 +53,7 @@ def run(test, params, env):
         for f in feature_pattern.keys():
             try:
                 temp = re.findall(
-                        "%s: (.*)" % feature_pattern.get(f), o)[0]
+                    "%s: (.*)" % feature_pattern.get(f), o)[0]
                 if temp.find("[fixed]") != -1:
                     logging.debug("%s is fixed" % f)
                     continue
@@ -256,7 +256,7 @@ def run(test, params, env):
             # lro is fixed for e1000 and e1000e, while trying to exclude
             # lro by setting "lro off", the command of ethtool returns error
             if not (f_type == "gro" and (vm.virtnet[0].nic_model == "e1000e"
-                    or vm.virtnet[0].nic_model == "e1000")):
+                                         or vm.virtnet[0].nic_model == "e1000")):
                 offload_stat.update(dict.fromkeys(test_matrix[f_type][2], "off"))
             if not ethtool_set(session, offload_stat):
                 e_msg = "Failed to set offload status"

--- a/qemu/tests/ovs_host_vlan.py
+++ b/qemu/tests/ovs_host_vlan.py
@@ -94,8 +94,7 @@ def netperf_setup(test, params, env):
     env_process.preprocess_vm(test, params, env, vm_name)
     vm = env.get_vm(vm_name)
     vm.verify_alive()
-    session = vm.wait_for_login(timeout=int(params.get("login_timeout",
-                                360)))
+    session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
     try:
         if params.get("os_type") == "linux":
             netperf_link = params["netperf_link"]


### PR DESCRIPTION
id: 1571613

1. some case does not clean ovs ports after finished, this case
will error because of trying to set mtu to all the ports in ovs
bridge but some of the ports are invalid.
2. fix python3 compatibale issue

Signed-off-by: Xiyue Wang <xiywang@redhat.com>