### PR TITLE
Update error message pattern for ALT7 guest

### DIFF
--- a/generic/tests/cfg/vlan.cfg
+++ b/generic/tests/cfg/vlan.cfg
@@ -14,7 +14,7 @@
     kill_vm_gracefully_vm2 = no
     cmd_type = ip
     msg_pattern = '8021q: Invalid VLAN id'
-    RHEL.7, RHEL.6:
+    RHEL.7, ALT.7, RHEL.6:
         msg_pattern = 'RTNETLINK answers: Numerical result out of range'
     Windows:
         # two windows VM, need more time to boot and login

--- a/generic/tests/vlan.py
+++ b/generic/tests/vlan.py
@@ -164,7 +164,6 @@ def run(test, params, env):
     for vm_index, vm in enumerate(vms):
         if params["os_type"] == "windows":
             session = vm.wait_for_serial_login(timeout=login_timeout)
-            win_vlan_id = int(params.get("win_vlan_id", 900))
             set_vlan_cmd = params.get("set_vlan_cmd")
             nicid = utils_net.get_windows_nic_attribute(session=session,
                                                         key="netenabled", value=True,


### PR DESCRIPTION
1. update corresponding pattern for ALT7 guest
2. fix "set_vlan_cmd" typo

ID: 1646793

Signed-off-by: Yihuang Yu <yihyu@redhat.com>