### PR TITLE
generic/hwclock: print expected output pattern on fail

### DIFF
--- a/generic/tests/hwclock.py
+++ b/generic/tests/hwclock.py
@@ -22,5 +22,7 @@ def run(test, params, env):
     session.cmd('/sbin/hwclock --set --date "2/2/80 03:04:00"')
     date = session.cmd_output('LC_ALL=C /sbin/hwclock')
     if not re.match(date_pattern, date):
-        test.fail("Fail to set hwclock back to the 80s."
-                  "Output of hwclock is '%s'" % date)
+        test.fail("Fail to set hwclock back to the 80s. "
+                  "Output of hwclock is '%s'. "
+                  "Expected output pattern is '%s'." % (date.rstrip(),
+                                                        date_pattern))


### PR DESCRIPTION
The generic hwclock test may fail as false-positive in reason
of a pattern output mismatch, but not exactly because it failed
to set the clock. In that case, printing the expected output pattern
on the fail message is useful to quickly spot the problem.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>