### PR TITLE
Avoid running ctrl_vlan cases with other devices except virtio-net

### DIFF
--- a/qemu/tests/cfg/ctrl_vlan.cfg
+++ b/qemu/tests/cfg/ctrl_vlan.cfg
@@ -1,4 +1,5 @@
 - ctrl_vlan:
+    only virtio_net
     type = ctrl_vlan
     image_snapshot = yes
     nic_model = virtio


### PR DESCRIPTION
only virtio-net supports ctrl_vlan parameter. Avoid running this case with other devices.

ID: 1663094

Signed-off-by: Yihuang Yu <yihyu@redhat.com>