### PR TITLE
Skip bridge testcases if host bridge backend is OVS

### DIFF
--- a/qemu/tests/cfg/bridge_mirror.cfg
+++ b/qemu/tests/cfg/bridge_mirror.cfg
@@ -1,12 +1,11 @@
 - bridge_mirror:
     only Linux
     only bridge
+    only virtio_net
     type = bridge_mirror
     vms = "vm1 vm2 vm3"
     start_vm = no
     private_bridge = tmpbr
-    add_private_bridge_cmd = "ip link add name ${private_bridge} type bridge;"
-    add_private_bridge_cmd += "ip link set ${private_bridge} up"
     tcpdump_cmd = "tcpdump -l -n host %s and icmp > %s &"
     tcpdump_log = "/tmp/tcpdump.log"
     get_tcpdump_log_cmd = "cat ${tcpdump_log}"
@@ -19,10 +18,12 @@
     image_snapshot = yes
     login_timeout = 720
     stop_NM_cmd = "systemctl stop NetworkManager"
-    stop_firewall_cmd = "systemctl stop firewalld.service"
-    enable_promisc_cmd = "ifconfig ${private_bridge} promisc up"
-    tc_qdisc = "/sbin/tc qdisc"
-    tc_filter = "/sbin/tc filter"
+    stop_firewall_cmd = "systemctl stop firewalld"
+    RHEL.6:
+        stop_NM_cmd = "service NetworkManager stop"
+        stop_firewall_cmd = "service iptables stop"
+    tc_qdisc = "tc qdisc"
+    tc_filter = "tc filter"
     tc_qdisc_add_ingress = "${tc_qdisc} add dev ${private_bridge} ingress"
     tc_filter_show_dev = "${tc_filter} show dev ${private_bridge} parent ffff:"
     tc_filter_replace_dev = "${tc_filter} replace dev ${private_bridge} parent ffff: protocol ip u32 match u8 0 0 action mirred egress mirror dev %s"
@@ -30,5 +31,3 @@
     tc_qdisc_show_dev = "${tc_qdisc} show dev ${private_bridge}"
     tc_filter_show_dev_port = "${tc_filter} show dev ${private_bridge} parent %s:"
     tc_filter_replace_dev_port = "${tc_filter} replace dev ${private_bridge} parent %s: protocol ip u32 match u8 0 0 action mirred egress mirror dev %s"
-    tc_qdisc_del_ingress = "${tc_qdisc} del dev ${private_bridge} ingress"
-    tc_qdisc_del_root = "${tc_qdisc} del dev ${private_bridge} root"

--- a/qemu/tests/cfg/bridge_vlan.cfg
+++ b/qemu/tests/cfg/bridge_vlan.cfg
@@ -1,17 +1,18 @@
 - bridge_vlan:
+    only Linux
+    only bridge
     virt_test_type = qemu
     type = bridge_vlan
-    only Linux
     vms += " vm2"
     start_vm = no
     image_snapshot = yes
     kill_vm_vm2 = yes
     kill_vm_gracefully_vm2 = no
-    host_br = switch
     host_vlan_id = 10
     subnet = "192.168"
     host_vlan_ip = "${subnet}.${host_vlan_id}.10"
     mac_str = 54:52:00:01:0a:01,54:52:00:01:0a:02
+    add_vlan_cmd = "ip link add link %s name %s type vlan id %s"
     rm_host_vlan_cmd = "ip link delete %s type vlan"
     # netperf stress config
     netperf_link = netperf-2.6.0.tar.bz2
@@ -26,4 +27,3 @@
     sub_exit_timeout = 10
     # netperf vlan config
     netperf_vlan_test = yes
-    vlan_nic = eth0.10


### PR DESCRIPTION
1. Skip bridge testcases if host bridge backend is OVS
These two testcases only supported linux bridge, skip test them if 
using ovs. Determine whether br_backend is equal to Bridge()

2. Use other methods to create bridge and set promiscuous mode
Use the methods in the framework to create bridge and modify 
promiscuous mode

3. Upgrade the codes of 'bridge_vlan'
Since "only linux" has been defined in cfg, make a small code upgrade

ID: 1663076

Signed-off-by: Yihuang Yu <yihyu@redhat.com>