### PR TITLE
qemu..smbios: Fix typo in Host.RHEL filter

### DIFF
--- a/qemu/tests/cfg/smbios.cfg
+++ b/qemu/tests/cfg/smbios.cfg
@@ -19,7 +19,7 @@
     # Please update these parameters based on your guest os system
     notset_output = "Not Specified"
     # RHEL uses different entries
-    Host_RHEL:
+    Host.RHEL, Host_RHEL:
         smbios_system_version = rhel
     variants:
         - type0:


### PR DESCRIPTION
The filter is suppose to be Host.RHEL and not Host_RHEL.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>