### PR TITLE
win_virtio_serial_data_transfer_reboot:fix python3 issue

### DIFF
--- a/qemu/deps/win_serial/serial-host-send.py
+++ b/qemu/deps/win_serial/serial-host-send.py
@@ -33,8 +33,8 @@ def main():
     vport.connect(sys.argv[1])
     data_file = sys.argv[2]
 
-    ff = open(data_file)
-    arg = ff.read(65535)
+    with open(data_file, 'rb') as ff:
+        arg = ff.read(65535)
     stream = pack_message(arg)
     vport.send(stream)
 

--- a/qemu/tests/win_virtio_serial_data_transfer_reboot.py
+++ b/qemu/tests/win_virtio_serial_data_transfer_reboot.py
@@ -93,7 +93,7 @@ def run(test, params, env):
     send_script = params.get("host_send_script", "serial-host-send.py")
     send_script = os.path.join(data_dir.get_deps_dir("win_serial"),
                                send_script)
-    serial_send_cmd = "python %s %s %s" % (send_script, host_file, data_file)
+    serial_send_cmd = "`command -v python python3 | head -1` %s %s %s" % (send_script, host_file, data_file)
     receive_script = params.get("guest_receive_script",
                                 "VirtIoChannel_guest_recieve.py")
     receive_script = "%s%s" % (guest_path, receive_script)


### PR DESCRIPTION
1.support python3 command.
2.fix struct.error: argument for 's' must be a bytes object
ID: 1660281
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>