### PR TITLE
watchdog: fix migration_protocol parameter name

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -49,11 +49,11 @@
                     watchdog_action = pause
             variants:
                 - @tcp:
-                    mig_protocol = tcp
+                    migration_protocol = tcp
                 - x_rdma:
-                    mig_protocol = x-rdma
+                    migration_protocol = x-rdma
                 - rdma:
-                    mig_protocol = rdma
+                    migration_protocol = rdma
         - hotplug_unplug_watchdog_device:
              only i6300esb
              no RHEL.4 RHEL.5


### PR DESCRIPTION
The bug caused all rdma and x-rdma tests used the default tcp protocol.