### PR TITLE
driver_in_use..during_bg_test: Fix balloon memory error

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -258,7 +258,7 @@ class BallooningTest(MemoryBaseTest):
         max_size = self.ori_mem
         min_size = self.params.get("minmem", "512M")
         min_size = int(float(utils_misc.normalize_data_size(min_size)))
-        balloon_buffer = self.params.get("balloon_buffer", 300)
+        balloon_buffer = int(self.params.get("balloon_buffer", 300))
         if self.params.get('os_type') == 'windows':
             logging.info("Get windows miminum balloon value:")
             self.vm.balloon(1)

--- a/qemu/tests/cfg/balloon_in_use.cfg
+++ b/qemu/tests/cfg/balloon_in_use.cfg
@@ -24,6 +24,7 @@
         default_memory = ${mem}
         check_guest_bsod = yes
         migration_test_command = ver && vol
+        balloon_buffer = 700
     Linux:
         # Use a low stress to make sure guest can response during stress
         driver_name = "virtio_balloon"
@@ -34,7 +35,7 @@
             run_bg_flag = "before_bg_test"
         - during_bg_test:
             run_bg_flag = "during_bg_test"
-            repeat_times = 200
+            repeat_times = 100
         - after_bg_test:
             run_bg_flag = "after_bg_test"
     variants:

--- a/qemu/tests/cfg/balloon_stress.cfg
+++ b/qemu/tests/cfg/balloon_stress.cfg
@@ -13,6 +13,7 @@
         mplayer_path = "WIN_UTILS:\mplayer.exe"
         play_video_cmd = "start /MIN %s %s -loop 0 -fs"
         video_url = http://FILESHARE.COM/pub/section2/kvmauto/video/big_buck_bunny_480p_stereo.avi
+        balloon_buffer = 700
     Linux:
         # Use a low stress to make sure guest can response during stress
         stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -138,8 +138,7 @@ def run(test, params, env):
                 utils_test.run_virt_sub_test(test, params, env, main_test)
                 break
         if stress_thread:
-            stress_thread.join(timeout=timeout,
-                               suppress_exception=suppress_exception)
+            stress_thread.join(suppress_exception=suppress_exception)
         if vm.is_alive():
             run_bg_test_sep(bg_stress_test)
     elif run_bg_flag == "after_bg_test":


### PR DESCRIPTION
1. Cancel timeout in stress_thread.join() to wait whole bg_test finish, else two balloon operation conflict and lead to error: "Failed to balloon memory to expect value during 240.0s";
2. Change repeat time from 200 to 100 to reduce testing time.
3. Increase balloon_buffer from 300 to 600 to avoid too smalle balloon value.

ID: 1658894

Signed-off-by: Li Jin <lijin@redhat.com>