### PR TITLE
qemu.test: update case multi_disk related steps

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -89,7 +89,7 @@
             no RHEL.3 RHEL.4 RHEL.5 RHEL.6.0 RHEL.6.1 RHEL.6.2
             stg_image_size = 50M
             drive_letters = 26
-            stg_params = "drive_format:scsi-disk "
+            stg_params = "drive_format:scsi-hd "
             variants:
                 - @passthrough:
                     stg_params = "drive_format:scsi-block "


### PR DESCRIPTION
1. change drive_format from scsi-disk to scsi-hd.
   scsi-disk is legacy, use scsi-hd instead of scsi-disk.
2. add umount partition step for passthrough scsi_debug disk test.
   when multiple SCSI disks are simulated by scsi_debug, they
   could be viewed as multiple paths to the same storage device.
   So need umount partition before operate next disk, in order
   to avoid corrupting the filesystem(xfs integrity checks error).

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1669025