### PR TITLE
virtio_rng_rhel6_driver: update rng cases to support rhel 6 guest

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -15,10 +15,11 @@
         session_cmd_timeout = 360
         read_rng_cmd  = "dd if=/dev/random  bs=1 count=10 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
-        driver_name = virtio
         rng_data_rex = "\w+"
+        driver_name = virtio_rng
         check_rngd_service = "systemctl status rngd"
         start_rngd_service = "systemctl start rngd"
         RHEL.6:
+            driver_name = virtio
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"

--- a/qemu/tests/cfg/rng_host_guest_read.cfg
+++ b/qemu/tests/cfg/rng_host_guest_read.cfg
@@ -19,10 +19,11 @@
     Linux:
         read_rng_cmd  = "dd if=/dev/random  bs=1 count=10 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
-        driver_name = virtio
         rng_data_rex = "\w+"
+        driver_name = virtio_rng
         check_rngd_service = "systemctl status rngd"
         start_rngd_service = "systemctl start rngd"
         RHEL.6:
+            driver_name = virtio
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"

--- a/qemu/tests/cfg/rng_hotplug.cfg
+++ b/qemu/tests/cfg/rng_hotplug.cfg
@@ -26,13 +26,14 @@
         session_cmd_timeout = 360
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
         read_rng_cmd  = "dd if=/dev/random  bs=1 count=10 2>/dev/null|hexdump"
-        driver_name = "virtio"
         rng_data_rex = "\w+"
         restart_rngd = "service rngd restart"
         stop_rngd = "service rngd stop"
+        driver_name = virtio_rng
         check_rngd_service = "systemctl status rngd"
         start_rngd_service = "systemctl start rngd"
         RHEL.6:
+            driver_name = virtio
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
     variants:

--- a/qemu/tests/cfg/rng_read_longtime.cfg
+++ b/qemu/tests/cfg/rng_read_longtime.cfg
@@ -23,10 +23,11 @@
         session_cmd_timeout = 360
         read_rng_cmd = "dd if=/dev/random bs=4 count=1000 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
-        driver_name = virtio
         rng_data_rex = "\w+"
+        driver_name = virtio_rng
         check_rngd_service = "systemctl status rngd"
         start_rngd_service = "systemctl start rngd"
         RHEL.6:
+            driver_name = virtio
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"

--- a/qemu/tests/cfg/rng_stress.cfg
+++ b/qemu/tests/cfg/rng_stress.cfg
@@ -22,15 +22,17 @@
         read_rng_cmd  = "dd if=/dev/random bs=1 count=10 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
         driver_available_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_available"
-        driver_name = virtio
         rng_data_rex = "\w+"
+        driver_name = virtio_rng
         check_rngd_service = "systemctl status rngd"
         start_rngd_service = "systemctl start rngd"
         RHEL.6:
+            driver_name = virtio
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
     variants:
         - two_device:
+            no RHEL.6
             virtio_rngs += " rng1"
             switch_rng_cmd = "echo -n %s > /sys/class/misc/hw_random/rng_current"
             pre_cmd = "dd if=/dev/random of=/dev/null bs=10 count=10"

--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -26,12 +26,13 @@
         read_rng_cmd  = "dd if=/dev/random bs=10 count=1000000 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
         target_process = rngd
-        driver_name = virtio_rng
         rng_data_rex = "\w+"
         list_cmd = "ps aux | grep rngd | grep 'Rs\|Ds'"
+        driver_name = virtio_rng
         check_rngd_service = "systemctl status rngd"
         start_rngd_service = "systemctl start rngd"
         RHEL.6:
+            driver_name = virtio
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
     variants:

--- a/qemu/tests/rng_stress.py
+++ b/qemu/tests/rng_stress.py
@@ -38,9 +38,10 @@ def run(test, params, env):
         Get available rng devices from /sys/devices
         """
         verify_cmd = params["driver_available_cmd"]
+        driver_name = params["driver_name"]
         try:
             output = session.cmd_output_safe(verify_cmd)
-            rng_devices = re.findall(r"virtio_rng.\d+", output)
+            rng_devices = re.findall(r"%s(?:\.\d+)?" % driver_name, output)
         except aexpect.ShellTimeoutError:
             err = "%s timeout, pls check if it's a product bug" % verify_cmd
             test.fail(err)


### PR DESCRIPTION
  For rhel 6 guest including virtio-rng device(s), there will be only
'virtio' in files 'rng_available' and 'rng_current', not 'virtio_rng.x'
like in rhel 7 guest. Also as a result, it is impossible to switch rng
device in rhel 6 guest with multiple virtio-rng devices.

  1.Add rhel 6 specific virtio-rng driver name 'virtio'
  2.Disable rng_stress.two_device for rhel 6 guest

ID: 1617286

Signed-off-by: ybduan <yduan@redhat.com>