### PR TITLE
Q35: Provide more pcie_extra_root_port for hotplug cases

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -26,6 +26,8 @@
             blk_num = 1
             repeat_times = 1
         - multi_pci:
+            q35, arm64-pci:
+                pcie_extra_root_port = 2
             blk_num = 2
             repeat_times = 1
             images += " stg1"

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -31,6 +31,8 @@
             pci_num = 1
             repeat_times = 1
         - multi_pci:
+            q35, arm64-pci:
+                pcie_extra_root_port = 2
             pci_num = 2
             repeat_times = 1
         - additional:

--- a/qemu/tests/cfg/rng_hotplug.cfg
+++ b/qemu/tests/cfg/rng_hotplug.cfg
@@ -38,6 +38,8 @@
     variants:
         - multi_rngs:
             rng_num = 4
+            q35, arm64-pci:
+                pcie_extra_root_port = 4
         - one_rng:
             variants:
                 - @default:

--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -151,6 +151,8 @@
                         - hotplug:
                             only spread_linear
                             virtio_console_test = hotplug
+                            q35, arm64-pci:
+                                pcie_extra_root_port = 4
                             variants:
                                 - timeout_0:
                                     virtio_console_pause = 0


### PR DESCRIPTION
Need provide sufficient extra root port when there are more than 1
 devices to be hotplugged, since the default pcie_extra_root_port
is 1

id: 1661084
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>