### PR TITLE
fio_linux: Add a case run fio for Linux

### DIFF
--- a/qemu/tests/cfg/fio_linux.cfg
+++ b/qemu/tests/cfg/fio_linux.cfg
@@ -1,0 +1,22 @@
+- fio_linux:
+    type = fio_linux
+    only Linux
+    no ide
+    images += " stg0"
+    image_name_stg0 = images/storage0
+    image_size_stg0 = 10G
+    blk_extra_params_stg0 = "serial=TARGET_DISK0"
+    remove_image_stg0 = yes
+    force_create_image_stg0 = yes
+    start_vm = yes
+    fio_default_options = '--direct=1 --bs=64K --size=2G --name=test --iodepth=4 --ioengine=libaio'
+    fio_options = '${fio_default_options} --rw=read;'
+    fio_options += '${fio_default_options} --rw=write;'
+    fio_options += '${fio_default_options} --rw=randread;'
+    fio_options += '${fio_default_options} --rw=randwrite;'
+    fio_options += '${fio_default_options} --rw=randrw'
+    variants:
+        - aio_native:
+            image_aio_stg0 = native
+        - aio_threads:
+            image_aio_stg0 = threads

--- a/qemu/tests/fio_linux.py
+++ b/qemu/tests/fio_linux.py
@@ -1,0 +1,61 @@
+"""
+fio_linux.py include following case:
+    1. Boot guest with "aio=native" or "aio=threads" CLI option and run fio
+       tools.
+"""
+import logging
+import re
+
+from virttest import error_context
+from virttest import utils_misc
+from provider.storage_benchmark import generate_instance
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Boot guest with "aio=native" or "aio=threads" CLI option and run fio tools.
+    Step:
+        1. Boot guest with "aio=threads,cache=none" option.
+        2. Run fio tool to the data disk in guest.
+        3. Boot guest with "aio=native, cache=none" option
+           (cmd lines refer to step 1).
+        4. Run fio tool to the data disk in guest.
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _get_data_disks():
+        """ Get the data disks by serial or wwn options. """
+        for data_image in data_images:
+            extra_params = params.get("blk_extra_params_%s" % data_image, '')
+            match = re.search(r"(serial|wwn)=(\w+)", extra_params, re.M)
+            if match:
+                drive_id = match.group(2)
+            else:
+                continue
+            drive_path = utils_misc.get_linux_drive_path(session, drive_id)
+            if not drive_path:
+                test.error("Failed to get '%s' drive path" % data_image)
+            yield drive_path[5:]
+
+    data_images = params["images"].split()[1:]
+    info = []
+    for image in data_images:
+        aio = params.get('image_aio_%s' % image, 'threads')
+        cache = params.get('drive_cache_%s' % image, 'none')
+        info.append('%s(\"aio=%s,cache=%s\")' % (image, aio, cache))
+    logging.info('Boot a guest with %s.' % ', '.join(info))
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=float(params.get("login_timeout", 240)))
+    try:
+        fio = generate_instance(params, session, 'fio')
+        for did in _get_data_disks():
+            for option in params['fio_options'].split(';'):
+                fio.run('--filename=%s %s' % (did, option))
+    finally:
+        fio.clean()
+        session.close()


### PR DESCRIPTION
Boot guest with "aio=native" or "aio=threads" CLI option
and run fio tools.

ID: 1630819
Signed-off-by: Yongxue Hong <yhong@redhat.com>