### PR TITLE
balloon_minimum.negative: Enlarge free memory compare value

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -74,12 +74,12 @@ class BallooningTest(MemoryBaseTest):
         mmem = self.get_ballooned_memory()
         gmem = self.get_memory_status()
         gcompare_threshold = int(self.params.get("guest_compare_threshold", 100))
-        # for windows illegal test:set windows guest balloon in (1,100),free memory will less than 50M
+        # for windows illegal test:set windows guest balloon in (1,100),free memory will less than 150M
         if ballooned_mem >= self.ori_mem - 100:
             timeout = float(self.params.get("login_timeout", 600))
             session = self.vm.wait_for_login(timeout=timeout)
             try:
-                if self.get_win_mon_free_mem(session) > 50:
+                if self.get_win_mon_free_mem(session) > 150:
                     self.test.fail("Balloon_min test failed %s" % step)
             finally:
                 session.close()

--- a/qemu/tests/balloon_minimum.py
+++ b/qemu/tests/balloon_minimum.py
@@ -1,0 +1,45 @@
+import time
+import logging
+
+from virttest import utils_test
+from virttest import error_context
+from virttest.qemu_monitor import QMPEventError
+from qemu.tests.balloon_check import BallooningTestWin
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Balloon negative test, balloon windows guest memory to very small value.
+    1) boot a guest with balloon device.
+    2) enable and check driver verifier in guest.
+    3) evict guest memory to 10M.
+    4) repeat step 3 for many times.
+    5) check guest free memory.
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+
+    error_context.context("Boot guest with balloon device", logging.info)
+    vm = env.get_vm(params["main_vm"])
+    session = vm.wait_for_login()
+    driver_name = params.get("driver_name", "balloon")
+    session = utils_test.qemu.windrv_check_running_verifier(session, vm,
+                                                            test, driver_name)
+    balloon_test = BallooningTestWin(test, params, env)
+    expect_mem = int(params["expect_memory"])
+    repeat_times = int(params.get("repeat_times", 10))
+
+    while repeat_times:
+        try:
+            balloon_test.vm.balloon(expect_mem)
+        except QMPEventError:
+            pass
+        balloon_test._balloon_post_action()
+        time.sleep(30)
+        repeat_times -= 1
+    ballooned_memory = balloon_test.ori_mem - expect_mem
+    balloon_test.memory_check("after balloon guest memory 10 times", ballooned_memory)
+    session.close()

--- a/qemu/tests/cfg/balloon_minimum.cfg
+++ b/qemu/tests/cfg/balloon_minimum.cfg
@@ -11,6 +11,7 @@
     kill_vm_on_error = yes
     variants:
         - negative:
+            type = balloon_minimum
             only Windows
             backup_image_before_testing = yes
             restore_image_after_testing = yes
@@ -18,6 +19,7 @@
             balloon_timeout = 900
             guest_check_step = 60.0
             guest_stable_threshold = 25
+            repeat_times = 10
             check_guest_bsod = yes
         - boundary:
             run_sub_test_after_balloon = yes


### PR DESCRIPTION
Original free memory compare value is 50M which is too small, especially for latest windows guests. So enlarge it to 150M.

ID: 1669959

Signed-off-by: Li Jin <lijin@redhat.com>