### PR TITLE
single_driver_install: Make driver version search be more tolerant

### DIFF
--- a/qemu/tests/single_driver_install.py
+++ b/qemu/tests/single_driver_install.py
@@ -98,8 +98,8 @@ def run(test, params, env):
     logging.info("Found inf file '%s'", inf_path)
 
     # `findstr` cannot handle unicode so calling `type` makes it work
-    expected_ver = session.cmd("type %s | findstr DriverVer=" % inf_path,
-                               timeout=OPERATION_TIMEOUT)
+    expected_ver = session.cmd("type %s | findstr /i /r DriverVer.*=" %
+                               inf_path, timeout=OPERATION_TIMEOUT)
     expected_ver = expected_ver.strip().split(",", 1)[-1]
     if not expected_ver:
         test.error("Failed to find driver version from inf file")


### PR DESCRIPTION
In some drivers' inf files, there are some spaces between 'DriverVer'
and '=', somes have no, so modify the search to be more tolerant.
ID: 1676722
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>