### PR TITLE
fio_perf: close the opened result file in the end

### DIFF
--- a/qemu/tests/fio_perf.py
+++ b/qemu/tests/fio_perf.py
@@ -288,4 +288,5 @@ def run(test, params, env):
     # del temporary files in guest
     clean_tmp_files(session, check_install_fio, tarball, os_type, guest_result_file, fio_path, cmd_timeout)
 
+    result_file.close()
     session.close()


### PR DESCRIPTION
The result file isn't closed.

bug id: 1676768
Signed-off-by: yama <yama@redhat.com>