### PR TITLE
virtio_scsi_cdrom: Add an installation case

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_cdrom.cfg
+++ b/qemu/tests/cfg/virtio_scsi_cdrom.cfg
@@ -1,0 +1,90 @@
+- virtio_scsi_cdrom:
+    virt_test_type = qemu
+    type = unattended_install
+    backup_image = yes
+    start_vm = no
+    kill_vm = yes
+    kill_vm_gracefully = yes
+    kill_vm_on_error = yes
+    shutdown_cleanly = yes
+    shutdown_cleanly_timeout = 120
+    force_create_image = yes
+    guest_port_unattended_install = 12323
+    kernel = vmlinuz
+    initrd = initrd.img
+    # Throw errors if guest screen is inactive
+    inactivity_watcher = error
+    # Inactivity treshold to error the test
+    inactivity_treshold = 1800
+    image_verify_bootable = no
+    only x86_64
+    only virtio_scsi, virtio_blk
+    virtio_drive_letter = 'D'
+    variants:
+        - with_installation:
+            cd_format_cd1 = scsi-cd
+            i440fx:
+                Windows:
+                    cd_format_unattended = ide
+            q35:
+                cd_format_unattended = ahci
+            variants:
+                - @default:
+                - multi_disk_install:
+                    no ide
+                    serial_name = SYSTEM_DISK0
+                    blk_extra_params_image1 = "serial=${serial_name}"
+                    cmd_only_use_disk = "ignoredisk --only-use=disk/by-id/*${serial_name}"
+                    images += " stg stg2 stg3 stg4 stg5 stg6 stg7 stg8 stg9"
+                    images += " stg10 stg11 stg12 stg13 stg14 stg15 stg16"
+                    images += " stg17 stg18 stg19 stg20 stg21 stg22 stg23 stg24"
+                    image_name_stg = images/storage
+                    image_name_stg2 = images/storage2
+                    image_name_stg3 = images/storage3
+                    image_name_stg4 = images/storage4
+                    image_name_stg5 = images/storage5
+                    image_name_stg6 = images/storage6
+                    image_name_stg7 = images/storage7
+                    image_name_stg8 = images/storage8
+                    image_name_stg9 = images/storage9
+                    image_name_stg10 = images/storage10
+                    image_name_stg11 = images/storage11
+                    image_name_stg12 = images/storage12
+                    image_name_stg13 = images/storage13
+                    image_name_stg14 = images/storage14
+                    image_name_stg15 = images/storage15
+                    image_name_stg16 = images/storage16
+                    image_name_stg17 = images/storage17
+                    image_name_stg18 = images/storage18
+                    image_name_stg19 = images/storage19
+                    image_name_stg20 = images/storage20
+                    image_name_stg21 = images/storage21
+                    image_name_stg22 = images/storage22
+                    image_name_stg23 = images/storage23
+                    image_name_stg24 = images/storage24
+                    image_name_stg25 = images/storage25
+                    image_size_equal = 1G
+                    ahci:
+                        images = "image1 stg stg2 stg3 stg4 stg5"
+            variants:
+                - aio_native:
+                    image_aio = native
+                - aio_threads:
+                    image_aio = threads
+            variants:
+                # Additional iso with kickstart is attached into the guest
+                - extra_cdrom_ks:
+                    no WinXP Win2000 Win2003 WinVista
+                    unattended_delivery_method = cdrom
+                    cdroms += " unattended"
+                    drive_index_unattended = 3
+                    drive_index_cd1 = 1
+            variants:
+                # Install guest from cdrom
+                - cdrom:
+                    Windows:
+                        cdroms += " winutils"
+                        cd_format_winutils = scsi-cd
+                        drive_index_winutils = 2
+                    boot_once = d
+                    medium = cdrom


### PR DESCRIPTION
Add a new case that guest could install os from
scsi-cd device for x86_64.

ID: 1628043
Signed-off-by: Yongxue Hong <yhong@redhat.com>