### PR TITLE
fio_perf: removing useless info when getting qemu-kvm version

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -8,7 +8,7 @@
     threads = "16"
     rw = "read write randread randwrite randrw"
     Host_RHEL:
-        kvm_ver_chk_cmd = "rpm -q qemu-kvm-rhev || rpm -q qemu-kvm"
+        kvm_ver_chk_cmd = "rpm -qa | grep -E 'qemu-kvm(-(rhev|ma|core))?-[0-9]+\.' | head -n 1"
     Linux:
         no ide
         pattern = ".*[read|write].*IOPS=(\d+(?:\.\d+)?[\w|\s]),\sBW=(\d+(?:\.\d+)?[\w|\s]*B/s)"


### PR DESCRIPTION
e.g. kvm-userspace-ver : b'package qemu-kvm-rhev is not installed
\nqemu-kvm-2.12.0-41.el8+2104+3e32e6f8.x86_64'
It should be 'qemu-kvm-2.12.0-41.el8+2104+3e32e6f8.x86_64'

bug id: 1677467
Signed-off-by: yama <yama@redhat.com>