### PR TITLE
Nic hotplug: Add pcie support

### DIFF
--- a/qemu/tests/cfg/multi_nics_hotplug.cfg
+++ b/qemu/tests/cfg/multi_nics_hotplug.cfg
@@ -6,6 +6,8 @@
     run_dhclient = yes
     nic_hotplug_count = 4
     flexible_nic_index = yes
+    q35, arm64-pci:
+        pcie_extra_root_port = 4
     RHEL.4, RHEL.5:
         additional_operation = yes
     variants:

--- a/qemu/tests/nic_hotplug.py
+++ b/qemu/tests/nic_hotplug.py
@@ -94,7 +94,7 @@ def run(test, params, env):
             session.cmd_output_safe(add_route_cmd)
             status, output = utils_test.ping(hotnic_ip, 10, timeout=30)
             logging.info("Del the route.")
-            status, output = session.cmd_output_safe(del_route_cmd)
+            session.cmd_output_safe(del_route_cmd)
         return status, output
 
     def device_add_nic(pci_model, netdev, device_id):
@@ -153,7 +153,7 @@ def run(test, params, env):
                 useddevice_id = primary_nic[0].netdev_id
                 logging.info("Hot-plug NIC with the netdev already in use")
                 try:
-                    add_output = device_add_nic(nic_model, useddevice_id, nic_name)
+                    device_add_nic(nic_model, useddevice_id, nic_name)
                 except Exception as err_msg:
                     match_error = params["devadd_match_string"]
                     if match_error in str(err_msg):


### PR DESCRIPTION
1. Get free root port and assign it as bus for hotplugging nic device.
2. The second commit removing unused variants in this script. For the 'status, output' in ping_hotplug_nic(), the return value of ping() is covered by the return value by cmd_output_safe(), I suppose what we want to return to the user is from ping(), so remove the second ones.

id: 1658131
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>