### PR TITLE
unattended_install: perform multivm unattended_install

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -37,6 +37,12 @@
     # Fedora guests. For other guests like ubuntu if your install failed with
     # don't have enough RAM error from anaconda, please enlarge this value.
     lowest_mem = 512
+    # This value can be set to define time between each VM installation trigger
+    # in MultiVM environment
+    install_trigger_time = 0
+    # This value can be set to 'yes' if required to perform installation trigger
+    # random time in the range random.randint(0, install_trigger_time)
+    random_trigger = "no"
     variants:
         - aio_native:
             image_aio = native

--- a/generic/tests/unattended_install.py
+++ b/generic/tests/unattended_install.py
@@ -1,4 +1,11 @@
+import logging
+import threading
+import time
+import random
+
 from virttest.tests import unattended_install
+
+error_flag = False
 
 
 def run(test, params, env):
@@ -11,4 +18,50 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters.
     :param env: Dictionary with test environment.
     """
-    unattended_install.run(test, params, env)
+    # use vm name to differentiate among single/multivm
+    vms = params.objects("vms")
+
+    if len(vms) < 2:
+        unattended_install.run(test, params, env)
+        return
+
+    def thread_func(vm):
+        """
+        Thread Method to trigger the unattended installation
+
+        :param vm: VM name
+        """
+        global error_flag
+        try:
+            vm_params = params.object_params(vm)
+            vm_params["main_vm"] = vm
+            unattended_install.run(test, vm_params, env)
+        except Exception as info:
+            logging.error(info)
+            error_flag = True
+
+    if not params.get("master_images_clone"):
+        test.cancel("provide the param `master_images_clone` to clone"
+                    "images for vms")
+
+    trigger_time = int(params.get("install_trigger_time", 0))
+    random_trigger = params.get("random_trigger", "no") == "yes"
+    install_threads = []
+
+    for vm in vms:
+        thread = threading.Thread(target=thread_func, args=(vm,))
+        install_threads.append(thread)
+
+    for thread in install_threads:
+        if trigger_time:
+            sleep_time = trigger_time
+            if random_trigger:
+                sleep_time = random.randint(0, trigger_time)
+            time.sleep(sleep_time)
+        thread.start()
+
+    for thread in install_threads:
+        thread.join()
+
+    if error_flag:
+        test.fail("Failed to perform unattended install")


### PR DESCRIPTION
perform multiVM installation/import parallely or one by one with specfic
trigger time or by random trigger based on the param `install_trigger_time`
and `ramdom_trigger` respectively. This patch doesn't change the default way
for single VM.

Suggested-by: Xu Han <xuhan@redhat.com>
Suggested-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>