### PR TITLE
qmp_event_notification: skip qmp_rtc_change test on aarch64

### DIFF
--- a/qemu/tests/cfg/qmp_event_notification.cfg
+++ b/qemu/tests/cfg/qmp_event_notification.cfg
@@ -49,7 +49,7 @@
             event_cmd = c
             event_check = "RESUME"
         - qmp_rtc_change:
-            no Windows
+            no Windows, aarch64
             event_cmd = hwclock --systohc
             event_check = "RTC_CHANGE"
         - qmp_suspend:


### PR DESCRIPTION
The test works on i440fx and q35 machines because MC146818 (the RTC
device on them) emulation code generates RTC_CHANGE event when its time
is set. For aarch64 virt machine, however, its RTC device is PL031,
whose emulation code doesn't generate that event. So skip the test on
aarch64.

Signed-off-by: Huan Xiong <huan.xiong@hxt-semitech.com>