### PR TITLE
Update nmi_bsod_catch case to match virtio-win scsi/blk crash dump check case

### DIFF
--- a/qemu/tests/cfg/nmi_bsod_catch.cfg
+++ b/qemu/tests/cfg/nmi_bsod_catch.cfg
@@ -2,6 +2,8 @@
     type = nmi_bsod_catch
     only Windows
     mem_fixed = 2048
+    Win2016, Win2019:
+        mem_fixed = 4096
     enable_pvpanic = no
     config_cmds = config_cmd1, config_cmd2, config_cmd3, config_cmd4, config_cmd5, config_cmd6
     # enable AutoReboot, guest will reboot after finishing create dump file.
@@ -22,3 +24,7 @@
     check_dump_cmd = dir C:\Memory.dmp 
     del_dump_cmd = del C:\Memory.dmp
     nmi_cmd = inject-nmi
+    virtio_blk:
+        driver_name = viostor
+    virtio_scsi:
+        driver_name = vioscsi

--- a/qemu/tests/nmi_bsod_catch.py
+++ b/qemu/tests/nmi_bsod_catch.py
@@ -2,6 +2,7 @@ import time
 import logging
 
 from virttest import error_context
+from virttest import utils_test
 
 
 @error_context.context_aware
@@ -9,11 +10,12 @@ def run(test, params, env):
     """
     Generate a dump on NMI, then analyse the dump file:
     1) Boot a windows guest.
-    2) Edit the guest's system registry if need.
-    3) Reboot the guest.
-    4) Send inject-nmi or nmi from host to guest.
-    5) Send a reboot command or a system_reset monitor command (optional)
-    6) Verify whether the dump files are generated.
+    2) Check whether driver verifier enabled in guest.
+    3) Edit the guest's system registry if need.
+    4) Reboot the guest.
+    5) Send inject-nmi or nmi from host to guest.
+    6) Send a reboot command or a system_reset monitor command (optional)
+    7) Verify whether the dump files are generated.
 
     :param test: QEMU test object
     :param params: Dictionary with the test parameters
@@ -30,6 +32,12 @@ def run(test, params, env):
     nmi_cmd = params.get("nmi_cmd")
     del_dump_cmd = params.get("del_dump_cmd")
     analyze_cmd = params.get("analyze_cmd")
+    driver_name = params.get("driver_name")
+
+    if driver_name:
+        session = utils_test.qemu.windrv_check_running_verifier(session,
+                                                                vm, test,
+                                                                driver_name)
 
     if del_dump_cmd:
         session.sendline(del_dump_cmd)


### PR DESCRIPTION
1. Add step to check whether driver verifier enabled in guest.
2. Add mem_fix for Win2016, Win2019 guest, due to 2G is less than their vm_mem_min(4G).

id: 1456099, 1566839
Signed-off-by: Peixiu Hou <phou@redhat.com>