### PR TITLE
live_snapshot: change the path of snapshot and remove it at the end 

### DIFF
--- a/qemu/tests/live_snapshot_base.py
+++ b/qemu/tests/live_snapshot_base.py
@@ -32,7 +32,7 @@ def run(test, params, env):
     copy_timeout = params.get("copy_timeoout", 600)
     base_file = storage.get_image_filename(params, data_dir.get_data_dir())
     device = vm.get_block({"file": base_file})
-    snapshot_file = "images/%s" % params.get("snapshot_name")
+    snapshot_file = "images/%s" % params.get("snapshot_file")
     snapshot_file = utils_misc.get_path(data_dir.get_data_dir(), snapshot_file)
     snapshot_format = params.get("snapshot_format", "qcow2")
     tmp_name = utils_misc.generate_random_string(5)


### PR DESCRIPTION
For case live_snapshot.with_file_transfer:
    1. change the path of live_snapshot_img to images/*
    2. remove live_snapshot_img after test finished
For case live_snapshot.base:
    The correct parameter name should be 'snapshot_file' instead of 'snapshot_name'.

id: 1679011
Signed-off-by: Yanan Fu <yfu@redhat.com>