### PR TITLE
Fix some multi_queues_test problems

### DIFF
--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -21,7 +21,7 @@
                 netperf_link = netperf-2.4.5.tar.bz2
             server_path = /var/tmp/
             client_path = /var/tmp/
-            netperf_test_duration = 360
+            netperf_test_duration = 180
             netperf_client = ${vms}
             netperf_server = localhost
             wait_bg_time = 60

--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -14,6 +14,7 @@
     enable_msix_vectors = yes
     variants:
         - with_netperf:
+            disable_pci_msi = no
             hostpassword = redhat
             netperf_link = netperf-2.6.0.tar.bz2
             RHEL.4:
@@ -54,6 +55,7 @@
                     queues = ${smp_fixed}
                     vhostfds_len = ${smp_fixed}
                     tapfds_len = ${smp_fixed}
+                    vt_ulimit_nofile = 10240
                 - cpu_affinity:
                     #this test smp must equal queues.
                     smp_fixed = 4
@@ -74,6 +76,7 @@
                     queues = 0
                     key_words = "(No such device|Cannot bring up TAP)"
         - multi_nics:
+            disable_pci_msi = no
             check_vhost_threads = no
             mac_filter = "HWaddr (.\w+:\w+:\w+:\w+:\w+:\w+)"
             ip_filter = "inet addr:(.\d+.\d+.\d+.\d+)"

--- a/generic/tests/multi_queues_test.py
+++ b/generic/tests/multi_queues_test.py
@@ -135,13 +135,12 @@ def run(test, params, env):
                                     "Wait %s start background" % bg_sub_test)
 
             if params.get("vhost") == 'vhost=on' and check_vhost == 'yes':
-                error_context.context("Check vhost threads on host",
-                                      logging.info)
                 vhost_thread_pattern = params.get("vhost_thread_pattern",
                                                   r"\w+\s+(\d+)\s.*\[vhost-%s\]")
                 vhost_threads = vm.get_vhost_threads(vhost_thread_pattern)
-                time.sleep(10)
-
+                time.sleep(120)
+                error_context.context("Check vhost threads on host",
+                                      logging.info)
                 top_cmd = (r'top -n 1 -bis | tail -n +7 | grep -E "^ *%s "'
                            % ' |^ *'.join(map(str, vhost_threads)))
                 top_info = None


### PR DESCRIPTION
max_queues:
1. Add "vt_ulimit_nofile" to fix "Too many  open files"
2. Modify the method to get "top_info" to fix "top: pid limit (20) exceeded"

cpu_affinity:
1. Modifiy the "cmd" to fix to get an empty "irq_statics" when irq_number > 99
2. Restart "irqbalance.service" finally

others:
1. Sleep 2min to make the results more accurate
2. Use "top -i" to get the correctly running pid.

ID: 1367010 1647284