### PR TITLE
balloon_hotplug: Optimize code to reduce case running time

### DIFF
--- a/qemu/tests/cfg/balloon_hotplug.cfg
+++ b/qemu/tests/cfg/balloon_hotplug.cfg
@@ -8,9 +8,6 @@
     reboot_method = shell
     shutdown_method = shell
     run_sub_test_after_balloon = no
-    test_tags = "evict enlarge"
-    balloon_type_evict = evict
-    balloon_type_enlarge = enlarge
     balloon_device = virtio-balloon-pci
     Windows:
         cdroms += " virtio"


### PR DESCRIPTION
Original code calls BallooningTest() at least twice in each plug time, it takes more than 16 hours to finish this case. Optimize the code to reduce the running time.

ID: 1679846

Signed-off-by: Li Jin <lijin@redhat.com>