### PR TITLE
expose_host_mtu: Modify method to get the bridge source interface

### DIFF
--- a/qemu/tests/cfg/expose_host_mtu.cfg
+++ b/qemu/tests/cfg/expose_host_mtu.cfg
@@ -9,9 +9,8 @@
     mtu_value = 4000
     nic_extra_params = ",host_mtu=${mtu_value}"
     nm_stop_cmd = systemctl stop NetworkManager
-    check_guest_mtu_cmd = "ifconfig %s"
-    set_guest_mtu_cmd = "ifconfig %s mtu ${mtu_value}"
-    bridge_get_if_cmd = "bridge link show | awk '{print $2}'"
+    check_guest_mtu_cmd = "ip link show dev %s"
+    set_mtu_cmd = "ip link set dev %s mtu ${mtu_value}"
     Windows:
         # TBD, will support later
         check_guest_mtu_cmd = "netsh interface ipv4 show subinterface "%s""

--- a/qemu/tests/expose_host_mtu.py
+++ b/qemu/tests/expose_host_mtu.py
@@ -56,15 +56,13 @@ def run(test, params, env):
 
         if is_ovs_backend(netdst) is True:
             ports = set(get_ovs_ports(netdst).splitlines()) - \
-                set(ports.splitlines())
+                    set(ports.splitlines())
             for p in ports:
                 process.system("ovs-vsctl del-port %s %s" % (netdst, p))
 
     netdst = params.get("netdst", "switch")
     if netdst in utils_net.Bridge().list_br():
-        cmd = params["bridge_get_if_cmd"]
-        host_hw_interface = process.system_output(
-                cmd, shell=True).decode().strip(':')
+        host_hw_interface = utils_net.Bridge().list_iface()[0]
     elif is_ovs_backend(netdst) is True:
         host_hw_interface = get_ovs_ports(netdst)
         tmp_ports = re.findall(r"t[0-9]-[a-zA-Z0-9]{6}", host_hw_interface)
@@ -83,12 +81,10 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
 
-    device_mac = vm.virtnet[0].mac
     vm_iface = vm.get_ifname()
     # TODO, will support windows later
-    process.system_output(params["nm_stop_cmd"])
-    process.system_output(params["set_guest_mtu_cmd"] % host_hw_interface)
-    process.system_output(params["set_guest_mtu_cmd"] % vm_iface)
+    process.system_output(params["set_mtu_cmd"] % host_hw_interface)
+    process.system_output(params["set_mtu_cmd"] % vm_iface)
 
     os_type = params.get("os_type", "linux")
     login_timeout = float(params.get("login_timeout", 360))


### PR DESCRIPTION
1. Use `utils_net.Bridge().list_iface()` to get the `netdst` bridge interface
2. Replace `ifconfig` with `ip link`

ID: 1683012

Signed-off-by: Yihuang Yu <yihyu@redhat.com>