### PR TITLE
timerdevice: skip all tests on aarch64

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -2,6 +2,7 @@
     no Host_RHEL.m6
     restart_vm = yes
     host_cpu_cnt_cmd = "cat /proc/cpuinfo | grep "physical id" | wc -l"
+    no aarch64
     Linux:
         hwclock_time_command = "LC_TIME=C hwclock -u"
         hwclock_time_filter_re = "(\d+-\d+-\d+ \d+:\d+:\d+).*"


### PR DESCRIPTION
Timerdevice tests were designed assuming at least one of the following:

- tsc clocksource is available in host
- kvmclock, tsc, or pit clocksources are available in guest
- msr-tools is available in guest

All of these are x86 specific features. So skip them on aarch64.

Signed-off-by: Huan Xiong <huan.xiong@hxt-semitech.com>