### PR TITLE
rh_kernel_update: backup image at the end of the test

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -6,6 +6,7 @@
     start_vm = yes
     kill_vm = yes
     image_snapshot = yes
+    backup_image = yes
     # Please update your file share web server url before test
     #download_root_url = <your_server_url>
     # brew tag for search latest package via brewtool


### PR DESCRIPTION
Our framwork support different methods to backup image:
1. backup_image_before_testing: will skip if there is a same backup
2. backup_image: will backup image by force.

Our test order in a loop can be:
1. Installation test backup image by force when install finished.
2. rh_kernel_update
3. some case use "backup_image_before_testing", it will skip backup
   when there is a same existing backup image
4. At the end of that case, it will restore(restore_image_after_testing)
   the backup image which be saved at step 1, without the change of
   rh_kernel_update in step 2.

So, use 'backup_image' in rh_kernel_update to backup image by force.

id: 1683557
Signed-off-by: Yanan Fu <yfu@redhat.com>