### PR TITLE
virtio_storage_in_use: Add linux support for virtio_storage_in_use

### DIFF
--- a/qemu/tests/cfg/iozone_linux.cfg
+++ b/qemu/tests/cfg/iozone_linux.cfg
@@ -1,0 +1,10 @@
+- iozone_linux: install setup image_copy unattended_install.cdrom
+    virt_test_type = qemu
+    only Linux
+    type = iozone_linux
+    iozone_cmd_options = "-azR -r 64k -n 1G -g 4G -M -f %s/iozone_test"
+    variants:
+        - aio_native:
+            image_aio = native
+        - aio_threads:
+            image_aio = threads

--- a/qemu/tests/cfg/virtio_storage_in_use.cfg
+++ b/qemu/tests/cfg/virtio_storage_in_use.cfg
@@ -5,10 +5,14 @@
     check_guest_bsod = yes
     login_timeout = 240
     suppress_exception = no
-    run_bgstress = iozone_windows
-    target_process = iozone.exe
-    cdrom_cd1 = isos/windows/winutils.iso
-    only Windows
+    Windows:
+        run_bgstress = iozone_windows
+        target_process = iozone.exe
+        cdrom_cd1 = isos/windows/winutils.iso
+    Linux:
+        run_bgstress = iozone_linux
+        target_process = iozone
+        check_bg_timeout = 300
     variants:
         - before_bg_test:
             run_bg_flag = "before_bg_test"
@@ -38,28 +42,51 @@
             migration_test_command = ver && vol
     variants:
         - system_disk:
-            disk_letter = C
+            Windows:
+                disk_letter = C
         - data_disk:
-            disk_letter = I
-            disk_index = 1
-            format_disk = yes
+            Windows:
+                disk_letter = I
+                disk_index = 1
+                format_disk = yes
             images += " stg"
             image_name_stg = "images/storage"
             image_size_stg = 4G
+            blk_extra_params_stg = "serial=TARGET_DISK0"
             force_create_image_stg = yes
             remove_image_stg = yes
     variants:
         - with_block:
             only virtio_blk
-            driver_name = viostor
+            Windows:
+                driver_name = viostor
+                iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 2G -M -i 0 -i 1 -b iozone.xls -f ${disk_letter}:\testfile"
+            Linux:
+                driver_name = virtio_blk
+                iozone_cmd_options = "-azR -r 64k -n 1G -g 2G -M -i 0 -i 1 -f %s/iozone_test"
+                with_block..with_live_migration.during_bg_test:
+                    wait_bg_finish = yes
+                    image_size_stg = 10G
+                    iozone_cmd_options = "-azR -r 64k -n 1G -g 5G -M -i 0 -i 1 -f %s/iozone_test"
+                with_block..with_stop_continue.during_bg_test:
+                    wait_bg_finish = yes
             drive_format = virtio
-            iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 2G -M -i 0 -i 1 -b iozone.xls -f ${disk_letter}:\testfile"
             iozone_timeout = 7200
             wait_bg_time = 180
         - with_vioscsi:
             only virtio_scsi
-            driver_name = vioscsi
+            Windows:
+                driver_name = vioscsi
+                iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 2G -M -i 0 -i 1 -b iozone.xls -f ${disk_letter}:\testfile"
+            Linux:
+                driver_name = virtio_scsi
+                iozone_cmd_options = "-azR -r 64k -n 1G -g 2G -M -i 0 -i 1 -f %s/iozone_test"
+                with_vioscsi..with_live_migration.during_bg_test:
+                    wait_bg_finish = yes
+                    image_size_stg = 10G
+                    iozone_cmd_options = "-azR -r 64k -n 1G -g 5G -M -i 0 -i 1 -f %s/iozone_test"
+                with_vioscsi..with_stop_continue.during_bg_test:
+                    wait_bg_finish = yes
             drive_format = scsi-hd
-            iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 1G -g 2G -M -i 0 -i 1 -b iozone.xls -f ${disk_letter}:\testfile"
             iozone_timeout = 7200
             wait_bg_time = 180

--- a/qemu/tests/iozone_linux.py
+++ b/qemu/tests/iozone_linux.py
@@ -1,0 +1,83 @@
+import re
+
+from virttest import error_context
+from virttest import utils_disk
+from virttest import utils_misc
+from provider.storage_benchmark import generate_instance
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Run IOzone for linux on a linux guest:
+    1) Log into a guest.
+    2) Execute the IOzone test.
+    :param test: kvm test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _get_data_disks():
+        """ Get the data disks by serial or wwn options. """
+        disks = {}
+        for data_image in params["images"].split()[1:]:
+            extra_params = params.get("blk_extra_params_%s" % data_image, '')
+            match = re.search(r"(serial|wwn)=(\w+)", extra_params, re.M)
+            if match:
+                drive_id = match.group(2)
+            else:
+                continue
+            drive_path = utils_misc.get_linux_drive_path(session, drive_id)
+            if not drive_path:
+                test.error("Failed to get '%s' drive path" % data_image)
+            disks[drive_path[5:]] = data_image
+        return disks
+
+    def _get_mounted_points():
+        """ Get the mounted points. """
+        points = []
+        for id in re.finditer(r'(%s\d+)' % did, ' '.join(disks)):
+            s = re.search(r'/dev/%s\s+(\S+)\s+' % id.group(1), mount_info, re.M)
+            if s:
+                points.append(s.group(1))
+        return points
+
+    def _wait_for_procs_done(timeout=1800):
+        """ Wait all the processes are done. """
+        if not utils_misc.wait_for(
+                lambda: 'iozone' not in session.cmd_output('pgrep -xl iozone'),
+                timeout, step=3.0):
+            test.error('Not all iozone processes done in %s sec.' % timeout)
+
+    iozone_test_dir = params.get('iozone_test_dir', '/home')
+    iozone_cmd_options = params['iozone_cmd_options']
+    iozone_timeout = float(params.get("iozone_timeout", 1800))
+    n_partitions = params.get('partitions_num', 1)
+    fstype = params.get('fstype', 'xfs')
+    labeltype = params.get('labeltype', utils_disk.PARTITION_TABLE_TYPE_GPT)
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=float(params.get("login_timeout", 360)))
+    _wait_for_procs_done()
+    error_context.context("Running IOzone command on guest.")
+    try:
+        iozone = generate_instance(params, session, 'iozone')
+        dids = _get_data_disks()
+        if dids:
+            mount_info = session.cmd_output_safe('cat /proc/mounts | grep \'/dev/\'')
+            disks = utils_disk.get_linux_disks(session, True)
+            for did, image_name in dids.items():
+                size = params.get('image_size_%s' % image_name)
+                start = params.get('image_start_%s' % image_name, "0M")
+                mounted_points = _get_mounted_points()
+                if not mounted_points:
+                    mounted_points = utils_disk.configure_empty_linux_disk(
+                        session, did, size, start, n_partitions, fstype, labeltype)
+                for mounted_point in mounted_points:
+                    iozone.run(iozone_cmd_options % mounted_point, iozone_timeout)
+                utils_disk.clean_partition_linux(session, did)
+        else:
+            iozone.run(iozone_cmd_options % iozone_test_dir, iozone_timeout)
+    finally:
+        iozone.clean()
+        session.close()


### PR DESCRIPTION
1. Support check the backgroud test for linux.
2. Add linux scenario support in virtio_storage_in_use cfg.
3. Add a new case iozone_linux called from virtio_storage_in_use.

ID: 1611971
Signed-off-by: Yongxue Hong yhong@redhat.com