### PR TITLE
block_copy: change the method of checking block job is steady

### DIFF
--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -359,7 +359,7 @@ class BlockCopy(object):
         """
         params = self.parser_test_args()
         info = self.get_status()
-        ret = bool(info and info["len"] == info["offset"])
+        ret = bool(info and info.get("ready") and not info.get("busy"))
         if params.get("check_event", "no") == "yes":
             ret &= bool(self.vm.monitor.get_event("BLOCK_JOB_READY"))
         return ret


### PR DESCRIPTION
Sometimes, 'query-block-jobs' get 'len'= 0 at the first few seaconds
after 'drive-mirror' start. In this condition, 'len' =='offset' == 0.
It is not really block job steady, will cause 'job-complete' hit error

id: 1684439
Signed-off-by: Yanan Fu <yfu@redhat.com>