### PR TITLE
timedrift&timerdevice: Skip running two test cases before RHEL7 OS

### DIFF
--- a/generic/tests/cfg/timedrift.cfg
+++ b/generic/tests/cfg/timedrift.cfg
@@ -36,6 +36,7 @@
                     drift_threshold = 10
                     drift_threshold_single = 3
                 - with_reboot:
+                    no RHEL.3 RHEL.4 RHEL.5 RHEL.6
                     type = timedrift_with_reboot
                     reboot_iterations = 1
                     drift_threshold = 10

--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -38,6 +38,7 @@
             i386, x86_64:
                 rtc_drift = slew
         - boot_test:
+            no RHEL.3 RHEL.4 RHEL.5 RHEL.6
             type = timerdevice_boot
             i386, x86_64:
                 rtc_drift = slew


### PR DESCRIPTION
The command "timedatectl" isn't supported before RHEL7, update cfg files to drop two test cases.

ID: 1686706

Signed-off-by: Yihuang Yu <yihyu@redhat.com>