### PR TITLE
expose_host_mtu and jumbo: delete redundant ovs ports

### DIFF
--- a/generic/tests/jumbo.py
+++ b/generic/tests/jumbo.py
@@ -44,7 +44,7 @@ def run(test, params, env):
     if not isinstance(host_bridges, utils_net.Bridge):
         ovs = host_bridges
         host_hw_interface = get_ovs_ports(netdst)
-        tmp_ports = re.findall(r"t[0-9]-[a-zA-Z0-9]{6}", host_hw_interface)
+        tmp_ports = re.findall(r"t[0-9]{1,}-[a-zA-Z0-9]{6}", host_hw_interface)
         if tmp_ports:
             for p in tmp_ports:
                 process.system_output("ovs-vsctl del-port %s %s" %

--- a/qemu/tests/expose_host_mtu.py
+++ b/qemu/tests/expose_host_mtu.py
@@ -65,7 +65,7 @@ def run(test, params, env):
         host_hw_interface = utils_net.Bridge().list_iface(netdst)[0]
     elif is_ovs_backend(netdst) is True:
         host_hw_interface = get_ovs_ports(netdst)
-        tmp_ports = re.findall(r"t[0-9]-[a-zA-Z0-9]{6}", host_hw_interface)
+        tmp_ports = re.findall(r"t[0-9]{1,}-[a-zA-Z0-9]{6}", host_hw_interface)
         if tmp_ports:
             for p in tmp_ports:
                 process.system_output("ovs-vsctl del-port %s %s" %


### PR DESCRIPTION
id: 1690216

There might be txx-xxxxxx (more than 1 number after 't') in the
port list, modify the regular expression to fit the situation

Signed-off-by: Xiyue Wang <xiywang@redhat.com>