### PR TITLE
Fix a diskpart timeout issue

### DIFF
--- a/generic/tests/cfg/iometer_windows.cfg
+++ b/generic/tests/cfg/iometer_windows.cfg
@@ -20,7 +20,8 @@
     run_cmd = "cmd /c Iometer.exe /c %s /r %s"
 
     # configuration form format disk:
-    create_partition_cmd = "echo select disk 1 > cmd &&"
+    create_partition_cmd = "echo rescan > cmd &&"
+    create_partition_cmd += "echo select disk 1 > cmd &&"
     create_partition_cmd += " echo create partition primary >> cmd &&"
     create_partition_cmd += " echo select partition 1 >> cmd &&"
     create_partition_cmd += " echo assign letter=I >> cmd &&"

--- a/generic/tests/iometer_windows.py
+++ b/generic/tests/iometer_windows.py
@@ -36,6 +36,9 @@ def run(test, params, env):
     timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=timeout)
 
+    # diskpart requires windows volume INF file and volume setup
+    # events ready, add 10s to wait events done.
+    time.sleep(10)
     # format the target disk
     utils_test.run_virt_sub_test(test, params, env, "format_disk")
 


### PR DESCRIPTION
Rescan first when running windows diskpart.

Diskpart requires windows volume INF file and volume setup
events ready, add 10s to wait events done.

Signed-off-by: Haotong Chen <hachen@redhat.com>

id: 1618586