### PR TITLE
hotplug_mem: Update guest kernel line to make unplug work

### DIFF
--- a/qemu/tests/hotplug_mem.py
+++ b/qemu/tests/hotplug_mem.py
@@ -3,6 +3,7 @@ import time
 
 from avocado.utils.wait import wait_for
 
+from virttest import utils_test
 from virttest import error_context
 from virttest.utils_test import BackgroundTest
 from virttest.utils_test import run_virt_sub_test
@@ -81,6 +82,7 @@ class MemoryHotplugSimple(MemoryHotplugTest):
         vm = self.env.get_vm(self.params["main_vm"])
         vm.wait_for_login(timeout=login_timeout)
         bootup_time = time.time() - vm.start_time
+        utils_test.update_boot_option(vm, args_added="movable_node")
         try:
             if stage != "after":
                 sub_test = sub_test_runner()


### PR DESCRIPTION
Memory hot-unplug only works after adding 'movable_node' to guest
kernel line. This patch will check if the option is there and add
it if not.

ID: 1689802
Signed-off-by: Yumei Huang <yuhuang@redhat.com>