### PR TITLE
balloon_hotplug: wait 10 senconds before unplug balloon devices.

### DIFF
--- a/qemu/tests/balloon_hotplug.py
+++ b/qemu/tests/balloon_hotplug.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import re
+import time
 
 from virttest.qemu_devices import qdevices
 from virttest import error_context
@@ -108,6 +109,9 @@ def run(test, params, env):
                 balloon_test.balloon_memory(int(random.uniform(min_sz, max_sz)))
             else:
                 return
+
+        if params['os_type'] == 'windows':
+            time.sleep(10)
 
         error_context.context("Unplug balloon device for %d times" % (i+1),
                               logging.info)


### PR DESCRIPTION
Unplug balloon device while device in using state are not allowed, windows will prompt a warning for that. So wait a while to make device in idle state then unplug it.

ID:1607208

Signed-off-by: Li Jin <lijin@redhat.com>