### PR TITLE
Fix ioquit call to kill_process_tree

### DIFF
--- a/generic/tests/ioquit.py
+++ b/generic/tests/ioquit.py
@@ -44,7 +44,7 @@ def run(test, params, env):
     session2.cmd(check_cmd, timeout=360)
 
     error_context.context("Kill the VM", logging.info)
-    utils_misc.kill_process_tree(vm.process.get_pid(), wait=60)
+    utils_misc.kill_process_tree(vm.process.get_pid(), timeout=60)
     error_context.context("Check img after kill VM", logging.info)
     base_dir = data_dir.get_data_dir()
     image_name = params.get("image_name")


### PR DESCRIPTION
The commit 58633a7b7e56 added a call to kill_process_tree on
ioquit test. It passes 'wait' parameter that actually does not
exist on kill_process_tree, and instead it should use 'timeout'.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>