### PR TITLE
netperf: some improvement for macvtap env

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -117,7 +117,9 @@
                     Linux:
                         no Jeos
                         # to test exthost <-> guest:
-                        # client = <external host ip>
+                        # client = <external host's private ip>
+                        # client_public_ip = <external host's public ip>
+                        # server_private_ip = <netperf server's private ip>
                     Windows:
                         #client = <external host/guest ip>
                 - best_registry_setting:


### PR DESCRIPTION
1. fix virttest.virt_vm.VMIPAddressMissingError in macvtap env
2. add parameter server_private_ip since guest could not get ip from
dhcp server in macvtap env
3. add parameter client_public_ip to set network interface&apos;s ip on
external host

Signed-off-by: Wenli Quan <wquan@redhat.com>
id: 1693600