### PR TITLE
virtio_scsi_mq: Refectoring virtio_scsi_mq

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_mq.cfg
+++ b/qemu/tests/cfg/virtio_scsi_mq.cfg
@@ -10,9 +10,6 @@
     system_image_drive_format = virtio
     bootindex_image1 = 0
     irq_regex = "virtio\d+-request"
-    ppc64le,ppc64:
-        system_image_drive_format = scsi-hd
-        scsi_hba_image1 = spapr-vscsi
     variants:
         - @default:
             only RHEL

--- a/qemu/tests/virtio_scsi_mq.py
+++ b/qemu/tests/virtio_scsi_mq.py
@@ -3,6 +3,7 @@ import re
 import time
 
 from avocado.utils import cpu as utils_cpu
+
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import env_process
@@ -16,88 +17,191 @@ def run(test, params, env):
     Qemu multiqueue test for virtio-scsi controller:
 
     1) Boot up a guest with virtio-scsi device which support multi-queue and
-       the vcpu and images number of guest should match the multi-queue number
-    2) Check the multi queue option from monitor
-    3) Check device init status in guest
-    4) Load I/O in all targets
-    5) Check the interrupt queues in guest
+       the vcpu and images number of guest should match the multi-queue number.
+    2) Pin the vcpus to the host cpus.
+    3) Check the multi queue option from monitor.
+    4) Check device init status in guest
+    5) Pin the interrupts to the vcpus.
+    6) Load I/O in all targets.
+    7) Check the interrupt queues in guest.
 
     :param test: QEMU test object
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    def proc_interrupts_results(results, irqs_pattern):
-        results_dict = {}
-        cpu_count = 0
-        cpu_list = []
-        for line in results.splitlines():
-            line = line.strip()
-            if re.match("CPU0", line):
-                cpu_list = re.findall(r"CPU\d+", line)
-                cpu_count = len(cpu_list)
-                continue
-            if cpu_count > 0:
-                irq_key = re.split(":", line)[0]
-                if re.findall(irqs_pattern, re.split(":", line)[-1]):
-                    results_dict[irq_key] = {}
-                    content = line[len(irq_key) + 1:].strip()
-                    if len(re.split(r"\s+", content)) < cpu_count:
-                        continue
-                    count = 0
-                    irq_des = ""
-                    for irq_item in re.split(r"\s+", content):
-                        if count < cpu_count:
-                            if count == 0:
-                                results_dict[irq_key]["count"] = []
-                            results_dict[irq_key]["count"].append(irq_item)
-                        else:
-                            irq_des += " %s" % irq_item
-                        count += 1
-                    results_dict[irq_key]["irq_des"] = irq_des.strip()
-        if not results_dict:
-            test.error("Couldn't find virtio request interrupts from procfs")
-        return results_dict, cpu_list
+    def get_mapping_interrupts2vcpus(irqs, pattern):
+        """ Get the mapping of between virtio interrupts and vcpus. """
+        regex = r'(\d+):(\s+(\d+\s+){%d})\s+.+\s%s\s' % (
+            len(re.findall(r"\s+CPU\d+", irqs, re.M)), pattern)
+        return {f[0]: {'count': f[1].split()} for f in re.findall(regex, irqs, re.M)}
 
-    timeout = float(params.get("login_timeout", 240))
-    host_cpu_num = utils_cpu.online_cpus_count()
-    while host_cpu_num:
-        num_queues = str(host_cpu_num)
-        host_cpu_num &= host_cpu_num - 1
-    params['smp'] = num_queues
-    params['num_queues'] = num_queues
-    images_num = int(num_queues)
-    extra_image_size = params.get("image_size_extra_images", "512M")
-    system_image = params.get("images")
-    system_image_drive_format = params.get("system_image_drive_format",
-                                           "virtio")
-    params["drive_format_%s" % system_image] = system_image_drive_format
+    def create_data_images():
+        """ Create date image objects. """
+        for extra_image in range(images_num):
+            image_tag = "stg%s" % extra_image
+            params["images"] += " %s" % image_tag
+            params["image_name_%s" % image_tag] = "images/%s" % image_tag
+            params["image_size_%s" % image_tag] = extra_image_size
+            params["force_create_image_%s" % image_tag] = "yes"
+            image_params = params.object_params(image_tag)
+            env_process.preprocess_image(test, image_params, image_tag)
 
-    error_context.context("Boot up guest with block devcie with num_queues"
-                          " is %s and smp is %s" % (num_queues, params['smp']),
-                          logging.info)
-    for vm in env.get_all_vms():
-        if vm.is_alive():
-            vm.destroy()
-    for extra_image in range(images_num):
-        image_tag = "stg%s" % extra_image
-        params["images"] += " %s" % image_tag
-        params["image_name_%s" % image_tag] = "images/%s" % image_tag
-        params["image_size_%s" % image_tag] = extra_image_size
-        params["force_create_image_%s" % image_tag] = "yes"
-        image_params = params.object_params(image_tag)
-        env_process.preprocess_image(test, image_params, image_tag)
+    def check_irqbalance_status():
+        """ Check the status of irqbalance service. """
+        error_context.context("Check irqbalance service status.", logging.info)
+        return re.findall("Active: active", session.cmd_output(status_cmd))
 
-    params["start_vm"] = "yes"
-    vm = env.get_vm(params["main_vm"])
-    env_process.preprocess_vm(test, params, env, vm.name)
-    session = vm.wait_for_login(timeout=timeout)
+    def start_irqbalance_service():
+        """ Start the irqbalance service. """
+        error_context.context("Start the irqbalance service.", logging.info)
+        session.cmd("systemctl start irqbalance")
+        output = utils_misc.strip_console_codes(session.cmd_output(status_cmd))
+        if not re.findall("Active: active", output):
+            test.cancel("Can not start irqbalance inside guest.Skip this test.")
 
-    if params.get("os_type") == "windows":
+    def pin_vcpus2host_cpus():
+        """ Pint the vcpus to the host cpus. """
+        error_context.context("Pin vcpus to host cpus.", logging.info)
+        host_numa_nodes = utils_misc.NumaInfo()
+        vcpu_num = 0
+        for numa_node_id in host_numa_nodes.nodes:
+            numa_node = host_numa_nodes.nodes[numa_node_id]
+            for _ in range(len(numa_node.cpus)):
+                if vcpu_num >= len(vm.vcpu_threads):
+                    break
+                vcpu_tid = vm.vcpu_threads[vcpu_num]
+                logging.debug(
+                    "pin vcpu thread(%s) to cpu(%s)" % (
+                        vcpu_tid, numa_node.pin_cpu(vcpu_tid)))
+                vcpu_num += 1
+
+    def verify_num_queues():
+        """ Verify the number of queues. """
+        error_context.context("Verify num_queues from monitor.", logging.info)
+        qtree = qemu_qtree.QtreeContainer()
+        try:
+            qtree.parse_info_qtree(vm.monitor.info('qtree'))
+        except AttributeError:
+            test.cancel("Monitor deson't supoort qtree skip this test")
+        error_msg = "Number of queues mismatch: expect %s report from monitor: %s(%s)"
+        scsi_bus_addr = ""
+        qtree_num_queues_full = ""
+        qtree_num_queues = ""
+        for node in qtree.get_nodes():
+            type = node.qtree['type']
+            if isinstance(node, qemu_qtree.QtreeDev) and (
+                    type == "virtio-scsi-device"):
+                qtree_num_queues_full = node.qtree["num_queues"]
+                qtree_num_queues = re.search(
+                    "[0-9]+", qtree_num_queues_full).group()
+            elif (isinstance(node, qemu_qtree.QtreeDev)) and (
+                    type == "virtio-scsi-pci"):
+                scsi_bus_addr = node.qtree['addr']
+
+        if qtree_num_queues != num_queues:
+            error_msg = error_msg % (
+                num_queues, qtree_num_queues, qtree_num_queues_full)
+            test.fail(error_msg)
+        if not scsi_bus_addr:
+            test.error("Didn't find addr from qtree. Please check the log.")
+
+    def check_interrupts():
+        """ Check the interrupt queues in guest. """
+        error_context.context("Check the interrupt queues in guest.", logging.info)
+        return session.cmd_output(irq_check_cmd)
+
+    def check_interrupts2vcpus(irq_map):
+        """ Check the status of interrupters to vcpus. """
+        error_context.context(
+            "Check the status of interrupters to vcpus.", logging.info)
+        cpu_selects = {}
+        cpu_select = 1
+        for _ in range(int(num_queues)):
+            val = ','.join([_[::-1] for _ in re.findall(r'\w{8}|\w+', format(
+                cpu_select, 'x')[::-1])][::-1])
+            cpu_selects[val] = format(cpu_select, 'b').count('0')
+            cpu_select = cpu_select << 1
+        irqs_id_reset = []
+        for irq_id in irq_map.keys():
+            cmd = 'cat /proc/irq/%s/smp_affinity' % irq_id
+            cpu_selected = re.sub(
+                r'(^[0+,?0+]+)|(,)', '', session.cmd_output(cmd)).strip()
+            if cpu_selected not in cpu_selects:
+                irqs_id_reset.append(irq_id)
+            else:
+                cpu_irq_map[irq_id] = cpu_selects[cpu_selected]
+                del cpu_selects[cpu_selected]
+        return irqs_id_reset, cpu_selects
+
+    def pin_interrupts2vcpus(irqs_id_reset, cpu_selects):
+        """ Pint the interrupts to vcpus. """
+        bind_cpu_cmd = []
+        for irq_id, cpu_select in zip(irqs_id_reset, cpu_selects):
+            bind_cpu_cmd.append(
+                "echo %s > /proc/irq/%s/smp_affinity" % (cpu_select, irq_id))
+            cpu_irq_map[irq_id] = cpu_selects[cpu_select]
+        if bind_cpu_cmd:
+            error_context.context("Pin interrupters to vcpus", logging.info)
+            session.cmd(' && '.join(bind_cpu_cmd))
+        return cpu_irq_map
+
+    def _get_data_disks(session):
+        """ Get the data disks. """
+        output = session.cmd_output(params.get("get_dev_cmd", "ls /dev/[svh]d*"))
+        system_dev = re.search(r"/dev/([svh]d\w+)(?=\d+)", output, re.M).group(1)
+        return (dev for dev in output.split() if system_dev not in dev)
+
+    def check_io_status(timeout):
+        """ Check the status of I/O. """
+        chk_session = vm.wait_for_login(timeout=360)
+        while int(chk_session.cmd_output("pgrep -lx dd | wc -l", timeout)):
+            time.sleep(5)
+        chk_session.close()
+
+    def load_io_data_disks():
+        """ Load I/O on data disks. """
+        error_context.context("Load I/O in all targets", logging.info)
+        dd_session = vm.wait_for_login(timeout=360)
+        dd_timeout = int(re.findall(r"\d+", extra_image_size)[0])
+        cmd = "dd of=%s if=/dev/urandom bs=1M count=%s oflag=direct &"
+        cmds = [cmd % (dev, dd_timeout) for dev in _get_data_disks(dd_session)]
+        if len(cmds) != images_num:
+            test.error(
+                "Disks are not all show up in system, only %s disks." % len(cmds))
+
+        # As Bug 1177332 exists, mq is not supported completely.
+        # So don't considering performance currently, dd_timeout is longer.
+        dd_session.cmd(' '.join(cmds), dd_timeout * images_num * 2)
+        check_io_status(dd_timeout)
+        dd_session.close()
+
+    def compare_interrupts(prev_irqs, cur_irqs):
+        """ Compare the interrupts between after and before IO. """
+        cpu_not_used = []
+        diff_interrupts = {}
+        for irq in prev_irqs.keys():
+            cpu = int(cpu_irq_map[irq])
+            diff_val = int(
+                cur_irqs[irq]['count'][cpu]) - int(prev_irqs[irq]['count'][cpu])
+            if diff_val == 0:
+                cpu_not_used.append('CPU%s' % cpu)
+            else:
+                diff_interrupts[cpu] = diff_val
+        logging.debug('The changed number of interrupts:')
+        for k, v in sorted(diff_interrupts.items()):
+            logging.debug('  CPU%s: %d' % (k, v))
+        if cpu_not_used:
+            cpus = " ".join(cpu_not_used)
+            error_msg = ("%s are not used during test. "
+                         "Please check debug log for more information.")
+            test.fail(error_msg % cpus)
+
+    def wmi_facility_test(session):
         driver_name = params["driver_name"]
         wmi_check_cmd = params["wmi_check_cmd"]
         pattern = params["pattern"]
-        session = utils_test.qemu.windrv_check_running_verifier(session, vm, test,
-                                                                driver_name, timeout)
+        session = utils_test.qemu.windrv_check_running_verifier(
+            session, vm, test, driver_name, timeout)
         wmi_check_cmd = utils_misc.set_winutils_letter(session, wmi_check_cmd)
         error_context.context("Run wmi check in guest.", logging.info)
         output = session.cmd_output(wmi_check_cmd)
@@ -109,130 +213,43 @@ def run(test, params, env):
                           % (queue_num, num_queues))
         finally:
             session.close()
-            return
-    error_context.context("Check irqbalance service status", logging.info)
-    output = session.cmd_output("systemctl status irqbalance")
-    if not re.findall("Active: active", output):
-        session.cmd("systemctl start irqbalance")
-        output = session.cmd_output("systemctl status irqbalance")
-        output = utils_misc.strip_console_codes(output)
-        if not re.findall("Active: active", output):
-            test.cancel("Can not start irqbalance inside guest. "
-                        "Skip this test.")
 
-    error_context.context("Pin vcpus to host cpus", logging.info)
-    host_numa_nodes = utils_misc.NumaInfo()
-    vcpu_num = 0
-    for numa_node_id in host_numa_nodes.nodes:
-        numa_node = host_numa_nodes.nodes[numa_node_id]
-        for _ in range(len(numa_node.cpus)):
-            if vcpu_num >= len(vm.vcpu_threads):
-                break
-            vcpu_tid = vm.vcpu_threads[vcpu_num]
-            logging.debug("pin vcpu thread(%s) to cpu"
-                          "(%s)" % (vcpu_tid,
-                                    numa_node.pin_cpu(vcpu_tid)))
-            vcpu_num += 1
-
-    error_context.context("Verify num_queues from monitor", logging.info)
-    qtree = qemu_qtree.QtreeContainer()
-    try:
-        qtree.parse_info_qtree(vm.monitor.info('qtree'))
-    except AttributeError:
-        test.cancel("Monitor deson't supoort qtree skip this test")
-    error_msg = "Number of queues mismatch: expect %s"
-    error_msg += " report from monitor: %s(%s)"
-    scsi_bus_addr = ""
-    qtree_num_queues_full = ""
-    qtree_num_queues = ""
-    for node in qtree.get_nodes():
-        if isinstance(node, qemu_qtree.QtreeDev) and (
-                node.qtree['type'] == "virtio-scsi-device"):
-            qtree_num_queues_full = node.qtree["num_queues"]
-            qtree_num_queues = re.search(
-                "[0-9]+",
-                qtree_num_queues_full).group()
-        elif isinstance(node, qemu_qtree.QtreeDev) and node.qtree['type'] == "virtio-scsi-pci":
-            scsi_bus_addr = node.qtree['addr']
-
-    if qtree_num_queues != num_queues:
-        error_msg = error_msg % (num_queues,
-                                 qtree_num_queues,
-                                 qtree_num_queues_full)
-        test.fail(error_msg)
-    if not scsi_bus_addr:
-        test.error("Didn't find addr from qtree. Please check the log.")
-    error_context.context("Check device init status in guest", logging.info)
+    cpu_irq_map = {}
+    timeout = float(params.get("login_timeout", 240))
+    num_queues = str(utils_cpu.online_cpus_count())
+    params['smp'] = num_queues
+    params['num_queues'] = num_queues
+    images_num = int(num_queues)
+    extra_image_size = params.get("image_size_extra_images", "512M")
+    system_image = params.get("images")
+    system_image_drive_format = params.get("system_image_drive_format", "virtio")
+    params["drive_format_%s" % system_image] = system_image_drive_format
     irq_check_cmd = params.get("irq_check_cmd", "cat /proc/interrupts")
-    output = session.cmd_output(irq_check_cmd)
     irq_name = params.get("irq_regex")
-    prev_irq_results, _ = proc_interrupts_results(output, irq_name)
-    logging.debug('The info of interrupters before testing:')
-    for irq_watch in prev_irq_results.keys():
-        logging.debug('%s : %s %s' % (irq_watch, prev_irq_results[irq_watch]['count'],
-                                      prev_irq_results[irq_watch]['irq_des']))
+    status_cmd = "systemctl status irqbalance"
 
-    error_context.context("Pin the interrupters to vcpus", logging.info)
-    cpu_select = 1
-    for irq_id in prev_irq_results.keys():
-        bind_cpu_cmd = "echo %s > /proc/irq/%s/smp_affinity" % \
-                       (hex(cpu_select).replace('0x', ''), irq_id)
-        cpu_select = cpu_select << 1
-        session.cmd(bind_cpu_cmd)
-
-    error_context.context("Load I/O in all targets", logging.info)
-    get_dev_cmd = params.get("get_dev_cmd", "ls /dev/[svh]d*")
-    output = session.cmd_output(get_dev_cmd)
-    system_dev = re.findall(r"/dev/[svh]d\w+(?=\d+)", output)[0]
-    dd_timeout = int(re.findall(r"\d+", extra_image_size)[0])
-    fill_cmd = ""
-    count = 0
-    for dev in re.split(r"\s+", output):
-        if not dev:
-            continue
-        if not re.findall(system_dev, dev):
-            fill_cmd += " dd of=%s if=/dev/urandom bs=1M " % dev
-            fill_cmd += "count=%s oflag=direct &" % dd_timeout
-            count += 1
-    if count != images_num:
-        test.error("Disks are not all show up in system. Output "
-                   "from the check command: %s" % output)
-    # As Bug 1177332 exists, mq is not supported completely.
-    # So don't considering performance currently, dd_timeout is longer.
-    dd_timeout = dd_timeout * images_num * 2
-    session.cmd(fill_cmd, timeout=dd_timeout)
-
-    dd_thread_num = count
-    while dd_thread_num:
-        time.sleep(5)
-        dd_thread_num = session.cmd_output("pgrep -x dd", timeout=dd_timeout)
-
-    error_context.context("Check the interrupt queues in guest", logging.info)
-    output = session.cmd_output(irq_check_cmd)
-    next_irq_results, cpu_list = proc_interrupts_results(output, irq_name)
-    logging.debug('The info of interrupters after testing :')
-    for irq_watch in next_irq_results.keys():
-        logging.debug('%s : %s %s' % (irq_watch, next_irq_results[irq_watch]['count'],
-                                      next_irq_results[irq_watch]['irq_des']))
-    irq_bit_map = 0
-    for irq_watch in next_irq_results.keys():
-        for index, count in enumerate(next_irq_results[irq_watch]["count"]):
-            if (int(count) - int(prev_irq_results[irq_watch]["count"][index])) > 0:
-                irq_bit_map |= 2 ** index
-
-    error_msg = ""
-    cpu_not_used = []
-    for index, cpu in enumerate(cpu_list):
-        if 2 ** index & irq_bit_map != 2 ** index:
-            cpu_not_used.append(cpu)
-
-    if cpu_not_used:
-        logging.debug("Interrupt info from procfs:\n%s" % output)
-        error_msg = " ".join(cpu_not_used)
-        if len(cpu_not_used) > 1:
-            error_msg += " are"
-        else:
-            error_msg += " is"
-        error_msg += " not used during test. Please check debug log for"
-        error_msg += " more information."
-        test.fail(error_msg)
+    error_context.context("Boot up guest with block devcie with num_queues"
+                          " is %s and smp is %s" % (num_queues, params['smp']),
+                          logging.info)
+    for vm in env.get_all_vms():
+        if vm.is_alive():
+            vm.destroy()
+    create_data_images()
+    params["start_vm"] = "yes"
+    vm = env.get_vm(params["main_vm"])
+    env_process.preprocess_vm(test, params, env, vm.name)
+    session = vm.wait_for_login(timeout=timeout)
+    if params["os_type"] == "windows":
+        wmi_facility_test(session)
+        return
+    if not check_irqbalance_status():
+        start_irqbalance_service()
+    pin_vcpus2host_cpus()
+    verify_num_queues()
+    prev_irqs = check_interrupts()
+    prev_mapping = get_mapping_interrupts2vcpus(prev_irqs, irq_name)
+    pin_interrupts2vcpus(*check_interrupts2vcpus(prev_mapping))
+    load_io_data_disks()
+    cur_irqs = check_interrupts()
+    cur_mapping = get_mapping_interrupts2vcpus(cur_irqs, irq_name)
+    compare_interrupts(prev_mapping, cur_mapping)


### PR DESCRIPTION
Wrap sentences to functions as below:
1. get_mapping_interrupts2vcpus: Get the mapping of between virtio
   interrupts and vcpus.
2. create_data_images: Creating date images.
3. check_irqbalance_status: Checking the status of irq balance server.
4. start_irqbalance_service: Start the irqbalance service.
5. pin_vcpus2host_cpus: Pinning the vcpus to host cpus.
6. verify_num_queues: Verifying the number of queues from qtree.
7. check_interrupts: Checking the info of interrupts.
8. check_interrupts2vcpus: Checking the status of interrupters to vcpus.
9. pin_interrupts2vcpus: Pinning the interrupts to vcpus.
10. check_io_status: Check the status of I/O.
11. load_io_data_disks: Loading io on data disks.
12. compare_interrupts: Comparing the info of interrupts after io testing.

Delete the setting of scsi hba for ppc, using the default(virtio-blk-pci).

ID: 1425298, 1567877
Signed-off-by: Yongxue Hong <yhong@redhat.com>