### PR TITLE
multi_disk_random_hotplug: Update the steps

### DIFF
--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -1,19 +1,31 @@
 - multi_disk_random_hotplug: install setup image_copy unattended_install.cdrom
     type = multi_disk_random_hotplug
+    start_vm = no
+    not_preprocess = yes
     force_create_image = yes
     force_create_image_image1 = no
     remove_image = yes
     remove_image_image1 = no
     stg_image_name = "images/stg%s"
     stg_image_num = 20
+    stg_image_size = 15G
     repeat_times = 3
     wait_between_hotplugs = 2
     wait_after_hotplug = 10
     wait_between_unplugs = 2
     ppc64le,ppc64:
-        wait_between_unplugs = 20    
+        wait_between_unplugs = 20
+    q35:
+        pcie_extra_root_port = ${stg_image_num}
     # since image check is executed after unplug wait can be 0
     wait_after_unplug = 10
+    Windows:
+        virtio_blk:
+            driver_name = viostor
+        virtio_scsi:
+            driver_name = vioscsi
+        iozone_cmd_option = '-azR -r 64k -n 1G -g 1G -M -i 0 -i 1 -I -b iozone_{0}.xls -f {0}:\testfile'
+        iozone_timeout = 1800
     Linux:
         # We have multiple disks so just ignor first one of each type
         no_stress_cmds = 100
@@ -26,6 +38,8 @@
         stress_stop_cmd = kill -19 `cat /tmp/disk_stress`
         stress_cont_cmd = kill -18 `cat /tmp/disk_stress`
         stress_kill_cmd = "rm -f /tmp/disk_stress"
+        dd_cmd = 'dd if={0} of=/dev/null bs=1M count=1000 iflag=direct '
+        dd_cmd += '&& dd if=/dev/zero of={0} bs=1M count=1000 oflag=direct'
     variants:
         - all_types:
             stg_params = "fmt:virtio,virtio_scsi,lsi_scsi,usb2"
@@ -36,8 +50,19 @@
             Host_RHEL.m6:
                 usbs= "ehci"
                 usb_type_ehci = ich9-usb-ehci1
+            dd_timeout = 1800
         - single_type:
             no ide, ahci, scsi
+            virtio_scsi:
+                stg_params = "fmt:virtio_scsi"
+                stg_image_num = 254
+                set_drive_bus = no
+                dd_timeout = 3600
+                q35:
+                    stg_image_num = 25
+                    set_drive_bus = yes
+                    pcie_extra_root_port = ${stg_image_num}
+                    dd_timeout = 1800
     variants:
         - @serial:
         - parallel:


### PR DESCRIPTION
block_devices_plug: Add lock to avoid duplicate bus device
Add a lock to avoid to add the duplicate bus device in the
parallel mode.

multi_disk_random_hotplug: Refactoring the codes
Summary:
1. Add a step that checks whether vioscsi.sys verifier
   enabled in guest.
2. Add a step that does iozone and dd test on the new disks
   after check hotplug status.
3. Fix support the machine type q35.
4. Call the BlockDevicesPlug's methods instead of the parts
   of hotplug and unplug.
5. Define a configure_images_params that configures images
   by params instead of the original parts.

ID: 1542350, 1566866
Signed-off-by: Yongxue Hong <yhong@redhat.com>