### PR TITLE
timerdevice: fix python3 issue

### DIFF
--- a/qemu/tests/timerdevice_clock_drift_with_ntp.py
+++ b/qemu/tests/timerdevice_clock_drift_with_ntp.py
@@ -40,7 +40,7 @@ def run(test, params, env):
                           logging.info)
     host_cmd = "cat /sys/devices/system/clocksource/"
     host_cmd += "clocksource0/current_clocksource"
-    if "tsc" not in process.system_output(host_cmd):
+    if "tsc" not in process.getoutput(host_cmd):
         test.cancel("Host must use 'tsc' clocksource")
 
     error_context.context("Boot the guest", logging.info)

--- a/qemu/tests/timerdevice_tscsync_change_host_clksource.py
+++ b/qemu/tests/timerdevice_tscsync_change_host_clksource.py
@@ -29,7 +29,7 @@ def run(test, params, env):
                           logging.info)
     host_cmd = "cat /sys/devices/system/clocksource/"
     host_cmd += "clocksource0/current_clocksource"
-    if "tsc" not in process.system_output(host_cmd):
+    if "tsc" not in process.getoutput(host_cmd):
         test.cancel("Host must use 'tsc' clocksource")
 
     error_context.context("Boot the guest with one cpu socket", logging.info)

--- a/qemu/tests/timerdevice_tscsync_longtime.py
+++ b/qemu/tests/timerdevice_tscsync_longtime.py
@@ -27,7 +27,7 @@ def run(test, params, env):
                           logging.info)
     host_cmd = "cat /sys/devices/system/clocksource/"
     host_cmd += "clocksource0/current_clocksource"
-    if "tsc" not in process.system_output(host_cmd):
+    if "tsc" not in process.getoutput(host_cmd):
         test.cancel("Host must use 'tsc' clocksource")
 
     error_context.context("Check host has more than one cpu socket",

--- a/qemu/tests/timerdevice_tscwrite.py
+++ b/qemu/tests/timerdevice_tscwrite.py
@@ -22,7 +22,7 @@ def run(test, params, env):
                           logging.info)
     host_cmd = "cat /sys/devices/system/clocksource/"
     host_cmd += "clocksource0/current_clocksource"
-    if "tsc" not in process.system_output(host_cmd):
+    if "tsc" not in process.getoutput(host_cmd):
         test.cancel("Host must use 'tsc' clocksource")
 
     error_context.context("Boot the guest", logging.info)


### PR DESCRIPTION
a bytes-like object is required, not 'str'

bug id: 1693995
Signed-off-by: yama <yama@redhat.com>