### PR TITLE
timerdevice_boot: Session is closed in advance

### DIFF
--- a/qemu/tests/timerdevice_boot.py
+++ b/qemu/tests/timerdevice_boot.py
@@ -183,6 +183,6 @@ def run(test, params, env):
         verify_timedrift(session)
         if params["os_type"] == "linux":
             verify_timedrift(session, is_hardware=True)
-    session.close()
     if need_restore_clksrc:
         update_clksrc(session, origin_clksrc)
+    session.close()


### PR DESCRIPTION
bug id: 1693928
Signed-off-by: yama <yama@redhat.com>