### PR TITLE
nvdimm: update the format nvdimm command

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -20,6 +20,8 @@
     pre_command = "dd if=/dev/zero of=${nv_backend} bs=1M count=1024"
     pmem = /dev/pmem0
     format_command = "mkfs.xfs -f ${pmem}"
+    RHEL.8:
+        format_command += " -m reflink=0"
     mount_command = "mount -o dax ${pmem} ${mount_dir}"
     post_command = "rm -rf ${nv_backend}"
     mem_devs = mem1


### PR DESCRIPTION
From RHEL8, according to product bz 1620330: "To test or use dax on
xfs, reflink must be turned off". So update the format command, add
"-m reflink=0"

id: 1699968
Signed-off-by: Yanan Fu <yfu@redhat.com>