### PR TITLE
Add limitation for some multi queues test cases

### DIFF
--- a/qemu/tests/cfg/flow_caches_stress_test.cfg
+++ b/qemu/tests/cfg/flow_caches_stress_test.cfg
@@ -23,6 +23,7 @@
     variants:
         - multi_queues:
             no Host_RHEL.m5, Host_RHEL.m6
+            only virtio_net
             queues = 4
         - no_multi_queues:
             queues = 1

--- a/qemu/tests/cfg/mq_change_qnum.cfg
+++ b/qemu/tests/cfg/mq_change_qnum.cfg
@@ -1,5 +1,6 @@
 - mq_change_qnum:
     only Linux
+    only virtio_net
     queues = 4
     no Host_RHEL.m5, Host_RHEL.m6
     # Here vectors should be queues * 2 + 2

--- a/qemu/tests/cfg/mq_max_queues.cfg
+++ b/qemu/tests/cfg/mq_max_queues.cfg
@@ -1,6 +1,7 @@
 - mq_max_queues:
     queues = 8
     only Linux
+    only virtio_net
     virt_test_type = qemu
     type = mq_change_qnum
     no Host_RHEL.m5, Host_RHEL.m6


### PR DESCRIPTION
Multi queues test cases are not meaningful for other virtual network
device except virtio-net-pci, add limitation (only virtio_net) for these
cases.

ID: 1700180
Signed-off-by: Yihuang Yu <yihyu@redhat.com>