### PR TITLE
set_link: drop 'set_link' test cases for spapr-vlan

### DIFF
--- a/qemu/tests/cfg/set_link.cfg
+++ b/qemu/tests/cfg/set_link.cfg
@@ -1,4 +1,5 @@
 - set_link: install setup image_copy unattended_install.cdrom
+    no spapr-vlan
     requires_root = yes
     type = set_link
     test_timeout = 2500


### PR DESCRIPTION
spapr-vlan doesn't advertise the link state, drop these cases for it.

ID: 1698838
Signed-off-by: Yihuang Yu <yihyu@redhat.com>