### PR TITLE
iometer_windows: Add new cases

### DIFF
--- a/generic/tests/cfg/iometer_windows.cfg
+++ b/generic/tests/cfg/iometer_windows.cfg
@@ -1,4 +1,3 @@
-
 - iometer_windows:
     only Windows
     type = iometer_windows
@@ -53,3 +52,24 @@
                     cpu_family = "0xf"
                 - msi_off:
                     cpu_family = "0xe"
+        - pm_test:
+            run_timeout = 1000
+            variants:
+                - shutdown_vm:
+                    shutdown_vm = yes
+                    command_qmp = system_powerdown
+                    command_shell = shutdown -t 0 -s
+                - reboot_vm:
+                    reboot_vm = yes
+                    command_qmp = system_reset
+                    command_shell = shutdown -t 0 -r
+            variants:
+                - send_qmp:
+                    command_opts = qmp,${command_qmp}
+                - send_shell:
+                    command_opts = shell,${command_shell}
+            variants:
+                - during_test:
+                    bg_mode = yes
+                - after_test:
+                    bg_mode = no


### PR DESCRIPTION
Add 4 cases:
1. Reboot guest after  Iometer running.
2. Shutdown guest after Iometer running.
3. Reboot guest when running iometer.
4. Shutdown guest when running iometer.

Wrap sentences to functions as below:
1. install_iometer
2. register_iometer
3. prepare_ifc_file
4. _run_backgroud
5. run_iometer
6. change_vm_status
7. check_vm_status

ID: 1566870
Signed-off-by: Yongxue Hong <yhong@redhat.com>