### PR TITLE
rh_kernel_update: stop vm before commit the change to base image

### DIFF
--- a/qemu/tests/rh_kernel_update.py
+++ b/qemu/tests/rh_kernel_update.py
@@ -322,4 +322,5 @@ def run(test, params, env):
     base_dir = params.get("images_base_dir", data_dir.get_data_dir())
     image_filename = storage.get_image_filename(params, base_dir)
     block = vm.get_block({"backing_file": image_filename})
+    vm.monitor.cmd("stop")
     vm.monitor.send_args_cmd("commit %s" % block)


### PR DESCRIPTION
This case use 'snapshot=on' when doing kernel update, and commit
the change to the base image after update successful.
But, in some case, during guest running, 'commit' is not reliable,
cause the image be damaged. So 'stop' vm before 'commit' to avoid
this issue.

id: 1700693
Signed-off-by: Yanan Fu <yfu@redhat.com>