### PR TITLE
block_hotplug: Refectoring block_hotplug

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -23,12 +23,10 @@
 
     variants:
         - one_pci:
-            blk_num = 1
             repeat_times = 1
         - multi_pci:
             q35, arm64-pci:
                 pcie_extra_root_port = 2
-            blk_num = 2
             repeat_times = 1
             images += " stg1"
             boot_drive_stg1 = no


### PR DESCRIPTION
    Update the order of importing modules by PEP8.
    
    Wrap the codes to function:
      1. Update function find_disk and rename it.
      2. Update function run_sub_test.
      3. Wrap the part of waiting plugging disks completely to
         function wait_plug_disks.
      4. Wrap the part of creating block devices to function
         create_block_devices.
      5. Wrap the part of getting block devices to function
         get_block_devices.
      6. Wrap the part of hotplug or unplug block devices to
         function plug_block_devices.
      7. Wrap the part of format windows disk to function format_disk_win.
      8. Wrap the part of doing io testing on disk to function
         run_io_test.
      9. Update function get_disk_size.

ID: 1550800, 1617971, 1624674
Signed-off-by: Yongxue Hong <yhong@redhat.com>