### PR TITLE
timedrift_check_when_crash: add "-no-shutdown" for linux guest

### DIFF
--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -34,6 +34,7 @@
                     only Windows
                     nmi_cmd = "monitor:inject-nmi"
                 - hang:
+                    extra_params += " -no-shutdown"
                     kill_vm = yes
                     # Notes:
                     # please stop kernel crash recovery service like 'kdump' before trigger kernek panic,

--- a/qemu/tests/timedrift_check_when_crash.py
+++ b/qemu/tests/timedrift_check_when_crash.py
@@ -29,6 +29,7 @@ def run(test, params, env):
     nmi_cmd = params.get("nmi_cmd", "inject-nmi")
     sleep_time = float(params.get("sleep_time", 1800))
     deviation = float(params.get("deviation", 5))
+    os_type = params["os_type"]
 
     error_context.context("sync host time with ntp server", logging.info)
     process.system(clock_sync_command, shell=True)
@@ -61,6 +62,8 @@ def run(test, params, env):
     time.sleep(sleep_time)
     # Autotest parses serial output and could raise VMDeadKernelCrash
     # we generated using sysrq. Ignore one "BUG:" line
+    if os_type == "linux":
+        vm.resume()
     try:
         session = vm.reboot(method="system_reset")
     except VMDeadKernelCrashError as details:


### PR DESCRIPTION
When guest kernel panic occurs, keep the qemu process alive.

bug id: 1549005
Signed-off-by: yama <yama@redhat.com>