### PR TITLE
timedrift_check_non_event: add pattern for rhel6 guest

### DIFF
--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -63,7 +63,7 @@
             hwclock_time_command = "LC_TIME=C hwclock -u"
             hwclock_time_filter_re = "(\d+-\d+-\d+ \d+:\d+:\d+).*"
             hwclock_time_format = "%Y-%m-%d %H:%M:%S"
-            RHEL.7:
+            RHEL.6, RHEL.7:
                 hwclock_time_filter_re = "(\S+ \S+\s+\d+ \d+:\d+:\d+ \d+).*"
                 hwclock_time_format = "%a %b %d %H:%M:%S %Y"
             time_forward = 3600


### PR DESCRIPTION
Because the output of "hwclock -u" in rhel6 is different.

bug id: 1695462
Signed-off-by: yama <yama@redhat.com>