### PR TITLE
timerdevice: remove "no up"

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -18,7 +18,6 @@
             msr_tools_cmd = "a=$(rdmsr -d 0x00000010); echo -e ibase=16\\n $a  | tail -n 1 | while read n; do wrmsr 0x00000010 $(($n+100000000000)); echo $n; done"
         - clock_drift_with_sleep:
             only RHEL
-            no up
             type = timerdevice_clock_drift_with_sleep
             rtc_base = utc
             rtc_clock = host


### PR DESCRIPTION
Timer device cases need variant up.

bug id: 1701138
Signed-off-by: yama <yama@redhat.com>