### PR TITLE
timerclock: define different patterns for different RHELs

### DIFF
--- a/generic/tests/cfg/timerclock.cfg
+++ b/generic/tests/cfg/timerclock.cfg
@@ -10,3 +10,6 @@
             type = tsc
         - hwclock:
             type = hwclock
+            date_pattern = "1980-02-02 *03:04:"
+            RHEL.6, RHEL.7:
+                date_pattern = "Sat *Feb *2 *03:04:.. 1980"


### PR DESCRIPTION
bug id: 1694054
Signed-off-by: yama <yama@redhat.com>