### PR TITLE
timedrift_check_when_crash: update ntp cmd for rhel6 and remove excep…

### DIFF
--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -6,8 +6,10 @@
     requires_root = yes
     ntp_server = "clock.redhat.com"
     ntp_cmd = "(systemctl stop chronyd || service ntpdate stop)"
-    ntp_cmd += " && chronyd -q 'server clock.redhat.com iburst'"
+    ntp_cmd += " && (chronyd -q 'server clock.redhat.com iburst'"
+    ntp_cmd +=  " || ntpdate clock.redhat.com)"
     ntp_query_cmd = "chronyd -Q 'server clock.redhat.com iburst'"
+    ntp_query_cmd += " || ntpdate -q clock.redhat.com"
     Windows:
         ntp_cmd = "sc start w32time && ping -n 6 -w 1000 127.0.0.1>nul && w32tm /config /manualpeerlist:${ntp_server} /syncfromflags:manual /update"
         ntp_query_cmd = "w32tm /stripchart /computer:${ntp_server} /samples:1 /dataonly"
@@ -26,8 +28,6 @@
             type = timedrift_check_when_crash
             start_vm = no
             ntp_server = "clock.redhat.com"
-            clock_sync_command = "(systemctl stop chronyd || service ntpdate stop)"
-            clock_sync_command += " && chronyd -q 'server clock.redhat.com iburst'"
             sleep_time = 1800
             variants:
                 - bsod:
@@ -41,18 +41,12 @@
                     # else guest will reboot immedicately that is unexpected in this test;
                     only Linux
                     nmi_cmd = "guest: echo '1' > /proc/sys/kernel/sysrq && echo '0' > /proc/sys/kernel/panic && service kdump stop; echo 'c' > /proc/sysrq-trigger"
-                    ntp_cmd = "(systemctl stop chronyd || service ntpdate stop)"
-                    ntp_cmd += " && chronyd -q 'server clock.redhat.com iburst'"
-                    ntp_query_cmd = "chronyd -Q 'server clock.redhat.com iburst'"
         - hotplug_vcpu:
             type = timedrift_check_when_hotplug_vcpu
             start_vm = yes
             vcpu_sockets = 2
             smp = 4
             vcpus_maxcpus = 6
-            ntp_query_cmd = "chronyd -Q 'server clock.redhat.com iburst'"
-            clock_sync_command = "(systemctl stop chronyd || service ntpdate stop)"
-            clock_sync_command += " && chronyd -q 'server clock.redhat.com iburst'"
             query_internal = 600
             query_times = 4
             drift_threshold = 3
@@ -69,8 +63,6 @@
                 hwclock_time_format = "%a %b %d %H:%M:%S %Y"
             time_forward = 3600
             hwclock_forward_cmd = 'hwclock --set --date "${time_forward} seconds"'
-            clock_sync_command = "(systemctl stop chronyd || service ntpdate stop)"
-            clock_sync_command += " && chronyd -q 'server clock.redhat.com iburst'"
             drift_threshold = 3
         - after_load_vm:
             only i386 x86_64 ppc64le ppc64
@@ -86,9 +78,9 @@
             gagent_stop_cmd = "systemctl stop qemu-guest-agent"
             gagent_status_cmd = "systemctl status qemu-guest-agent"
             RHEL.6:
-                gagent_start_cmd = "service qemu-guest-agent start"
-                gagent_stop_cmd = "service qemu-guest-agent stop"
-                gagent_status_cmd = "service qemu-guest-agent status"
+                gagent_start_cmd = "service qemu-ga start"
+                gagent_stop_cmd = "service qemu-ga stop"
+                gagent_status_cmd = "service qemu-ga status"
             gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
             gagent_serial_type = virtio
             virtio_ports += " org.qemu.guest_agent.0"

--- a/qemu/tests/timedrift_check_non_event.py
+++ b/qemu/tests/timedrift_check_non_event.py
@@ -45,10 +45,10 @@ def run(test, params, env):
             raise err
         return guest_time
 
-    clock_sync_command = params["clock_sync_command"]
+    ntp_cmd = params["ntp_cmd"]
 
     error_context.context("Sync host system time with ntpserver", logging.info)
-    process.system(clock_sync_command, shell=True)
+    process.system(ntp_cmd, shell=True)
 
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login()

--- a/qemu/tests/timedrift_check_when_crash.py
+++ b/qemu/tests/timedrift_check_when_crash.py
@@ -23,7 +23,6 @@ def run(test, params, env):
     :param params: Dictionary with test parameters.
     :param env: Dictionary with the test environment.
     """
-    clock_sync_command = params["clock_sync_command"]
     ntp_cmd = params["ntp_cmd"]
     ntp_query_cmd = params["ntp_query_cmd"]
     nmi_cmd = params.get("nmi_cmd", "inject-nmi")
@@ -32,7 +31,7 @@ def run(test, params, env):
     os_type = params["os_type"]
 
     error_context.context("sync host time with ntp server", logging.info)
-    process.system(clock_sync_command, shell=True)
+    process.system(ntp_cmd, shell=True)
 
     error_context.context("start guest", logging.info)
     params["start_vm"] = "yes"

--- a/qemu/tests/timedrift_check_when_crash.py
+++ b/qemu/tests/timedrift_check_when_crash.py
@@ -91,7 +91,7 @@ def run(test, params, env):
     error_context.context("check time offset via ntp", logging.info)
     output = session.cmd_output(ntp_query_cmd)
     try:
-        offset = re.findall(r"[+-](\d+\.\d+)", output, re.M)[-1]
+        offset = re.findall(r"[+-]?(\d+\.\d+)", output, re.M)[-1]
     except IndexError:
         offset = 0.0
     if float(offset) > deviation:

--- a/qemu/tests/timedrift_check_when_hotplug_vcpu.py
+++ b/qemu/tests/timedrift_check_when_hotplug_vcpu.py
@@ -23,10 +23,10 @@ def run(test, params, env):
     :param params: Dictionary with test parameters.
     :param env: Dictionary with the test environment.
     """
-    clock_sync_command = params["clock_sync_command"]
+    ntp_cmd = params["ntp_cmd"]
 
     error_context.context("Sync host system time with ntpserver", logging.info)
-    process.system(clock_sync_command, shell=True)
+    process.system(ntp_cmd, shell=True)
 
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login()
@@ -37,7 +37,7 @@ def run(test, params, env):
     drift_threshold = float(params.get("drift_threshold", "3"))
 
     error_context.context("Sync time from guest to ntpserver", logging.info)
-    session.cmd(clock_sync_command)
+    session.cmd(ntp_cmd)
 
     error_context.context("Hotplug a vcpu to guest", logging.info)
     if int(params["smp"]) < int(params["vcpus_maxcpus"]):

--- a/qemu/tests/timedrift_check_when_hotplug_vcpu.py
+++ b/qemu/tests/timedrift_check_when_hotplug_vcpu.py
@@ -51,7 +51,7 @@ def run(test, params, env):
     for query in range(query_times):
         output = session.cmd_output(ntp_query_cmd)
         try:
-            offset = re.findall(r"([+-]*\d+\.\d+) seconds", output, re.M)[0]
+            offset = re.findall(r"([+-]*\d+\.\d+) sec", output, re.M)[-1]
         except IndexError:
             test.error("Failed to get time offset")
         if float(offset) >= drift_threshold:


### PR DESCRIPTION
…t clause

The previous except clause will miss the error caused by wrong
pattern "r"[+-]?(\d+\.\d+)"".

bug id: 1695457
Signed-off-by: yama <yama@redhat.com>