### PR TITLE
netperf: update nic_model_nic2 for different arch

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -19,7 +19,9 @@
     enable_msix_vectors = yes
     #Configure different types of network adapters.
     nic_model_nic1 = virtio
-    nic_model_nic2 = e1000
+    nic_model_nic2 = virtio
+    i386, x86_64:
+        nic_model_nic2 = e1000
     netdst_nic1 = private
     netdst_nic2 = switch
     # please fix the mac for nic2 if you needed with this, this can be empty


### PR DESCRIPTION
nic_model 'e1000' is only supported by x86, for other arch
use 'virtio' instead

id: 1702216

Signed-off-by: Yanan Fu <yfu@redhat.com>