### PR TITLE
win_irq_check: Add irq check for all other supported driver

### DIFF
--- a/qemu/tests/cfg/win_irq_check.cfg
+++ b/qemu/tests/cfg/win_irq_check.cfg
@@ -3,6 +3,8 @@
     type = win_irq_check
     kill_vm = yes
     login_timeout = 360
+    get_irq_cmd = '%sdevcon.exe resources @"%s" | find "IRQ"'
+    check_vectors = yes
     # devcon.exe path for windows guests
     i386:
         devcon_folder = "WIN_UTILS:\devcon\x86\"
@@ -15,11 +17,70 @@
             balloon = balloon0
             balloon_dev_devid = balloon0
             balloon_dev_add_bus = yes
+            check_vectors = no
         - with_viorng:
             driver_name = viorng
             device_name = "VirtIO RNG Device"
+            check_vectors = no
             no_virtio_rng:
                 virtio_rngs += " rng0"
                 backend_rng0 = rng-random
                 backend_type = passthrough
                 filename_passthrough = /dev/urandom
+        - with_viostor:
+            driver_name = viostor
+            device_name = "Red Hat VirtIO SCSI controller"
+            device_type = "virtio-blk-pci"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1001" "PCI\VEN_1AF4&DEV_1042"'
+            images += " stg"
+            image_name_stg = "images/storage"
+            image_size_stg = 4G
+            drive_format_stg = virtio
+            force_create_image_stg = yes
+            remove_image_stg = yes
+        - with_vioscsi:
+            driver_name = vioscsi
+            device_name = "Red Hat VirtIO SCSI pass-through controller"
+            device_type = "virtio-scsi-pci"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1004" "PCI\VEN_1AF4&DEV_1048"'
+            images += " stg"
+            image_name_stg = "images/storage"
+            image_size_stg = 4G
+            drive_format_stg = scsi-hd
+            force_create_image_stg = yes
+            remove_image_stg = yes
+       - with_vioserial:
+            driver_name = vioser
+            device_name = "VirtIO Serial Driver"
+            device_type = "virtio-serial-pci"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1003" "PCI\VEN_1AF4&DEV_1043"'
+            virtio_ports = "vs"
+            virtio_port_type = serialport
+        - with_netkvm:
+            driver_name = netkvm
+            device_name = "Red Hat VirtIO Ethernet Adapter"
+            device_type = "virtio-net-pci"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1000" "PCI\VEN_1AF4&DEV_1041"'
+        - with_vioinput:
+            no Host_RHEL.m6 Host_RHEL.m7.u0 Host_RHEL.m7.u1 Host_RHEL.m7.u2 Host_RHEL.m7.u3
+            no Win2008..sp2
+            driver_name = vioinput
+            device_name = "VirtIO Input Driver"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1052"'
+            inputs = input1
+            input_dev_bus_type_input1 = virtio
+            variants:
+                - device_mouse:
+                    device_type = "virtio-mouse-pci"
+                    input_dev_type_input1 = mouse
+                - device_keyboard:
+                    device_type = "virtio-keyboard-pci"
+                    input_dev_type_input1 = keyboard
+                - device_tablet:
+                    device_type = "virtio-tablet-pci"
+                    input_dev_type_input1 = tablet
+    variants:
+        - @default:
+        - msi_disable_fguest:
+            no with_balloon, with_viorng
+            msi_cmd = "reg add "HKLM\System\CurrentControlSet\Enum\%s\Device Parameters\Interrupt Management\MessageSignaledInterruptProperties" /v MSISupported /d %d /t REG_DWORD /f"


### PR DESCRIPTION
1. Add default irq check for vioscsi, viostor, vioserial, vioinput, netkvm drivers.
2. Add disable MSI from guest test case for vioscsi, viostor, vioserial, vioinput, netkvm drivers.

id: 1566855 1566852
Signed-off-by: Peixiu Hou <phou@redhat.com>