### PR TITLE
multi_disk: Add spapr-vscsi support for max disk and scsi passthrough test

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -43,8 +43,7 @@
                 stg_image_num = 3
                 stg_image_size = 1G
                 stg_params = "image_format:qcow2,qcow2,raw "
-            virtio_blk, virtio_scsi:
-                no spapr_vscsi
+            virtio_blk, virtio_scsi, spapr_vscsi:
                 usbs = ""
                 usb_devices = ""
                 soundcards = ""
@@ -141,6 +140,29 @@
                         stg_params += "drive_port:range(0,255,127) "
                         need_reboot = yes
                         need_shutdown = yes
+        - spapr_vscsi_variants:
+            only spapr_vscsi
+            stg_image_size = 50M
+            stg_params = "drive_format:scsi-hd "
+            variants:
+                - @passthrough:
+                    stg_params = "drive_format:scsi-block "
+                    kill_vm = yes
+                    force_create_image = no
+                    pre_command = "modprobe -r scsi_debug; modprobe sg; modprobe scsi_debug add_host=9 dev_size_mb=50"
+                    post_command = "rmmod scsi_debug"
+                    stg_params += "image_raw_device:yes "
+                    stg_params += "image_format:raw "
+                    stg_params += "indirect_image_select:range(-9,0) "
+                    need_reboot = yes
+                    variants:
+                        - block:
+                            stg_params += "image_name:/dev/sd* "
+                        - generic:
+                            stg_params += "drive_cache:writethrough "
+                            stg_params += "image_aio:threads "
+                            stg_params += "drive_format:scsi-generic "
+                            stg_params += "image_name:/dev/sg* "
         - debug_params:
             # Remove this to execute this test-params-devel test
             no multi_disk


### PR DESCRIPTION
1. Add spapr-vscsi support in the max_disk test case
2. Add new test cases to test the scsi passthrough of spapr-vscsi

ID: 1702628, 1703953
Signed-off-by: Nini Gu <ngu@redhat.com>