### PR TITLE
qemu_disk_img.info.change_block_interface: Add pseries support

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -137,6 +137,11 @@
                     drive_format_snA = ide
                     q35:
                         drive_format_snA = ahci
+                    pseries:
+                        virtio_scsi:
+                            drive_format_snA = virtio
+                        virtio_blk:
+                            drive_format_snA = scsi-hd
         - snapshot:
             type = qemu_disk_img_snapshot
             guest_file_name = "${tmp_dir}/test.img"


### PR DESCRIPTION
1. To support pseries test, specify drive_format of the snapshot
image to be virtio_blk for the originally virtio_scsi image,
while specify it to be virtio_scsi for the originally virtio_blk
one

ID: 1692255

Signed-off-by: Nini Gu <ngu@redhat.com>