### PR TITLE
openflow_acl_test: use wget as a replacement of lftp

### DIFF
--- a/qemu/tests/cfg/openflow_acl_test.cfg
+++ b/qemu/tests/cfg/openflow_acl_test.cfg
@@ -4,6 +4,7 @@
     image_snapshot = yes
     acl_protocol = "tcp"
     Linux:
+        firewalld_service = "disable"
         disable_iptables = "yes"
     ref_cmd_linux = ping -c 4 ACCESS_TARGET
     ref_cmd_windows = ping ACCESS_TARGET
@@ -29,7 +30,7 @@
             service_windows = ftp
             prepare_cmd_linux = dd if=/dev/zero of=/var/ftp/pub/autotest-test bs=1M count=2
             cleanup_cmd_linux = rm -rf /var/ftp/pub/autotest-test
-            access_cmd_linux =  rm -rf autotest-test; lftpget ftp://ACCESS_TARGET/autotest-test &> /dev/ttyS0
+            access_cmd_linux =  rm -rf autotest-test; wget ftp://ACCESS_TARGET/pub/autotest-test &> /dev/ttyS0
             clean_guest_linux = rm -rf autotest-test
             setup_cmd_windows = Dism /Online /Enable-Feature /FeatureName:IIS-ManagementConsole /FeatureName:IIS-WebServerRole /FeatureName:IIS-FTPServer /FeatureName:IIS-FTPSvc /FeatureName:IIS-FTPExtensibility
             stop_cmd_windows =
@@ -38,6 +39,7 @@
             access_cmd_windows = echo get autotest-test > C:\ftp.txt && echo quit >> C:\ftp.txt && ftp -n -s:C:\ftp.txt ACCESS_TARGET
             check_from_output_windows = Not connected
             op_timeout = 30
+            vsftpd_conf = /etc/vsftpd/vsftpd.conf
             Windows:
                 copy_scripts = dd.py
                 copy_ftp_site = openflow_acl_test/applicationHost.config


### PR DESCRIPTION
lftp is removed from RHEL8 repo. Use wget to replace lftpget.

id: 1665445

Signed-off-by: Xiyue Wang <xiywang@redhat.com>