### PR TITLE
timerdevice: add "only Linux" for some cases

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -26,6 +26,7 @@
             ntp_sync_cmd = "(systemctl stop chronyd || service ntpdate stop)"
             ntp_sync_cmd += " && chronyd -q 'server clock.redhat.com iburst'"
         - clock_drift_with_ntp:
+            only Linux
             no RHEL.6
             type = timerdevice_clock_drift_with_ntp
             test_run_timeout = 7200
@@ -91,6 +92,7 @@
                         - reboot_after_sleep:
                             timerdevice_sleep_time = 3600
         - tscsync:
+            only Linux
             no RHEL.6
             variants:
                 - change_host_clksource:


### PR DESCRIPTION
bug id: 1707687
Signed-off-by: yama <yama@redhat.com>