### PR TITLE
Add windows guest support for some timer device cases

### DIFF
--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -11,8 +11,11 @@
     ntp_query_cmd = "chronyd -Q 'server clock.redhat.com iburst'"
     ntp_query_cmd += " || ntpdate -q clock.redhat.com"
     Windows:
-        ntp_cmd = "sc start w32time && ping -n 6 -w 1000 127.0.0.1>nul && w32tm /config /manualpeerlist:${ntp_server} /syncfromflags:manual /update"
+        ntp_cmd = "ping -n 6 -w 1000 127.0.0.1>nul && w32tm /config /manualpeerlist:${ntp_server} /syncfromflags:manual /update"
         ntp_query_cmd = "w32tm /stripchart /computer:${ntp_server} /samples:1 /dataonly"
+        ntp_host_cmd = "(systemctl stop chronyd || service ntpdate stop)"
+        ntp_host_cmd += " && (chronyd -q 'server clock.redhat.com iburst'"
+        ntp_host_cmd +=  " || ntpdate clock.redhat.com)"
     variants:
         - with_syscall:
             type = timedrift_check_with_syscall

--- a/qemu/tests/timedrift_check_when_hotplug_vcpu.py
+++ b/qemu/tests/timedrift_check_when_hotplug_vcpu.py
@@ -5,6 +5,7 @@ import logging
 from avocado.utils import process
 
 from virttest import error_context
+from virttest import utils_test
 
 
 @error_context.context_aware
@@ -23,10 +24,12 @@ def run(test, params, env):
     :param params: Dictionary with test parameters.
     :param env: Dictionary with the test environment.
     """
+    os_type = params["os_type"]
     ntp_cmd = params["ntp_cmd"]
+    ntp_host_cmd = params.get("ntp_host_cmd", ntp_cmd)
 
     error_context.context("Sync host system time with ntpserver", logging.info)
-    process.system(ntp_cmd, shell=True)
+    process.system(ntp_host_cmd, shell=True)
 
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login()
@@ -37,6 +40,8 @@ def run(test, params, env):
     drift_threshold = float(params.get("drift_threshold", "3"))
 
     error_context.context("Sync time from guest to ntpserver", logging.info)
+    if os_type == "windows":
+        utils_test.start_windows_service(session, "w32time")
     session.cmd(ntp_cmd)
 
     error_context.context("Hotplug a vcpu to guest", logging.info)

--- a/qemu/tests/timedrift_check_when_hotplug_vcpu.py
+++ b/qemu/tests/timedrift_check_when_hotplug_vcpu.py
@@ -56,7 +56,7 @@ def run(test, params, env):
     for query in range(query_times):
         output = session.cmd_output(ntp_query_cmd)
         try:
-            offset = re.findall(r"([+-]*\d+\.\d+) sec", output, re.M)[-1]
+            offset = re.findall(r"([+-]*\d+\.\d+)[s sec]", output, re.M)[-1]
         except IndexError:
             test.error("Failed to get time offset")
         if float(offset) >= drift_threshold:


### PR DESCRIPTION
1. Need to add pattern for windows guest.
2. Need to specify ntp_cmd for host when running windows guest.
3. For some windows guests, e.g. Win2019, the service w32time is running by default. So need to judge it first when starting.

bug id: 1707732
Signed-off-by: yama <yama@redhat.com>