### PR TITLE
migration_with_reboot: fix ImportError when using virtual env

### DIFF
--- a/qemu/tests/migration_with_reboot.py
+++ b/qemu/tests/migration_with_reboot.py
@@ -4,7 +4,7 @@ import tempfile
 from virttest import utils_misc
 
 # Import helper methods from test "migration"
-import migration
+from qemu.tests import migration
 
 
 def run(test, params, env):


### PR DESCRIPTION
tp-qemu will not be installed to global if we using virtual env. So import `migration` from `qemu.tests`

ID: 1708019
Signed-off-by: Yihuang Yu <yihyu@redhat.com>