### PR TITLE
avocado_guest: add memory, numa and stress testcases

### DIFF
--- a/generic/tests/cfg/avocado_guest.cfg
+++ b/generic/tests/cfg/avocado_guest.cfg
@@ -71,8 +71,32 @@
             avocadotest = "memory/integrity.py"
         - memtester:
             avocadotest = "memory/memtester.py"
+        - mprotect:
+            avocadotest = "memory/mprotect.py"
+        - ksmpoison:
+            avocadotest = "memory/ksm_poison.py"
+        - childspawn:
+            avocadotest = "memory/child_spawn.py"
+        - vatest:
+            avocadotest = "memory/vatest.py"
         - stutter:
             avocadotest = "memory/stutter.py"
+        - sumcheck:
+            avocadotest = "memory/sum_check.py"
+        - tm:
+            avocadotest = "memory/tm-tests.py"
+        - memcached:
+            avocadotest = "memory/memcached.py"
+        - forkmem:
+            avocadotest = "memory/fork_mem.py"
+        - ltp_mem:
+            avocadotest = "memory/ltp-memory.py"
+        - migratepages:
+            avocadotest = "memory/migrate_pages.py"
+        - memoryapi:
+            avocadotest = "memory/memory_api.py"
+        - HP:
+            avocadotest = "memory/hugepage_sanity.py,memory/libhugetlbfs.py"
         - THP:
             avocadotest = "memory/transparent_hugepages.py,memory/transparent_hugepages_defrag.py"
             avocadotest += ",memory/transparent_hugepages_swapping.py"
@@ -93,8 +117,14 @@
             avocadotest = "perf/unixbench.py"
         - ppc64_cpu_test:
             avocadotest = "cpu/ppc64_cpu_test.py"
+        - numatest:
+            avocadotest = "memory/numa_test.py"
+        - numactl:
+            avocadotest = "cpu/numactl.py"
         - stress-ng:
             avocadotest = "generic/stress-ng.py"
+        - htx:
+            avocadotest = "generic/htx_test.py"
         - sysbench:
             avocadotest = "generic/sysbench.py"
         - multiport_stress:


### PR DESCRIPTION
include new testcases from avocado-misc-tests in
`avocado_guest` to test inside guest.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>