### PR TITLE
timerdevice_change_guest_clksource: change kernel param via grubby

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -33,6 +33,10 @@
         - change_guest_clksource:
             only RHEL
             type = timerdevice_change_guest_clksource
+            cur_clk = "cat /sys/devices/system/clocksource/"
+            cur_clk += "clocksource0/current_clocksource"
+            avl_clk = "cat /sys/devices/system/clocksource/"
+            avl_clk += "clocksource0/available_clocksource"
             rtc_base = utc
             rtc_clock = host
             i386, x86_64:


### PR DESCRIPTION
For rhel8 guest, directly edit grub2.cfg isn't supported.
And even if for rhel7 and rhel6, directly edit grub2.cfg
isn't recommend.

bug id: 1708540
Signed-off-by: yama <yama@redhat.com>