### PR TITLE
hpt_miscellaneous: add waiting time before HPT resizing 

### DIFF
--- a/qemu/tests/cfg/hpt.cfg
+++ b/qemu/tests/cfg/hpt.cfg
@@ -20,6 +20,8 @@
             maxmem_mem = 64G
             slots_mem = 32
             size = "1073741824"
+            plug_timeout = 20
+            free_mem_cmd = free -b | grep -E 'Mem' | awk '{print $2}'
         - negative:
             sub_type = "negative"
             increment_sequence = "-20 -25 -30 -100 20 30 100"


### PR DESCRIPTION
Add waiting time after mem_hotpug since there's time delay for HPT resizing in a compatible guest on P9.As it is not a really product problem,we need this patch to pass our test case.
ID:Bug 1709655
Signed-off-by:Miriam Deng mdeng@redhat.com
