### PR TITLE
virtual_nic.send_buffer: set params 'wait_bg_time'

### DIFF
--- a/qemu/tests/cfg/virtual_nic.cfg
+++ b/qemu/tests/cfg/virtual_nic.cfg
@@ -45,6 +45,7 @@
             netperf_para_sessions = 1
             ping_timeout = 60
             bg_stress_run_flag = netperf_run
+            wait_bg_time = ${netperf_test_duration}
             Windows:
                 netperf_server_link_win = netserver-2.6.0.exe
                 netperf_client_link_win = netperf.exe


### PR DESCRIPTION
set params 'wait_bg_time' equal to 'netperf_test_duration'

ID: 1711120
Signed-off-by: Yihuang Yu <yihyu@redhat.com>