### PR TITLE
multi_nics_verify: boot with 8 nics with mq on windows 32bit guest

### DIFF
--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -5,3 +5,9 @@
     nics_num = 27
     start_vm = no
     kill_vm = no
+    variants:
+        - @default:
+        - with_multiqueue:
+            queues = ${smp}
+            Windows..i386:
+                nics_num = 8


### PR DESCRIPTION
Add multique variant and limit 8 mq for windows 32 bit

Signed-off-by: Yu Wang <wyu@redhat.com>

id: 1688109