### PR TITLE
ntttcp.cfg: need not use numa_node for this case

### DIFF
--- a/generic/tests/cfg/ntttcp.cfg
+++ b/generic/tests/cfg/ntttcp.cfg
@@ -11,7 +11,6 @@
     buffers = "2k 4k 8k 16k 32k 64k 128k 256k 512k 1024k 2048k"
     timeout = 600
     kill_vm = yes
-    numa_node = -1
     vms += " vm2"
     driver_name = "netkvm"
     i386:


### PR DESCRIPTION
delete "numa_node = -1"

Signed-off-by: Yu Wang <wyu@redhat.com>

id:1709635