### PR TITLE
qmp_command: Specify bus when execute 'device_add' with q35

### DIFF
--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -95,6 +95,10 @@
             pre_command += "qemu-img create -f qcow2 /tmp/device_add01.qcow2 100M"
             pre_cmd = "__com.redhat_drive_add file=/tmp/device_add01.qcow2,format=qcow2,id=device_add01"
             qmp_cmd = "device_add driver=virtio-blk-pci,drive=device_add01,id=device_add01"
+            q35:
+                pci_controllers += " pcie_root_port_qmp"
+                type_pcie_root_port_qmp = "pcie-root-port"
+                qmp_cmd += ",bus=pcie_root_port_qmp"
             post_cmd = "query-block"
             cmd_result_check = post_contain
             cmd_return_value = "[{'device': 'device_add01'}]"


### PR DESCRIPTION
For q35, hotplug device should specidy bus, add device to "pcie-root-port".
without "bus",it will use bus "pcie.0" which does not suppot hotplug.

id: 1709814
Signed-off-by: Yanan Fu <yfu@redhat.com>