### PR TITLE
Fix UnboundLocalError of generate_instance object

### DIFF
--- a/qemu/tests/fio_linux.py
+++ b/qemu/tests/fio_linux.py
@@ -51,8 +51,8 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     session = vm.wait_for_login(timeout=float(params.get("login_timeout", 240)))
+    fio = generate_instance(params, session, 'fio')
     try:
-        fio = generate_instance(params, session, 'fio')
         for did in _get_data_disks():
             for option in params['fio_options'].split(';'):
                 fio.run('--filename=%s %s' % (did, option))

--- a/qemu/tests/ioeventfd.py
+++ b/qemu/tests/ioeventfd.py
@@ -66,8 +66,8 @@ def run(test, params, env):
         logging.info('Doing fio testing inside guest.')
         session = utils_test.qemu.windrv_check_running_verifier(
             session, vm, test, params["driver_name"])
+        fio = generate_instance(params, session, 'fio')
         try:
-            fio = generate_instance(params, session, 'fio')
             fio.run(params['fio_options'], float(params['stress_timeout']))
         finally:
             fio.clean()
@@ -82,8 +82,8 @@ def run(test, params, env):
         if os_type == 'windows':
             session = utils_test.qemu.windrv_check_running_verifier(
                 session, vm, test, params["driver_name"])
+        iozone = generate_instance(params, session, 'iozone')
         try:
-            iozone = generate_instance(params, session, 'iozone')
             iozone.run(params['iozone_options'], float(params['iozone_timeout']))
         finally:
             iozone.clean()

--- a/qemu/tests/iozone_linux.py
+++ b/qemu/tests/iozone_linux.py
@@ -60,8 +60,8 @@ def run(test, params, env):
     session = vm.wait_for_login(timeout=float(params.get("login_timeout", 360)))
     _wait_for_procs_done()
     error_context.context("Running IOzone command on guest.")
+    iozone = generate_instance(params, session, 'iozone')
     try:
-        iozone = generate_instance(params, session, 'iozone')
         dids = _get_data_disks()
         if dids:
             mount_info = session.cmd_output_safe('cat /proc/mounts | grep \'/dev/\'')

--- a/qemu/tests/multi_disk.py
+++ b/qemu/tests/multi_disk.py
@@ -271,10 +271,10 @@ def run(test, params, env):
     except Exception:
         _do_post_cmd(session)
         raise
+    if iozone_options:
+        iozone = generate_instance(params, session, 'iozone')
+        random.shuffle(disks)
     try:
-        if iozone_options:
-            iozone = generate_instance(params, session, 'iozone')
-            random.shuffle(disks)
         for i in range(n_repeat):
             logging.info("iterations: %s", (i + 1))
             for n, disk in enumerate(disks):


### PR DESCRIPTION
Move the local variable generate_instance object outside
of try sentence so that it could avoid hitting UnboundLocalError
when executing the sentence finally.

ID: 1713234
Signed-off-by: Yongxue Hong <yhong@redhat.com>