### PR TITLE
qemu.migration: Use globals instead of locals for get_functions

### DIFF
--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -200,7 +200,7 @@ def run(test, params, env):
             session2.close()
 
             # run some functions before migrate start.
-            pre_migrate = get_functions(params.get("pre_migrate"), locals())
+            pre_migrate = get_functions(params.get("pre_migrate"), globals())
             for func in pre_migrate:
                 func(vm, params, test)
 
@@ -244,7 +244,7 @@ def run(test, params, env):
             params["action"] = "stop"
 
             # run some functions after migrate finish.
-            post_migrate = get_functions(params.get("post_migrate"), locals())
+            post_migrate = get_functions(params.get("post_migrate"), globals())
             for func in post_migrate:
                 func(vm, params, test)
 


### PR DESCRIPTION
When the test is executed via "run_virt_sub_test" (imported) it will not
contain the top-level functions in locals() and the use of globals() is
needed.

Reported-by: Li Jin <lijin@redhat.com>
Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>