### PR TITLE
block_with_iommu: Add new cases to test iommu with block device

### DIFF
--- a/qemu/tests/block_with_iommu.py
+++ b/qemu/tests/block_with_iommu.py
@@ -1,0 +1,39 @@
+import logging
+
+from virttest import cpu
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test the vIOMMU platform.
+
+    Steps:
+        1. Add "intel_iommu=on" to kernel line of q35 guest.
+        2. Boot a guest with virtio-scsi with iommu_platform=on.
+        3. Verify IOMMU enabled in the guest.
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    def verify_iommu_enabled():
+        """ Verify whether the iommu is enabled. """
+        error_context.context(
+            'Verify whether IOMMU is enabled in the guest.', logging.info)
+        for key_words in params['check_key_words'].split(';'):
+            output = session.cmd_output("journalctl -k | grep -i \"%s\"" % key_words)
+            if not output:
+                test.fail("No found the info \"%s\" "
+                          "from the systemd journal log." % key_words)
+            logging.debug(output)
+
+    if cpu.get_cpu_vendor(verbose=False) != 'GenuineIntel':
+        test.cancel("This case only support Intel platform.")
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=360)
+    verify_iommu_enabled()

--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -1,0 +1,51 @@
+- block_with_iommu:
+    type = block_with_iommu
+    only q35
+    only x86_64, i386
+    start_vm = yes
+    virtio_dev_iommu_platform = on
+    enable_guest_iommu = yes
+    virtio_dev_ats = on
+    machine_type_extra_params = "kernel-irqchip=split"
+    variants:
+        - verify_enabled:
+            only Linux
+            only RHEL.8
+            only Host_RHEL.m8
+            only virtio_scsi
+            extra_params = "-device intel-iommu,device-iotlb=on,intremap"
+            virtio_dev_disable_legacy = on
+            virtio_dev_disable_modern = off
+            check_key_words = "DMAR: IOMMU enabled;"
+            check_key_words += "DMAR: Intel(R) Virtualization Technology for Directed I/O"
+        - with_installation:
+            type = unattended_install
+            only Windows
+            only virtio_scsi, virtio_blk
+            no WinXP WinVista Win7 Win8 Win8.1 Win2000 Win2003
+            no Win2008 Win2008..r2 Win2012 Win2012..r2
+            shutdown_cleanly = yes
+            shutdown_cleanly_timeout = 120
+            start_vm = no
+            images = "stg_iommu"
+            image_name_stg_iommu = "images/storage_iommu"
+            image_size_stg_iommu = 40G
+            force_create_image_stg_iommu = yes
+            remove_image_image_stg_iommu = yes
+            guest_port_unattended_install = 12323
+            inactivity_watcher = error
+            extra_params = "-device intel-iommu,device-iotlb=on,intremap"
+            variants:
+                - extra_cdrom_ks:
+                    unattended_delivery_method = cdrom
+                    cdroms += " unattended"
+                    cd_format_unattended = ahci
+                    drive_index_unattended = 1
+                    drive_index_cd1 = 2
+            variants:
+                - cdrom:
+                    cd_format_cd1 = ahci
+                    cd_format_winutils = ahci
+                    boot_once = d
+                    medium = cdrom
+                    redirs += " unattended_install"


### PR DESCRIPTION
New cases:
1. verify_enabled: Verify whether IOMMU is enabled in a guest
   with virtio_scsi block device.
2. with_installation: Check virtio driver can be installed
   successfully with iommu_platform=on during guest installation.

ID: 1716793, 1705625
Signed-off-by: Yongxue Hong <yhong@redhat.com>