### PR TITLE
win_irq_check: Add a case disable msi by setting vectors

### DIFF
--- a/qemu/tests/cfg/win_irq_check.cfg
+++ b/qemu/tests/cfg/win_irq_check.cfg
@@ -81,6 +81,18 @@
                     input_dev_type_input1 = tablet
     variants:
         - @default:
-        - msi_disable_fguest:
-            no with_balloon, with_viorng
-            msi_cmd = "reg add "HKLM\System\CurrentControlSet\Enum\%s\Device Parameters\Interrupt Management\MessageSignaledInterruptProperties" /v MSISupported /d %d /t REG_DWORD /f"
+        - msi_disable:
+            variants:
+                - by_registry:
+                    no with_balloon, with_viorng
+                    msi_cmd = "reg add "HKLM\System\CurrentControlSet\Enum\%s\Device Parameters\Interrupt Management\MessageSignaledInterruptProperties" /v MSISupported /d %d /t REG_DWORD /f"
+                - by_vectors:
+                    only with_vioscsi, with_viostor, with_netkvm
+                    vectors = 0
+                    with_viostor:
+                        virtio_blk:
+                            blk_extra_params_image1 += ",vectors=${vectors}"
+                        blk_extra_params_stg += ",vectors=${vectors}"
+                    with_vioscsi:
+                        bus_extra_params_image1 = "vectors=${vectors}"
+                        bus_extra_params_stg = "vectors=${vectors}"


### PR DESCRIPTION
Add disable MSI test case by vectors for vioscsi, viostor, netkvm drivers.

id: 1566853
Signed-off-by: Peixiu Hou <phou@redhat.com>