### PR TITLE
slof_device_tree: Update case to support different qemu build

### DIFF
--- a/qemu/tests/cfg/slof_device_tree.cfg
+++ b/qemu/tests/cfg/slof_device_tree.cfg
@@ -8,3 +8,4 @@
     only Linux
     uuid = random
     no scsi-cd
+    match_str = "No such file or directory"


### PR DESCRIPTION
Since some qemu build does not expose "host-serial",
so it can't be got then skip to compare "host-serial"
and "system-id".

ID:1719637

Signed-off-by: Xianwang <xianwang@redhat.com>