### PR TITLE
[WIP]virtio_storage_in_use: Add a argument join_timeout for thread

### DIFF
--- a/qemu/tests/cfg/virtio_storage_in_use.cfg
+++ b/qemu/tests/cfg/virtio_storage_in_use.cfg
@@ -5,6 +5,7 @@
     check_guest_bsod = yes
     login_timeout = 240
     suppress_exception = no
+    join_timeout = 30
     Windows:
         run_bgstress = iozone_windows
         target_process = iozone.exe

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -146,7 +146,9 @@ def run(test, params, env):
             if wait_bg_finish:
                 stress_thread.join(suppress_exception=suppress_exception)
             else:
-                stress_thread.join(timeout=timeout, suppress_exception=suppress_exception)
+                join_timeout = int(params.get('join_timeout', timeout))
+                stress_thread.join(timeout=join_timeout,
+                                   suppress_exception=suppress_exception)
         if vm.is_alive():
             run_bg_test_sep(bg_stress_test)
     elif run_bg_flag == "after_bg_test":


### PR DESCRIPTION
 virtio_storage_in_use: Add a argument join_timeout for thread    
    Add an argument join_timeout for the cases related during_bg_test that
    starts a thread under background.

 driver_in_use: Update the way of getting argument timeout of thread
    To avoid sharing the login_timeout, add an extra available argument
    timeout of thread.

ID: 1719111

Signed-off-by: Yongxue Hong yhong@redhat.com