### PR TITLE
timedrift_check_when_crash: add "-no-shutdown" for windows guest

### DIFF
--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -32,12 +32,12 @@
             start_vm = no
             ntp_server = "clock.redhat.com"
             sleep_time = 1800
+            extra_params += " -no-shutdown"
             variants:
                 - bsod:
                     only Windows
                     nmi_cmd = "monitor:inject-nmi"
                 - hang:
-                    extra_params += " -no-shutdown"
                     kill_vm = yes
                     # Notes:
                     # please stop kernel crash recovery service like 'kdump' before trigger kernek panic,

--- a/qemu/tests/timedrift_check_when_crash.py
+++ b/qemu/tests/timedrift_check_when_crash.py
@@ -65,8 +65,7 @@ def run(test, params, env):
     time.sleep(sleep_time)
     # Autotest parses serial output and could raise VMDeadKernelCrash
     # we generated using sysrq. Ignore one "BUG:" line
-    if os_type == "linux":
-        vm.resume()
+    vm.resume()
     try:
         session = vm.reboot(method="system_reset")
     except VMDeadKernelCrashError as details:


### PR DESCRIPTION
When guest kernel panic occurs, keep the qemu process alive.

bug id: 1721813
Signed-off-by: yama <yama@redhat.com>