### PR TITLE
Update block cases: Update block cases to support blockdev

### DIFF
--- a/provider/cdrom.py
+++ b/provider/cdrom.py
@@ -9,6 +9,7 @@ import logging
 
 from avocado import fail_on
 from virttest import utils_misc
+from virttest.qemu_capabilities import Flags
 
 
 class CDRomError(Exception):
@@ -48,6 +49,9 @@ def is_device_tray_opened(vm, device_id):
     : device_id: block device identifier
     """
     blocks_info = vm.monitor.info('block')
+
+    if vm.check_capability(Flags.BLOCKDEV):
+        device_id = vm.devices.get_qdev_by_drive(device_id)
 
     if isinstance(blocks_info, str):
         open_str = 'tray open'

--- a/qemu/tests/block_hotplug.py
+++ b/qemu/tests/block_hotplug.py
@@ -7,6 +7,7 @@ from virttest import utils_test
 from virttest.qemu_devices import qdevices
 from virttest import utils_disk
 from virttest import utils_numeric
+from virttest.qemu_capabilities import Flags
 
 
 @error_context.context_aware
@@ -168,7 +169,9 @@ def run(test, params, env):
                                   "Output: %s" % output)
                 session.close()
 
-                devs = [dev for dev in devs if not isinstance(dev, qdevices.QDrive)]
+                dtype = qdevices.QBlockdevNode if vm.check_capability(
+                    Flags.BLOCKDEV) else qdevices.QDrive
+                devs = [dev for dev in devs if not isinstance(dev, dtype)]
                 device_list.extend(devs)
             else:
                 for device in vm.devices:

--- a/qemu/tests/block_hotplug_in_pause.py
+++ b/qemu/tests/block_hotplug_in_pause.py
@@ -5,6 +5,7 @@ from virttest import error_context
 from virttest import utils_misc
 from virttest import utils_disk
 from virttest.qemu_devices import qdevices
+from virttest.qemu_capabilities import Flags
 
 
 @error_context.context_aware
@@ -70,7 +71,9 @@ def run(test, params, env):
             if ret[1] is False:
                 test.fail("Failed to hotplug device '%s'."
                           "Output:\n%s" % (dev, ret[0]))
-        devs = [dev for dev in devs if not isinstance(dev, qdevices.QDrive)]
+        dtype = qdevices.QBlockdevNode if vm.check_capability(
+            Flags.BLOCKDEV) else qdevices.QDrive
+        devs = [dev for dev in devs if not isinstance(dev, dtype)]
         return devs
 
     def block_unplug(device_list):

--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -12,6 +12,7 @@ from virttest.utils_windows import drive
 from virttest.qemu_storage import QemuImg
 
 from provider.storage_benchmark import generate_instance
+from virttest.qemu_capabilities import Flags
 
 
 @error_context.context_aware
@@ -106,7 +107,11 @@ def run(test, params, env):
 
         error_context.context("Change disk size to %s in monitor"
                               % block_size, logging.info)
-        vm.monitor.block_resize(data_image_dev, block_size)
+        if vm.check_capability(Flags.BLOCKDEV):
+            args = (None, block_size, data_image_dev)
+        else:
+            args = (data_image_dev, block_size)
+        vm.monitor.block_resize(*args)
 
         if params.get("guest_prepare_cmd", ""):
             session.cmd(params.get("guest_prepare_cmd"))

--- a/qemu/tests/cdrom_block_size_check.py
+++ b/qemu/tests/cdrom_block_size_check.py
@@ -9,6 +9,7 @@ from virttest import env_process
 from virttest import error_context
 from virttest import utils_misc
 from virttest import data_dir
+from virttest.qemu_capabilities import Flags
 
 
 # This decorator makes the test function aware of context strings
@@ -72,6 +73,10 @@ def run(test, params, env):
             for block in blocks:
                 if 'inserted' not in block.keys():
                     device = block['device']
+                else:
+                    if (vm.check_capability(Flags.BLOCKDEV) and
+                            block['inserted']['file'] == 'null-co://'):
+                        device = block['inserted']['node-name']
         return device
 
     def create_iso_image(params, name, prepare=True, file_size=None):

--- a/qemu/tests/change_media.py
+++ b/qemu/tests/change_media.py
@@ -6,6 +6,8 @@ from virttest import error_context
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import data_dir
+from virttest.qemu_capabilities import Flags
+from virttest.qemu_storage import QemuImg
 
 
 @error_context.context_aware
@@ -37,7 +39,11 @@ def run(test, params, env):
                     return True
         else:
             for block in blocks_info:
-                if block['device'] == block_name and block['locked']:
+                if vm.check_capability(Flags.BLOCKDEV):
+                    condition = block['qdev'] == vm.devices.get_qdev_by_drive(block_name)
+                else:
+                    condition = block['device'] == block_name
+                if condition and block['locked']:
                     return True
         return False
 
@@ -66,6 +72,9 @@ def run(test, params, env):
     orig_img_name = params.get("orig_img_name")
     change_insert_cmd = "change device=%s,target=%s" % (device_name,
                                                         orig_img_name)
+    if vm.check_capability(Flags.BLOCKDEV):
+        change_insert_cmd = ("blockdev-change-medium id=%s,filename=%s" %
+                             (vm.devices.get_qdev_by_drive(device_name), orig_img_name))
     monitor.send_args_cmd(change_insert_cmd)
     logging.info("Wait until device is ready")
     exists = utils_misc.wait_for(lambda: (orig_img_name in
@@ -116,6 +125,9 @@ def run(test, params, env):
     new_img_name = params.get("new_img_name")
     change_insert_cmd = "change device=%s,target=%s" % (device_name,
                                                         new_img_name)
+    if vm.check_capability(Flags.BLOCKDEV):
+        change_insert_cmd = ("blockdev-change-medium id=%s,filename=%s" % (
+            vm.devices.get_qdev_by_drive(device_name), new_img_name))
     output = change_block(change_insert_cmd)
     if not ("is locked" in output or "is not open" in output):
         msg = ("%s is not locked or is open "
@@ -134,6 +146,11 @@ def run(test, params, env):
         test.error("VM doesn't have any non-removable devices.")
     change_insert_cmd = "change device=%s,target=%s" % (device_name,
                                                         new_img_name)
+    if vm.check_capability(Flags.BLOCKDEV):
+        sys_image = QemuImg(params, data_dir.get_data_dir(), params['images'].split()[0])
+        device_name = vm.get_block({"filename": sys_image.image_filename})
+        change_insert_cmd = ("blockdev-change-medium id=%s,filename=%s" % (
+            vm.devices.get_qdev_by_drive(device_name), new_img_name))
     output = change_block(change_insert_cmd)
     if "is not removable" not in output:
         test.fail("Could remove non-removable device!")

--- a/qemu/tests/eject_media.py
+++ b/qemu/tests/eject_media.py
@@ -3,6 +3,9 @@ import time
 
 from virttest import error_context
 from provider.cdrom import QMPEventCheckCDEject, QMPEventCheckCDChange
+from virttest import data_dir
+from virttest.qemu_capabilities import Flags
+from virttest.qemu_storage import QemuImg
 
 
 @error_context.context_aware
@@ -94,6 +97,9 @@ def run(test, params, env):
     error_context.context("Try to eject non-removable device", logging.info)
     p_dict = {"removable": False}
     device_name = vm.get_block(p_dict)
+    if vm.check_capability(Flags.BLOCKDEV):
+        sys_image = QemuImg(params, data_dir.get_data_dir(), params['images'].split()[0])
+        device_name = vm.get_block({"filename": sys_image.image_filename})
     if device_name is None:
         test.error("Could not find non-removable device")
     try:

--- a/qemu/tests/multi_disk_random_hotplug.py
+++ b/qemu/tests/multi_disk_random_hotplug.py
@@ -17,6 +17,7 @@ from virttest import env_process
 from virttest.qemu_devices import utils
 from virttest.remote import LoginTimeoutError
 from virttest.qemu_monitor import MonitorError
+from virttest.qemu_capabilities import Flags
 
 
 # qdev is not thread safe so in case of dangerous ops lock this thread
@@ -162,6 +163,8 @@ def run(test, params, env):
                 args['scsi_hba'] = 'spapr-vscsi'
             else:
                 args['fmt'] = fmt
+            args['imgfmt'] = params['image_format_%s' % name] if params.get(
+                'image_format_%s' % name) else params['image_format']
             # Other params
             for key, value in param_matrix.items():
                 args[key] = random.choice(value)
@@ -291,7 +294,8 @@ def run(test, params, env):
                 # as dirty.
                 if LOCK:
                     LOCK.acquire()
-                qdev.remove(device)
+                qdev.remove(
+                    device, False if vm.check_capability(Flags.BLOCKDEV) else True)
                 if LOCK:
                     LOCK.release()
         time.sleep(unplug_sleep)


### PR DESCRIPTION
cdrom: Support blockdev
    To support blockdev, device_id is repalced by qdev.

Update block cases: Update block cases to support blockdev options
Need to update the block cases to support blockdev options, since
qemu enable the blockdev options from the certain version.
    Updated cases:
     1. block_hotplug
     2. block_resize
     3. cdrom
     4. cdrom_block_size_check
     5. change_media
     6. eject_media
     7. block_hotplug_in_pause
     8. multi_disk_random_hotplug

ID: 1707730
Signed-off-by: Yongxue Hong <yhong@redhat.com>