### PR TITLE
vlan:fix cannot use "Set-NetAdapter" in powershell on windows7 guest

### DIFF
--- a/generic/tests/cfg/vlan.cfg
+++ b/generic/tests/cfg/vlan.cfg
@@ -21,7 +21,9 @@
         login_timeout = 720
         vlan_num = 1
         win_vlan_id = 900
-        set_vlan_cmd = powershell -command "Set-NetAdapter -Name '%s' -VlanID ${win_vlan_id} -Confirm:$false"
+        cdroms += " virtio"
+        prepare_netkvmco_cmd = 'xcopy %s c:\\ /y && rundll32 netkvmco.dll,RegisterNetKVMNetShHelper'
+        set_vlan_cmd = 'netsh netkvm setparam 0 param=vlanid value=${win_vlan_id}'
     variants:
         - @vlan_connective_test:
         - vlan_scalability_test:

--- a/qemu/tests/cfg/ctrl_vlan.cfg
+++ b/qemu/tests/cfg/ctrl_vlan.cfg
@@ -11,7 +11,9 @@
         vlan_set_cmd += "ip link set %s address 00:52:11:36:3f:00 up; "
         vlan_set_cmd += "ifconfig %s ${vlan_ip}/24 up"
     Windows:
-        vlan_set_cmd = powershell -command "Set-NetAdapter -Name '%s' -VlanID ${vlan_id} -Confirm:$false"
+        cdroms += " virtio"
+        prepare_netkvmco_cmd = 'xcopy %s c:\\ /y && rundll32 netkvmco.dll,RegisterNetKVMNetShHelper'
+        vlan_set_cmd = 'netsh netkvm setparam 0 param=vlanid value=${vlan_id}'
     variants:
         - ctrl_on:
             nic_extra_params += ",ctrl_vlan=on"

--- a/qemu/tests/ctrl_vlan.py
+++ b/qemu/tests/ctrl_vlan.py
@@ -1,8 +1,10 @@
 import logging
+import time
 
 from virttest import error_context
 from virttest import utils_net
 from virttest import utils_test
+from virttest.utils_windows import virtio_win
 
 
 @error_context.context_aware
@@ -38,11 +40,38 @@ def run(test, params, env):
             test.fail("Guest vlan table is not correct, expect: %s, actual: %s"
                       % (expect_vlan, vlan_table[0]))
 
+    def get_netkvmco_path(session):
+        """
+        Get the proper netkvmco.dll path from iso.
+
+        :param session: a session to send cmd
+        :return: the proper netkvmco.dll path
+        """
+
+        viowin_ltr = virtio_win.drive_letter_iso(session)
+        if not viowin_ltr:
+            err = "Could not find virtio-win drive in guest"
+            test.error(err)
+        guest_name = virtio_win.product_dirname_iso(session)
+        if not guest_name:
+            err = "Could not get product dirname of the vm"
+            test.error(err)
+        guest_arch = virtio_win.arch_dirname_iso(session)
+        if not guest_arch:
+            err = "Could not get architecture dirname of the vm"
+            test.error(err)
+
+        middle_path = "%s\\%s" % (guest_name, guest_arch)
+        find_cmd = 'dir /b /s %s\\netkvmco.dll | findstr "\\%s\\\\"'
+        find_cmd %= (viowin_ltr,  middle_path)
+        netkvmco_path = session.cmd(find_cmd).strip()
+        logging.info("Found netkvmco.dll file at %s" % netkvmco_path)
+        return netkvmco_path
+
     login_timeout = float(params.get("login_timeout", 360))
     error_context.context("Init the VM, and try to login", logging.info)
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
-    session = vm.wait_for_serial_login(timeout=login_timeout)
 
     if ("ctrl_vlan=on" in params["nic_extra_params"] and
             params["os_type"] == "linux"):
@@ -50,29 +79,50 @@ def run(test, params, env):
     else:
         expect_vlan = None
 
-    if params["os_type"] == "windows":
-        error_context.context("Verify if netkvm.sys is enabled in guest",
-                              logging.info)
-        session = utils_test.qemu.windrv_check_running_verifier(session, vm,
-                                                                test, "netkvm",
-                                                                timeout=120)
-    verify_vlan_table(expect_vlan)
-
     if "ctrl_vlan=on" in params["nic_extra_params"]:
-        error_context.context("Add vlan tag for guest network", logging.info)
+        error_context.context(
+            "Add vlan tag for guest network", logging.info)
         vlan_set_cmd = params["vlan_set_cmd"]
         vlan_id = params["vlan_id"]
-        if params["os_type"] == "linux":
-            ifname = utils_net.get_linux_ifname(session, vm.virtnet[0].mac)
-            vlan_set_cmd = vlan_set_cmd % (ifname, ifname, ifname, ifname)
-        else:
-            ifname = utils_net.get_windows_nic_attribute(session=session,
-                                                         key="netenabled",
-                                                         value=True,
-                                                         target="netconnectionID")
-            vlan_set_cmd = vlan_set_cmd % ifname
-        status, output = session.cmd_status_output(vlan_set_cmd)
-        if status:
-            test.error("Error occured when set vlan tag for network interface: %s, "
-                       "err info: %s " % (ifname, output))
+        try:
+            if params["os_type"] == "linux":
+                session = vm.wait_for_serial_login(timeout=login_timeout)
+                verify_vlan_table(expect_vlan)
+                ifname = utils_net.get_linux_ifname(
+                            session, vm.virtnet[0].mac)
+                vlan_set_cmd = vlan_set_cmd % (ifname, ifname, ifname, ifname)
+                status, output = session.cmd_status_output(vlan_set_cmd)
+                if status:
+                    test.error("Error occured when set vlan tag for network interface: %s, "
+                               "err info: %s " % (ifname, output))
+            else:
+                session = vm.wait_for_login(timeout=login_timeout)
+                error_context.context("Verify if netkvm.sys is enabled in guest",
+                                      logging.info)
+                session = utils_test.qemu.windrv_check_running_verifier(
+                            session, vm, test, "netkvm", timeout=120)
+                verify_vlan_table(expect_vlan)
+                ifname = utils_net.get_windows_nic_attribute(
+                            session=session, key="netenabled", value=True,
+                            target="netconnectionID")
+                netkvmco_path = get_netkvmco_path(session)
+                prepare_netkvmco_cmd = params.get("prepare_netkvmco_cmd")
+                session.cmd(prepare_netkvmco_cmd % netkvmco_path, timeout=240)
+                session.close()
+                session = vm.wait_for_serial_login(timeout=login_timeout)
+                status, output = session.cmd_status_output(vlan_set_cmd)
+                if status:
+                    test.error("Error occured when set vlan tag for "
+                               "network interface: %s, err info: %s "
+                               % (ifname, output))
+                # restart nic for windows guest
+                dev_mac = vm.virtnet[0].mac
+                connection_id = utils_net.get_windows_nic_attribute(
+                    session, "macaddress", dev_mac, "netconnectionid")
+                utils_net.restart_windows_guest_network(
+                    session, connection_id)
+                time.sleep(10)
+        finally:
+            if session:
+                session.close()
         verify_vlan_table(vlan_id)


### PR DESCRIPTION
Win7 and win2008 cannot use "Set-NetAdapter" in powershell, so replace with "Netsh".

Signed-off-by: Yu Wang <wyu@redhat.com>

id:1657625