### PR TITLE
 boot_with_multiqueue.py: fix using "rm" on windows guests

### DIFF
--- a/qemu/tests/cfg/boot_with_max_queues.cfg
+++ b/qemu/tests/cfg/boot_with_max_queues.cfg
@@ -10,4 +10,5 @@
         msi_check_cmd = "lspci -vvv -s %s | grep MSI"
     Windows:
         no Win2008..sp2
-	cdroms += " virtio"
+        cdroms += " virtio"
+        clean_cmd = del

--- a/qemu/tests/cfg/mq_enabled_chk.cfg
+++ b/qemu/tests/cfg/mq_enabled_chk.cfg
@@ -22,4 +22,5 @@
         file_transfer_client = "scp"
         filesize = 1024
         vt_ulimit_nofile = 10240
+        clean_cmd = del
 


### PR DESCRIPTION
Should use "del" on windows guests, add "clean_cmd = del" in cfg file

Signed-off-by: Yu Wang <wyu@redhat.com>

id:1723699