### PR TITLE
Migration:Update unstable command "x-multifd" to "multifd" 

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -36,11 +36,11 @@
                     mig_speed = 1b
                     pre_migrate = "mig_set_speed"
                 - with_multifd:
+                    required_qemu = [4.0.0,)
                     only tcp,unix,fd
-                    migrate_capabilities = "{'x-multifd': 'on'}"
-                    migrate_parameters = "{'x-multifd-channels': 8, 'x-multifd-page-count': 64}"
-                    target_migrate_parameters = "{'x-multifd-channels': 8, 'x-multifd-page-count': 64}"
-
+                    migrate_capabilities = "{'multifd': 'on'}"
+                    migrate_parameters = "{'multifd-channels': 8}"
+                    target_migrate_parameters = "{'multifd-channels': 8}"
     variants:
         - x-rdma:
             migration_protocol = "x-rdma"


### PR DESCRIPTION
Drop unstable command "x-multifd", update it to formal
command "multifd".

ID:1720112
Signed-off-by: Xianwang <xianwang@redhat.com>