### PR TITLE
Check basic driver function after main_test executed

### DIFF
--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -14,7 +14,7 @@
         target_process = random\w*.exe
         rng_data_rex = "0x\w"
         driver_name = "viorng"
-        read_rng_cmd = for /l %i in (1, 1, 1000) do "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
         list_cmd = "wmic process get name"
         i386:
             driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
@@ -23,7 +23,7 @@
             driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
     Linux:
-        read_rng_cmd  = "dd if=/dev/random bs=10 count=1000000 2>/dev/null|hexdump"
+        read_rng_cmd  = "dd if=/dev/random bs=10 count=10 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
         target_process = rngd
         rng_data_rex = "\w+"
@@ -38,9 +38,15 @@
     variants:
         - before_bg_test:
             run_bg_flag = "before_bg_test"
+            no rng_egd
         - during_bg_test:
             suppress_exception = yes
             run_bg_flag = "during_bg_test"
+            Windows:
+                read_rng_cmd = for /l %i in (1, 1, 1000) do "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+            Linux:
+                read_rng_cmd  = "dd if=/dev/random bs=10 count=1000000 2>/dev/null|hexdump"
+            no rng_egd
         - after_bg_test:
             run_bg_flag = "after_bg_test"
     variants:

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -154,3 +154,5 @@ def run(test, params, env):
         if vm.is_dead():
             vm.create(params=params)
         utils_test.run_virt_sub_test(test, params, env, main_test)
+        if vm.is_alive():
+            run_bg_test_sep(bg_stress_test)


### PR DESCRIPTION
1. Check basic driver function after main_test executed 
2. Adjust viorng config to optimize rng cases.

ID: 1725565

Signed-off-by: Li Jin <lijin@redhat.com>