### PR TITLE
virtio_console: Fix q35 hotplug issues

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -213,7 +213,7 @@
                 - hotplug_virtio_pci:
                     only spread_linear
                     virtio_console_test = hotplug_virtio_pci
-                    virtio_console_pause = 0.2
+                    virtio_console_pause = 1
                     virtio_console_loops = 10
                 # Without VMS
                 - max_serials_and_consoles:

--- a/qemu/tests/virtio_port_hotplug.py
+++ b/qemu/tests/virtio_port_hotplug.py
@@ -1,7 +1,6 @@
 import time
 import logging
 
-from virttest.qemu_devices import qdevices
 from virttest import error_context
 
 
@@ -25,31 +24,6 @@ def run(test, params, env):
     :param env:    Dictionary with test environment.
     """
 
-    def get_virtio_port_by_name(vm, name):
-        """
-        Get virtio port object by name in VM.
-
-        :param name: name of the port
-        """
-        for device in vm.devices:
-            if isinstance(device, qdevices.QDevice):
-                if device.get_param("name") == name:
-                    return device
-        return None
-
-    def get_virtio_port_name_by_params(params, tag):
-        """
-        Get virtio port name via params according tag.
-
-        :param params: test params.
-        :param tag: port name or tag(eg, vc1).
-        """
-        prefix = params.get('virtio_port_name_prefix')
-        index = params.objects("virtio_ports").index(tag)
-        if prefix:
-            return "%s%d" % (prefix, index)
-        return tag
-
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     timeout = int(params.get("login_timeout", 360))
@@ -60,12 +34,13 @@ def run(test, params, env):
         if module:
             error_context.context("Load module %s" % module, logging.info)
             session.cmd("modprobe %s" % module)
-        for port in params.objects("virtio_ports"):
+        for port in params.objects("serials"):
             port_params = params.object_params(port)
-            port_name = get_virtio_port_name_by_params(port_params, port)
-            virtio_port = get_virtio_port_by_name(vm, port_name)
+            if not port_params['serial_type'].startswith('virt'):
+                continue
+            virtio_port = vm.devices.get(port)
             if not virtio_port:
-                test.fail("Virtio Port named '%s' not found" % port_name)
+                test.fail("Virtio Port '%s' not found" % port)
             chardev_qid = virtio_port.get_param("chardev")
             port_chardev = vm.devices.get_by_qid(chardev_qid)[0]
             if module:
@@ -74,15 +49,15 @@ def run(test, params, env):
                 session.cmd("modprobe -r %s" % module)
             error_context.context("Unplug virtio port '%s' in %d tune(s)" %
                                   (port, repeat), logging.info)
-            virtio_port.unplug(vm.monitor)
+            vm.devices.simple_unplug(virtio_port, vm.monitor)
             if port_params.get("unplug_chardev") == "yes":
                 error_context.context(
                     "Unplug chardev '%s' for virtio port '%s'" %
                     (port, chardev_qid), logging.info)
-                port_chardev.unplug(vm.monitor)
+                vm.devices.simple_unplug(port_chardev, vm.monitor)
                 time.sleep(0.5)
-                port_chardev.hotplug(vm.monitor)
-            virtio_port.hotplug(vm.monitor)
+                vm.devices.simple_hotplug(port_chardev, vm.monitor)
+            vm.devices.simple_hotplug(virtio_port, vm.monitor)
             if module:
                 error_context.context("Load  module %s" % module, logging.info)
                 session.cmd("modprobe %s" % module)


### PR DESCRIPTION
Use simple_hotplug() instead of device.hotplug() for q35 support,
'serials' instead of 'virtio_ports' to align new definition. And
remove get device id by name methods since not necessary now

id: 1726614, 1529434, 1724599
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>