### PR TITLE
Add sync_timezone_vm for timer device cases

### DIFF
--- a/qemu/tests/cfg/timedrift_adjust_time.cfg
+++ b/qemu/tests/cfg/timedrift_adjust_time.cfg
@@ -7,7 +7,6 @@
     start_vm = no
     kill_vm = yes
     requries_root = yes
-    image_snapshot = yes
     pre_command = "systemctl stop chronyd || service ntpdate stop"
     post_command = "systemctl restart chronyd || service ntpdate restart"
     sync_host_time_cmd = "chronyd -q 'server clock.redhat.com iburst'; hwclock -w"

--- a/qemu/tests/timedrift.py
+++ b/qemu/tests/timedrift.py
@@ -7,6 +7,7 @@ from avocado.utils import process
 from avocado.utils import cpu
 
 from virttest import utils_test
+from virttest import utils_time
 from virttest.compat_52lts import decode_to_text
 
 
@@ -73,6 +74,9 @@ def run(test, params, env):
         utils_test.update_boot_option(vm,
                                       args_removed=boot_option_removed,
                                       args_added=boot_option_added)
+
+    if params["os_type"] == "windows":
+        utils_time.sync_timezone_win(vm)
 
     timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_serial_login(timeout=timeout)

--- a/qemu/tests/timedrift_adjust_time.py
+++ b/qemu/tests/timedrift_adjust_time.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 from virttest import env_process
 from virttest import test_setup
 from virttest import error_context
+from virttest import utils_time
 
 from generic.tests.guest_suspend import GuestSuspendBaseTest
 
@@ -240,6 +241,8 @@ class BackwardtimeTest(TimedriftTest):
         self.setup_private_network()
         self.sync_host_time()
         vm = self.get_vm(create=True)
+        if self.params["os_type"] == 'windows':
+            utils_time.sync_timezone_win(vm)
         session = self.get_session(vm)
         self.check_dirft_before_adjust_time(session)
         if self.params.get("read_clock_source_cmd"):

--- a/qemu/tests/timedrift_check_when_crash.py
+++ b/qemu/tests/timedrift_check_when_crash.py
@@ -7,6 +7,7 @@ from virttest.env_process import preprocess
 from virttest.virt_vm import VMDeadKernelCrashError
 from virttest import error_context
 from virttest import utils_test
+from virttest import utils_time
 
 
 @error_context.context_aware
@@ -40,6 +41,10 @@ def run(test, params, env):
     preprocess(test, params, env)
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
+
+    if params["os_type"] == 'windows':
+        utils_time.sync_timezone_win(vm)
+
     timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=timeout)
 

--- a/qemu/tests/timedrift_check_when_hotplug_vcpu.py
+++ b/qemu/tests/timedrift_check_when_hotplug_vcpu.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 
 from virttest import error_context
 from virttest import utils_test
+from virttest import utils_time
 
 
 @error_context.context_aware
@@ -32,6 +33,8 @@ def run(test, params, env):
     process.system(ntp_host_cmd, shell=True)
 
     vm = env.get_vm(params["main_vm"])
+    if params["os_type"] == 'windows':
+        utils_time.sync_timezone_win(vm)
     session = vm.wait_for_login()
 
     ntp_query_cmd = params.get("ntp_query_cmd", "")

--- a/qemu/tests/timedrift_monotonicity.py
+++ b/qemu/tests/timedrift_monotonicity.py
@@ -6,6 +6,7 @@ import shutil
 
 from virttest import utils_test
 from virttest import utils_misc
+from virttest import utils_time
 
 
 def run(test, params, env):
@@ -52,6 +53,9 @@ def run(test, params, env):
         utils_test.update_boot_option(vm,
                                       args_removed=boot_option_removed,
                                       args_added=boot_option_added)
+
+    if params["os_type"] == 'windows':
+        utils_time.sync_timezone_win(vm)
 
     timeout = int(params.get("login_timeout", 360))
     session1 = vm.wait_for_login(timeout=timeout)

--- a/qemu/tests/timedrift_with_migration.py
+++ b/qemu/tests/timedrift_with_migration.py
@@ -1,6 +1,7 @@
 import logging
 
 from virttest import utils_test
+from virttest import utils_time
 
 
 def run(test, params, env):
@@ -26,6 +27,9 @@ def run(test, params, env):
         utils_test.update_boot_option(vm,
                                       args_removed=boot_option_removed,
                                       args_added=boot_option_added)
+
+    if params["os_type"] == 'windows':
+        utils_time.sync_timezone_win(vm)
 
     timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=timeout)

--- a/qemu/tests/timedrift_with_stop.py
+++ b/qemu/tests/timedrift_with_stop.py
@@ -4,6 +4,7 @@ import os
 import signal
 
 from virttest import utils_test
+from virttest import utils_time
 
 
 def run(test, params, env):
@@ -33,6 +34,9 @@ def run(test, params, env):
         utils_test.update_boot_option(vm,
                                       args_removed=boot_option_removed,
                                       args_added=boot_option_added)
+
+    if params["os_type"] == 'windows':
+        utils_time.sync_timezone_win(vm)
 
     session = vm.wait_for_login(timeout=login_timeout)
 


### PR DESCRIPTION
The windows guest's time zone needs to be the same as host
before test.

bug id: 1694959
Signed-off-by: yama <yama@redhat.com>