### PR TITLE
iozone_windows: Add a case to test the stability of guest

### DIFF
--- a/generic/tests/cfg/iozone_windows.cfg
+++ b/generic/tests/cfg/iozone_windows.cfg
@@ -12,3 +12,20 @@
             image_aio = native
         - aio_threads:
             image_aio = threads
+        - long_time_stress:
+            format_disk = yes
+            disk_index = "1 2"
+            disk_letter = "I J"
+            disk_fstype = "fat32 fat"
+            run_iozone_parallel = yes
+            iozone_cmd = "WIN_UTILS:\Iozone\iozone.exe -a -I -f {0}:\testfile"
+            stress_timeout = 43200
+            images += " stg0 stg1"
+            image_name_stg0 = images/storage0
+            image_size_stg0 = 20G
+            image_name_stg1 = images/storage1
+            image_size_stg1 = 1G
+            force_create_image_stg0 = yes
+            force_create_image_stg1 = yes
+            remove_image_stg0 = yes
+            remove_image_stg1 = yes


### PR DESCRIPTION
Add a case to test the stability of guest by running iozone
on multiple disks in a long time.

ID: 1715710
Signed-off-by: Yongxue Hong <yhong@redhat.com>