### PR TITLE
timer-device: add qemu_stop = off for timer device cases

### DIFF
--- a/generic/tests/cfg/timedrift.cfg
+++ b/generic/tests/cfg/timedrift.cfg
@@ -1,5 +1,6 @@
 - timedrift: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu libvirt
+    qemu_stop = off
     i386, x86_64:
         rtc_drift = "slew"
     variants:

--- a/generic/tests/cfg/timerclock.cfg
+++ b/generic/tests/cfg/timerclock.cfg
@@ -1,6 +1,7 @@
 - timerclock:
     only Linux
     virt_test_type = qemu
+    qemu_stop = off
     variants:
         - monotonic_time:
             type = monotonic_time

--- a/qemu/tests/cfg/time_manage.cfg
+++ b/qemu/tests/cfg/time_manage.cfg
@@ -1,5 +1,6 @@
 - time_manage:
     type = time_manage
+    qemu_stop = off
     kill_vm = yes
     extra_params +=" -rtc base=utc,driftfix=slew -snapshot"
     # The stress command *must* be installed in the host.

--- a/qemu/tests/cfg/timedrift_adjust_time.cfg
+++ b/qemu/tests/cfg/timedrift_adjust_time.cfg
@@ -2,6 +2,7 @@
     no WinXp, Win2000, Win2003, WinVista
     virt_test_type = qemu libvirt
     clock_source = 'kvm-clock'
+    qemu_stop = off
     type = timedrift_adjust_time
     tolerance = 5.0
     start_vm = no

--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -1,4 +1,5 @@
 - check_clock_offset:
+    qemu_stop = off
     rtc_clock = host
     rtc_base = utc
     i386, x86_64:

--- a/qemu/tests/cfg/timedrift_no_net.cfg
+++ b/qemu/tests/cfg/timedrift_no_net.cfg
@@ -2,6 +2,7 @@
     virt_test_type = qemu libvirt
     nettype = none
     login_timeout = 240
+    qemu_stop = off
     guest_clock_source = "kvm-clock"
     clock_sync_command = "(systemctl stop chronyd || service ntpdate stop)"
     clock_sync_command += " && chronyd -q 'server clock.redhat.com iburst'"

--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -1,5 +1,6 @@
 - timerdevice:
     no Host_RHEL.m6
+    qemu_stop = off
     restart_vm = yes
     host_cpu_cnt_cmd = "cat /proc/cpuinfo | grep "physical id" | wc -l"
     no aarch64


### PR DESCRIPTION
-S will cause the guest system time is different with host system
 time when -rtc clock=vm.

bug id: 1694657
Signed-off-by: yama <yama@redhat.com>