### PR TITLE
virtual_nic: correct the path of 'tshark.exe' in 'tcpdump_cmd'

### DIFF
--- a/qemu/tests/cfg/virtual_nic.cfg
+++ b/qemu/tests/cfg/virtual_nic.cfg
@@ -12,7 +12,7 @@
             tcpdump_check_cmd = pgrep -f tcpdump.*ADDR1.*ADDR0
             tcpdump_kill_cmd = killall -9 tcpdump
             Windows:
-                tcpdump_cmd = C:\tshark\tshark.exe -s 0 -n ssh and dst %s and src %s -i "%s"
+                tcpdump_cmd = '"C:\Program Files\Wireshark\tshark.exe" -s 0 -n ssh and dst %s and src %s -i "%s"'
                 clean_cmd = del
                 tmp_dir = C:\
                 dd_cmd = D:\coreutils\DummyCMD.exe %s %s 1


### PR DESCRIPTION
id: 1646790
Signed-off-by: Yanan Fu <yfu@redhat.com>