### PR TITLE
smbios: avoid using virtio device in smbios_table.machine_type

### DIFF
--- a/qemu/tests/cfg/smbios.cfg
+++ b/qemu/tests/cfg/smbios.cfg
@@ -29,6 +29,8 @@
         - type0and1:
             smbios_type = Bios System
         - machine_type:
+            drive_format_image1 = ahci
+            nic_model_nic1 = rtl8139
             traversal_machine_emulated = yes
             smbios_type_disable = yes
             dmikeyword_System = Version


### PR DESCRIPTION
When testing with q35 machine type, RHEL6 guest cannot run with default virtio-1.0 driver.
This case is not related with virtio, so use non-virtio device instead to support RHEL6.

ID: 1728570

Signed-off-by: ybduan <yduan@redhat.com>