### PR TITLE
multi_nics_verify.with_multiqueue: fix "Too many open files" issue

### DIFF
--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -9,5 +9,6 @@
         - @default:
         - with_multiqueue:
             queues = ${smp}
+            vt_ulimit_nofile = 10240
             Windows..i386:
                 nics_num = 8


### PR DESCRIPTION
Add "vt_ulimit_nofile"

Signed-off-by: Yu Wang <wyu@redhat.com>

id:1716712