### PR TITLE
timerdevice: modify ntp_sync_cmd to support rhel6 guest

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -28,7 +28,8 @@
             i386, x86_64:
                 rtc_drift = slew
             ntp_sync_cmd = "(systemctl stop chronyd || service ntpdate stop)"
-            ntp_sync_cmd += " && chronyd -q 'server clock.redhat.com iburst'"
+            ntp_sync_cmd += " && (chronyd -q 'server clock.redhat.com iburst'"
+            ntp_sync_cmd +=  " || ntpdate clock.redhat.com)"
         - clock_drift_with_ntp:
             only Linux
             no RHEL.6


### PR DESCRIPTION
bug id: 1729906
Signed-off-by: yama <yama@redhat.com>