### PR TITLE
Numa_memdev_options: Assign proper host numa node automatically

### DIFF
--- a/qemu/tests/cfg/numa_memdev_options.cfg
+++ b/qemu/tests/cfg/numa_memdev_options.cfg
@@ -5,8 +5,7 @@
     mem_devs = "mem0 mem1"
     backend_mem = memory-backend-ram
     use_mem = no
-    host-nodes_mem0 = 0
-    host-nodes_mem1 = 1
+    not_preprocess = yes
     size_mem0 = 1024M
     size_mem1 = 3072M
     guest_numa_nodes = "node0 node1"
@@ -22,8 +21,6 @@
     variants:
         - policy_default:
             policy_mem = default
-            del host-nodes_mem0
-            del host-nodes_mem1
         - policy_bind:
             policy_mem = bind
         - policy_interleave:
@@ -38,19 +35,10 @@
             start_vm = no
         - numa_hugepage:
             backend_mem = memory-backend-file
-            setup_hugepages = yes
+            set_node_hugepage = yes
             mem-path = /mnt/kvm_hugepage
-            target_nodes = 0 1
-            # Please update following numbers according to actual hugepage size,
-            # It intends for 2M hugepage by default.
-            target_num_node0 = 522
-            target_num_node1 = 1546
         - numa_ram_hugepage:
             backend_mem_mem0 = memory-backend-file
             backend_mem_mem1 = memory-backend-ram
-            setup_hugepages = yes
+            set_node_hugepage = yes
             mem-path_mem0 = /mnt/kvm_hugepage
-            target_nodes = 0
-            # Please update following numbers according to actual hugepage size,
-            # It intends for 2M hugepage by default.
-            target_num_node0 = 522


### PR DESCRIPTION
1.Update function "check_host_numa_node_amount" to
  "get_host_numa_node" to check host numa node
  whose node size is non-zero
2.Assign host numa nodes whose node size is non-zero to
  "host-nodes" and "target_num"

ID:1716737
ID:1722351
Signed-off-by: Xianwang <xianwang@redhat.com>