### PR TITLE
 sgainfo_update: update sgabios_info 

### DIFF
--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -10,9 +10,9 @@
             boot_menu = on
             enable_sga = yes
             image_verify_bootable = no
-            boot_menu_key = "f12"
-            Host_RHEL.m7:
-                boot_menu_key = "esc"
+            boot_menu_key = "esc"
+            Host_RHEL.m6:
+                boot_menu_key = "f12"
             boot_menu_hint = "Press .*(F12|ESC) for boot menu"
             # Specify the boot device name which you want to test here.
             boot_device = "iPXE"

--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -24,7 +24,7 @@
             Host_RHEL:
                 sgabios_info = "Google, Inc.\s"
                 sgabios_info += "Serial Graphics Adapter .*\s"
-                sgabios_info += "SGABIOS \$Id: sgabios.S .*\s"
+                sgabios_info += "SGABIOS \$Id.*\s"
                 sgabios_info += "\d \d\s"
         - bin_file:
             type = seabios_bin


### PR DESCRIPTION
1.The latest SGABIOS output has changed. Update sgabios_info to be compatible.
2.Update the way to specify boot_menu_key for RHEL 8 compatibility.

ID: 1728997
Signed-off-by: ybduan yduan@redhat.com