### PR TITLE
block_hotplug: Update with_block_resize cfg

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -67,38 +67,24 @@
             only one_pci
             sub_type_after_plug = block_resize
             blk_extra_params_stg0 += ",serial=TARGET_DISK0"
-            block_size_cmd = "fdisk -l | grep {0}"
-            block_size_pattern = ",\s+(\d+\s+b)ytes"
             disk_change_ratio = "1.5 0.5"
             repeat_times = 1
+            image_size_stg0 = 10G
+            Linux:
+                image_size_stg = ${image_size_stg0}
+                format_disk = yes
             Windows:
-                block_size_cmd = "wmic diskdrive get size, index"
-                block_size_pattern = "1\s+(\d+)"
                 accept_ratio = 0.0005
-                disk_update_cmd = "echo rescan > cmd"
-                disk_update_cmd += " && echo select disk 1 > cmd"
-                disk_update_cmd += " && echo select partition 1 >> cmd"
-                disk_update_cmd += " && echo extend >> cmd"
-                disk_update_cmd += " && echo exit >> cmd"
-                disk_update_cmd += " && diskpart /s cmd"
-                # "::" is used to separate the commands as it is not used in both Linux and Windows
-                disk_update_cmd += "::"
-                disk_update_cmd += "echo select disk 1 > cmd"
-                disk_update_cmd += " && echo select partition 1 >> cmd"
-                disk_update_cmd += " && echo shrink desired=DISK_CHANGE_SIZE >> cmd"
-                disk_update_cmd += " && echo exit >> cmd && diskpart /s cmd"
-                disk_unit = M
-                disk_rescan_cmd = "echo rescan > cmd"
-                disk_rescan_cmd += " && echo exit >> cmd"
-                disk_rescan_cmd += " && diskpart /s cmd"
+                need_rescan = yes
+                disk_letter = I
+                disk_index = 1
             virtio_scsi:
                 driver_name = vioscsi
             virtio_blk:
                 driver_name = viostor
             fmt_qcow2:
-                disk_change_ratio = 1.5
-            fmt_raw:
-                disk_change_ratio = "1.5 0.5"
+                Host_RHEL.m6, Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2, Host_RHEL.m7.u3, Host_RHEL.m7.u4, Host_RHEL.m7.u5:
+                    disk_change_ratio = 1.5
 
     variants:
         - with_plug:


### PR DESCRIPTION
Due to new block_resize file no need disk_update_cmd params,
so delete them, and update a few new block_resize.py needed params.

id: 1734227
Signed-off-by: Peixiu Hou <phou@redhat.com>