### PR TITLE
bin_file: Add support for rhel8-related machine type

### DIFF
--- a/qemu/tests/seabios_bin.py
+++ b/qemu/tests/seabios_bin.py
@@ -20,7 +20,11 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
 
-    bin_dict = {'rhel6': 'bios.bin', 'rhel7': 'bios-256k.bin'}
+    bin_dict = {
+                   'rhel6': 'bios.bin',
+                   'rhel7': 'bios-256k.bin',
+                   'rhel8': 'bios-256k.bin'
+               }
 
     error_context.context("Get available bin files", logging.info)
     output = process.system_output('ls /usr/share/seabios', shell=True).decode()


### PR DESCRIPTION
Update bin_dict to add support for latest rhel8-related machine type.

ID: 1731138
Signed-off-by: ybduan <yduan@redhat.com>