### PR TITLE
timerdevice: modify login_timeout for cases with host load

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -89,6 +89,8 @@
                     variants:
                         - without_host_load:
                         - with_host_load:
+                            only Linux
+                            login_timeout = 600
                             timerdevice_host_load_cmd = "for (( I=0; I<`grep processor /proc/cpuinfo"
                             timerdevice_host_load_cmd += " | wc -l`; I++ )); do taskset -c $I /bin/bash -c"
                             timerdevice_host_load_cmd += " 'for ((;;)); do X=1; done &'; done"


### PR DESCRIPTION
With host 100% load, the serial login needs more time, 240s
 isn't enough. For windows guest, the response is too slow,
so no need to support it.

bug id: 1722784
Signed-off-by: yama <yama@redhat.com>