### PR TITLE
boot: restrict qemu version to test case time65536

### DIFF
--- a/qemu/tests/cfg/seabios_reboot_timeout.cfg
+++ b/qemu/tests/cfg/seabios_reboot_timeout.cfg
@@ -23,4 +23,5 @@
         - time65535:
             boot_reboot_timeout = 65535
         - time65536:
+            required_qemu = [, 4)
             boot_reboot_timeout = 65536


### PR DESCRIPTION
Latest qemu 4.x doesn't support boot option reboot-timeout larger than
65535, it only works with older qemu version.

ID: 1735665
Signed-off-by: ybduan <yduan@redhat.com>