### PR TITLE
virtio_console: destroy vm at the end of the case

### DIFF
--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -1885,3 +1885,5 @@ def run(test, params, env):
             return fce()
         finally:
             EXIT_EVENT.set()
+            vm = env.get_vm(params["main_vm"])
+            vm.destroy()


### PR DESCRIPTION
Otherwise sometimes cause unexpected exceptions when case finished

id: 1735756
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>