### PR TITLE
timerdevice: modify test_run_timeout

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -109,7 +109,7 @@
             variants:
                 - change_host_clksource:
                     type = timerdevice_tscsync_change_host_clksource
-                    test_run_timeout = 10
+                    test_run_timeout = 60
                 - longtime:
                     type = timerdevice_tscsync_longtime
                     host_socket_cnt_cmd = "cat /proc/cpuinfo | grep "physical id" | uniq | wc -l"


### PR DESCRIPTION
10s is too short, sometimes no results. Need more time to get
output.

bug id: 1736835
Signed-off-by: yama <yama@redhat.com>