### PR TITLE
x86_cpu_model: add cases to test more cpu models

### DIFF
--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -14,9 +14,45 @@
         - EPYC:
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c"
             model_pattern = "AMD EPYC Processor%s"
+        - Opteron_G5:
+            flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de f16c avx xsave aes popcnt sse4_2 sse4_1 cx16 fma ssse3 pclmulqdq lm pdpe1gb nx syscall tbm fma4 xop 3dnowprefetch misalignsse sse4a abm lahf_lm fpu"
+            model_pattern = "AMD Opteron 63xx class CPU%s"
+        - Opteron_G4:
+            flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de  avx xsave aes popcnt sse4_2 sse4_1 cx16 ssse3 pclmulqdq lm pdpe1gb nx syscall fma4 xop 3dnowprefetch misalignsse sse4a abm lahf_lm fpu"
+            model_pattern = "AMD Opteron 62xx class CPU%s"
+        - Opteron_G3:
+            flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de  popcnt cx16 lm nx syscall misalignsse sse4a abm lahf_lm fpu"
+            model_pattern = "AMD Opteron 23xx \(Gen 3 Class Opteron%s\)"
+        - Icelake-Server:
+            flags = "la57 wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512bitalg avx512_vpopcntdq clflushopt pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
+            model_pattern = "Intel Xeon Processor \(Icelake%s\)"
+        - Icelake-Client:
+            flags = "wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512bitalg avx512_vpopcntdq"
+            model_pattern = "Intel Core Processor \(Icelake%s\)"
+        - Cascadelake-Server:
+            flags = "avx512_vnni clflushopt ibrs ibpb pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
+            model_pattern = "Intel Xeon Processor \(Cascadelake%s\)"
         - Skylake-Server:
             flags = "pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Skylake%s\)"
         - Skylake-Client:
             flags = "xsavec xgetbv1"
             model_pattern = "Intel Core Processor \(Skylake%s\)"
+        - Broadwell:
+            flags = "adx rdseed 3dnowprefetch smap hle rtm"
+            model_pattern = "Intel Core Processor \(Broadwell%s\)"
+        - Broadwell-noTSX:
+            flags = "adx rdseed 3dnowprefetch smap"
+            model_pattern = "Intel Core Processor \(Broadwell, no TSX%s\)"
+        - Haswell:
+            flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de fpu avx xsave aes tsc_deadline_timer fma movbe popcnt x2apic sse4_2 sse4_1 cx16 ssse3 pclmulqdq pni f16c rdrand fsgsbase bmi1 hle avx2 smep bmi2 erms invpcid rtm lm rdtscp nx syscall lahf_lm xsaveopt arat pcid"
+            model_pattern = "Intel Core Processor \(Haswell%s\)"
+        - Haswell-noTSX:
+            flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de fpu avx xsave aes tsc_deadline_timer fma movbe popcnt x2apic sse4_2 sse4_1 cx16 ssse3 pclmulqdq pni f16c rdrand fsgsbase bmi1 avx2 smep bmi2 erms invpcid lm rdtscp nx syscall lahf_lm xsaveopt arat pcid"
+            model_pattern = "Intel Core Processor \(Haswell, no TSX%s\)"
+        - IvyBridge:
+            flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de fpu avx xsave aes tsc_deadline_timer popcnt x2apic sse4_2 sse4_1 cx16 ssse3 pclmulqdq pni rdrand fsgsbase smep erms lm rdtscp nx syscall lahf_lm xsaveopt arat f16c"
+            model_pattern = "Intel Xeon E3-12xx v2 \(Ivy Bridge%s\)"
+        - SandyBridge:
+            flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de fpu avx xsave aes tsc_deadline_timer popcnt x2apic sse4_2 sse4_1 cx16 ssse3 pclmulqdq pni lm rdtscp nx syscall lahf_lm xsaveopt arat"
+            model_pattern = "Intel Xeon E312xx \(Sandy Bridge%s\)"


### PR DESCRIPTION
Add more cpu models, including Opteron_G5, Opteron_G4, Opteron_G3,
Icelake-Server, Icelake-Client, Cascadelake-Server, Broadwell,
Broadwell-noTSX, Haswell, Haswell-noTSX, IvyBridge, and SandyBridge.

ID: 1737687, 1737688, 1737689, 1737691,1737692,1737693,1737694, 1737695, 1737697, 1737696

Signed-off-by: Yumei Huang <yuhuang@redhat.com>