### PR TITLE
Move driver microsoft signature check to win_sigverif case

### DIFF
--- a/qemu/tests/cfg/physical_resources_check.cfg
+++ b/qemu/tests/cfg/physical_resources_check.cfg
@@ -10,7 +10,6 @@
     cpu_vendor_id_chk_cmd = "cat /proc/cpuinfo | grep 'vendor_id'"
     # Parameter for checking virtio driver's signature in windows guest,
     # useless for linux guest.
-    vio_driver_chk_cmd = ""
     mem_chk_re_str = (\b[0-9]+\b)
     cpu_cores_chk_cmd = "lscpu | grep '^Core'"
     cpu_sockets_chk_cmd = "lscpu | grep -E '(^Socket|^CPU socket)'"

--- a/qemu/tests/cfg/win_sigverif.cfg
+++ b/qemu/tests/cfg/win_sigverif.cfg
@@ -8,9 +8,16 @@
     check_sigverif_cmd = 'type ${sigverif_log} | findstr /i "%s"'
     clean_sigverif_cmd = "del ${sigverif_log}"
     variants:
+        - @default:
+        - msft_sign_check:
+          type = win_msft_sign_check
+          vio_driver_chk_cmd = 'driverquery /si | find /i "%s"'
+          chk_timeout = 240
+    variants:
         - with_netkvm:
             only virtio_net
             driver_name = netkvm
+            device_name = "Red Hat VirtIO Ethernet Adapter"
         - with_viorng:
             driver_name = viorng
             no_virtio_rng:
@@ -18,6 +25,7 @@
                 backend_rng0 = rng-random
                 backend_type = passthrough
                 filename_passthrough = /dev/urandom
+            device_name = "VirtIO RNG Device"
         - with_viostor:
             driver_name = viostor
             images += " stg"
@@ -26,6 +34,7 @@
             drive_format_stg = virtio
             force_create_image_stg = yes
             remove_image_stg = yes
+            device_name = "Red Hat VirtIO SCSI controller"
         - with_vioscsi:
             driver_name = vioscsi
             images += " stg"
@@ -34,18 +43,22 @@
             drive_format_stg = scsi-hd
             force_create_image_stg = yes
             remove_image_stg = yes
+            device_name = "Red Hat VirtIO SCSI pass-through controller"
         - with_vioserial:
             driver_name = vioser
             serials += " vs"
             serial_type_vs = virtserialport
+            device_name = "VirtIO Serial Driver"
         - with_balloon:
             driver_name = balloon
             balloon = balloon0
             balloon_dev_devid = balloon0
             balloon_dev_add_bus = yes
+            device_name = "VirtIO Balloon Driver"
         - with_pvpanic:
             no Host_RHEL.m6
             driver_name = pvpanic
+            device_name = "QEMU PVPanic Device"
         - with_vioinput:
             required_qemu = [2.4.0, )
             no Win2008..sp2
@@ -53,3 +66,4 @@
             inputs = input1
             input_dev_bus_type_input1 = virtio
             input_dev_type_input1 = mouse
+            device_name = "VirtIO Input Driver"

--- a/qemu/tests/physical_resources_check.py
+++ b/qemu/tests/physical_resources_check.py
@@ -361,17 +361,6 @@ def run(test, params, env):
                            catch_serial_cmd)
     n_fail.extend(f_fail)
 
-    # only check if the MS Windows VirtIO driver is digital signed.
-    chk_cmd = params.get("vio_driver_chk_cmd")
-    if chk_cmd:
-        error_context.context("Virtio Driver Check", logging.info)
-        chk_output = session.cmd_output(chk_cmd, timeout=chk_timeout)
-        if "FALSE" in chk_output:
-            fail_log = "VirtIO driver is not digitally signed!"
-            fail_log += "    VirtIO driver check output: '%s'" % chk_output
-            n_fail.append(fail_log)
-            logging.error(fail_log)
-
     error_context.context("Machine Type Check", logging.info)
     f_fail = verify_machine_type()
     n_fail.extend(f_fail)

--- a/qemu/tests/win_msft_sign_check.py
+++ b/qemu/tests/win_msft_sign_check.py
@@ -1,0 +1,39 @@
+import logging
+
+from virttest import error_context
+from virttest import utils_test
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    sigverif test:
+    1) Boot guest with related virtio devices
+    2) Run driver signature check command in guest
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    vm = env.get_vm(params["main_vm"])
+    session = vm.wait_for_login()
+
+    driver_name = params["driver_name"]
+    session = utils_test.qemu.windrv_check_running_verifier(session, vm,
+                                                            test, driver_name)
+
+    # check if Windows VirtIO driver is msft digital signed.
+    device_name = params["device_name"]
+    chk_cmd = params["vio_driver_chk_cmd"] % device_name[0:30]
+    chk_timeout = int(params.get("chk_timeout", 240))
+    error_context.context("%s Driver Check" % driver_name, logging.info)
+    chk_output = session.cmd_output(chk_cmd, timeout=chk_timeout)
+    if "FALSE" in chk_output:
+        fail_log = "VirtIO driver is not digitally signed!"
+        fail_log += "    VirtIO driver check output: '%s'" % chk_output
+        test.fail(fail_log)
+    elif "TRUE" in chk_output:
+        pass
+    else:
+        test.error("Device %s is not found in guest" % device_name)


### PR DESCRIPTION
Move driver microsoft signature check part from physical_resources_check to win_sigverif case as prewhql drivers are not msft signed. It's better to move it from regular cases.

ID: 1569925

Signed-off-by: lijin <lijin@redhat.com>