### PR TITLE
Add several virtio serial new cases

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -125,3 +125,22 @@
                 test_after_load = rng_bat
                 bg_stress_test_is_cmd = yes
                 read_rng_timeout = 360
+        - with_vioser:
+            only during_bg_test
+            driver_name = vioser
+            driver_id_pattern = "(.*?):.*?VirtIO Serial Driver"
+            run_bgstress = virtio_serial_file_transfer
+            guest_scripts = VirtIoChannel_guest_send_receive.py;windows_support.py
+            file_transfer_serial_port = vs1
+            serials += " vs1"
+            serial_type_vs1 = virtserialport
+            transfer_timeout = 720
+            filesize = 500
+            host_script = serial_host_send_receive.py
+            guest_script = VirtIoChannel_guest_send_receive.py
+            guest_script_folder = C:\
+            clean_cmd = del /f /q
+            tmp_dir = %TEMP%
+            python_bin = python2.7
+            file_sender = guest
+            target_process = ${python_bin}.exe

--- a/qemu/tests/cfg/vioser_in_use.cfg
+++ b/qemu/tests/cfg/vioser_in_use.cfg
@@ -1,0 +1,52 @@
+- vioser_in_use:
+    type = vioser_in_use
+    suppress_exception = yes
+    file_transfer_serial_port = vs1
+    serials += " vs1"
+    serial_type_vs1 = virtserialport
+    transfer_timeout = 720
+    host_script = serial_host_send_receive.py
+    guest_script = VirtIoChannel_guest_send_receive.py
+    guest_scripts = VirtIoChannel_guest_send_receive.py;windows_support.py
+    driver_name = "vioser"
+    filesize = 100
+    clean_cmd = del /f /q
+    guest_script_folder = C:\
+    tmp_dir = %TEMP%
+    python_bin = python2.7
+    target_process = ${python_bin}.exe
+    Linux:
+        guest_script_folder = /var/tmp/
+        tmp_dir = /var/tmp/
+        clean_cmd = rm -f
+        filesize = 1000
+        python_bin = "`command -v python python3 | head -1`"
+        target_process = "python"
+    variants:
+        - guest_to_host:
+            file_sender = guest
+        - host_to_guest:
+            file_sender = host
+    variants:
+        - with_stop_continue:
+            only Windows
+            interrupt_test = subw_guest_pause_resume
+            suppress_exception = no
+            wait_timeout = 10
+        - with_shutdown:
+            only Windows
+            interrupt_test = shutdown_guest
+            shutdown_method = shell
+            shutdown_command = "shutdown -s -t 0"
+        - with_reboot:
+            only Windows
+            interrupt_test = reboot_guest
+            reboot_method = shell
+        - with_system_reset:
+            only Windows
+            interrupt_test = reboot_guest
+            reboot_method = system_reset
+        - with_live_migration:
+            interrupt_test = live_migration_guest
+            mig_speed = 512M
+            pre_migrate = "mig_set_speed"

--- a/qemu/tests/cfg/virtio_serial_file_transfer.cfg
+++ b/qemu/tests/cfg/virtio_serial_file_transfer.cfg
@@ -11,7 +11,6 @@
     filesize = 10
     host_script = serial_host_send_receive.py
     guest_script = VirtIoChannel_guest_send_receive.py
-    repeat_times = 1
     Windows:
         guest_script_folder = C:\
         clean_cmd = del /f /q

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -156,3 +156,23 @@
             backup_image_before_testing = yes
             restore_image_after_testing = yes
             set_panic_cmd = 'wmic class stdregprov call SetDwordValue hDefKey="&h80000002" sSubKeyName="SYSTEM\CurrentControlSet\Control\CrashControl" sValueName="NMICrashDump" uValue=1'
+        - with_vioser:
+            only during_bg_test
+            driver_name = vioser
+            device_name = "VirtIO Serial Driver"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1003" "PCI\VEN_1AF4&DEV_1043"'
+            guest_scripts = VirtIoChannel_guest_send_receive.py;windows_support.py
+            file_transfer_serial_port = vs1
+            serials += " vs1"
+            serial_type_vs1 = virtserialport
+            transfer_timeout = 720
+            filesize = 500
+            host_script = serial_host_send_receive.py
+            guest_script = VirtIoChannel_guest_send_receive.py
+            run_bgstress = virtio_serial_file_transfer
+            guest_script_folder = C:\
+            clean_cmd = del /f /q
+            tmp_dir = %TEMP%
+            python_bin = python2.7
+            file_sender = guest
+            target_process = ${python_bin}.exe

--- a/qemu/tests/vioser_in_use.py
+++ b/qemu/tests/vioser_in_use.py
@@ -1,0 +1,121 @@
+import re
+import os
+import signal
+import logging
+
+from avocado.utils import process
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import error_context
+
+from qemu.tests import virtio_serial_file_transfer
+from qemu.tests import driver_in_use
+from qemu.tests.timedrift_no_net import subw_guest_pause_resume  # pylint: disable=W0611
+
+
+@error_context.context_aware
+def reboot_guest(test, params, vm, session):
+    """
+    Reboot guest from system_reset or shell.
+    """
+
+    vm.reboot(session, method=params["reboot_method"])
+
+
+@error_context.context_aware
+def shutdown_guest(test, params, vm, session):
+    """
+    Shutdown guest via system_powerdown or shell.
+    """
+
+    if params.get("shutdown_method") == "shell":
+        session.sendline(params["shutdown_command"])
+    elif params.get("shutdown_method") == "system_powerdown":
+        vm.monitor.system_powerdown()
+    if not vm.wait_for_shutdown(int(params.get("shutdown_timeout", 360))):
+        test.fail("guest refuses to go down")
+
+
+@error_context.context_aware
+def live_migration_guest(test, params, vm, session):
+    """
+    Run migrate_set_speed, then migrate guest.
+    """
+
+    vm.monitor.migrate_set_speed(params.get("mig_speed", "1G"))
+    vm.migrate()
+
+
+@error_context.context_aware
+def kill_host_serial_pid(params, vm):
+    """
+    Kill serial script process on host to avoid two threads run
+    simultaneously.
+    """
+    port_path = virtio_serial_file_transfer.get_virtio_port_property(
+            vm, params["file_transfer_serial_port"])[1]
+
+    host_process = 'ps aux | grep "serial_host_send_receive.py"'
+    host_process = process.system_output(host_process,
+                                         shell=True).decode()
+    host_process = re.findall(r'(.*?)%s(.*?)\n' % port_path, host_process)
+    if host_process:
+        host_process = str(host_process[0]).split()[1]
+        logging.info("Kill previous serial process on host")
+        os.kill(int(host_process), signal.SIGINT)
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Driver in use test:
+    1) boot guest with serial device.
+    2) Transfer data between host and guest via serialport.
+    3) run interrupt test during background stress test.
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    def run_bg_test():
+        """
+        Run serial data transfer backgroud test.
+
+        :return: return the background case thread if it's successful;
+                 else raise error.
+        """
+        error_context.context("Run serial transfer test in background",
+                              logging.info)
+        stress_thread = utils_misc.InterruptedThread(
+                virtio_serial_file_transfer.transfer_data, (params, vm),
+                {"sender": sender})
+        stress_thread.start()
+
+        check_bg_timeout = float(params.get('check_bg_timeout', 120))
+        if not utils_misc.wait_for(lambda: driver_in_use.check_bg_running(vm,
+                                   params), check_bg_timeout, 0, 1):
+            test.fail("Backgroud test is not alive!")
+        return stress_thread
+
+    driver = params["driver_name"]
+    sender = params['file_sender']
+    timeout = int(params.get("login_timeout", 360))
+    suppress_exception = params.get("suppress_exception", "no") == "yes"
+
+    vm = env.get_vm(params["main_vm"])
+    session = vm.wait_for_login()
+    if params["os_type"] == "windows":
+        session = utils_test.qemu.windrv_check_running_verifier(session, vm,
+                                                                test, driver,
+                                                                timeout)
+
+    bg_thread = run_bg_test()
+    globals().get(params["interrupt_test"])(test, params, vm, session)
+    if bg_thread:
+        bg_thread.join(timeout=timeout, suppress_exception=suppress_exception)
+    if vm.is_alive():
+        kill_host_serial_pid(params, vm)
+        if (virtio_serial_file_transfer.transfer_data(params, vm, sender=sender) is
+                not True):
+            test.fail("Serial data transfter test failed.")

--- a/qemu/tests/virtio_serial_file_transfer.py
+++ b/qemu/tests/virtio_serial_file_transfer.py
@@ -162,6 +162,7 @@ def transfer_data(params, vm, host_file_name=None, guest_file_name=None,
     :return: True if pass, False and error message if check fail
     """
     session = vm.wait_for_login()
+    os_type = params["os_type"]
     guest_path = params.get("guest_script_folder", "C:\\")
     guest_scripts = params.get("guest_scripts",
                                "VirtIoChannel_guest_send_receive.py")
@@ -193,8 +194,10 @@ def transfer_data(params, vm, host_file_name=None, guest_file_name=None,
                   port_name, guest_file_name, guest_action))
     result = _transfer_data(session, host_cmd, guest_cmd, transfer_timeout, sender)
     clean_cmd = params['clean_cmd']
-    for script in guest_scripts.split(";"):
-        session.cmd('%s %s' % (clean_cmd, script))
+    os.remove(host_file_name)
+    if os_type == "windows":
+        guest_file_name = guest_file_name.replace("/", "\\")
+    session.cmd('%s %s' % (clean_cmd, guest_file_name))
     session.close()
     return result
 
@@ -218,7 +221,7 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     logging.info('Transfer data from %s' % sender)
-    result = transfer_data(params, vm, sender='both')
+    result = transfer_data(params, vm, sender=sender)
     vm.destroy()
     if result is not True:
         test.fail("Test failed. %s" % result[1])


### PR DESCRIPTION
1. Clean generated files in guest and host in virtio_serial_file_transfer case;
2. Move check_bg_running out of run to make other cases call it;
3. Add following new cases:
   - reboot/shutdown/system_reset/stop/cont/migration vm during
   virtio serial driver in use;
   - install/uninstall, downgrade/upgrade in usevirtio driver;
   - disable/enbale in use virtio driver

ID:1231046, 1231042, 1230682, 1231023, 1231003, 1231657, 1483440

Signed-off-by: Li Jin <lijin@redhat.com>