### PR TITLE
add case image_locking_read_test

### DIFF
--- a/qemu/tests/cfg/image_locking_read_test.cfg
+++ b/qemu/tests/cfg/image_locking_read_test.cfg
@@ -1,0 +1,37 @@
+- image_locking_read_test:
+    type = image_locking_read_test
+    virt_test_type = qemu
+    only qcow2
+    only Linux
+    not_preprocess = yes
+    vms += " vm2"
+    start_vm_vm2 = no
+    images += " sn1_chain1 sn2_chain1"
+    image_chain = "image1 sn1_chain1 sn2_chain1"
+    image_chain_second = "image1 sn1_chain2 sn2_chain2 sn3_chain2"
+    boot_drive_image1 = no
+    boot_drive_sn1_chain1 = no
+    boot_drive_sn2_chain1 = yes
+    boot_drive_sn1_chain2 = no
+    boot_drive_sn2_chain2 = no
+    boot_drive_sn3_chain2 = no
+    image_name_sn1_chain1 = images/sn1_chain1
+    image_format_sn1_chain1 = qcow2
+    image_size_sn1_chain1 = ""
+    force_create_image_sn1_chain1 = yes
+    image_name_sn2_chain1 = images/sn2_chain1
+    image_format_sn2_chain1 = qcow2
+    image_size_sn2_chain1 = ""
+    force_create_image_sn2_chain1 = yes
+    image_name_sn1_chain2 = images/sn1_chain2
+    image_format_sn1_chain2 = qcow2
+    image_size_sn1_chain2 = ""
+    image_name_sn2_chain2 = images/sn2_chain2
+    image_format_sn2_chain2 = qcow2
+    image_size_sn2_chain2 = ""
+    image_name_sn3_chain2 = images/sn3_chain2
+    image_format_sn3_chain2 = qcow2
+    image_size_sn3_chain2 = ""
+    tmp_file_name = /tmp/src.tmp
+    guest_tmp_filename = "/tmp/tempfile"
+    file_create_cmd = "dd if=/dev/urandom of=%s bs=1M count=512"

--- a/qemu/tests/image_locking_read_test.py
+++ b/qemu/tests/image_locking_read_test.py
@@ -1,0 +1,75 @@
+import logging
+
+from avocado import fail_on
+
+from virttest import env_process
+from virttest import error_context
+from virttest import virt_vm
+
+from qemu.tests.qemu_disk_img import QemuImgTest
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Verification that image lock has no effect on the read operation from
+    different image chain.
+    Steps:
+        1. create the first snapshot chain: image1 -> sn01 -> sn02
+        2. boot first vm from sn02
+        3. create the second snapshot chain: image1 -> sn11 -> sn12 ->sn13
+        4. boot second vm frm sn13 and create a temporary file
+        5. commit sn13
+        6. boot second vm from sn12 and verify the temporary file is presented.
+    """
+
+    params.update({"image_name_image1": params["image_name"],
+                   "image_format_image1": params["image_format"]})
+
+    error_context.context("boot first vm from first image chain", logging.info)
+    env_process.process(test, params, env, env_process.preprocess_image,
+                        env_process.preprocess_vm)
+    vm1 = env.get_vm(params["main_vm"])
+    vm1.verify_alive()
+
+    params["images"] = params["image_chain"] = params["image_chain_second"]
+    params["main_vm"] = params["vms"].split()[-1]
+    sn_tags = params["image_chain"].split()[1:]
+    images = [QemuImgTest(test, params, env, image) for image in sn_tags]
+
+    error_context.context("create the second snapshot chain", logging.info)
+    for image in images:
+        logging.debug("create snapshot %s based on %s", image.image_filename,
+                      image.base_image_filename)
+        image.create_snapshot()
+        logging.debug("boot from snapshot %s", image.image_filename)
+        try:
+            # ensure vm only boot with this snapshot
+            image.start_vm({"boot_drive_%s" % image.tag: "yes"})
+        except virt_vm.VMCreateError:
+            # add images in second chain to images so they could be deleted
+            # in postprocess
+            params["images"] += " %s" % image
+            test.fail("fail to start vm from snapshot %s" %
+                      image.image_filename)
+        else:
+            if image is not images[-1]:
+                image.destroy_vm()
+
+    tmpfile = params.get("guest_tmp_filename")
+    error_context.context("create a temporary file: %s in %s" %
+                          (tmpfile, image.image_filename), logging.info)
+    hash_val = image.save_file(tmpfile)
+    logging.debug("The hash of temporary file:\n%s", hash_val)
+    image.destroy_vm()
+
+    error_context.context("commit image %s" % image.image_filename,
+                          logging.info)
+    fail_on()(image.commit)()
+
+    error_context.context("check temporary file after commit", logging.info)
+    image = images[-2]
+    logging.debug("boot vm from %s", image.image_filename)
+    image.start_vm({"boot_drive_%s" % image.tag: "yes"})
+    if not image.check_file(tmpfile, hash_val):
+        test.fail("File %s's hash is different after commit" % tmpfile)


### PR DESCRIPTION
id:1739342 
Add a new testcase to test QEMU image locking should allow read
operation over the same base image. This case aims to verify that
snapshot in different snapshot chain could be used at the same time.

Signed-off-by: lolyu <lolyu@redhat.com>