### PR TITLE
used '-device' option for block migration tests

### DIFF
--- a/qemu/tests/cfg/block_commit.cfg
+++ b/qemu/tests/cfg/block_commit.cfg
@@ -2,6 +2,7 @@
 # monitor, so suggest to use QMP monitor as default qemu monitor run below test
 #
 - block_commit:
+    qemu_force_use_drive_expression = yes
     no raw qed vmdk
     backup_image_before_testing = yes
     restore_image_after_testing = yes

--- a/qemu/tests/cfg/block_stream.cfg
+++ b/qemu/tests/cfg/block_stream.cfg
@@ -2,6 +2,7 @@
 # monitor, so suggest to use QMP monitor as default qemu monitor run below test
 #
 - block_stream:
+    qemu_force_use_drive_expression = yes
     no raw qed vmdk
     monitors = qmp1
     monitor_type = qmp

--- a/qemu/tests/cfg/block_stream_negative.cfg
+++ b/qemu/tests/cfg/block_stream_negative.cfg
@@ -2,6 +2,7 @@
 # monitor, so suggest to use QMP monitor as default qemu monitor run below test
 #
 - block_stream_negative:
+    qemu_force_use_drive_expression = yes
     no raw qed vmdk
     backup_image_before_testing = yes
     restore_image_after_testing = yes

--- a/qemu/tests/cfg/drive_mirror.cfg
+++ b/qemu/tests/cfg/drive_mirror.cfg
@@ -1,4 +1,5 @@
 - drive_mirror:
+    qemu_force_use_drive_expression = yes
     no Host_RHEL.m5
     no Host_RHEL.m6.u1
     no Host_RHEL.m6.u2

--- a/qemu/tests/cfg/drive_mirror_negative_tests.cfg
+++ b/qemu/tests/cfg/drive_mirror_negative_tests.cfg
@@ -1,4 +1,5 @@
 - drive_mirror_negative_tests:
+    qemu_force_use_drive_expression = yes
     no Host_RHEL.m5
     no Host_RHEL.m6.u1
     no Host_RHEL.m6.u2

--- a/qemu/tests/cfg/live_snapshot.cfg
+++ b/qemu/tests/cfg/live_snapshot.cfg
@@ -1,4 +1,5 @@
 - live_snapshot:
+    qemu_force_use_drive_expression = yes
     virt_test_type = qemu
     type = live_snapshot
     no raw vmdk qed

--- a/qemu/tests/cfg/live_snapshot_chain.cfg
+++ b/qemu/tests/cfg/live_snapshot_chain.cfg
@@ -1,4 +1,5 @@
 - live_snapshot_chain:
+    qemu_force_use_drive_expression = yes
     no qed vmdk raw
     virt_test_type = qemu
     type = live_snapshot_chain


### PR DESCRIPTION
temporary fix to avoid blockdev updates

Signed-off-by: Xu Tian <xutian@redhat.com>