### PR TITLE
unattended_install: Workaround install windows guest with blockdev option

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -129,6 +129,10 @@
             unattended_delivery_method = cdrom
             cdroms += " unattended"
             Windows:
+                # FIXME: Guest could not be installed successfully without
+                # the serial option when using the blockdev option.
+                serial_name = SYSTEM_DISK0
+                blk_extra_params_image1 = "serial=${serial_name}"
                 i440fx:
                     cd_format_unattended = ide
                 q35:


### PR DESCRIPTION
Windows guest could not be installed successfully when using
the "blockdev" options, so workarund it with the "serial" option.

ID: 1740010
Signed-off-by: Yongxue Hong <yhong@redhat.com>