### PR TITLE
block_with_share_rw: New cases to test block device with share-rw

### DIFF
--- a/qemu/tests/block_with_share_rw.py
+++ b/qemu/tests/block_with_share_rw.py
@@ -1,0 +1,44 @@
+import logging
+
+from virttest import error_context
+from virttest import env_process
+from virttest import virt_vm
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test the scsi device with "share-rw" option.
+
+    Steps:
+      1. Boot up a guest with a data disk which image format is raw and
+         "share-rw" option is "off" or "on".
+      2. Run another vm with the data images:
+        2.1 Failed to execute the qemu commands due to fail to get "write" lock
+            with "share-rw=off"
+        2.2 Could execute the qemu commands with "share-rw=on".
+      3. Repeat step 1~2 with the drive format is "scsi-block" and "scsi-generic".
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    msgs = ['"write" lock', 'Is another process using the image']
+    vm1 = env.get_vm(params["main_vm"])
+    vm1.verify_alive()
+    vm1.wait_for_login(timeout=360)
+
+    try:
+        error_context.context('Start another vm with the data image.', logging.info)
+        params['images'] = params['images'].split()[-1]
+        env_process.preprocess_vm(test, params, env, "avocado-vt-vm2")
+        vm2 = env.get_vm("avocado-vt-vm2")
+        vm2.verify_alive()
+    except virt_vm.VMCreateError as e:
+        if params['share_rw'] == 'off':
+            if not all(msg in str(e) for msg in msgs):
+                test.fail("Image lock information is not as expected.")
+        else:
+            test.error(str(e))
+    else:
+        vm2.destroy(False, False)

--- a/qemu/tests/cfg/block_with_share_rw.cfg
+++ b/qemu/tests/cfg/block_with_share_rw.cfg
@@ -1,0 +1,37 @@
+- block_with_share_rw:
+    virt_test_type = qemu
+    type = block_with_share_rw
+    start_vm = yes
+    images += " stg"
+    image_format_stg = raw
+    qemu_io_cmd = read 0 1G
+    variants:
+        - with_scsi_hd:
+            image_name_stg = "images/storage"
+            image_size_stg = 40G
+            force_create_image_stg = yes
+            remove_image_stg = yes
+            drive_format_stg = scsi-hd
+        -@passthrough:
+            pre_command = "modprobe -r scsi_debug; modprobe sg; "
+            pre_command += "modprobe scsi_debug add_host=1 dev_size_mb=50"
+            post_command = "rmmod scsi_debug"
+            image_raw_device_stg = yes
+            indirect_image_select_stg = -1
+            variants:
+                - with_scsi_block:
+                    image_name_stg = /dev/sd*
+                    drive_format_stg = scsi-block
+                - with_scsi_generic:
+                    drive_format_stg = scsi-generic
+                    drive_cache_stg = writethrough
+                    image_aio_stg = threads
+                    image_name_stg = /dev/sg*
+    variants:
+        - turn_on:
+            share_rw = on
+        - turn_off:
+            share_rw = off
+    variants:
+        - @default:
+            blk_extra_params_stg = "share-rw=${share_rw}"


### PR DESCRIPTION
New cases that boot up two VMs to test scsi block device
with "share-rw=on" and "share-rw=off" option.

ID: 1731610
Signed-off-by: Yongxue Hong <yhong@redhat.com>