### PR TITLE
driver_load: Support ppc for loading driver

### DIFF
--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -39,6 +39,8 @@
 
         - with_block:
             drive_format_image1 = ide
+            pseries:
+               drive_format_image1 = scsi-hd
             q35:
                 drive_format_image1 = ahci
             images += " stg"
@@ -54,6 +56,9 @@
         - with_vioscsi:
             cd_format_fixed = ide
             drive_format_image1 = ide
+            pseries:
+               cd_format_fixed = scsi-cd
+               drive_format_image1 = virtio
             q35:
                 cd_format_fixed = ahci
                 drive_format_image1 = ahci


### PR DESCRIPTION
Since ppc doesn't suppurt ide interface, so replace it
with scsi-hd.

ID: 1741400
Signed-off-by: zhenyu zhang <zhenyzha@redhat.com>