### PR TITLE
virtio_port_hotplug:fix unfriendly error info

### DIFF
--- a/qemu/tests/virtio_port_hotplug.py
+++ b/qemu/tests/virtio_port_hotplug.py
@@ -67,7 +67,10 @@ def run(test, params, env):
             if not virtio_port:
                 test.fail("Virtio Port named '%s' not found" % port_name)
             chardev_qid = virtio_port.get_param("chardev")
-            port_chardev = vm.devices.get_by_qid(chardev_qid)[0]
+            try:
+                port_chardev = vm.devices.get_by_qid(chardev_qid)[0]
+            except IndexError:
+                test.error("Failed to get device %s" % chardev_qid)
             if module:
                 error_context.context("Unload module %s" % module,
                                       logging.info)


### PR DESCRIPTION
There is a unfriendly log when failed to
hotplug a port. It should give more specific
error info but no more like code error

ID:1741090

Signed-off-by: Nana Liu <nanliu@redhat.com>