### PR TITLE
timedrift_adjust_time: add test results for rhel6

### DIFF
--- a/qemu/tests/cfg/timedrift_adjust_time.cfg
+++ b/qemu/tests/cfg/timedrift_adjust_time.cfg
@@ -65,6 +65,11 @@
             time_difference = 1800
         timedrift_adjust_time.guest_s3.clock_host.adjust_host_clock:
             time_difference = 1800
+    RHEL.6:
+        timedrift_adjust_time.guest_reboot..adjust_guest_clock:
+        time_difference = 1800
+        timedrift_adjust_time.guest_reboot.clock_host.adjust_host_clock:
+        time_difference = 1800
     Windows:
         workaround_timeout = 360
         guest_epoch_time_cmd = 'powershell -command "& {$datetime=get-date -uformat "%c";'


### PR DESCRIPTION
The expected results for rhel6 and rhel8 are different.
Need to add results check for rhel6.

bug id: 1693232, 1693242
Signed-off-by: yama <yama@redhat.com>