### PR TITLE
boot_order_check: add support for q35 machine type

### DIFF
--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -1,6 +1,5 @@
 - boot_order_check:
     virt_test_type = qemu
-    only Linux
     only i386, x86_64
     type = boot_order_check
     kill_vm = yes
@@ -25,7 +24,7 @@
     image_size_stg2 = 2G
     force_create_image_stg2 = yes
     remove_image_stg2 = yes
-    nic_addr_filter = "%s.*?Bus\s+\d+,\s+device\s+(\d+)"
+    nic_addr_filter = "%s.*?Bus\s+(\d+),\s+device\s+(\d+),\s+function\s+(\d+)"
     variants:
         - bootorder0:
             # Some firmware has limitations on which devices can be considered for
@@ -42,11 +41,11 @@
             bootindex_nic3 = 5
             boot_fail_infos = "Booting from Hard Disk.*"
             boot_fail_infos += "Boot failed: not a bootable disk.*"
-            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices.*"
-            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices.*"
-            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices"
         - bootorder1:
             bootorder_type = "type1"
@@ -56,13 +55,13 @@
             bootindex_nic1 = 1
             bootindex_nic2 = 3
             bootindex_nic3 = 5
-            boot_fail_infos = "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos = "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "Booting from Hard Disk.*"
             boot_fail_infos += "Boot failed: not a bootable disk.*"
-            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices.*"
-            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices"
         - bootorder2:
             bootorder_type = "type2"
@@ -72,10 +71,10 @@
             bootindex_nic1 = 1
             bootindex_nic2 = 2
             bootindex_nic3 = 3
-            boot_fail_infos = "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos = "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices.*"
-            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices.*"
-            boot_fail_infos += "PXE \(PCI 00:%s.0\) starting execution.*"
+            boot_fail_infos += "PXE \(PCI %s\) starting execution.*"
             boot_fail_infos += "No more network devices.*"
             boot_fail_infos += "Booting from Hard Disk"


### PR DESCRIPTION
1. The original implementation only support pc machine type,
   add pci address resolution support for q35 machine type.
2. Remove the restriction for "only Linux".

ID: 1730964
Signed-off-by: ybduan <yduan@redhat.com>