### PR TITLE
Enable physical and logical block size 4096 on ovmf installation

### DIFF
--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -19,9 +19,10 @@
     chk_blks_cmd_windows = "powershell "get-disk|format-list""
     variants:
         - extra_cdrom_ks:
-            no 4096_4096
             cdroms += " unattended"
             unattended_delivery_method = cdrom
+            default_bios:
+                no 4096_4096
             Windows:
                 i440fx:
                     cd_format_cd1 = ide
@@ -45,6 +46,17 @@
             image_boot_stg = no
             physical_block_size_stg = 4096
             logical_block_size_stg = 4096
+            ovmf:
+                no base
+                need_install = yes
+                start_vm = no
+                images = "stg"
+                boot_drive_stg = yes
+                medium = cdrom
+                installation = cdrom
+                kernel = vmlinuz
+                initrd = initrd.img
+                nic_mode = tap
         - 4096_512:
             need_install = yes
             start_vm = no


### PR DESCRIPTION
ID : 1743608

Signed-off-by: Qing Wang <qinwang@redhat.com>