### PR TITLE
Add serial hotplug/unplug related cases

### DIFF
--- a/qemu/tests/cfg/virtio_port_hotplug.cfg
+++ b/qemu/tests/cfg/virtio_port_hotplug.cfg
@@ -3,17 +3,32 @@
     serials += " vc1 vc2"
     serial_type_vc1 = virtserialport
     serial_type_vc2 = virtconsole
+    file_transfer_serial_port = vc1
     unplug_device = vc1 vc2
     kill_vm = yes
     kill_vm_on_error = yes
     repeat_times = 100
+    target_process = "python"
+    guest_scripts = VirtIoChannel_guest_send_receive.py;windows_support.py
+    host_script = serial_host_send_receive.py
+    guest_script = VirtIoChannel_guest_send_receive.py
+    clean_cmd = rm -f
+    guest_script_folder = /var/tmp/
+    Windows:
+        guest_script_folder = C:\
+        clean_cmd = del /f /q
+        tmp_dir = %TEMP%
+        python_bin = python2.7
+        target_process = ${python_bin}.exe
     Linux:
         modprobe_module = virtio_console
     variants:
         - unplug_chardev:
+            filesize = 100
             unplug_chardev_vc1 = yes
             unplug_chardev_vc2 = yes
         - @unplug_port:
+            filesize = 100
             unplug_chardev_vc1 = no
             unplug_chardev_vc2 = no
         - hotplug_port_pci:
@@ -23,16 +38,30 @@
             extra_serials = "port1 port2"
             serial_type_port1 = "virtserialport"
             serial_type_port2 = "virtserialport"
-            guest_scripts = VirtIoChannel_guest_send_receive.py;windows_support.py
-            host_script = serial_host_send_receive.py
-            guest_script = VirtIoChannel_guest_send_receive.py
-            clean_cmd = rm -f
-            guest_script_folder = /var/tmp/
-            Windows:
-                guest_script_folder = C:\
-                clean_cmd = del /f /q
-                tmp_dir = %TEMP%
-                python_bin = python2.7
+            shutdown_method = system_powerdown
+            repeat_times = 1
+            unplug_pci = yes
+            variants:
+                - @default:
+                    plug_same_nr = yes
+                    unplug_pci = no
+                - with_reboot:
+                    interrupt_test_after_unplug = reboot_guest
+                    interrupt_test_after_plug = reboot_guest
+                    reboot_method = shell
+                - with_system_reset:
+                    interrupt_test_after_unplug = reboot_guest
+                    interrupt_test_after_plug = reboot_guest
+                    reboot_method = system_reset
+                    sleep_before_reset = 0
+                - with_shutdown_after_unplug:
+                    interrupt_test_after_unplug = shutdown_guest
+                - with_shutdown_after_plug:
+                    interrupt_test_after_plug = shutdown_guest
+                - with_live_migration_after_unplug:
+                    interrupt_test_after_unplug = live_migration_guest
+                - repeat_pci_in_loop:
+                    repeat_times = 100
         - hotplug_various_chardev:
             type = virtio_serial_various_chardev_hotplug
             serials = ""

--- a/qemu/tests/virtio_serial_hotplug_port_pci.py
+++ b/qemu/tests/virtio_serial_hotplug_port_pci.py
@@ -1,3 +1,5 @@
+import logging
+
 from virttest import error_context
 from virttest import env_process
 from virttest.qemu_monitor import QMPCmdError
@@ -6,6 +8,9 @@ from qemu.tests.virtio_console import add_chardev
 from qemu.tests.virtio_console import add_virtserial_device
 from qemu.tests.virtio_console import add_virtio_ports_to_vm
 from qemu.tests.virtio_serial_file_transfer import transfer_data
+from qemu.tests.vioser_in_use import shutdown_guest  # pylint: disable=W0611
+from qemu.tests.vioser_in_use import reboot_guest  # pylint: disable=W0611
+from qemu.tests.vioser_in_use import live_migration_guest  # pylint: disable=W0611
 
 
 @error_context.context_aware
@@ -18,15 +23,43 @@ def run(test, params, env):
     3. Hot add virtserialport, attached on chardev 1
     4. Hot plug another serial port on chardev 2 with "nr=1", should fail
     5. Hot plug the serial port again with "nr=2"
-    6. Transfer data from host to guest via port1
-    7. Transfer data from guest to host via port2
+    6. Transfer data between guest and host via port1 and port2
+    7. Reboot/system_reset/shudown guest after hotplug(optional)
+    8. Transfer data between guest and host via port1 and port2
+    9. Hot-unplug virtio-serial-bus
+    10. Reboot/system_reset/shudown/migration guest after hot-unplug(optional)
+    11. Repeat step 2 to step 10 100 times
 
     :param test: kvm test object
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment
     """
 
+    def run_interrupt_test(interrupt_test):
+        """
+        Run interrupt test(reboot/shutdown/migration) after hot plug/unplug.
+
+        :param interrupt_test: reboot/shutdown/migration test
+        """
+
+        session = vm.wait_for_login()
+        globals().get(interrupt_test)(test, params, vm, session)
+        session.close()
+
+    def run_serial_data_transfer():
+        """
+        Transfer data between two ports.
+        """
+
+        params['file_transfer_serial_port'] = serials[0]
+        transfer_data(params, vm, sender='host')
+        params['file_transfer_serial_port'] = serials[1]
+        transfer_data(params, vm, sender='guest')
+
     params['serials'] = params.objects('serials')[0]
+    repeat_times = int(params.get("repeat_times", 1))
+    interrupt_test_after_plug = params.get("interrupt_test_after_plug")
+    interrupt_test_after_unplug = params.get("interrupt_test_after_unplug")
     vm = env.get_vm(params['main_vm'])
     char_devices = add_chardev(vm, params)
     for device in char_devices:
@@ -48,24 +81,44 @@ def run(test, params, env):
                 buses.append(device)
             else:
                 serial_devices.append(device)
-    vm.devices.simple_hotplug(buses[0], vm.monitor)
-    vm.devices.simple_hotplug(serial_devices[0], vm.monitor)
-    pre_nr = serial_devices[0].get_param('nr')
-    # Try hotplug different device with same 'nr'
-    serial_devices[1].set_param('bus', serial_devices[0].get_param('bus'))
-    serial_devices[1].set_param('nr', pre_nr)
-    try:
-        serial_devices[1].hotplug(vm.monitor)
-    except QMPCmdError as e:
-        if 'A port already exists at id %d' % pre_nr not in str(e.data):
-            test.fail('Hotplug fail for %s, not as expected' % str(e.data))
-    else:
-        test.fail('Hotplug with same "nr" option success while should fail')
-    serial_devices[1].set_param('nr', int(pre_nr) + 1)
-    vm.devices.simple_hotplug(serial_devices[1], vm.monitor)
-    for device in serial_devices:
-        add_virtio_ports_to_vm(vm, params, device)
-    params['file_transfer_serial_port'] = serials[0]
-    transfer_data(params, vm, sender='host')
-    params['file_transfer_serial_port'] = serials[1]
-    transfer_data(params, vm, sender='guest')
+
+    for i in range(repeat_times):
+        error_context.context("Hotplug/unplug serial devices the %s time"
+                              % (i+1), logging.info)
+        vm.devices.simple_hotplug(buses[0], vm.monitor)
+        vm.devices.simple_hotplug(serial_devices[0], vm.monitor)
+        pre_nr = serial_devices[0].get_param('nr')
+
+        # Try hotplug different device with same 'nr'
+        if params.get("plug_same_nr") == "yes":
+            serial_devices[1].set_param('bus', serial_devices[0].get_param('bus'))
+            serial_devices[1].set_param('nr', pre_nr)
+            try:
+                serial_devices[1].hotplug(vm.monitor)
+            except QMPCmdError as e:
+                if 'A port already exists at id %d' % pre_nr not in str(e.data):
+                    test.fail('Hotplug fail for %s, not as expected' % str(e.data))
+            else:
+                test.fail('Hotplug with same "nr" option success while should fail')
+            serial_devices[1].set_param('nr', int(pre_nr) + 1)
+        vm.devices.simple_hotplug(serial_devices[1], vm.monitor)
+        for device in serial_devices:
+            add_virtio_ports_to_vm(vm, params, device)
+
+        run_serial_data_transfer()
+
+        if interrupt_test_after_plug:
+            logging.info("Run %s after hotplug" % interrupt_test_after_plug)
+            run_interrupt_test(interrupt_test_after_plug)
+            if not vm.is_alive():
+                return
+            run_serial_data_transfer()
+
+        if params.get("unplug_pci") == "yes":
+            out = vm.devices.simple_unplug(buses[0], vm.monitor)
+            if out[1] is False:
+                msg = "Still get %s in qtree after unplug" % device
+                test.fail(msg)
+            if interrupt_test_after_unplug:
+                logging.info("Run %s after hot-unplug" % interrupt_test_after_unplug)
+                run_interrupt_test(interrupt_test_after_unplug)


### PR DESCRIPTION
1. Move run_bg_test() out of run function in vioser_in_use.py;
2. Add windows serial hotplug and unplug related cases.
   - serial port/pci unplug and plug;
   - reboot/shutdown/system_reset/migartion after plug/unplug;
   - repeat plug/unplug serial port/pci 100 times

ID: 1456080, 1456078, 1456081, 1231116, 1231115, 1745382, 1483431, 1575477, 1575481, 1575478

Signed-off-by: Li Jin <lijin@redhat.com>