### PR TITLE
vsock:Fix the issue of vsock_hotplug

### DIFF
--- a/qemu/tests/cfg/vsock.cfg
+++ b/qemu/tests/cfg/vsock.cfg
@@ -11,4 +11,4 @@
             type = vsock_hotplug
             vsocks = ''
             addr_pattern = '\d\d:\d\d\.\d'
-            device_pattern = 'Communication controller: Red Hat.* Device 1012'
+            device_pattern = 'Communication controller: Red Hat.* Device'


### PR DESCRIPTION
1.For Q35 machine type,Hotplugged vsock device ID is change
2.Remove hard code vsock device ID from vsock.cfg

id: 1744932
Signed-off-by:Xiangchun Fu xfu@redhat.com