### PR TITLE
virtio_scsi_mq: Change the timeout for wmi_facility_check

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_mq.cfg
+++ b/qemu/tests/cfg/virtio_scsi_mq.cfg
@@ -20,4 +20,4 @@
             system_image_drive_format = scsi-hd
             driver_name = vioscsi
             pattern = "instance\.QueuesCount=(\d+)"
-            wmi_check_cmd = "WIN_UTILS:\vioscsi.vbs && timeout 5 && type vioscsi.log"
+            wmi_check_cmd = "WIN_UTILS:\vioscsi.vbs && timeout 10 && type vioscsi.log"


### PR DESCRIPTION
When the device has large queue number,
get the queues state need more time,
original 5 sec is not enough.

id: 1748275
Signed-off-by: Peixiu Hou <phou@redhat.com>