### PR TITLE
Fix it can only run with virtio-net when migration after nic hotunplug

### DIFF
--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -76,6 +76,8 @@
                     nics = ""
                 - after_nichotunplug:
                     with_unplug = yes
+                    nics = nic1
+                    nic_model_nic1 = ${pci_model}
                     pcie_extra_root_port = 0
                     Windows:
                         check_nic_cmd = "ipconfig /all"


### PR DESCRIPTION
Assign the correct nic_model for nic_model_nic1

Signed-off-by: Yu Wang <wyu@redhat.com>

id:1751000