### PR TITLE
qemu_disk_img.info: support luks

### DIFF
--- a/qemu/tests/qemu_disk_img.py
+++ b/qemu/tests/qemu_disk_img.py
@@ -208,10 +208,15 @@ class QemuImgTest(qemu_storage.QemuImg):
                 msg = ("Expected backing file is null")
                 msg += " Actual backing file: %s" % backingfile
                 raise exceptions.TestFail(msg)
-            elif backingfile != self.base_image_filename:
-                msg = ("Expected backing file: %s" % self.base_image_filename)
-                msg += " Actual backing file: %s" % backingfile
-                raise exceptions.TestFail(msg)
+            else:
+                base_params = self.params.object_params(self.base_tag)
+                base_image_repr = qemu_storage.get_image_repr(
+                    self.base_tag, base_params, self.root_dir)
+                if base_image_repr != backingfile:
+                    msg = ("Expected backing file: %s" %
+                           self.base_image_filename)
+                    msg += " Actual backing file: %s" % backingfile
+                    raise exceptions.TestFail(msg)
         except AttributeError:
             if self.base_tag and self.base_tag != "null":
                 msg = ("Could not find backing file for image '%s'" %


### PR DESCRIPTION
ID: 1752701
1. modify qemu_disk_img.check_backingfile that it will use json to
compare backing file if backing is in luks format.
2. add qemu_disk_img_info.InfoTest.start_vm to keep base params that
will be used to retrieve backing image's secret to start VM.

Signed-off-by: lolyu <lolyu@redhat.com>