### PR TITLE
Rebase with nonexist_old_backing_file can work since qemu-4.1

### DIFF
--- a/qemu/tests/cfg/qemu_img_negative.cfg
+++ b/qemu/tests/cfg/qemu_img_negative.cfg
@@ -19,6 +19,7 @@
             variants:
                 - nonexist_old_backing_file:
                     rebase_list = "sn > base"
+                    required_qemu = [, 4.1.0)
                 - nonexist_new_backing_file:
                     images += " new"
                     image_chain = "base sn"


### PR DESCRIPTION
Limit required_qemu version for
qemu_img_negative.rebase.nonexist_old_backing_file

Signed-off-by: Tingting Mao <timao@redhat.com>