### PR TITLE
avocado_guest: fix ltp memory test for avocado-misc-tests

### DIFF
--- a/generic/tests/cfg/avocado_guest.cfg
+++ b/generic/tests/cfg/avocado_guest.cfg
@@ -90,7 +90,8 @@
         - forkmem:
             avocadotest = "memory/fork_mem.py"
         - ltp_mem:
-            avocadotest = "memory/ltp-memory.py"
+            avocadomux = "generic/ltp.py.data/ltp-mem.yaml"
+            avocadotest = "generic/ltp.py"
         - migratepages:
             avocadotest = "memory/migrate_pages.py"
         - memoryapi:


### PR DESCRIPTION
provide ltp mux file for memory test and run ltp test to pick
memory tests appropriately.

Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>