### PR TITLE
use convert_target to specify convert target image 

### DIFF
--- a/qemu/tests/cfg/convert_after_resize_snapshot.cfg
+++ b/qemu/tests/cfg/convert_after_resize_snapshot.cfg
@@ -17,8 +17,9 @@
     image_name_sn2 = "images/sn2"
     image_size_sn2 = ""
     image_convert = "sn2"
-    convert_name_sn2 = "images/combined"
-    convert_format_sn2 = "qcow2"
+    convert_target_sn2 = "converted"
+    image_name_converted = "images/combined"
+    image_format_converted = qcow2
     variants:
         - after_enlarge_snapshot:
                 sn1_size_change = "+1G"

--- a/qemu/tests/cfg/convert_image_from_raw_to_qcow2.cfg
+++ b/qemu/tests/cfg/convert_image_from_raw_to_qcow2.cfg
@@ -2,13 +2,15 @@
     only raw
     virt_test_type = qemu
     type = convert_image_from_raw_to_qcow2
+    start_vm = no
     kill_vm = yes
     force_create_image = no
     # md5sum binary path
     md5sum_bin = "md5sum"
+    image_name_tgt = "images/tgt"
+    image_format_tgt = qcow2
+    convert_target = tgt
     image_convert = "tgt"
-    convert_name_tgt = "images/tgt"
-    convert_format_tgt = qcow2
     tmp_dir = /var/tmp
     tmp_file_name = ${tmp_dir}/testfile
     file_create_cmd = "dd if=/dev/urandom of=%s bs=1M count=512"
@@ -37,5 +39,5 @@
             required_qemu = [1.1, )
             variants:
                 - compat_0.10:
-                    compat = 0.10
+                    qcow2_compatible = 0.10
                 - compat_default:

--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -32,11 +32,11 @@
             option_verified += " csize"
             variants:
                 - cluster_size_512:
-                    cluster_size = 512
+                    image_cluster_size = 512
                 - cluster_size_2K:
-                    cluster_size = 2K
+                    image_cluster_size = 2K
                 - cluster_size_2M:
-                    cluster_size = 2M
+                    image_cluster_size = 2M
         - cache_mode:
             only convert.base_to_qcow2.default, commit, rebase.snB.to_base
             variants:
@@ -58,9 +58,10 @@
             guest_file_name = ${tmp_dir}/test.img
             variants:
                 - base_to_qcow2:
-                    image_convert = "image1"
-                    convert_name_image1 = "images/image1_to_qcow2"
-                    convert_format_image1 = "qcow2"
+                    convert_source = "image1"
+                    convert_target = "convert"
+                    image_name_convert = images/image1_to_qcow2
+                    image_format_convert = qcow2
                     option_verified = "format"
                     variants:
                         - @default:
@@ -91,9 +92,9 @@
                             option_verified += " compat"
                             variants:
                                 - compat_0.10:
-                                    compat = 0.10
+                                    qcow2_compatible = 0.10
                                 - compat_1.1:
-                                    compat = 1.1
+                                    qcow2_compatible = 1.1
                             variants:
                                 - @default:
                                 - lazy_refcounts_on:
@@ -109,17 +110,20 @@
                             sparse_size = 0
                 - base_to_raw:
                     option_verified = "format"
-                    image_convert = "image1"
-                    convert_name_image1 = "images/image1_to_raw"
-                    convert_format_image1 = "raw"
+                    convert_source = "image1"
+                    convert_target = "convert"
+                    image_name_convert = images/image1_to_raw
+                    image_format_convert = raw
                 - snapshot_to_qcow2:
                     option_verified = "format"
                     image_convert = "sn1"
                     image_chain += " sn1"
                     image_name_sn1 = "images/sn1"
                     image_format_sn1 = "qcow2"
-                    convert_name_sn1 = "images/sn1_to_qcow2"
-                    convert_format_sn1 = "qcow2"
+                    convert_source = "sn1"
+                    convert_target = "convert"
+                    image_name_convert = images/image1_to_qcow2
+                    image_format_convert = qcow2
         - commit:
             type = qemu_disk_img_commit
             guest_file_name = ${tmp_dir}/test.img

--- a/qemu/tests/cfg/qemu_img_create_snapshot_on_qcow2_target_from_raw_source.cfg
+++ b/qemu/tests/cfg/qemu_img_create_snapshot_on_qcow2_target_from_raw_source.cfg
@@ -2,6 +2,7 @@
     only raw
     virt_test_type = qemu
     type = qemu_img_create_snapshot_on_qcow2_target_from_raw_source
+    start_vm = no
     kill_vm = yes
     force_create_image = no
     # md5sum binary path
@@ -12,9 +13,9 @@
     # the cmdline will not have specified size option
     image_size_sn = ""
     image_format_sn = qcow2
-    image_convert = "tgt"
-    convert_name_tgt = "images/tgt"
-    convert_format_tgt = qcow2
+    convert_target = tgt
+    image_name_tgt = "images/tgt"
+    image_format_tgt = qcow2
     tmp_dir = /var/tmp
     tmp_file_name = ${tmp_dir}/testfile
     file_create_cmd = "dd if=/dev/urandom of=%s bs=1M count=512"

--- a/qemu/tests/cfg/qemu_img_measure.cfg
+++ b/qemu/tests/cfg/qemu_img_measure.cfg
@@ -16,17 +16,15 @@
             type = qemu_img_measure_convert_image
             write_size = 1G
             convert_tags = "tgt1 tgt2"
-            image_convert_tgt1 = "tgt1"
-            convert_name_tgt1 = "images/tgt1"
-            image_convert_tgt2 = "tgt2"
-            convert_name_tgt2 = "images/tgt2"
+            image_name_tgt1 = "images/tgt1"
+            image_name_tgt2 = "images/tgt2"
             sparse_size_tgt2 = 0
             variants:
                 - convert_to_qcow2:
                     target_format = qcow2
-                    convert_format_tgt1 = ${target_format}
-                    convert_format_tgt2 = ${target_format}
+                    image_format_tgt1 = ${target_format}
+                    image_format_tgt2 = ${target_format}
                 - convert_to_raw:
                     target_format = raw
-                    convert_format_tgt1 = ${target_format}
-                    convert_format_tgt2 = ${target_format}
+                    image_format_tgt1 = ${target_format}
+                    image_format_tgt2 = ${target_format}

--- a/qemu/tests/convert_after_resize_snapshot.py
+++ b/qemu/tests/convert_after_resize_snapshot.py
@@ -81,8 +81,5 @@ def run(test, params, env):
     img_sn2 = _qemu_img_info(sn2, sn1)
     img_sn2.convert(params.object_params(sn2), img_root_dir)
 
-    converted = {"image_name_converted": params["convert_name_%s" % sn2],
-                 "image_format_converted": params["convert_format_%s" % sn2]}
-    params.update(converted)
     img_converted = _qemu_img_info("converted")
     _compare_images(img_sn2, img_converted)

--- a/qemu/tests/convert_image_from_raw_to_qcow2.py
+++ b/qemu/tests/convert_image_from_raw_to_qcow2.py
@@ -53,7 +53,7 @@ def run(test, params, env):
 
     file = params["guest_file_name"]
     initial_tag = params["images"].split()[0]
-    c_tag = params["image_convert"]
+    c_tag = params["convert_target"]
 
     logging.info("Boot a guest up from initial image: %s, and create a"
                  " file %s on the disk.", initial_tag, file)
@@ -70,12 +70,8 @@ def run(test, params, env):
     else:
         logging.info("Convert initial image %s to %s", initial_tag, c_tag)
     img, img_param = _get_img_obj_and_params(initial_tag)
-    img.convert(params.object_params(c_tag),
-                data_dir.get_data_dir(), cache_mode)
+    img.convert(img_param, data_dir.get_data_dir(), cache_mode)
 
-    tgt = {"image_name_%s" % c_tag: params["convert_name_%s" % c_tag],
-           "image_format_%s" % c_tag: params["convert_format_%s" % c_tag]}
-    params.update(tgt)
     tgt, tgt_img_param = _get_img_obj_and_params(c_tag)
 
     if params.get("compare_image", "no") == "yes":

--- a/qemu/tests/qemu_disk_img.py
+++ b/qemu/tests/qemu_disk_img.py
@@ -184,12 +184,14 @@ class QemuImgTest(qemu_storage.QemuImg):
                 elif params.get("lazy_refcounts") == "off":
                     evalue = "false"
             elif option == "csize":
-                csize = params.get("cluster_size")
+                csize = params.get("image_cluster_size")
                 evalue = int(float(utils_misc.normalize_data_size(csize, "B")))
             elif option == "sparse_size":
                 if info.get("dsize") < info.get("vsize"):
                     avalue = info.get("dsize")
                     evalue = info.get("vsize")
+            elif option == "compat":
+                evalue = params.get("qcow2_compatible")
             else:
                 evalue = params.get(option)
             if avalue is not None and avalue != evalue:

--- a/qemu/tests/qemu_disk_img_convert.py
+++ b/qemu/tests/qemu_disk_img_convert.py
@@ -12,7 +12,7 @@ from qemu.tests import qemu_disk_img
 class ConvertTest(qemu_disk_img.QemuImgTest):
 
     def __init__(self, test, params, env):
-        self.tag = params["image_convert"]
+        self.tag = params["convert_source"]
         t_params = params.object_params(self.tag)
         super(ConvertTest, self).__init__(test, t_params, env, self.tag)
 
@@ -26,9 +26,9 @@ class ConvertTest(qemu_disk_img.QemuImgTest):
         if t_params:
             params.update(t_params)
         cache_mode = params.get("cache_mode")
-        super(ConvertTest, self).convert(params, self.data_dir, cache_mode)
-        params["image_name"] = params["convert_name"]
-        params["image_format"] = params["convert_format"]
+        conv = super(ConvertTest, self).convert(
+            params, self.data_dir, cache_mode)
+        params = params.object_params(conv)
         converted = storage.get_image_filename(params, self.data_dir)
         process.run("sync")
         self.trash.append(converted)

--- a/qemu/tests/qemu_img_create_snapshot_on_qcow2_target_from_raw_source.py
+++ b/qemu/tests/qemu_img_create_snapshot_on_qcow2_target_from_raw_source.py
@@ -31,7 +31,7 @@ def run(test, params, env):
 
     file = params["guest_file_name"]
     initial_tag = params["images"].split()[0]
-    c_tag = params["image_convert"]
+    c_tag = params["convert_target"]
 
     logging.info("Boot a guest up with initial image: %s, and create a"
                  " file %s on the disk." % (initial_tag, file))
@@ -43,12 +43,9 @@ def run(test, params, env):
 
     logging.info("Convert initial image %s to %s" % (initial_tag, c_tag))
     img, img_param = _get_img_obj_and_params(initial_tag)
-    img.convert(params.object_params(c_tag), data_dir.get_data_dir())
+    img.convert(img_param, data_dir.get_data_dir())
 
     logging.info("Check image %s." % (c_tag))
-    tgt = {"image_name_%s" % c_tag: params["convert_name_%s" % c_tag],
-           "image_format_%s" % c_tag: params["convert_format_%s" % c_tag]}
-    params.update(tgt)
     tgt, tgt_img_param = _get_img_obj_and_params(c_tag)
     tgt.check_image(tgt_img_param, data_dir.get_data_dir())
 

--- a/qemu/tests/qemu_img_measure_convert_image.py
+++ b/qemu/tests/qemu_img_measure_convert_image.py
@@ -63,11 +63,8 @@ def run(test, params, env):
                                        output="json").stdout_text)
 
     for c_tag in params["convert_tags"].split():
-        img.convert(params.object_params(c_tag), data_dir.get_data_dir())
-
-        cvt = {"image_name_%s" % c_tag: params["convert_name_%s" % c_tag],
-               "image_format_%s" % c_tag: params["convert_format_%s" % c_tag]}
-        params.update(cvt)
+        img_param["convert_target"] = c_tag
+        img.convert(img_param, data_dir.get_data_dir())
 
         cvt, cvt_img_param = _get_img_obj_and_params(c_tag)
         size = _get_file_size(cvt)


### PR DESCRIPTION
change the way to specify convert target image to use the following
format:
```
images += convert
convert_target_image1 = convert
image_name_convert = images/convert
image_format_convert = qcow2
```
and adapt to parameter changes:
`compat` to `qcow2_compatible`
`cluster_size` to `image_cluster_size`

Signed-off-by: lolyu <lolyu@redhat.com>