### PR TITLE
Revert "Add pre_command for some memory cases to drop cache before test"

### DIFF
--- a/qemu/tests/cfg/hotplug_mem.cfg
+++ b/qemu/tests/cfg/hotplug_mem.cfg
@@ -11,7 +11,6 @@
     maxmem_mem = 32G
     mem_devs = mem1
     login_timeout = 600
-    pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
     no Host_RHEL.6
     no RHEL.5
     no Windows..i386

--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -10,7 +10,6 @@
     max_vms = 2
     mig_timeout = 3600
     ping_pong = 1
-    pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
     # you can uncomment the following line to enable the state
     # check
     # vmstate_check = yes

--- a/qemu/tests/cfg/numa_memdev_options.cfg
+++ b/qemu/tests/cfg/numa_memdev_options.cfg
@@ -11,7 +11,6 @@
     guest_numa_nodes = "node0 node1"
     numa_memdev_node0 = mem-mem0
     numa_memdev_node1 = mem-mem1
-    pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
     variants:
         - prealloc:
             prealloc_mem0 = yes


### PR DESCRIPTION
This reverts commit 7966b4abbd0056050811f8cda6412d03a8d85a34 from
https://github.com/autotest/tp-qemu/pull/1889 because drop_caches should
never be used for ordinary memory management. It should be only used
exceptionally for example to obtain hugepages or for performance
testing.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>