### PR TITLE
luks_convert: introduces cases to support convert from luks

### DIFF
--- a/provider/qemu_img_utils.py
+++ b/provider/qemu_img_utils.py
@@ -1,0 +1,102 @@
+"""qemu-img related functions."""
+import avocado
+import logging
+import tempfile
+
+from virttest import data_dir
+from virttest import env_process
+from virttest import qemu_storage
+from virttest import utils_misc
+
+from avocado.utils import process
+
+
+def boot_vm_with_images(test, params, env, images=None, vm_name=None):
+    """Boot VM with images specified."""
+    params = params.copy()
+    # limit to those specified in images
+    if images:
+        images = " ".join(images)
+        params["images"] = images
+    params["start_vm"] = "yes"
+    vm_name = vm_name or params["main_vm"]
+    logging.debug("Boot vm %s with images: %s", vm_name, params["images"])
+    env_process.preprocess_vm(test, params, env, vm_name)
+    vm = env.get_vm(vm_name)
+    vm.verify_alive()
+    return vm
+
+
+def qemu_img_compare(params, image0, image1, strict=False, force_share=False):
+    """qemu-img compare command wrapper function."""
+    image0_params = params.object_params(image0)
+    image1_params = params.object_params(image1)
+    root_dir = data_dir.get_data_dir()
+    image0 = qemu_storage.QemuImg(image0_params, root_dir, image0)
+    image1 = qemu_storage.QemuImg(image1_params, root_dir, image1)
+    compare_cmd = ["qemu-img compare"]
+    secret_objects = image0._secret_objects + image1._secret_objects
+    if secret_objects:
+        compare_cmd.append(" ".join(secret_objects))
+    if strict:
+        compare_cmd.append("-s")
+    if force_share:
+        compare_cmd.append("-U")
+    filename0, filename1 = image0.image_filename, image1.image_filename
+    if image0.encryption_config.key_secret:
+        filename0 = "'%s'" % qemu_storage.get_image_json(
+            image0.tag, image0_params, root_dir)
+    if image1.encryption_config.key_secret:
+        filename1 = "'%s'" % qemu_storage.get_image_json(
+            image1.tag, image1_params, root_dir)
+    compare_cmd.extend((filename0, filename1))
+    logging.debug("Compare %s with %s, strict: %s",
+                  filename0, filename1, strict)
+    result = process.run(" ".join(compare_cmd), ignore_status=True, shell=True)
+    if result.exit_status == 0:
+        logging.debug(result.stdout_text)
+    else:
+        logging.error(result.stdout_text)
+        if result.exit_status == 1:
+            raise avocado.TestFail(result.stdout_text)
+        raise avocado.TestError(result.stdout_text)
+
+
+def save_random_file_to_vm(vm, save_path, count, sync_bin, blocksize=512,
+                           timeout=240):
+    """
+    Save a random file to vm.
+
+    :param vm: vm
+    :param save_path: file path saved in vm
+    :param count: block count
+    :param sync_bin: sync binary path
+    :param blocksize: block size, default 512
+    :param timeout: time wait to finish
+    """
+    dd_cmd = "dd if=/dev/urandom of=%s bs=%s count=%s conv=fsync"
+    with tempfile.NamedTemporaryFile() as f:
+        dd_cmd = dd_cmd % (f.name, blocksize, count)
+        process.run(dd_cmd, shell=True, timeout=timeout)
+        vm.copy_files_to(f.name, save_path)
+    session = vm.wait_for_login()
+    sync_bin = utils_misc.set_winutils_letter(session, sync_bin)
+    status, out = session.cmd_status_output(sync_bin, timeout=240)
+    if status:
+        raise EnvironmentError("Fail to execute %s: %s" % (sync_bin, out))
+    session.close()
+
+
+@avocado.fail_on(exceptions=(ValueError,))
+def check_md5sum(filepath, md5sum_bin, session, md5_value_to_check=None):
+    """Check md5sum value of the file specified."""
+    md5cmd = "%s %s" % (md5sum_bin, filepath)
+    status, out = session.cmd_status_output(md5cmd, timeout=240)
+    if status:
+        raise EnvironmentError("Fail to get md5 value of file: %s" % filepath)
+    md5_value = out.split()[0]
+    logging.debug("md5sum value of %s: %s", filepath, md5_value)
+    if md5_value_to_check and md5_value != md5_value_to_check:
+        raise ValueError("md5 values mismatch, got: %s, expected: %s" %
+                         (md5_value, md5_value_to_check))
+    return md5_value

--- a/qemu/tests/cfg/luks_convert.cfg
+++ b/qemu/tests/cfg/luks_convert.cfg
@@ -1,0 +1,30 @@
+- luks_convert:
+    only luks
+    virt_test_type = qemu
+    type = luks_convert
+    start_vm = no
+    kill_vm = yes
+    force_create_image = no
+    guest_temp_file = "/var/tmp/convert.tmp"
+    md5sum_bin = "md5sum"
+    Windows:
+        guest_temp_file = "C:\testfile"
+        x86_64:
+            sync_bin = WIN_UTILS:\Sync\sync64.exe /accepteula
+        i386, i686:
+            sync_bin = WIN_UTILS:\Sync\sync.exe /accepteula
+    convert_source = ${images}
+    variants:
+        - to_raw:
+            convert_target = convert
+            image_name_convert = "images/luks_to_raw"
+            image_format_convert = raw
+        - to_qcow2:
+            convert_target = convert
+            image_name_convert = "images/luks_to_qcow2"
+            image_format_convert = qcow2
+        - to_luks:
+            convert_target = convert
+            image_name_convert = "images/luks_to_luks"
+            image_format_convert = luks
+            image_secret_convert = convert

--- a/qemu/tests/luks_convert.py
+++ b/qemu/tests/luks_convert.py
@@ -1,0 +1,44 @@
+import logging
+
+from virttest import data_dir
+from virttest import qemu_storage
+
+from avocado import fail_on
+from avocado.utils import process
+from provider import qemu_img_utils as img_utils
+
+
+def run(test, params, env):
+    """Convert from/to luks image."""
+    vm = img_utils.boot_vm_with_images(test, params, env)
+    session = vm.wait_for_login()
+    guest_temp_file = params["guest_temp_file"]
+    md5sum_bin = params.get("md5sum_bin", "md5sum")
+    sync_bin = params.get("sync_bin", "sync")
+
+    logging.debug("Create temporary file on guest: %s", guest_temp_file)
+    img_utils.save_random_file_to_vm(vm, guest_temp_file, 2048 * 512, sync_bin)
+
+    logging.debug("Get md5 value of the temporary file")
+    md5_value = img_utils.check_md5sum(guest_temp_file, md5sum_bin, session)
+    session.close()
+    vm.destroy()
+
+    root_dir = data_dir.get_data_dir()
+    convert_source = params["convert_source"]
+    convert_target = params["convert_target"]
+    source_params = params.object_params(convert_source)
+    source = qemu_storage.QemuImg(source_params, root_dir, convert_source)
+    logging.debug("Convert from %s to %s", convert_source, convert_target)
+    fail_on((process.CmdError,))(source.convert)(source_params, root_dir)
+
+    logging.debug("Compare images: %s and %s", convert_source, convert_target)
+    img_utils.qemu_img_compare(params, convert_source, convert_target)
+
+    vm = img_utils.boot_vm_with_images(test, params, env, (convert_target,))
+    session = vm.wait_for_login()
+    logging.debug("Verify md5 value of the temporary file")
+    img_utils.check_md5sum(guest_temp_file, md5sum_bin, session,
+                           md5_value_to_check=md5_value)
+    session.close()
+    vm.destroy()


### PR DESCRIPTION
1. add three cases:
convert from luks to qcow2
convert from luks to raw
convert from luks to luks

2. introduce new provider module `qemu_img_utils`, which includes
common funtions needed by QEMU image related testcases.

Signed-off-by: lolyu <lolyu@redhat.com>