### PR TITLE
qemu_guest_agent: bug fix of init3 shell cmd timeout

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -239,6 +239,8 @@
         - gagent_check_after_init:
             no Windows
             gagent_check_type = after_init
+            RHEL.8:
+                new_session = no
         - gagent_frozen_io:
             only Windows
             gagent_check_type = frozen_io

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -1607,10 +1607,14 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param env: Dictionary with test environment
         """
         error_context.context("Run init 3 in guest", logging.info)
-        session = self._get_session(params, self.vm)
-        session.cmd("init 3")
+        session = self.vm.wait_for_serial_login()
+        session.sendline("init 3")
+
         error_context.context("Check guest agent status after running init 3",
                               logging.info)
+        if params.get("new_session", "yes") == "yes":
+            session = self.vm.wait_for_serial_login()
+
         if self._check_ga_service(session, params.get("gagent_status_cmd")):
             logging.info("Guest agent service is still running after init 3.")
         else:


### PR DESCRIPTION
For RHEL7 and RHEL6 guest,if change system run level with init 3 command,
ssh session will disconnet,so init 3 command will timeout.

ID: bz1753093
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>