### PR TITLE
qemu_img: setting shorter sleep time for send signal function

### DIFF
--- a/qemu/tests/qemu_img.py
+++ b/qemu/tests/qemu_img.py
@@ -187,12 +187,12 @@ def run(test, params, env):
         logging.info("Send signal to qemu-img")
         end_time = time.time() + timeout
         while time.time() < end_time:
-            time.sleep(1)
             pid = process.system_output("pidof qemu-img",
                                         ignore_status=True,
                                         verbose=False).decode().strip()
             if bool(pid):
                 break
+            time.sleep(1)
         try:
             os.kill(int(pid), signal.SIGUSR1)
         except Exception as error:


### PR DESCRIPTION
Setting shorter sleep time for sending signal function,
or 'qemu-img rebase' can not recieve the signal before exit.

ID: 1754381
Signed-off-by: Tingting Mao <timao@redhat.com>