### PR TITLE
multi_nics_verify: fix cannot get enough ip of nics for windows guest

### DIFF
--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -4,10 +4,15 @@
     no RHEL.3.9
     nics_num = 27
     start_vm = no
+    login_timeout = 1800
     variants:
         - @default:
         - with_multiqueue:
             queues = ${smp}
             vt_ulimit_nofile = 10240
-            Windows..i386:
-                nics_num = 8
+            Windows:
+                # Windows product limit, it will fail when queues is too large
+                smp = 4
+                queues = 4
+                i386:
+                    nics_num = 8

--- a/qemu/tests/multi_nics_verify.py
+++ b/qemu/tests/multi_nics_verify.py
@@ -4,6 +4,7 @@ import logging
 from virttest import error_context
 from virttest import utils_net
 from virttest import env_process
+from virttest import utils_misc
 
 
 @error_context.context_aware
@@ -90,9 +91,20 @@ def run(test, params, env):
         # NICs matched.
         logging.info(msg)
 
+    def _check_ip_number():
+        for index, nic in enumerate(vm.virtnet):
+            guest_ip = utils_net.get_guest_ip_addr(session_srl, nic.mac, os_type,
+                                                   ip_version="ipv4")
+            if not guest_ip:
+                return False
+        return True
+
     # Check all the interfaces in guest get ips
-    nic_interface = []
     session_srl = vm.wait_for_serial_login(timeout=int(params.get("login_timeout", 360)))
+    if not utils_misc.wait_for(_check_ip_number, 1000, step=10):
+        test.error("Timeout when wait for nics to get ip")
+
+    nic_interface = []
     for index, nic in enumerate(vm.virtnet):
         logging.info("index %s nic" % index)
         guest_ip = utils_net.get_guest_ip_addr(session_srl, nic.mac, os_type,


### PR DESCRIPTION
Increase the timeout for getting ip and boot time.

Signed-off-by: Yu Wang <wyu@redhat.com>

id:1709328