### PR TITLE
Add test for disk extension

### DIFF
--- a/qemu/tests/cfg/disk_extension.cfg
+++ b/qemu/tests/cfg/disk_extension.cfg
@@ -1,0 +1,57 @@
+- disk_extension:
+    only virtio_blk virtio_scsi
+    virt_test_type = qemu
+    type = disk_extension
+    not_preprocess = yes
+    wait_timeout = 60
+    iothreads = iothread0
+    drive_werror = stop
+    drive_rerror = stop
+    tmpfs_folder = "/tmp/xtmpfs"
+    loop_device = /dev/loop6
+    # Please keep consistent unit
+    begin_size = 50M
+    max_size = 500M
+    increment_size = 100M
+    # Equal max_size
+    max_size_in_bytes = 524288000
+    # Data disk
+    loop_device_backend_img_tag = "stg0"
+    loop_device_img_tag = "stg1"
+    images += " ${loop_device_img_tag}"
+    boot_drive_stg0 = no
+    image_raw_device_stg0 = yes
+    image_name_stg0 = ${tmpfs_folder}/stg0.raw
+    image_size_stg0 = ${begin_size}
+    # Must be raw format
+    image_format_stg0 = raw
+    # Loop device
+    image_raw_device_stg1 = yes
+    remove_image_stg1 = no
+    disk_serial = TARGET_DISK0
+    blk_extra_params_stg1 += "serial=${disk_serial}"
+    image_name_stg1 = ${loop_device}
+    image_format_stg1 = qcow2
+    image_size_stg1 = ${max_size}
+    Linux:
+        guest_cmd = "dd if=/dev/urandom of=%s oflag=direct bs=${max_size}"
+    Windows:
+        guest_cmd = "WIN_UTILS:\coreutils\DummyCMD.exe %s ${max_size_in_bytes} 1"
+    virtio_blk:
+        driver_name = viostor
+    virtio_scsi:
+        driver_name = vioscsi
+    # The test cover virtio_blk and virtio_scsi
+    # With aio native and threads meanwhile
+    variants:
+        - with_virtio_blk:
+            drive_format_stg1 = virtio
+            blk_extra_params_stg1 += ",iothread=${iothreads}"
+        - with_virtio_scsi:
+            drive_format_stg1 = scsi-hd
+            bus_extra_params += "iothread=${iothreads}"
+    variants:
+        - aio_native:
+            image_aio_stg1 = native
+        - aio_threads:
+            image_aio_stg1 = threads

--- a/qemu/tests/disk_extension.py
+++ b/qemu/tests/disk_extension.py
@@ -1,0 +1,159 @@
+import logging
+
+from avocado.utils import process
+
+from virttest import env_process, utils_misc, utils_test
+from virttest import error_context, data_dir
+from virttest import utils_disk
+from virttest.qemu_storage import QemuImg
+from virttest.utils_misc import get_linux_drive_path
+
+
+# This decorator makes the test function aware of context strings
+@error_context.context_aware
+def run(test, params, env):
+    """
+    QEMU 'disk images extension in io-error status' test
+
+    1) Create folder and mounted it as tmpfs type.
+    2) Create a raw image file with small size(50M) under the tmpfs folder.
+    3) Attach loop device with above raw image file.
+    4) Create qcow2 image on the loop device with larger size (500M).
+    5) Boot vm with loop device as data disk.
+    6) Access  guest vm and execute dd operation on the data disk.
+     the IO size is same as the loop device virtual disk size.
+    7) Verify vm status is paused status in qmp or hmp.
+    8) Continue to increase disk size of the raw image file,
+     and update the loop device.
+    9) Verify vm status whether in expected status:
+      if the raw image file size is smaller than loop device virtual disk size,
+      it is in paused status,Otherwise it is in running status.
+
+    :param test: QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+
+    def cleanup_test_env(dirname, loop_device_name):
+        cmd = "if losetup -l {0};then losetup -d {0};fi;".format(
+            loop_device_name)
+        cmd += "umount -l {0};rm -rf {0};".format(dirname)
+        process.system_output(cmd, shell=True)
+
+    def prepare_tmpfs_folder(dirname):
+        cmd = "umount -l {0};rm -rf {0};mkdir -p {0};".format(dirname)
+        process.system_output(cmd, ignore_status=True, shell=True)
+        cmd = "mount -t tmpfs -o rw,nosuid,nodev,seclabel tmpfs {}".format(
+            dirname)
+        process.system_output(cmd, shell=True)
+
+    def create_image_on_loop_device(backend_img, device_img):
+        backend_img.create(backend_img.params)
+        backend_filename = backend_img.image_filename
+        loop_device_name = device_img.image_filename
+        cmd = "losetup -d {}".format(loop_device_name)
+        process.system_output(cmd, ignore_status=True, shell=True)
+        cmd = "losetup {0} {1} && chmod 666 {0}".format(loop_device_name,
+                                                        backend_filename)
+        process.system_output(cmd, shell=True)
+        device_img.create(device_img.params)
+
+    def update_loop_device_backend_size(backend_img, device_img, size):
+        cmd = "qemu-img resize -f raw %s %s && losetup -c %s" % (
+            backend_img.image_filename, size, device_img.image_filename)
+        process.system_output(cmd, shell=True)
+
+    current_size = int(params["begin_size"][0:-1])
+    max_size = int(params["max_size"][0:-1])
+    increment_size = int(params["increment_size"][0:-1])
+    size_unit = params["increment_size"][-1]
+    guest_cmd = params["guest_cmd"]
+
+    loop_device_backend_img_tag = params["loop_device_backend_img_tag"]
+    loop_device_img_tag = params["loop_device_img_tag"]
+
+    loop_device_backend_img_param = params.object_params(
+        loop_device_backend_img_tag)
+    loop_device_img_param = params.object_params(loop_device_img_tag)
+    tmpfs_folder = params.get("tmpfs_folder", "/tmp/xtmpfs")
+
+    if loop_device_backend_img_param["image_format"] != "raw":
+        test.cancel("Wrong loop device backend image format in config file.")
+
+    error_context.context("Start to setup tmpfs folder", logging.info)
+    prepare_tmpfs_folder(tmpfs_folder)
+
+    error_context.context("Start to create image on loop device", logging.info)
+    loop_device_backend_img = QemuImg(loop_device_backend_img_param,
+                                      data_dir.get_data_dir(),
+                                      loop_device_backend_img_tag)
+    loop_device_img = QemuImg(loop_device_img_param, data_dir.get_data_dir(),
+                              loop_device_img_tag)
+    create_image_on_loop_device(loop_device_backend_img, loop_device_img)
+
+    try:
+        # start to boot vm
+        params["start_vm"] = "yes"
+        timeout = int(params.get("login_timeout", 360))
+        os_type = params["os_type"]
+        driver_name = params.get("driver_name")
+        disk_serial = params["disk_serial"]
+
+        env_process.preprocess_vm(test, params, env, params["main_vm"])
+        error_context.context("Get the main VM", logging.info)
+        vm = env.get_vm(params["main_vm"])
+        vm.verify_alive()
+
+        session = vm.wait_for_login(timeout=timeout)
+        if os_type == 'windows' and driver_name:
+            session = utils_test.qemu.windrv_check_running_verifier(session,
+                                                                    vm,
+                                                                    test,
+                                                                    driver_name,
+                                                                    timeout)
+
+        if os_type == 'windows':
+            img_size = loop_device_img_param["image_size"]
+            guest_cmd = utils_misc.set_winutils_letter(session, guest_cmd)
+            disk = utils_disk.get_windows_disks_index(session, img_size)[0]
+            utils_disk.update_windows_disk_attributes(session, disk)
+            logging.info("Formatting disk:%s" % disk)
+            driver = utils_disk.configure_empty_disk(session, disk, img_size,
+                                                     os_type)[0]
+            output_path = driver + ":\\test.dat"
+
+        else:
+            output_path = get_linux_drive_path(session, disk_serial)
+
+        if not output_path:
+            test.fail("Can not get output file path in guest.")
+
+        logging.debug("Get output file path %s" % output_path)
+
+        guest_cmd = guest_cmd % output_path
+        wait_timeout = int(params.get("wait_timeout", 60))
+
+        session.sendline(guest_cmd)
+
+        test.assertTrue(vm.wait_for_status("paused", wait_timeout))
+
+        while current_size < max_size:
+            current_size += increment_size
+            current_size_string = str(current_size) + size_unit
+
+            error_context.context(
+                "Update backend image size to %s" % current_size_string,
+                logging.info)
+            update_loop_device_backend_size(loop_device_backend_img,
+                                            loop_device_img,
+                                            current_size_string)
+
+            vm.monitor.cmd("cont")
+
+            # Verify the guest status
+            if current_size < max_size:
+                test.assertTrue(vm.wait_for_status("paused", wait_timeout))
+            else:
+                test.assertTrue(vm.wait_for_status("running", wait_timeout))
+    finally:
+        cleanup_test_env(tmpfs_folder, params["loop_device"])


### PR DESCRIPTION
Add test for disk extension

There is insufficient disk space result in guest in io-error status.
This test doing disk extension until it meet real disk size and
guest may back to running status.

Signed-off-by: qingwangrh <qinwang@redhat.com>