### PR TITLE
multi_disk: Add cache option for testing scsi-generic

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -114,10 +114,14 @@
                         - block:
                             stg_params += "image_name:/dev/sd* "
                         - generic:
-                            stg_params += "drive_cache:writethrough "
                             stg_params += "image_aio:threads "
                             stg_params += "drive_format:scsi-generic "
                             stg_params += "image_name:/dev/sg* "
+                            variants:
+                                - with_cache_writethrough:
+                                    stg_params += "drive_cache:writethrough "
+                                - with_cache_writeback:
+                                    stg_params += "drive_cache:writeback "
                 - multi_lun:
                     Linux:
                         stg_params += "drive_port:range(0,16383,63) "
@@ -164,10 +168,14 @@
                         - block:
                             stg_params += "image_name:/dev/sd* "
                         - generic:
-                            stg_params += "drive_cache:writethrough "
                             stg_params += "image_aio:threads "
                             stg_params += "drive_format:scsi-generic "
                             stg_params += "image_name:/dev/sg* "
+                            variants:
+                                - with_cache_writethrough:
+                                    stg_params += "drive_cache:writethrough "
+                                - with_cache_writeback:
+                                    stg_params += "drive_cache:writeback "
         - debug_params:
             # Remove this to execute this test-params-devel test
             no multi_disk


### PR DESCRIPTION
Add cache options "writethrough" and "writeback" for
testing scsi-generic.

ID: 1731613
Signed-off-by: Yongxue Hong <yhong@redhat.com>