### PR TITLE
Correct convert params

### DIFF
--- a/qemu/tests/cfg/convert_after_resize_snapshot.cfg
+++ b/qemu/tests/cfg/convert_after_resize_snapshot.cfg
@@ -16,7 +16,6 @@
     image_size_sn1 = ""
     image_name_sn2 = "images/sn2"
     image_size_sn2 = ""
-    image_convert = "sn2"
     convert_target_sn2 = "converted"
     image_name_converted = "images/combined"
     image_format_converted = qcow2

--- a/qemu/tests/cfg/convert_image_from_raw_to_qcow2.cfg
+++ b/qemu/tests/cfg/convert_image_from_raw_to_qcow2.cfg
@@ -10,7 +10,6 @@
     image_name_tgt = "images/tgt"
     image_format_tgt = qcow2
     convert_target = tgt
-    image_convert = "tgt"
     tmp_dir = /var/tmp
     tmp_file_name = ${tmp_dir}/testfile
     file_create_cmd = "dd if=/dev/urandom of=%s bs=1M count=512"

--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -116,7 +116,6 @@
                     image_format_convert = raw
                 - snapshot_to_qcow2:
                     option_verified = "format"
-                    image_convert = "sn1"
                     image_chain += " sn1"
                     image_name_sn1 = "images/sn1"
                     image_format_sn1 = "qcow2"

--- a/qemu/tests/cfg/qemu_disk_img_compare.cfg
+++ b/qemu/tests/cfg/qemu_disk_img_compare.cfg
@@ -9,9 +9,10 @@
     backup_image_before_testing = yes
     restore_image_before_testing = yes
     option_verified = "format"
-    image_convert = "image1"
-    convert_name_image1 = "images/image1_to_raw"
-    convert_format_image1 = "raw"
+    convert_source = image1
+    convert_target = convert
+    image_name_convert = "images/image1_to_raw"
+    image_format_convert = "raw"
     compare_mode_list = "default strict"
     md5sum_bin = "md5sum"
     tmp_dir = /var/tmp


### PR DESCRIPTION
1. use `convert_target` to specify convert target.
2. remove deprecated param `image_convert`.

Signed-off-by: lolyu <lolyu@redhat.com>