### PR TITLE
rng_bat: Run random.exe from hard disk instead of cdrom to avoid windows bsod

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -117,11 +117,12 @@
             run_bgstress = rng_bat
             target_process = random\w*.exe
             session_cmd_timeout = 240
-            read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+            rng_dst = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
+            read_rng_cmd  = ${rng_dst}
             rng_data_rex = "0x\w"
             driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
             during_bg_test:
-                run_bgstress = for /l %i in (1, 1, 2000) do WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe &
+                run_bgstress = for /l %i in (1, 1, 2000) do ${rng_dst} &
                 test_after_load = rng_bat
                 bg_stress_test_is_cmd = yes
                 read_rng_timeout = 360

--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -8,7 +8,8 @@
         # Please update path of rng_dll_register_cmd to right path which included you driver
         #rng_dll_register_cmd = if not exist "C:\Windows\system32\viorngum.dll" copy PATH:\INCLUDEDRIVER\viorngum.dll C:\Windows\system32\ /y &&"
         session_cmd_timeout = 240
-        read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        rng_dst = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd  = ${rng_dst}
         driver_name = "viorng"
         rng_data_rex = "0x\w"
     Linux:

--- a/qemu/tests/cfg/rng_host_guest_read.cfg
+++ b/qemu/tests/cfg/rng_host_guest_read.cfg
@@ -6,7 +6,8 @@
     guest_rng_test = rng_bat
     host_read_cmd = "dd if=/dev/urandom of=/dev/null"
     Windows:
-        read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        rng_dst = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd  = ${rng_dst}
         driver_name = "viorng"
         rng_data_rex = "0x\w"
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"

--- a/qemu/tests/cfg/rng_hotplug.cfg
+++ b/qemu/tests/cfg/rng_hotplug.cfg
@@ -12,7 +12,8 @@
     check_image = yes
     Windows:
         session_cmd_timeout = 240
-        read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        rng_dst = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd  = ${rng_dst}
         driver_name = "viorng"
         rng_data_rex = "0x\w"
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"

--- a/qemu/tests/cfg/rng_read_longtime.cfg
+++ b/qemu/tests/cfg/rng_read_longtime.cfg
@@ -9,7 +9,8 @@
         # Please update path of rng_dll_register_cmd to right path which included you driver
         #rng_dll_register_cmd = if not exist "C:\Windows\system32\viorngum.dll" copy PATH:\INCLUDEDRIVER\viorngum.dll C:\Windows\system32\ /y &&"
         session_cmd_timeout = 240
-        read_rng_cmd = for /l %i in (1, 1, 1000) do "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        rng_dst = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd = for /l %i in (1, 1, 1000) do ${rng_dst} 
         driver_name = "viorng"
         rng_data_rex = "0x\w"
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"

--- a/qemu/tests/cfg/rng_stress.cfg
+++ b/qemu/tests/cfg/rng_stress.cfg
@@ -7,7 +7,8 @@
     no no_virtio_rng
     Windows:
         session_cmd_timeout = 240
-        read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        rng_dst  = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd  = ${rng_dst}
         driver_name = "viorng"
         rng_data_rex = "0x\w"
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"

--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -14,7 +14,8 @@
         target_process = random\w*.exe
         rng_data_rex = "0x\w"
         driver_name = "viorng"
-        read_rng_cmd = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        rng_dst = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
+        read_rng_cmd = ${rng_dst}
         list_cmd = "wmic process get name"
         i386:
             driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
@@ -43,7 +44,7 @@
             suppress_exception = yes
             run_bg_flag = "during_bg_test"
             Windows:
-                read_rng_cmd = for /l %i in (1, 1, 1000) do "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+                read_rng_cmd = for /l %i in (1, 1, 1000) do ${rng_dst}"
             Linux:
                 read_rng_cmd  = "dd if=/dev/random bs=10 count=1000000 2>/dev/null|hexdump"
             no rng_egd

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -132,7 +132,8 @@
             target_process = random\w*.exe
             session_cmd_timeout = 240
             rng_data_rex = "0x\w"
-            read_rng_cmd  = "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+            rng_dst  = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
+            read_rng_cmd  = ${rng_dst}
             driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
             i386:
                 driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
@@ -141,7 +142,7 @@
                 driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
                 driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
             during_bg_test:
-                read_rng_cmd = for /l %i in (1, 1, 1000) do "WIN_UTILS:\random_%PROCESSOR_ARCHITECTURE%.exe"
+                read_rng_cmd = for /l %i in (1, 1, 1000) do ${rng_dst}"
                 driver_check_cmd = ""
         - with_pvpanic:
             only before_bg_test


### PR DESCRIPTION
Run random.exe from cdrom sometimes make windows BSOD, copy it to vm harddisk to workaround bsod issue.

ID: 1748683

Signed-off-by: Li Jin <lijin@redhat.com>