### PR TITLE
rebase_second_snapshot_to_base: support luks

### DIFF
--- a/provider/qemu_img_utils.py
+++ b/provider/qemu_img_utils.py
@@ -62,8 +62,7 @@ def qemu_img_compare(params, image0, image1, strict=False, force_share=False):
         raise avocado.TestError(result.stdout_text)
 
 
-def save_random_file_to_vm(vm, save_path, count, sync_bin, blocksize=512,
-                           timeout=240):
+def save_random_file_to_vm(vm, save_path, count, sync_bin, blocksize=512):
     """
     Save a random file to vm.
 
@@ -72,13 +71,12 @@ def save_random_file_to_vm(vm, save_path, count, sync_bin, blocksize=512,
     :param count: block count
     :param sync_bin: sync binary path
     :param blocksize: block size, default 512
-    :param timeout: time wait to finish
     """
-    session = vm.wait_for_login()
+    session = vm.wait_for_login(timeout=360)
     dd_cmd = "dd if=/dev/urandom of=%s bs=%s count=%s conv=fsync"
     with tempfile.NamedTemporaryFile() as f:
         dd_cmd = dd_cmd % (f.name, blocksize, count)
-        process.run(dd_cmd, shell=True, timeout=timeout)
+        process.run(dd_cmd, shell=True, timeout=360)
         vm.copy_files_to(f.name, save_path)
     sync_bin = utils_misc.set_winutils_letter(session, sync_bin)
     status, out = session.cmd_status_output(sync_bin, timeout=240)

--- a/qemu/tests/cfg/rebase_second_snapshot_to_base.cfg
+++ b/qemu/tests/cfg/rebase_second_snapshot_to_base.cfg
@@ -1,5 +1,5 @@
 - rebase_second_snapshot_to_base:
-    only raw
+    only raw, luks
     virt_test_type = qemu
     type = rebase_second_snapshot_to_base
     kill_vm = yes
@@ -8,7 +8,6 @@
     # md5sum binary path
     md5sum_bin = "md5sum"
     image_chain = "image1 sn1 sn2"
-    image_format_image1 = "raw"
     image_name_sn1 = "images/sn1"
     image_format_sn1 = qcow2
     backing_chain_sn1 = yes
@@ -19,12 +18,10 @@
     # the cmdline will not have specified size option
     image_size_sn1 = ""
     image_size_sn2 = ""
-    tmp_dir = /var/tmp
-    tmp_file_name = ${tmp_dir}/testfile
-    file_create_cmd = "dd if=/dev/urandom of=%s bs=1M count=512"
-    guest_file_name = ${tmp_file_name}
+    guest_tmp_filename = "/tmp/%s"
     Windows:
-        guest_file_name = C:\testfile
+        timeout = 360
+        guest_tmp_filename = "C:\\%s"
         x86_64:
             sync_bin = WIN_UTILS:\Sync\sync64.exe /accepteula
         i386, i686:
@@ -32,6 +29,7 @@
     variants:
         - cache_mode:
             variants:
+                - off:
                 - writethrough:
                     cache_mode = writethrough
                 - writeback:
@@ -43,7 +41,7 @@
                 - directsync:
                     cache_mode = directsync
         - compat_level:
-            remove_sn1 = yes
+            remove_intermediate_layers = yes
             required_qemu = [1.1, )
             variants:
                 - compat_0.10:

--- a/qemu/tests/rebase_second_snapshot_to_base.py
+++ b/qemu/tests/rebase_second_snapshot_to_base.py
@@ -2,11 +2,12 @@ import os
 import json
 import logging
 
-from virttest import data_dir
-from virttest.qemu_storage import QemuImg
+from avocado import fail_on
 
-from qemu.tests.qemu_disk_img import QemuImgTest
-from qemu.tests.qemu_disk_img import generate_base_snapshot_pair
+from virttest import data_dir
+from virttest import qemu_storage
+
+from provider import qemu_img_utils as img_utils
 
 
 def run(test, params, env):
@@ -27,82 +28,86 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment
     """
-    def _get_img_obj_and_params(tag):
-        """Get an QemuImg object and its params based on the tag."""
-        img_param = params.object_params(tag)
-        img = QemuImg(img_param, data_dir.get_data_dir(), tag)
-        return img, img_param
+    def get_img_objs(images, params):
+        return [qemu_storage.QemuImg(params.object_params(tag), root_dir, tag)
+                for tag in images]
 
-    def _get_compat_version():
-        """Get snapshot compat version."""
-        if params.get("image_extra_params") is None:
-            # default compat version for now is 1.1
-            return "1.1"
-        return params.get("image_extra_params").split("=")[1]
-
-    def _verify_qemu_img_info_backing_chain(output, b_fmt, b_name):
+    @fail_on((AssertionError,))
+    def verify_qemu_img_info_backing_chain(output):
         """Verify qemu-img info output for this case."""
+        def _get_compat_version():
+            """Get compat version from params."""
+            return params.get("image_extra_params", "compat=1.1").split("=")[1]
+
         logging.info("Verify snapshot's backing file information.")
-        res = json.loads(output)[:-1]
-        for idx, backing in enumerate(res):
-            if (backing["backing-filename-format"] != b_fmt[idx] or
-                    backing["backing-filename"] != b_name[idx]):
-                test.fail("Backing file information is not correct,"
-                          " got %s." % b_name[idx])
-            compat = backing["format-specific"]["data"]["compat"]
-            expected = _get_compat_version()
-            if (compat != expected):
-                test.fail("Snapshot's compat mode is not correct,"
-                          " got %s, expected %s." % (compat, expected))
+        for image, img_info in zip(images, reversed(output)):
+            # skip base layer
+            if not image.base_tag:
+                continue
+            base_params = params.object_params(image.base_tag)
+            base_image = qemu_storage.get_image_repr(image.base_tag,
+                                                     base_params, root_dir)
+            base_format = image.base_format
+            compat = _get_compat_version()
+            base_image_info = img_info.get("backing-filename")
+            assert base_image == base_image_info, "backing image mismatches"
+            if base_image_info and not base_image_info.startswith("json"):
+                base_format_info = img_info.get("backing-filename-format")
+                assert base_format == base_format_info, \
+                    "backing format mismatches"
+            compat_info = img_info["format-specific"]["data"]["compat"]
+            assert compat == compat_info, "compat mode mismatches"
 
-    file = params["guest_file_name"]
-    gen = generate_base_snapshot_pair(params["image_chain"])
-    base, sn1 = next(gen)
-    base_img, _ = _get_img_obj_and_params(base)
-    sn1_img, _ = _get_img_obj_and_params(sn1)
+    timeout = int(params.get("timeout", 240))
+    images = params["image_chain"].split()
+    params["image_name_%s" % images[0]] = params["image_name"]
+    params["image_format_%s" % images[0]] = params["image_format"]
+    root_dir = data_dir.get_data_dir()
+    images = get_img_objs(images, params)
+    base, active_layer = images[0], images[-1]
 
-    logging.info("Create a snapshot %s based on %s." % (sn1, base))
-    # workaround to assign system disk's image_name to image_name_image1
-    params["image_name_image1"] = params["image_name"]
-    sn1_qit = QemuImgTest(test, params, env, sn1)
-    sn1_qit.create_snapshot()
-    _verify_qemu_img_info_backing_chain(sn1_img.info(output="json"),
-                                        [base_img.image_format],
-                                        [base_img.image_filename])
-    sn1_qit.start_vm()
-    md5 = sn1_qit.save_file(file)
-    logging.info("Got %s's md5 %s from the initial image disk." % (file, md5))
-    sn1_qit.destroy_vm()
-
-    sn1, sn2 = next(gen)
-    sn2_img, sn2_img_params = _get_img_obj_and_params(sn2)
-    logging.info("Create a snapshot %s based on %s." % (sn2, sn1))
-    sn2_qit = QemuImgTest(test, params, env, sn2)
-    sn2_qit.create_snapshot()
-    _verify_qemu_img_info_backing_chain(
-        sn2_img.info(output="json"),
-        [sn1_img.image_format, base_img.image_format],
-        [sn1_img.image_filename, base_img.image_filename])
+    md5sum_bin = params.get("md5sum_bin", "md5sum")
+    sync_bin = params.get("sync_bin", "sync")
+    hashes = {}
+    for image in images[1:]:
+        logging.debug("Create snapshot %s based on %s",
+                      image.image_filename, image.base_image_filename)
+        image.create(image.params)
+        info_output = json.loads(image.info(output="json"))
+        verify_qemu_img_info_backing_chain(info_output)
+        if image is not active_layer:
+            vm = img_utils.boot_vm_with_images(test, params, env, (image.tag,))
+            guest_file = params["guest_tmp_filename"] % image.tag
+            logging.debug("Create tmp file %s in image %s", guest_file,
+                          image.image_filename)
+            img_utils.save_random_file_to_vm(vm, guest_file,
+                                             2048 * 100, sync_bin)
+            session = vm.wait_for_login(timeout=timeout)
+            logging.debug("Get md5 value fo the temporary file")
+            hashes[guest_file] = img_utils.check_md5sum(guest_file,
+                                                        md5sum_bin, session)
+            session.close()
+            vm.destroy()
 
     cache_mode = params.get("cache_mode")
-    if cache_mode:
-        logging.info("Rebase the snapshot %s to %s with cache %s." %
-                     (sn2, base, params["cache_mode"]))
-    else:
-        logging.info("Rebase the snapshot %s to %s." % (sn2, base))
-    sn2_img.base_image_filename = base_img.image_filename
-    sn2_img.base_format = base_img.image_format
-    sn2_img.rebase(sn2_img_params, cache_mode)
-    _verify_qemu_img_info_backing_chain(sn2_img.info(output="json"),
-                                        [base_img.image_format],
-                                        [base_img.image_filename])
+    msg = "Rebase the snapshot %s to %s"
+    msg += "with cache %s." % cache_mode if cache_mode else "."
+    logging.info(msg)
+    active_layer.base_tag = base.tag
+    active_layer.rebase(active_layer.params, cache_mode)
+    info_output = json.loads(active_layer.info(output="json"))
+    verify_qemu_img_info_backing_chain(info_output)
 
-    if params.get("remove_sn1", "no") == "yes":
-        logging.info("Remove the snapshot %s." % sn1)
-        os.unlink(sn1_img.image_filename)
+    if params.get("remove_intermediate_layers", "no") == "yes":
+        for image in images:
+            if image not in (base, active_layer):
+                logging.info("Remove the snapshot %s.", image.image_filename)
+                os.unlink(image.image_filename)
 
-    sn2_qit.start_vm()
-    if not sn2_qit.check_file(file, md5):
-        test.fail("The file %s's md5 on initial image and"
-                  " target file are different." % file)
-    sn2_qit.destroy_vm()
+    vm = img_utils.boot_vm_with_images(test, params, env, (active_layer.tag,))
+    session = vm.wait_for_login(timeout=timeout)
+    for guest_file, hash_val in hashes.items():
+        img_utils.check_md5sum(guest_file, md5sum_bin, session,
+                               md5_value_to_check=hash_val)
+    session.close()
+    vm.destroy()


### PR DESCRIPTION
1. support luks as the base image
2. replace functions from `qemu_disk_img` with those in
`provider/qemu_img_utils`.

Signed-off-by: lolyu <lolyu@redhat.com>