### PR TITLE
unsafe_rebase_to_none_existing_backing_file: fix rebase

### DIFF
--- a/qemu/tests/cfg/unsafe_rebase_to_none_existing_backing_file.cfg
+++ b/qemu/tests/cfg/unsafe_rebase_to_none_existing_backing_file.cfg
@@ -9,7 +9,9 @@
     image_format_image1 = "raw"
     image_name_sn = "images/sn"
     rebase_mode_sn = unsafe
-    none_existing_image_name = a-none-existing-image.raw
+    image_name_beingless = beingless
+    image_format_beingless = ${image_format_image1}
+    none_existing_image = beingless
     # set size to "", so during snapshot creation
     # the cmdline will not have specified size option
     image_size_sn = ""

--- a/qemu/tests/unsafe_rebase_to_none_existing_backing_file.py
+++ b/qemu/tests/unsafe_rebase_to_none_existing_backing_file.py
@@ -71,8 +71,7 @@ def run(test, params, env):
     _verify_qemu_img_info(sn_img.info(output="json"),
                           base_img.image_format, base_img.image_filename)
 
-    sn_img.base_image_filename = params["none_existing_image_name"]
-    sn_img.base_format = sn_img.base_image_filename.split('.')[-1]
+    sn_img.base_tag = params["none_existing_image"]
     sn_img.rebase(sn_img_params)
     _verify_qemu_img_info(sn_img.info(output="json"),
                           sn_img.base_format, sn_img.base_image_filename)


### PR DESCRIPTION
Update `rebase` to adjust the way to specify rebase target.

Signed-off-by: lolyu <lolyu@redhat.com>