### PR TITLE
Add cases to test virtio_blk with discard and write_zeroes

### DIFF
--- a/qemu/tests/cfg/virtio_blk_with_discard_write_zeroes.cfg
+++ b/qemu/tests/cfg/virtio_blk_with_discard_write_zeroes.cfg
@@ -1,0 +1,30 @@
+- virtio_blk_with_discard_write_zeroes:
+    only virtio_blk
+    only Linux
+    required_qemu = [4.0.0,)
+    type = virtio_blk_with_discard_write_zeroes
+    images += " stg0"
+    boot_drive_stg0 = yes
+    image_name_stg0 = images/storage0
+    image_size_stg0 = 1G
+    remove_image_stg0 = yes
+    force_create_image_stg0 = yes
+    blk_extra_params_stg0 = "serial=TARGET_DISK0"
+    cmd_dd = "dd if=/dev/zero of={0} bs=1M count=900 oflag=direct && "
+    cmd_dd += "dd if={0} of=/dev/null bs=1M count=900 iflag=direct"
+    variants:
+        - all_enabled:
+            blk_extra_params_stg0 += ",discard=on,write-zeroes=on"
+            attributes_checked = "{'discard': 'true', 'write-zeroes': 'true'}"
+            check_cmd_discard = "blkdiscard {0} && echo "PASS" || echo "FAIL""
+            check_cmd_zeroes = "blkdiscard -z {0} && dd if={0} bs=64k count=10000 | "
+            check_cmd_zeroes += "tr -d '\0' | read -n 1 && echo "FAIL" || echo "PASS (All zeroes)""
+            status_checked = "{'check_cmd_discard': 'PASS', 'check_cmd_zeroes': 'PASS (All zeroes)'}"
+        - all_disabled:
+            blk_extra_params_stg0 += ",discard=off,write-zeroes=off"
+            attributes_checked = "{'discard': 'false', 'write-zeroes': 'false'}"
+            check_cmd_discard = "blkdiscard {0} && echo "PASS" || echo "FAIL""
+            check_cmd_zeroes = "dd if=/dev/urandom of={0} bs=64k count=10000 conv=fsync && "
+            check_cmd_zeroes += "dd if={0} bs=64k count=10000 | tr -d '\0' | read -n 1 && "
+            check_cmd_zeroes += "echo "PASS (not all zeroes)" || echo "FAIL""
+            status_checked = "{'check_cmd_discard': 'FAIL', 'check_cmd_zeroes': 'PASS (not all zeroes)'}"

--- a/qemu/tests/virtio_blk_with_discard_write_zeroes.py
+++ b/qemu/tests/virtio_blk_with_discard_write_zeroes.py
@@ -1,0 +1,80 @@
+import ast
+import re
+import logging
+
+from virttest import error_context
+from virttest import qemu_qtree
+from virttest import utils_misc
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test virtio_blk with options "discard" and "write_zeroes".
+    Steps:
+        1. Boot up a virtio-blk guest with options 'discard' and
+           'write_zeroes' enabled or disabled.
+        2. Check if discard and write-zeroes attribute works.
+        3. In guest, check if discard enabled or disabled.
+        4. In guest, check if write_zeroes enabled or disabled.
+        5. Do some IO tests on the disk.
+
+    :param test: KVM test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+    def check_attribute_in_qtree(dev_id, name, excepted_val):
+        """Check if discard and write-zeroes attribute work."""
+        error_context.context('Check if %s attribute works.' % name, logging.info)
+        qtree = qemu_qtree.QtreeContainer()
+        qtree.parse_info_qtree(vm.monitor.info('qtree'))
+        for node in qtree.get_nodes():
+            if (isinstance(node, qemu_qtree.QtreeDev) and
+                    node.qtree.get('id') == dev_id):
+                _node = node.children[0].children[0]
+                if _node.qtree.get('drive').endswith('_%s"' % dev_id):
+                    if _node.qtree.get(name) is None:
+                        test.fail('The qtree device %s has no property %s.' %
+                                  (dev_id, name))
+                    elif _node.qtree.get(name) == excepted_val:
+                        logging.info('The "%s" matches with qtree device "%s"'
+                                     '(%s).' % (name, dev_id, excepted_val))
+                        break
+                    else:
+                        test.fail('The "%s" mismatches with qtree device "%s"'
+                                  '(%s).' % (name, dev_id, excepted_val))
+        else:
+            test.error('No such "%s" qtree device.' % dev_id)
+
+    def check_status_inside_guest(session, cmd, excepted_val):
+        """Check if the discard or write-zeroes is enabled or disabled."""
+        if excepted_val not in session.cmd(cmd, 600):
+            test.fail('The output should be "%s"' % excepted_val)
+
+    def get_data_disk_by_serial(session, image_tag):
+        """Get the data disks by serial options."""
+        match = re.search(
+            r"serial=(\w+)", params["blk_extra_params_%s" % image_tag], re.M)
+        drive_path = utils_misc.get_linux_drive_path(session, match.group(1))
+        if not drive_path:
+            test.error("Failed to get '%s' drive path" % image_tag)
+        return drive_path
+
+    def dd_test(session, target):
+        """Do dd test on the data disk."""
+        error_context.context('Do dd test on the data disk.', logging.info)
+        session.cmd(params['cmd_dd'].format(target), 600)
+
+    data_tag = params["images"].split()[1]
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login()
+    data_disk = get_data_disk_by_serial(session, data_tag)
+
+    for attr_name, val in ast.literal_eval(params['attributes_checked']).items():
+        check_attribute_in_qtree(data_tag, attr_name, val)
+
+    for cmd, val in ast.literal_eval(params['status_checked']).items():
+        check_status_inside_guest(session, params[cmd].format(data_disk), val)
+
+    dd_test(session, data_disk)


### PR DESCRIPTION
Add cases to test virtio_blk with the options discard and
wirte_zeores by checking their attributes and status.

ID: 1731471
Signed-off-by: Yongxue Hong <yhong@redhat.com>