### PR TITLE
qemu..migrate: Override force_reset_go_down_check on with_reboot

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -95,6 +95,8 @@
         - with_reboot:
             iterations = 1
             type = migration_with_reboot
+            # Disable force-go-down-check as it's not reliable with reboot
+            force_reset_go_down_check = none
         - after_vm_paused:
             only tcp
             only Linux


### PR DESCRIPTION
The with_reboot migration is not reliable when using QMP RESET event as
check for reset, because the VM object is constantly changing.

This is related to: https://github.com/avocado-framework/avocado-vt/pull/2289 which implements the "force_reset_go_down_check" parameter.