### PR TITLE
qemu_img_lock: support luks

### DIFF
--- a/qemu/tests/cfg/qemu_img_lock.cfg
+++ b/qemu/tests/cfg/qemu_img_lock.cfg
@@ -1,5 +1,5 @@
 - qemu_img_lock:
-    only qcow2 raw
+    only qcow2 raw luks
     virt_test_type = qemu
     force_create_image = no
     start_vm = no


### PR DESCRIPTION
Add support for luks in case: `qemu_img_lock.reject_boot_same_img_twice`

Signed-off-by: lolyu <lolyu@redhat.com>