### PR TITLE
Add cases to test vcpu device hot plug/unplug

### DIFF
--- a/provider/cpu_utils.py
+++ b/provider/cpu_utils.py
@@ -1,0 +1,91 @@
+import re
+import logging
+
+from virttest.utils_test import VMStress
+
+
+class VMStressBinding(VMStress):
+    """
+    Run stress tool on VMs, and bind the process to the specified cpu
+    """
+    def __init__(self, vm, params, stress_args=""):
+        super(VMStressBinding, self).__init__(vm, "stress", params,
+                                              stress_args=stress_args)
+        self.install()  # pylint: disable=E0203
+        self.install = lambda: None
+
+    def load_stress_tool(self, cpu_id):
+        """
+        Load the stress tool and bind it to the specified CPU
+
+        :param cpu_id: CPU id you want to bind
+        """
+        self.stress_cmds = "taskset -c %s stress" % cpu_id  # pylint: disable=W0201
+        super(VMStressBinding, self).load_stress_tool()
+
+
+def get_guest_cpu_ids(session, os_type):
+    """
+    Get the ids of all CPUs of the guest
+
+    :param session: ShellSession object of VM
+    :param os_type: guest os type, windows or linux
+    :return: list of cpu id
+    """
+    if os_type == "windows":
+        # Windows can not get each core id of socket, so this function is
+        # meaningless, directly returns an empty set
+        return set()
+    cmd = "grep processor /proc/cpuinfo"
+    output = session.cmd_output(cmd)
+    return set(map(int, re.findall(r"(\d+)$", output, re.M)))
+
+
+def check_guest_cpu_topology(session, os_type, cpuinfo):
+    """
+    check the cpu topology of the guest.
+
+    :param session: session Object
+    :param os_type: guest os type, windows or linux
+    :param cpuinfo: virt_vm.CpuInfo Object
+    :return: True if guest topology is same as we expected
+    """
+    if os_type == "linux":
+        out = session.cmd_output_safe("lscpu")
+        cpu_info = dict(re.findall(r"([A-Z].+):\s+(.+)", out, re.M))
+        sockets = int(cpu_info["Socket(s)"])
+        cores = int(cpu_info["Core(s) per socket"])
+        threads = int(cpu_info["Thread(s) per core"])
+    else:
+        cmd = ('powershell "Get-WmiObject Win32_processor | Format-List '
+               'NumberOfCores,ThreadCount"')
+        out = session.cmd_output_safe(cmd).strip()
+        try:
+            cpu_info = [dict(re.findall(r"(\w+)\s+:\s(\d+)", cpu_out, re.M))
+                        for cpu_out in out.split("\n\n")]
+            sockets = len(cpu_info)
+            cores = int(cpu_info[0]["NumberOfCores"])
+            threads = int(cpu_info[0]["ThreadCount"])
+        except KeyError:
+            logging.warning("Attempt to get output via 'powershell' failed, "
+                            "output returned by guest:\n%s", out)
+            logging.info("Try again via 'wmic'")
+            cmd = 'wmic CPU get NumberOfCores,ThreadCount /Format:list'
+            out = session.cmd_output_safe(cmd).strip()
+            try:
+                cpu_info = [dict(re.findall(r"(\w+)=(\d+)", cpu_out, re.M))
+                            for cpu_out in out.split("\n\n")]
+                sockets = len(cpu_info)
+                cores = int(cpu_info[0]["NumberOfCores"])
+                threads = int(cpu_info[0]["ThreadCount"])
+            except KeyError:
+                logging.error("Attempt to get output via 'wmic' failed, output"
+                              " returned by guest:\n%s", out)
+                return False
+
+    is_matched = (cpuinfo.sockets == sockets and cpuinfo.cores == cores and
+                  cpuinfo.threads == threads)
+    if not is_matched:
+        logging.debug("CPU infomation of guest:\n%s", out)
+
+    return is_matched

--- a/qemu/tests/cfg/cpu_device_hotpluggable.cfg
+++ b/qemu/tests/cfg/cpu_device_hotpluggable.cfg
@@ -1,0 +1,81 @@
+# Notes:
+#    For ppc64/ppc64le, please manually specify cpu_model in your environment
+- cpu_device_hotpluggable: install setup image_copy unattended_install.cdrom
+    only ppc64 ppc64le x86_64
+    Windows:
+        no WinXP, WinVista, Win7, Win8, Win10, Win2000, Win2003
+    # ovmf does not support hotpluggable vCPU yet, this line will be removed
+    # when it is fully supported.
+    no ovmf
+    required_qemu = [2.6.0, )
+    virt_test_type = qemu
+    type = cpu_device_hotpluggable
+    # Sleep for a while after vCPUs change, make guest stable
+    sleep_after_cpu_change = 30
+    login_timeout = 360
+    qemu_sandbox = on
+    variants:
+        - with_reboot:
+            sub_test_type = reboot
+            variants:
+                - shell_reboot:
+                    reboot_method = shell
+                - qemu_system_reset:
+                    reboot_method = system_reset
+        - with_shutdown:
+            sub_test_type = shutdown
+            variants:
+                - shell_shutdown:
+                    shutdown_method = shell
+                - qemu_system_powerdown:
+                    shutdown_method = system_powerdown
+        - with_migrate:
+            sub_test_type = migrate
+            reboot_method = shell
+            hotplug:
+                Linux:
+                    sub_test_after_migrate = reboot hotunplug
+                Windows:
+                    sub_test_after_migrate = reboot
+            hotunplug:
+                sub_test_after_migrate = reboot
+        - with_pause_resume:
+            only hotplug
+            pause_vm_before_hotplug = yes
+            Linux:
+                sub_test_type = pause_resume
+        - with_online_offline:
+            only hotplug
+            only Linux
+            sub_test_type = online_offline
+        - with_stress:
+            only hotplug
+            only multi_vcpu
+            type = cpu_device_hotpluggable_with_stress
+            image_snapshot = yes
+            Linux:
+                stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 256M"
+            Windows:
+                install_path = "C:\Program Files\JAM Software\HeavyLoad"
+                install_cmd = "start /wait %s:\HeavyLoadSetup.exe /verysilent"
+        - with_numa:
+            only hotplug
+            only multi_vcpu
+            type = cpu_device_hotpluggable_with_numa
+            start_vm = no
+            guest_numa_nodes = node0 node1
+            numa_nodeid_node0 = 0
+            numa_nodeid_node1 = 1
+    variants:
+        - single_vcpu:
+            vcpu_devices = vcpu1
+        - multi_vcpu:
+            vcpu_devices = vcpu1 vcpu2 vcpu3 vcpu4
+    variants:
+        - hotplug:
+            hotpluggable_test = hotplug
+            vcpu_enable = no
+        - hotunplug:
+            only Linux
+            hotpluggable_test = hotunplug
+            vcpu_enable = yes

--- a/qemu/tests/cpu_device_hotpluggable.py
+++ b/qemu/tests/cpu_device_hotpluggable.py
@@ -1,0 +1,167 @@
+import logging
+
+from provider import cpu_utils
+
+from aexpect import ShellCmdError
+from virttest import error_context
+from virttest import utils_misc
+from virttest.virt_vm import VMDeviceCheckError
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test hotplug/hotunplug of vcpu device.
+
+    1) Boot up guest w/o vcpu device.
+    2) Hot plug/unplug vcpu devices and check successfully or not. (qemu side)
+    3) Check if the number of CPUs in guest changes accordingly. (guest side)
+    4) Do sub test after hot plug/unplug.
+    5) Recheck the number of CPUs in guest.
+    6) Check the CPU topology of guest. (if all vcpu plugged)
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+    def check_guest_cpu_count(expected_count):
+        if not utils_misc.wait_for(
+                lambda: vm.get_cpu_count() == expected_count,
+                verify_wait_timeout, first=sleep_after_change):
+            logging.error("CPU quantity mismatched! Guest got %s but the"
+                          " expected is %s", vm.get_cpu_count(),
+                          expected_count)
+            test.fail("Actual number of guest CPUs is not equal to expected")
+        logging.info("CPU quantity matched: %s", expected_count)
+
+    def sub_hotunplug():
+        error_context.context("Hotunplug vcpu devices after vcpu %s"
+                              % hotpluggable_test, logging.info)
+        for plugged_dev in pluggable_vcpu_dev[::-1]:
+            try:
+                vm.hotunplug_vcpu_device(plugged_dev)
+            except VMDeviceCheckError:
+                if not vm.is_paused():
+                    raise
+                logging.warning("%s can not be unplugged directly because "
+                                "guest is paused, will check again after "
+                                "resume", plugged_dev)
+
+    def sub_reboot():
+        error_context.context("Reboot guest after vcpu %s"
+                              % hotpluggable_test, logging.info)
+        vm.reboot(session=session, method=params["reboot_method"],
+                  timeout=login_timeout)
+
+    def sub_shutdown():
+        error_context.context("Shutdown guest after vcpu %s"
+                              % hotpluggable_test, logging.info)
+        shutdown_method = params["shutdown_method"]
+        if shutdown_method == "shell":
+            session.sendline(params["shutdown_command"])
+            error_context.context("waiting VM to go down (guest shell cmd)",
+                                  logging.info)
+        elif shutdown_method == "system_powerdown":
+            vm.monitor.system_powerdown()
+            error_context.context("waiting VM to go down (qemu monitor cmd)",
+                                  logging.info)
+        if not vm.wait_for_shutdown(360):
+            test.fail("Guest refuses to go down after vcpu %s"
+                      % hotpluggable_test)
+
+    def sub_migrate():
+        sub_migrate_reboot = sub_reboot
+        sub_migrate_hotunplug = sub_hotunplug
+        error_context.context("Migrate guest after vcpu %s"
+                              % hotpluggable_test, logging.info)
+        vm.migrate()
+        vm.verify_alive()
+        sub_test_after_migrate = params.objects("sub_test_after_migrate")
+        while sub_test_after_migrate:
+            check_guest_cpu_count(expected_vcpus)
+            sub_test = sub_test_after_migrate.pop(0)
+            error_context.context("%s after migration completed" % sub_test)
+            eval("sub_migrate_%s" % sub_test)()
+
+    def sub_online_offline():
+        error_context.context("Offline then online guest CPUs after vcpu %s"
+                              % hotpluggable_test, logging.info)
+        cpu_ids = list(current_guest_cpu_ids - guest_cpu_ids)
+        cpu_ids.sort()
+        cmd = "echo %d > /sys/devices/system/cpu/cpu%d/online"
+        try:
+            for cpu_id in cpu_ids[::-1]:
+                session.cmd(cmd % (0, cpu_id))
+            check_guest_cpu_count(smp)
+            for cpu_id in cpu_ids:
+                session.cmd(cmd % (1, cpu_id))
+        except ShellCmdError as err:
+            logging.error(str(err))
+            test.error("Failed to change the CPU state on guest.")
+
+    def sub_pause_resume():
+        error_context.context("Pause guest to hotunplug all vcpu devices",
+                              logging.info)
+        vm.pause()
+        sub_hotunplug()
+        error_context.context("Resume guest after hotunplug")
+        vm.resume()
+
+    login_timeout = params.get_numeric("login_timeout", 360)
+    sleep_after_change = params.get_numeric("sleep_after_cpu_change", 30)
+    os_type = params["os_type"]
+    hotpluggable_test = params["hotpluggable_test"]
+    verify_wait_timeout = params.get_numeric("verify_wait_timeout", 60)
+    sub_test_type = params.get("sub_test_type")
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=login_timeout)
+    smp = vm.cpuinfo.smp
+    maxcpus = vm.cpuinfo.maxcpus
+    vcpus_count = vm.params.get_numeric("vcpus_count", 1)
+    vcpu_devices = params.objects("vcpu_devices")
+    guest_cpu_ids = cpu_utils.get_guest_cpu_ids(session, os_type)
+
+    if hotpluggable_test == "hotplug":
+        pluggable_vcpu_dev = vcpu_devices
+        pluggable_vcpu = vcpus_count * len(pluggable_vcpu_dev)
+    else:
+        pluggable_vcpu_dev = vcpu_devices[::-1]
+        pluggable_vcpu = -(vcpus_count * len(pluggable_vcpu_dev))
+    expected_vcpus = vm.get_cpu_count() + pluggable_vcpu
+
+    if params.get("pause_vm_before_hotplug", "no") == "yes":
+        error_context.context("Pause guest before %s" % hotpluggable_test,
+                              logging.info)
+        vm.pause()
+    error_context.context("%s all vcpu devices" % hotpluggable_test,
+                          logging.info)
+    for vcpu_dev in pluggable_vcpu_dev:
+        getattr(vm, "%s_vcpu_device" % hotpluggable_test)(vcpu_dev)
+    if vm.is_paused():
+        error_context.context("Resume guest after %s" % hotpluggable_test,
+                              logging.info)
+        vm.resume()
+
+    check_guest_cpu_count(expected_vcpus)
+    current_guest_cpu_ids = cpu_utils.get_guest_cpu_ids(session, os_type)
+
+    if sub_test_type:
+        eval("sub_%s" % sub_test_type)()
+        # Close old session since guest maybe dead/reboot
+        if session:
+            session.close()
+        if ("hotunplug" in params.objects("sub_test_after_migrate")
+                or sub_test_type == "pause_resume"):
+            expected_vcpus -= pluggable_vcpu
+
+    if vm.is_alive():
+        session = vm.wait_for_login(timeout=login_timeout)
+        check_guest_cpu_count(expected_vcpus)
+        if (expected_vcpus == maxcpus and
+                not cpu_utils.check_guest_cpu_topology(session, os_type,
+                                                       vm.cpuinfo)):
+            session.close()
+            test.fail("CPU topology of guest is inconsistent with "
+                      "expectations.")

--- a/qemu/tests/cpu_device_hotpluggable_with_numa.py
+++ b/qemu/tests/cpu_device_hotpluggable_with_numa.py
@@ -1,0 +1,109 @@
+import re
+import logging
+
+from virttest import error_context
+from virttest import utils_package
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test hotplug vcpu devices with specified numa nodes.
+
+    1) Boot up guest without vcpu device and with multi numa nodes.
+    2) Hotplug vcpu devices and check successfully or not. (qemu side)
+    3) Check if the number of CPUs in guest changes accordingly. (guest side)
+    4) Check numa info in guest
+    5) Hotunplug vcpu devices
+    6) Recheck the numa info in guest
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+
+    def assign_numa_cpus(nodes, count):
+        """Average allocation of cpu to each node."""
+        cpus = list(map(str, range(maxcpus)))
+        avg_count = maxcpus / float(len(nodes))
+        if avg_count % count != 0:
+            avg_count = round(avg_count / count) * count
+        numa_cpus_list = []
+
+        last = 0.0
+        while last < maxcpus:
+            numa_cpus_list.append(cpus[int(last):int(last + avg_count)])
+            last += avg_count
+        return dict(zip(nodes, numa_cpus_list))
+
+    def get_guest_numa_cpus_info():
+        """Get guest numa information via numactl"""
+        # Skip this step on windows guest
+        if os_type == "windows":
+            return
+        numa_out = session.cmd_output("numactl -H | grep cpus")
+        numa_cpus_info = re.findall(r"^node (\d+) cpus:([\d| ]*)$",
+                                    numa_out, re.M)
+        return dict(map(lambda x: (x[0], x[1].split()), numa_cpus_info))
+
+    os_type = params["os_type"]
+    machine = params["machine_type"]
+    vcpu_devices = params.objects("vcpu_devices")
+    login_timeout = params.get_numeric("login_timeout", 360)
+    vm = env.get_vm(params["main_vm"])
+    vm.create()
+    maxcpus = vm.cpuinfo.maxcpus
+    alignment = vm.cpuinfo.threads if machine.startswith("pseries") else 1
+    vm.destroy()
+
+    error_context.base_context("Define the cpu list for each numa node",
+                               logging.info)
+    numa_nodes = params.objects("guest_numa_nodes")
+    node_ids = [params["numa_nodeid_%s" % node] for node in numa_nodes]
+    node_cpus_mapping = assign_numa_cpus(node_ids, alignment)
+    for node in numa_nodes:
+        params["numa_cpus_%s" % node] = ",".join(
+            node_cpus_mapping[params["numa_nodeid_%s" % node]])
+    params["start_vm"] = "yes"
+
+    error_context.context("Launch the guest with our assigned numa node",
+                          logging.info)
+    vm.create(params=params)
+    session = vm.wait_for_login(timeout=login_timeout)
+    if os_type == "linux" and not utils_package.package_install("numactl",
+                                                                session):
+        test.cancel("Please install numactl to proceed")
+    numa_before_plug = get_guest_numa_cpus_info()
+    for vcpu_dev in vcpu_devices:
+        error_context.context("hotplug vcpu device: %s" % vcpu_dev,
+                              logging.info)
+        vm.hotplug_vcpu_device(vcpu_dev)
+    if vm.get_cpu_count() != maxcpus:
+        test.fail("Actual number of guest CPUs is not equal to expected.")
+
+    if os_type == "linux":
+        error_context.context("Check the CPU information of each numa node",
+                              logging.info)
+        guest_numa_cpus = get_guest_numa_cpus_info()
+        for node_id, node_cpus in node_cpus_mapping.items():
+            try:
+                if guest_numa_cpus[node_id] != node_cpus:
+                    logging.debug("Current guest numa info:\n%s",
+                                  session.cmd_output("numactl -H"))
+                    test.fail("The cpu obtained by guest is inconsistent with "
+                              "we assigned.")
+            except KeyError:
+                test.error("Could not find node %s in guest." % node_id)
+        logging.info("Number of each CPU in guest matches what we assign.")
+
+        for vcpu_dev in vcpu_devices[::-1]:
+            error_context.context("hotunplug vcpu device: %s" % vcpu_dev,
+                                  logging.info)
+            vm.hotunplug_vcpu_device(vcpu_dev)
+        if vm.get_cpu_count() != vm.cpuinfo.smp:
+            test.fail("Actual number of guest CPUs is not equal to the "
+                      "expected.")
+        if get_guest_numa_cpus_info() != numa_before_plug:
+            logging.debug("Current guest numa info:\n%s",
+                          session.cmd_output("numactl -H"))
+            test.fail("Numa info of guest is incorrect after vcpu hotunplug.")

--- a/qemu/tests/cpu_device_hotpluggable_with_stress.py
+++ b/qemu/tests/cpu_device_hotpluggable_with_stress.py
@@ -1,0 +1,120 @@
+import re
+import time
+import random
+import logging
+
+from provider import cpu_utils
+
+from virttest import error_context
+from virttest import utils_misc
+from virttest import utils_package
+from virttest.utils_test import BackgroundTest
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test hotplug vcpu devices and execute stress test.
+
+    1) Boot up guest without vcpu device.
+    2) Hotplug vcpu devices and check successfully or not. (qemu side)
+    3) Check if the number of CPUs in guest changes accordingly. (guest side)
+    4) Execute stress test on all hotplugged vcpu devices
+    5) Hotunplug vcpu devices during stress test
+    6) Recheck the number of CPUs in guest.
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+
+    def heavyload_install():
+        if session.cmd_status(test_installed_cmd) != 0:
+            logging.warning("Could not find installed heavyload in guest, will"
+                            " install it via winutils.iso ")
+            winutil_drive = utils_misc.get_winutils_vol(session)
+            if not winutil_drive:
+                test.cancel("WIN_UTILS CDROM not found.")
+            install_cmd = params["install_cmd"] % winutil_drive
+            session.cmd(install_cmd)
+
+    os_type = params["os_type"]
+    login_timeout = params.get_numeric("login_timeout", 360)
+    stress_duration = params.get_numeric("stress_duration", 180)
+    verify_wait_timeout = params.get_numeric("verify_wait_timeout", 60)
+    vcpu_devices = params.objects("vcpu_devices")
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=login_timeout)
+    smp = vm.cpuinfo.smp
+    maxcpus = vm.cpuinfo.maxcpus
+
+    guest_cpu_ids = cpu_utils.get_guest_cpu_ids(session, os_type)
+    for vcpu_dev in vcpu_devices:
+        error_context.context("Hotplug vcpu device: %s" % vcpu_dev,
+                              logging.info)
+        vm.hotplug_vcpu_device(vcpu_dev)
+    if not utils_misc.wait_for(lambda: vm.get_cpu_count() == maxcpus,
+                               verify_wait_timeout):
+        test.fail("Actual number of guest CPUs is not equal to expected")
+
+    if os_type == "linux":
+        stress_args = params["stress_args"]
+        stress_tool = cpu_utils.VMStressBinding(vm, params,
+                                                stress_args=stress_args)
+        current_guest_cpu_ids = cpu_utils.get_guest_cpu_ids(session, os_type)
+        plugged_cpu_ids = list(current_guest_cpu_ids - guest_cpu_ids)
+        plugged_cpu_ids.sort()
+        for cpu_id in plugged_cpu_ids:
+            error_context.context("Run stress on vCPU(%d) inside guest."
+                                  % cpu_id, logging.info)
+            stress_tool.load_stress_tool(cpu_id)
+        error_context.context("Successfully launched stress sessions, execute "
+                              "stress test for %d seconds" % stress_duration,
+                              logging.info)
+        time.sleep(stress_duration)
+        if utils_package.package_install("sysstat", session):
+            error_context.context("Check usage of guest CPUs", logging.info)
+            mpstat_cmd = "mpstat 1 5 -P %s | cat" % ",".join(
+                map(str, plugged_cpu_ids))
+            mpstat_out = session.cmd_output(mpstat_cmd)
+            cpu_stat = dict(re.findall(r"Average:\s+(\d+)\s+(\d+\.\d+)",
+                                       mpstat_out, re.M))
+            for cpu_id in plugged_cpu_ids:
+                cpu_usage_rate = float(cpu_stat[str(cpu_id)])
+                if cpu_usage_rate < 50:
+                    test.error("Stress test on vCPU(%s) failed, usage rate: "
+                               "%.2f%%" % (cpu_id, cpu_usage_rate))
+                logging.info("Usage rate of vCPU(%s) is: %.2f%%", cpu_id,
+                             cpu_usage_rate)
+        for vcpu_dev in vcpu_devices:
+            error_context.context("Hotunplug vcpu device: %s" % vcpu_dev,
+                                  logging.info)
+            vm.hotunplug_vcpu_device(vcpu_dev)
+            # Drift the running stress task to other vCPUs
+            time.sleep(random.randint(5, 10))
+        if vm.get_cpu_count() != smp:
+            test.fail("Actual number of guest CPUs is not equal to expected")
+        stress_tool.unload_stress()
+        stress_tool.clean()
+    else:
+        install_path = params["install_path"]
+        test_installed_cmd = 'dir "%s" | findstr /I heavyload' % install_path
+        heavyload_install()
+        error_context.context("Run heavyload inside guest.", logging.info)
+        heavyload_bin = r'"%s\heavyload.exe" ' % install_path
+        heavyload_options = ["/CPU %d" % maxcpus,
+                             "/DURATION %d" % (stress_duration // 60),
+                             "/AUTOEXIT",
+                             "/START"]
+        start_cmd = heavyload_bin + " ".join(heavyload_options)
+        stress_tool = BackgroundTest(session.cmd, (start_cmd, stress_duration,
+                                                   stress_duration))
+        stress_tool.start()
+        if not utils_misc.wait_for(stress_tool.is_alive, verify_wait_timeout,
+                                   first=5):
+            test.error("Failed to start heavyload process.")
+        stress_tool.join(stress_duration)
+
+    session.close()


### PR DESCRIPTION
Add some test cases to test vcpu device hot plug and unplug. And after
that, do some sub test, verify guest work well and the number of vcpu is
the same as expected.

Depends on: [Add vcpu device support [V2]](https://github.com/avocado-framework/avocado-vt/pull/2293)
ID: 1777153,1777161,1777163,1777164,1777165,1777167,1777171,1777172,1777169,1777181,1777182,1777183,1777184,1777185,1777187,1777190,1777192,1777194,1778561
Signed-off-by: Yihuang Yu <yihyu@redhat.com>