### PR TITLE
seabioa_scsi_lun: correct data image name

### DIFF
--- a/qemu/tests/cfg/seabios_scsi_lun.cfg
+++ b/qemu/tests/cfg/seabios_scsi_lun.cfg
@@ -7,7 +7,7 @@
     Host_RHEL.m6:
         boot_menu_key = "f12"
     images = "stg1"
-    image_name_stg = "images/stg1"
+    image_name_stg1 = "images/stg1"
     image_size_stg1 = 200M
     force_create_image_stg1 = yes
     remove_image_stg1 = yes


### PR DESCRIPTION
1. correct it in order to avoid removing system image

ID: 1762276

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>