### PR TITLE
create_snapshot_on_running_base: support luks

### DIFF
--- a/qemu/tests/cfg/create_snapshot_on_running_base.cfg
+++ b/qemu/tests/cfg/create_snapshot_on_running_base.cfg
@@ -1,6 +1,7 @@
 - create_snapshot_on_running_base:
     virt_test_type = qemu
     type = create_snapshot_on_running_base
+    start_vm = no
     kill_vm = yes
     force_create_image = no
     # md5sum binary path
@@ -10,12 +11,10 @@
     # set size to "", so during snapshot creation
     # the cmdline will not have specified size option
     image_size_sn = ""
-    tmp_dir = /var/tmp
-    tmp_file_name = ${tmp_dir}/testfile
-    file_create_cmd = "dd if=/dev/urandom of=%s bs=1M count=512"
-    guest_file_name = ${tmp_file_name}
+    image_format_sn = "qcow2"
+    guest_temp_file = "/var/tmp/base.tmp"
     Windows:
-        guest_file_name = C:\testfile
+        guest_temp_file = "C:\\base.tmp"
         x86_64:
             sync_bin = WIN_UTILS:\Sync\sync64.exe /accepteula
         i386, i686:


### PR DESCRIPTION
As the subject, add support for luks for
`create_snapshot_on_running_base`, which tests the creation of snapshot
over a in-use base image.

Signed-off-by: lolyu <lolyu@redhat.com>