### PR TITLE
qemu-guest-agent: bug fix of get fsinfo in rhel7 guest

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -239,7 +239,7 @@
         - check_fsinfo:
             gagent_check_type = fsinfo
             blk_extra_params = "serial=GAGENT_TEST"
-            cmd_get_disk = cat /proc/mounts |awk '$2~/^\%s$/{print $1,$3}'
+            cmd_get_disk = cat /proc/mounts |grep -v rootfs |awk '$2~/^\%s$/{print $1,$3}'
             Windows:
                 cmd_get_disk = wmic volume where "DriveLetter='%s'" get FileSystem,DeviceID |findstr /v /i FileSystem
         - check_nonexistent_cmd:


### PR DESCRIPTION
The command to get the mount point info is different
 between rhel7 and rhel8
ID: 1752748
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>