### PR TITLE
Update the function name as the refactor

### DIFF
--- a/qemu/tests/mq_change_qnum.py
+++ b/qemu/tests/mq_change_qnum.py
@@ -186,7 +186,7 @@ def run(test, params, env):
 
         if params.get("ping_after_changing_queues", "yes") == "yes":
             default_host = "www.redhat.com"
-            ext_host = utils_net.get_host_default_gateway()
+            ext_host = utils_net.get_default_gateway()
             if not ext_host:
                 # Fallback to a hardcode host, eg:
                 logging.warn("Can't get specified host,"


### PR DESCRIPTION
Update the function name as the refactor in utilt_net.py in avocado-vt.
Refer to avocado-vt PR#1877. Refactor the function name of
get_host_default_gateway() to be get_default_gateway().

Signed-off-by: yalzhang <yalzhang@redhat.com>