### PR TITLE
qemu_disk_img: Support target files with luks format

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -123,6 +123,13 @@
                     convert_target = "convert"
                     image_name_convert = images/image1_to_qcow2
                     image_format_convert = qcow2
+                - base_to_luks:
+                    option_verified = "format"
+                    convert_source = "image1"
+                    convert_target = "convert"
+                    image_name_convert = images/image1_to_luks
+                    image_format_convert = luks
+                    image_secret_convert = convert_from_qcow2
         - commit:
             type = qemu_disk_img_commit
             guest_file_name = ${tmp_dir}/test.img


### PR DESCRIPTION
Update config file for targets from convertion to support luks format

Signed-off-by: Tingting Mao <timao@redhat.com>