### PR TITLE
seabios_reboot_timeout: disable reboot-timeout=65536 testing from rhel8.1

### DIFF
--- a/qemu/tests/cfg/seabios_reboot_timeout.cfg
+++ b/qemu/tests/cfg/seabios_reboot_timeout.cfg
@@ -24,4 +24,6 @@
             boot_reboot_timeout = 65535
         - time65536:
             required_qemu = [, 4)
+            Host_RHEL.m8:
+                only Host_RHEL.m8.u0
             boot_reboot_timeout = 65536


### PR DESCRIPTION
1. Can't set timeout to 65536 from rhel8.1 and later versions,
   so disable reboot-timeout=65536 testing on them.
2. If set reboot-timeout=65536, qemu will force it to 65535 on rhel6,
   rhel7 and rhel8.0, so continue reboot-timeout=65536 testing on them.

ID: 1764509
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>