### PR TITLE
Add md5 checking for disk resize

### DIFF
--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -4,15 +4,19 @@
     no RHEL.4
     only qcow2 raw
     type = block_resize
-    disk_change_ratio = "1.5 0.9"
+    extend_ratio = 1.5
+    shrink_ratio = 0.9
+    disk_change_ratio = "${extend_ratio} ${shrink_ratio}"
     accept_ratio = 0.005
+    md5_file = md5.dat
     iozone_path = "WIN_UTILS:\Iozone\iozone.exe"
     iozone_option = " -azR -r 64k -n 512M -g 1G -M -I -i 0 -i 1 -b iozone.xls -f %s:\testfile"
+    dd_cmd = "dd if=/dev/urandom of=%s oflag=direct bs=1M count=10"
     Linux:
         iozone_option = " -azR -r 64k -n 512M -g 1G -I -i 0 -i 1 -f %s/testfile"
     qcow2:
         Host_RHEL.m6, Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2, Host_RHEL.m7.u3, Host_RHEL.m7.u4, Host_RHEL.m7.u5:
-            disk_change_ratio = "1.5"
+            disk_change_ratio = ${extend_ratio}
     variants:
         - with_data_disk:
             images += " stg"
@@ -27,6 +31,27 @@
                 blk_extra_params_stg = "wwn=0x5000123456789abc"
             Windows:
                 need_rescan = yes
+            variants:
+                - default_partition:
+                    Windows:
+                        labeltype = msdos
+                        fstype = ntfs
+                    Linux:
+                        labeltype = msdos
+                        fstype = ext4
+                - with_gpt_ext4:
+                    only Linux
+                    labeltype = gpt
+                    disk_change_ratio = "${extend_ratio}"
+                - with_msdos_xfs:
+                    only Linux
+                    fstype = xfs
+                    disk_change_ratio = "${extend_ratio}"
+                - with_gpt_xfs:
+                    only Linux
+                    labeltype = gpt
+                    fstype = xfs
+                    disk_change_ratio = "${extend_ratio}"
             variants:
                 - fmt_qcow2:
                     image_format_stg = qcow2
@@ -55,6 +80,14 @@
     variants:
         - with_iozone:
             iozone_test = yes
+        - with_md5:
+            only default_partition
+            md5_test = yes
+            Windows:
+                md5_cmd = "%s: && md5sum.exe %s"
+                tmp_md5_file = /tmp/tmp_md5_file
+                pre_command = "dd if=/dev/urandom of=${tmp_md5_file} oflag=direct bs=1M count=10"
+                post_command = "rm -rf ${tmp_md5_file}"
     variants:
         - @default:
         - data_plane:


### PR DESCRIPTION
1.Add md5 checking for disk resize
2.Add enlarging disk size testing
on partition type gpt_ext4/xfs and msdos_xfs

ID: 1430204
Signed-off-by: qingwangrh <qinwang@redhat.com>