### PR TITLE
qemu_guest_agent: the first vcpu's info differs for different cpu model

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -461,24 +461,34 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param params: Dictionary with the test parameters
         :param env: Dictionary with test environment.
         """
-        error_context.context("Check can-offline field of guest agent.", logging.info)
+        session = self._get_session(params, self.vm)
+        self._open_session_list.append(session)
+
+        error_context.context("Check can-offline field of guest agent.",
+                              logging.info)
         vcpus_info = self.gagent.get_vcpus()
         cpu_num_qga = len(vcpus_info)
         for vcpu in vcpus_info:
             if params.get("os_type") == "linux":
-                if vcpu["logical-id"] == 0 and vcpu["can-offline"] is True:
-                    test.fail("The first logical vcpu can't be offline.")
+                if vcpu["logical-id"] == 0:
+                    vcpu_can_offline_qga = vcpu["can-offline"]
+                    cmd = "find /sys/devices/system/cpu/cpu0/ -name online"
+                    if session.cmd_output(cmd):
+                        vcpu_can_offline_guest = True
+                    else:
+                        vcpu_can_offline_guest = False
+                    if vcpu_can_offline_qga != vcpu_can_offline_guest:
+                        test.fail("The first logical vcpu's can-offline field"
+                                  " isn't aligned with what it's in guest.")
                 if vcpu["logical-id"] != 0 and vcpu["can-offline"] is False:
-                    test.fail("Linux guest cpu can't be offline from qga "
-                              "which isn't expected.")
+                    test.fail("The vcpus should be able to offline "
+                              "except vcpu0.")
             if params.get("os_type") == "windows" and vcpu["can-offline"]:
-                test.fail("Windows guest cpu can be offline from qga "
-                          "which isn't expected.")
+                test.fail("All vcpus should not be able to offline in"
+                          " windows guest.")
 
         error_context.context("Check cpu number.", logging.info)
-        session = self._get_session(params, self.vm)
         output = session.cmd_output(params["get_cpu_cmd"])
-        session.close()
 
         if params.get("os_type") == "windows":
             cpu_list = output.strip().split('\n')


### PR DESCRIPTION
The first vcpu's "can-offline" field differs between amd and intel cpu
 model according to them in linux os.
ID: 1766458
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>