### PR TITLE
New case of discard_for_raw_block_target

### DIFF
--- a/provider/qemu_img_utils.py
+++ b/provider/qemu_img_utils.py
@@ -102,13 +102,14 @@ def check_md5sum(filepath, md5sum_bin, session, md5_value_to_check=None):
 
 
 @contextlib.contextmanager
-def strace(image, trace_events=None, output_file=None):
+def strace(image, trace_events=None, output_file=None, trace_child=False):
     """
     Add strace to trace image related operations.
 
     :param image: image object
     :param trace_events: events list to trace
     :param output_file: if presented, redirect the output to file
+    :param trace_child: True to enable tracing child processes with -f
     """
     image_cmd = image.image_cmd
     strace_prefix = ["strace"]
@@ -116,6 +117,8 @@ def strace(image, trace_events=None, output_file=None):
         strace_prefix.extend(("-e", ",".join(trace_events)))
     if output_file:
         strace_prefix.extend(("-o", output_file))
+    if trace_child:
+        strace_prefix.append("-f")
     strace_prefix = " ".join(strace_prefix)
     image.image_cmd = strace_prefix + " " + image_cmd
     try:

--- a/qemu/tests/cfg/discard_for_raw_block_target.cfg
+++ b/qemu/tests/cfg/discard_for_raw_block_target.cfg
@@ -1,0 +1,19 @@
+- discard_for_raw_block_target:
+    only raw
+    virt_test_type = qemu
+    type = discard_for_raw_block_target
+    start_vm = no
+    required_qemu = [3.0.0, )
+    remove_image = yes
+    images = "test"
+    image_name_test = "images/test"
+    image_format_test = raw
+    create_with_dd_test = yes
+    image_size_test = 1G
+    convert_target = "target"
+    image_format_target = raw
+    image_raw_device_target = yes
+    strace_event = fallocate
+    scsi_mod = "scsi_debug"
+    pre_command = "modprobe ${scsi_mod} dev_size_mb=1024 lbpws=1"
+    post_command = "rmmod ${scsi_mod}"

--- a/qemu/tests/discard_for_raw_block_target.py
+++ b/qemu/tests/discard_for_raw_block_target.py
@@ -1,0 +1,56 @@
+import logging
+import os
+
+from provider.qemu_img_utils import strace
+
+from avocado import fail_on
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest.qemu_storage import QemuImg
+
+
+def run(test, params, env):
+    """
+    qemu-img supports 'discard' for raw block target images.
+
+    1. Create source image via dd with all zero.
+    2. Modprobe a 1G scsi_debug disk with writesame_16 mode.
+    3. Trace the system calls while converting the zero image to the
+       scsi_debug block device, then check whether 'fallocate' system call
+       works in the log.
+    :param test: Qemu test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+    def check_output(strace_event, strace_output, match_str):
+        """Check whether the value is good in the output file."""
+        logging.debug("Check the output file '%s'." % strace_output)
+        with open(strace_output) as fd:
+            if match_str not in fd.read():
+                test.fail("The system call of '%s' is not right, "
+                          "check '%s' for more details."
+                          % (strace_event, strace_output))
+
+    src_image = params["images"]
+    root_dir = data_dir.get_data_dir()
+    source = QemuImg(params.object_params(src_image), root_dir, src_image)
+    strace_event = params["strace_event"]
+    strace_events = strace_event.split()
+    strace_output_file = os.path.join(test.debugdir,
+                                      "convert_to_block.log")
+
+    source.create(source.params)
+    # Generate the target scsi block file.
+    tgt_disk = process.system_output("lsscsi | grep '%s' | awk '{print $NF}'"
+                                     % params["scsi_mod"], shell=True).decode()
+    params["image_name_target"] = tgt_disk
+
+    logging.debug("Convert from %s to %s with cache mode none, strace log: %s."
+                  % (source.image_filename, tgt_disk, strace_output_file))
+    with strace(source, strace_events, strace_output_file, trace_child=True):
+        fail_on((process.CmdError,))(source.convert)(
+            params.object_params(src_image), root_dir, cache_mode="none")
+
+    check_output(strace_event, strace_output_file,
+                 "FALLOC_FL_PUNCH_HOLE, 0, 1073741824")


### PR DESCRIPTION
1. Create source image via 'dd'.
2. Modprobe 1G scsi disk with writesame_16 mode.
3. Convert source to scsi disk, then check whether
   'fallocate' system call works

ID: 1768354
Signed-off-by: Tingting Mao <timao@redhat.com>