### PR TITLE
qemu_img_lock.reject_boot_base_img_and_snapshot: support luks

### DIFF
--- a/qemu/tests/cfg/qemu_img_lock.cfg
+++ b/qemu/tests/cfg/qemu_img_lock.cfg
@@ -18,6 +18,7 @@
             force_create_image_sn = yes
             images += " sn"
             image_chain= "image1 sn"
+            boot_drive_sn = no
             image_name_sn = images/sn
             image_format_sn = qcow2
             second_vm_name = avocado-vt-vm2
@@ -27,3 +28,6 @@
                 - raw_format:
                     only raw
                     image_format_image1 = raw
+                - luks_format:
+                    only luks
+                    image_format_image1 = luks

--- a/qemu/tests/qemu_img_lock_reject_boot.py
+++ b/qemu/tests/qemu_img_lock_reject_boot.py
@@ -44,8 +44,6 @@ def run(test, params, env):
         _create_os_snapshot()
         env_process.preprocess_vm(test, params, env, "avocado-vt-vm1")
         vm1 = env.get_vm("avocado-vt-vm1")
-        # remove sn in 'images' to prevent boot with two images
-        vm1.params["images"] = "image1"
     else:
         vm1 = env.get_vm("avocado-vt-vm1")
     vm2 = vm1.clone(name=params["second_vm_name"])
@@ -56,8 +54,8 @@ def run(test, params, env):
 
     if params.get("create_snapshot", "no") == "yes":
         # boot vm2 up using the external snapshot
-        vm2.params["image_name_image1"] = params["image_name_sn"]
-        vm2.params["image_format_image1"] = params["image_format_sn"]
+        vm2.params["boot_drive_image1"] = "no"
+        vm2.params["boot_drive_sn"] = "yes"
         img_file = None
         logging.info("Boot a seconde vm from the snapshot.")
     else:


### PR DESCRIPTION
id: 1771289
As the subject, add support to test if boot base and snapshot images
simultaneously.

Signed-off-by: lolyu <lolyu@redhat.com>