### PR TITLE
rebase_second_snapshot_to_base: add support of unsafe rebase

### DIFF
--- a/qemu/tests/cfg/rebase_second_snapshot_to_base.cfg
+++ b/qemu/tests/cfg/rebase_second_snapshot_to_base.cfg
@@ -19,6 +19,9 @@
     image_size_sn1 = ""
     image_size_sn2 = ""
     guest_tmp_filename = "/tmp/%s"
+    rebase_mode = "safe"
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
     Windows:
         timeout = 360
         guest_tmp_filename = "C:\\%s"
@@ -45,5 +48,9 @@
             required_qemu = [1.1, )
             variants:
                 - compat_0.10:
-                    image_extra_params = "compat=0.10"
+                    qcow2_compatible = 0.10
                 - compat_default:
+        - rebase_mode:
+            variants:
+                - unsafe:
+                    rebase_mode = "unsafe"


### PR DESCRIPTION
id:1775507
1. use `qcow2_compatible` to specify `compat` version for qcow2.
2. add `unsafe` mode support for rebase.
3. modify that tmp files will be created in base and active layers.

Signed-off-by: lolyu <lolyu@redhat.com>