### PR TITLE
vioinput_enable: Add new cases when vioinput device enabled

### DIFF
--- a/qemu/tests/cfg/vioinput_enable.cfg
+++ b/qemu/tests/cfg/vioinput_enable.cfg
@@ -1,0 +1,27 @@
+- vioinput_enable: install setup image_copy unattended_install.cdrom
+    virt_test_type = qemu
+    type = driver_in_use
+    inputs = input1
+    input_dev_bus_type_input1 = virtio
+    driver_name = "vioinput"
+    extra_driver_verify = "viohidkmdf hidclass.sys hidparse.sys"
+    run_bg_flag = "before_bg_test"
+    variants:
+        - with_shutdown:
+            sub_test = shutdown
+            shutdown_method = shell
+        - with_reboot:
+            sub_test = boot
+            reboot_count = 1
+            reboot_method = shell
+        - with_system_reset:
+            sub_test = boot
+            reboot_method = system_reset
+            sleep_before_reset = 20
+        - with_live_migration:
+            sub_test = migration
+    variants:
+        - device_keyboard:
+            key_table_file = key_to_keycode_win.json
+            input_dev_type_input1 = keyboard
+            run_bgstress = vioinput_keyboard

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -113,6 +113,7 @@ def run(test, params, env):
             utils_test.run_virt_sub_test(test, params, env, sub_type)
 
     driver = params["driver_name"]
+    extra_driver_verify = params.objects("extra_driver_verify")
     timeout = int(params.get("login_timeout", 360))
 
     vm = env.get_vm(params["main_vm"])
@@ -124,6 +125,11 @@ def run(test, params, env):
         session = utils_test.qemu.windrv_check_running_verifier(session, vm,
                                                                 test, driver,
                                                                 timeout)
+        if extra_driver_verify:
+            for ext_driver in extra_driver_verify:
+                session = utils_test.qemu.setup_win_driver_verifier(session,
+                                                                    ext_driver, vm)
+
         session.close()
     env["bg_status"] = 0
     run_bg_flag = params.get("run_bg_flag")

--- a/qemu/tests/vioinput_keyboard.py
+++ b/qemu/tests/vioinput_keyboard.py
@@ -74,7 +74,7 @@ def key_tap_test(test, params, vm):
 
     key_table_file = params.get('key_table_file')
     key_check_cfg = get_keycode_cfg(key_table_file)
-    wait_time = float(params.get("wait_time", 0.1))
+    wait_time = float(params.get("wait_time", 0.2))
 
     error_context.context("Start event listener in guest", logging.info)
     listener = input_event_proxy.EventListener(vm)


### PR DESCRIPTION
Add new cases that do reboot/shutdown/system_rest/migrate when
vioinput device enabled.

id: 1775504, 1775503, 1775505
Signed-off-by: Peixiu Hou <phou@redhat.com>