### PR TITLE
cluster_size_check: Extend the values of cluster_size

### DIFF
--- a/qemu/tests/cfg/cluster_size_check.cfg
+++ b/qemu/tests/cfg/cluster_size_check.cfg
@@ -14,7 +14,8 @@
     variants:
         - positive_testing:
             status_error = "no"
-            cluster_size_set = "default 4k"
+            # Cluster size must be a power of two between 512 and 2048k.
+            cluster_size_set = "512 1K 2K 4K 8K 16K 32K default 128K 256K 512K 1M 2M"
         - negative_testing:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Extend the values of cluster_size to cover all of the supported
values - A power of two between 512 and 2048k.

ID: 1776140
Signed-off-by: Tingting Mao <timao@redhat.com>