### PR TITLE
win_virtio_driver_update_test: check balloon background test status

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -58,6 +58,9 @@
             test_tags = "evict enlarge"
             balloon_type_evict = evict
             balloon_type_enlarge = enlarge
+            bg_stress_run_flag = balloon_test
+            set_bg_stress_flag = yes
+            wait_bg_time = 720
         - with_netkvm:
             driver_name = netkvm
             nics += " nic2"

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -19,7 +19,7 @@ def check_bg_running(vm, params):
              else return False
     """
     session = vm.wait_for_login()
-    target_process = params["target_process"]
+    target_process = params.get("target_process", "")
     if params['os_type'] == 'linux':
         output = session.cmd_output_safe('pgrep -l %s' % target_process)
     else:
@@ -58,7 +58,6 @@ def run(test, params, env):
                               logging.info)
         stress_thread = None
         wait_time = float(params.get("wait_bg_time", 60))
-        target_process = params.get("target_process", "")
         bg_stress_run_flag = params.get("bg_stress_run_flag")
         # Need to set bg_stress_run_flag in some cases to make sure all
         # necessary steps are active


### PR DESCRIPTION
1. Assign empty value to target_process;
2. Add "set_bg_stress_flag" in cfg file in order to check balloon backgroud test.

ID: 1772832

Signed-off-by: lijin <lijin@redhat.com>