### PR TITLE
Set installed OS image file to specified file name

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_cdrom.cfg
+++ b/qemu/tests/cfg/virtio_scsi_cdrom.cfg
@@ -1,7 +1,7 @@
 - virtio_scsi_cdrom:
     virt_test_type = qemu
     type = unattended_install
-    backup_image_after_testing_passed = yes
+    image_name_image1 = images/virtio_scsi_cdrom
     start_vm = no
     kill_vm = yes
     kill_vm_gracefully = yes
@@ -17,7 +17,7 @@
     # Inactivity treshold to error the test
     inactivity_treshold = 1800
     image_verify_bootable = no
-    only x86_64, i386
+    only x86_64, i386, ppc64, ppc64le
     only virtio_scsi, virtio_blk
     virtio_drive_letter = 'D'
     variants:


### PR DESCRIPTION
Set installed OS image file to specified file name

1. Specify image file for the OS installation
2. Remove backup action to save disk space

ID:1776570
Signed-off-by: qingwangrh <qinwang@redhat.com>