### PR TITLE
qemu_disk_img: Complete the supported cluster_size values

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -28,15 +28,9 @@
     variants:
         - @default:
         - cluster_size:
-            only convert.base_to_qcow2.default, convert.base_to_qcow2.compat.default
+            only convert.base_to_qcow2.default
             option_verified += " csize"
-            variants:
-                - cluster_size_512:
-                    image_cluster_size = 512
-                - cluster_size_2K:
-                    image_cluster_size = 2K
-                - cluster_size_2M:
-                    image_cluster_size = 2M
+            cluster_size_set = "512 1K 2K 4K 8K 16K 32K 64K 128K 256K 512K 1M 2M"
         - cache_mode:
             only convert.base_to_qcow2.default, commit, rebase.snB.to_base
             variants:

--- a/qemu/tests/cfg/qemu_img.cfg
+++ b/qemu/tests/cfg/qemu_img.cfg
@@ -51,17 +51,6 @@
                 - to_qcow2:
                     dest_image_format = qcow2
                     variants:
-                        - @cluster_size_default:
-                        - cluster_size_2048:
-                            # This case come from qemu-kvm bug that " qcow2 converting
-                            # error when -o cluster_size <= 2048"
-                            # qemu_img_options set qemu-img -o options. It support multi options.
-                            # If you want support multi options here, e.g.  A, B. JUst set qemu_img_options = A B
-                            # Then set A = xx, B = xx in configure
-                            qemu_img_options = cluster_size
-                            #cluster_size set cluster size used in qemu-img -o cluster_size=, default is 64k.
-                            cluster_size = 2048
-                            no Host_RHEL.m5
                         - show_progress:
                             command_result_pattern = "\(\d+\.\d+/100%\)"
                             variants:
@@ -73,9 +62,6 @@
                                     qemu_img_options = cluster_size
                                     cluster_size = 512
                                     check_output = stderr
-                - to_raw:
-                    dest_image_format = raw
-
         - snapshot:
             subcommand = snapshot
             only qcow2

--- a/qemu/tests/qemu_disk_img_convert.py
+++ b/qemu/tests/qemu_disk_img_convert.py
@@ -80,13 +80,18 @@ def run(test, params, env):
     if not md5:
         test.error("Fail to save tmp file")
     convert_test.destroy_vm()
-    n_params = convert_test.convert()
-    convert_test.compare_test(n_params)
-    convert_test.verify_info(n_params)
-    convert_test.start_vm(n_params)
 
-    # check md5sum after conversion
-    ret = convert_test.check_file(t_file, md5)
-    if not ret:
-        test.error("image content changed after convert")
-    convert_test.clean()
+    cluster_size_lst = params.get("cluster_size_set", "").split()
+    if not cluster_size_lst:
+        cluster_size_lst.append(None)
+    for cluster_size in cluster_size_lst:
+        if cluster_size is not None:
+            logging.info("convert image file with cluster_size=%s." % cluster_size)
+        n_params = convert_test.convert({"image_cluster_size": cluster_size})
+        convert_test.compare_test(n_params)
+        convert_test.verify_info(n_params)
+        convert_test.start_vm(n_params)
+        # check md5sum after conversion
+        if not convert_test.check_file(t_file, md5):
+            test.error("image content changed after convert")
+        convert_test.clean()


### PR DESCRIPTION
qemu_img: Delete the dup cases with the ones in qemu_disk_img

1. Add the remain supported cluster_size values - A power of two between 512 and 2048k.
2. Delete the duplicate case with the ones in qemu_disk_img cfg file.

ID: 1781474
Signed-off-by: Tingting Mao <timao@redhat.com>