### PR TITLE
guest_test: Use nmcli to control network on rhel8

### DIFF
--- a/generic/tests/cfg/guest_test.cfg
+++ b/generic/tests/cfg/guest_test.cfg
@@ -43,6 +43,9 @@
             pre_command = "echo 'dd if=/dev/zero of=/home/bigfile bs=1M count=2048 && "
             pre_command += "\cp -f /home/{bigfile,bigfile.bak} && "
             pre_command += "\rm -f /home/{bigfile,bigfile.bak} && "
-            pre_command += "(! pgrep dhclient || killall dhclient) && "
-            pre_command += "dhclient -v && ifconfig -a' > ${guest_script}"
+            Host_RHEL.m6, Host_RHEL.m7:
+                pre_command += "dhclient -r -v && ifconfig -a' > ${guest_script}"
+            !Host_RHEL.m6, Host_RHEL.m7:
+                pre_command += "nmcli networking off && nmcli networking on && "
+                pre_command += "ifconfig -a' > ${guest_script}"
             post_command = "\rm -f ${guest_script}"

--- a/generic/tests/cfg/guest_test.cfg
+++ b/generic/tests/cfg/guest_test.cfg
@@ -4,7 +4,8 @@
     login_timeout = 360
     test_timeout = 600
     # script_params =
-    reboot = yes
+    reboot_before_test = yes
+    reboot_after_test = yes
     variants:
         - autoit:
             only Windows
@@ -31,7 +32,7 @@
                     dst_rsc_path = "C:\powershell\stub\stub.ps1"
         - isa_serial_operations:
             only Linux
-            reboot = yes
+            reboot_before_test = no
             test_timeout = 900
             serial_login = yes
             image_snapshot = yes

--- a/generic/tests/guest_test.py
+++ b/generic/tests/guest_test.py
@@ -67,7 +67,8 @@ def run(test, params, env):
             session.cmd(rsc_cmd, timeout=test_timeout)
             logging.info("Download resource finished.")
         else:
-            session.cmd_output("del %s" % dst_rsc_path, internal_timeout=0)
+            session.cmd_output("del /f %s || rm -r %s" % (dst_rsc_path, dst_rsc_path),
+                               internal_timeout=0)
             script_path = utils_misc.get_path(test.virtdir, script)
             vm.copy_files_to(script_path, dst_rsc_path, timeout=60)
 

--- a/generic/tests/guest_test.py
+++ b/generic/tests/guest_test.py
@@ -20,7 +20,8 @@ def run(test, params, env):
     :param env: Dictionary with the test environment.
     """
     login_timeout = int(params.get("login_timeout", 360))
-    reboot = params.get("reboot", "no") == "yes"
+    reboot_before_test = params.get("reboot_before_test", "yes") == "yes"
+    reboot_after_test = params.get("reboot_after_test", "yes") == "yes"
     serial_login = params.get("serial_login", "no") == "yes"
 
     vm = env.get_vm(params["main_vm"])
@@ -30,7 +31,7 @@ def run(test, params, env):
     else:
         session = vm.wait_for_login(timeout=login_timeout)
 
-    if reboot:
+    if reboot_before_test:
         logging.debug("Rebooting guest before test ...")
         session = vm.reboot(session, timeout=login_timeout,
                             serial=serial_login)
@@ -78,7 +79,7 @@ def run(test, params, env):
         finally:
             logging.info("------------ End of script output ------------")
 
-        if reboot:
+        if reboot_after_test:
             logging.debug("Rebooting guest after test ...")
             session = vm.reboot(session, timeout=login_timeout,
                                 serial=serial_login)


### PR DESCRIPTION
1. guest_test.isa_serial_operations: don't need to reboot before test
2. Remove existing "dst_rsc_path" for both linux and windows
3. Use 'dhclient -r' instead of kill and restart on old version
4. For RHEL8 and later, use nmcli to control network

id: 1781468
Signed-off-by: Yanan Fu <yfu@redhat.com>
