### PR TITLE
4 new cases to test hotplug invalid cpu device

### DIFF
--- a/qemu/tests/cfg/invalid_cpu_device_hotplug.cfg
+++ b/qemu/tests/cfg/invalid_cpu_device_hotplug.cfg
@@ -1,0 +1,46 @@
+- invalid_cpu_device_hotplug:
+    only x86_64 ppc64 ppc64le
+    virt_test_type = qemu
+    type = invalid_cpu_device_hotplug
+    required_qemu = [2.6.0, )
+    # ovmf does not support hotpluggable vCPU yet
+    no ovmf
+    no RHEL.6
+    qemu_sandbox = on
+    vcpu_devices = vcpu1
+    monitor_type = qmp
+    variants:
+        - in_use_id:
+            execute_test = in_use_vcpu
+            ppc64, ppc64le:
+                error_desc = "core {0} already populated"
+            x86_64:
+                Windows:
+                    no WinXP, WinVista, Win7, Win8, Win10, Win2000, Win2003
+                error_desc = "CPU\[{0}\] with APIC ID \d+ exists"
+        - invalid_id:
+            execute_test = invalid_vcpu
+            ppc64, ppc64le:
+                vcpu_sockets = 1
+                vcpu_cores = 0
+                vcpu_threads = 2
+            variants:
+                - core_id:
+                    invalid_property = core-id
+                    x86_64:
+                        error_desc = "CPU ${invalid_property} is not set"
+                        invalid_ids = -1
+                    ppc64, ppc64le:
+                        error_desc = "invalid core id {0}"
+                        invalid_ids = 1 -1 -2
+                - nr_threads:
+                    invalid_property = nr-threads
+                    only ppc64 ppc64le
+                    invalid_ids = 1
+                    error_desc = "invalid nr-threads ${invalid_ids}, must be ${vcpu_threads}"
+        - out_of_range_id:
+            execute_test = out_of_range_vcpu
+            ppc64, ppc64le:
+                error_desc = "core id {0} out of range"
+            x86_64:
+                error_desc = "Invalid CPU {1}: {0} must be in range 0:{2}"

--- a/qemu/tests/invalid_cpu_device_hotplug.py
+++ b/qemu/tests/invalid_cpu_device_hotplug.py
@@ -1,0 +1,130 @@
+import re
+import json
+import logging
+
+from virttest import arch
+from virttest import error_context
+from virttest.qemu_monitor import QMPCmdError
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test hotplug invalid vcpu device.
+
+    1) Boot up guest without vcpu device.
+    2) Hotplug an invalid vcpu device we want
+    3) Check error messages and analyze if it is correct
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    not_match_err = ("Hotplug %s failed but the error description does not "
+                     "match: '%s'")
+    expected_info = "Hotplug %s failed as expected, error description: '%s'"
+    hotplug_pass_err = "Still able to hotplug %s via qmp"
+
+    def hotplug_inuse_vcpu():
+        """Hotplug 2 in use vcpu devices: main vcpu and duplicate vcpu"""
+        # Main vCPU
+        main_vcpu_props = {}
+        for vcpu_prop in vcpu_props:
+            main_vcpu_props.setdefault(vcpu_prop, "0")
+        vm.params["vcpu_props_main_vcpu"] = json.dumps(main_vcpu_props)
+        error_context.context("Define the invalid vcpu: %s" % "main_vcpu",
+                              logging.info)
+        in_use_vcpu_dev = vm.devices.vcpu_device_define_by_params(vm.params,
+                                                                  "main_vcpu")
+        try:
+            error_context.context("Hotplug the main vcpu", logging.info)
+            in_use_vcpu_dev.enable(vm.monitor)
+        except QMPCmdError as err:
+            qmp_desc = err.data["desc"]
+            if not re.match(error_desc.format("0"), qmp_desc):
+                test.error(not_match_err % ("main vcpu", qmp_desc))
+            logging.info(expected_info, "main vcpu", qmp_desc)
+        else:
+            test.fail(hotplug_pass_err % "main vcpu")
+
+        # New vCPU
+        error_context.context("hotplug vcpu device: %s" % vcpu_device_id,
+                              logging.info)
+        vm.hotplug_vcpu_device(vcpu_device_id)
+        if vm.get_cpu_count() != maxcpus:
+            test.fail("Actual number of guest CPUs is not equal to expected.")
+
+        # Duplicate vCPU
+        duplicate_vcpu_params = vm.devices.get_by_qid(
+            vcpu_device_id)[0].params.copy()
+        del duplicate_vcpu_params["id"]
+        vm.params["vcpu_props_duplicate_vcpu"] = json.dumps(
+            duplicate_vcpu_params)
+        duplicate_vcpu_dev = vm.devices.vcpu_device_define_by_params(
+            vm.params, "duplicate_vcpu")
+        try:
+            error_context.context("hotplug the duplicate vcpu", logging.info)
+            duplicate_vcpu_dev.enable(vm.monitor)
+        except QMPCmdError as err:
+            dev_count = maxcpus
+            if 'ppc64' in arch_name:
+                dev_count //= threads
+            qmp_desc = err.data["desc"]
+            if not re.match(error_desc.format(str(dev_count - 1)), qmp_desc):
+                test.error(not_match_err % ("duplicate vcpu", qmp_desc))
+            logging.info(expected_info, "duplicate vcpu", qmp_desc)
+        else:
+            test.fail(hotplug_pass_err % "duplicate vcpu")
+
+    def hotplug_invalid_vcpu():
+        """Hotplug a vcpu device with invalid property id"""
+        vcpu_device = vm.devices.get_by_qid(vcpu_device_id)[0]
+        vm.devices.remove(vcpu_device)
+        for invalid_id in params.objects("invalid_ids"):
+            vcpu_device.set_param(params["invalid_property"], invalid_id)
+            try:
+                vcpu_device.enable(vm.monitor)
+            except QMPCmdError as err:
+                qmp_desc = err.data["desc"]
+                if "ppc64" in arch_name:
+                    # When the invalid_id is positive or negative, the initial
+                    # letter format is different
+                    qmp_desc = qmp_desc.lower()
+                if error_desc.format(invalid_id) != qmp_desc:
+                    test.error(not_match_err % ("invalid vcpu", qmp_desc))
+                logging.info(expected_info, "invalid vcpu", qmp_desc)
+            else:
+                test.fail(hotplug_pass_err % "invalid vcpu")
+
+    def hotplug_outofrange_vcpu():
+        """Hotplug a vcpu device with out of range property id"""
+        vcpu_device = vm.devices.get_by_qid(vcpu_device_id)[0]
+        vm.devices.remove(vcpu_device)
+        outofrange_vcpu_num = max(vcpu_bus.addr_lengths)
+        vcpu_device.set_param(vcpu_props[0], outofrange_vcpu_num)
+        try:
+            vcpu_device.enable(vm.monitor)
+        except QMPCmdError as err:
+            qmp_desc = err.data["desc"]
+            if error_desc.format(outofrange_vcpu_num, vcpu_props[0],
+                                 (vcpu_bus.addr_lengths[0] - 1)) != qmp_desc:
+                test.error(not_match_err % ("out_of_range vcpu", qmp_desc))
+            logging.info(expected_info, "out_of_range vcpu", qmp_desc)
+        else:
+            test.fail(hotplug_pass_err % "out_of_range vcpu")
+
+    arch_name = params.get('vm_arch_name', arch.ARCH)
+    vcpu_device_id = params["vcpu_devices"]
+    error_desc = params["error_desc"]
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    vm.wait_for_login()
+    vcpu_bus = vm.devices.get_buses({'aobject': 'vcpu'})[0]
+    vcpu_props = vcpu_bus.addr_items
+    maxcpus = vm.cpuinfo.maxcpus
+    threads = vm.cpuinfo.threads
+
+    invalid_hotplug_tests = {"in_use_vcpu": hotplug_inuse_vcpu,
+                             "invalid_vcpu": hotplug_invalid_vcpu,
+                             "out_of_range_vcpu": hotplug_outofrange_vcpu}
+    invalid_hotplug_tests[params["execute_test"]]()


### PR DESCRIPTION
Add 4 new test cases to test hotplug cpu device with invalid properties.

Bugzilla ID: 1782030, 1782031, 1782032, 1782033, 1787264
Signed-off-by: Yihuang Yu <yihyu@redhat.com>