### PR TITLE
block_iscsi_lvm: New case to install on lvm device with iSCSI target

### DIFF
--- a/qemu/tests/block_iscsi_lvm.py
+++ b/qemu/tests/block_iscsi_lvm.py
@@ -1,0 +1,47 @@
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import utils_misc
+from virttest.env_process import preprocess_vm
+from virttest.iscsi import Iscsi
+from virttest.lvm import LVM
+from virttest.tests import unattended_install
+
+
+def run(test, params, env):
+    """
+    Test to install the guest OS on the lvm device which is created
+    on an iSCSI target.
+    Steps:
+        1) Setup iSCSI initiator on local host.
+        2) Discovery and login the above iSCSI target.
+        3) Create a partition on the iSCSI target.
+        4) Create a lvm on the partition.
+        5) Install a guest from ISO with the logical volume.
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+    params['image_size'] = params['emulated_image_size']
+    post_commands = []
+    try:
+        iscsi = Iscsi.create_iSCSI(params, data_dir.get_data_dir())
+        post_commands.extend((params['post_commands_iscsi'] %
+                              (iscsi.emulated_image, iscsi.id)).split(','))
+        lvm = LVM(params)
+        iscsi.login()
+        dev_name = utils_misc.wait_for(lambda: iscsi.get_device_name(), 60)
+        if not dev_name:
+            test.error('Can not get the iSCSI device.')
+        process.run(params['cmd_fdisk'] % dev_name, 600, shell=True)
+        params['pv_name'] = process.system_output(
+                params['cmd_get_partition'].format(dev_name),
+                60, shell=True).decode().strip()
+        post_commands.extend((params['post_commands_lvm'] %
+                              params['pv_name']).split(','))
+        lvm.setup()
+        preprocess_vm(test, params, env, params["main_vm"])
+        unattended_install.run(test, params, env)
+    finally:
+        params['post_command'] = ' ; '.join(post_commands[::-1])

--- a/qemu/tests/cfg/block_iscsi_lvm.cfg
+++ b/qemu/tests/cfg/block_iscsi_lvm.cfg
@@ -1,0 +1,89 @@
+- block_iscsi_lvm:
+    only virtio_scsi
+    type = block_iscsi_lvm
+    kill_vm = yes
+    start_vm = no
+    not_preprocess = yes
+    virt_test_type = qemu
+    kill_vm_gracefully = yes
+    shutdown_cleanly = yes
+    shutdown_cleanly_timeout = 120
+    guest_port_unattended_install = 12323
+    kernel = vmlinuz
+    initrd = initrd.img
+    inactivity_watcher = error
+    inactivity_treshold = 1800
+    target = iqn.2019-12.com.redhat:kvm-qe
+    vg_name = vg_test
+    lv_name = lv_test
+    Linux:
+        lv_size = 20G
+    Windows:
+        lv_size = 30G
+    block_raw_name = sys
+    emulated_image = images/${block_raw_name}
+    Linux:
+        emulated_image_size = 21G
+    Windows:
+        emulated_image_size = 31G
+    images = 'image0'
+    image_verify_bootable = no
+    force_create_image0 = no
+    image_format_image0 = raw
+    image_name_image0 = /dev/${vg_name}/${lv_name}
+    image_raw_device_image0 = yes
+    remove_image_image0 = no
+    cmd_fdisk = "echo -e "g\nn\n1\n\n\nw\n" | fdisk %s"
+    cmd_get_partition = "fdisk -l {0} | grep {0}[1-9] | awk '{{print $1}}'"
+    cmd_remove_dm = "dmsetup remove ${vg_name}-${lv_name}"
+    cmd_remove_lv = "lvm lvremove -ff --yes ${image_name_image0}"
+    cmd_remove_vg = "lvm vgremove -ff --yes ${vg_name}"
+    cmd_remove_pv = "lvm pvremove -ff --yes %s"
+    cmd_delete_iscsi_block = "name=`targetcli /backstores/fileio/ ls | grep ${block_raw_name} | awk '{print $2}'` && "
+    cmd_delete_iscsi_block += "targetcli /backstores/fileio/ delete $name"
+    cmd_get_iscsi_iqn = "iqn=`targetcli /iscsi/ ls | grep ${target} | awk '{print $2}'`"
+    cmd_delete_luns = "targetcli /iscsi/$iqn/tpg1/luns/ delete lun=0"
+    cmd_delete_iqn = "targetcli /iscsi/ delete $iqn"
+    cmd_remove_raw_block = "rm -rf %s"
+    cmd_remove_dev_vg = "rm -rf /dev/${vg_name}"
+    cmd_iscsi_logout = "iscsiadm --mode node --logout -T ${target}"
+    cmd_iscsi_delete_node = "iscsiadm -m node -o delete -T ${target} --portal 127.0.0.1"
+    cmd_iscsi_mv_config = "mv -f /etc/iscsi/initiatorname.iscsi-%s /etc/iscsi/initiatorname.iscsi"
+    cmd_iscsi_restart = "systemctl reset-failed iscsid.service && systemctl restart iscsid.service"
+    post_commands_iscsi = "${cmd_remove_dev_vg},${cmd_remove_raw_block},${cmd_iscsi_restart},"
+    post_commands_iscsi += "${cmd_iscsi_mv_config},${cmd_delete_iscsi_block},"
+    post_commands_iscsi += "${cmd_delete_iqn},${cmd_delete_luns},${cmd_get_iscsi_iqn},"
+    post_commands_iscsi += "${cmd_iscsi_delete_node},${cmd_iscsi_logout}"
+    post_commands_lvm = "${cmd_remove_dm},${cmd_remove_pv},${cmd_remove_vg},${cmd_remove_lv}"
+    post_command_noncritical = yes
+    variants:
+        - with_scsi_hd:
+            drive_format_image0 = scsi-hd
+            Windows:
+                blk_extra_params_image0 = "serial=TARGET_DISK0"
+        - with_scsi_block:
+            drive_format_image0 = scsi-block
+    variants:
+        - with_installation:
+            cd_format_cd1 = ide
+            ppc64le, ppc64:
+                cd_format_cd1 = scsi-cd
+            i440fx:
+                Windows:
+                    cd_format_unattended = ide
+            q35:
+                cd_format_unattended = ahci
+            variants:
+                - extra_cdrom_ks:
+                    no WinXP Win2000 Win2003 WinVista
+                    cdroms += " unattended"
+                    drive_index_unattended = 3
+                    drive_index_cd1 = 1
+            variants:
+                - cdrom:
+                    Windows:
+                        cdroms += " winutils"
+                        cd_format_winutils = ide
+                        drive_index_winutils = 2
+                    boot_once = d
+                    medium = cdrom


### PR DESCRIPTION
New a case that installs the guest OS on the lvm device which is
created on an iSCSI target.

ID: 1731616
Signed-off-by: Yongxue Hong <yhong@redhat.com>