### PR TITLE
hpt_max_page_size: New cases to test maximum page size for hpt guests

### DIFF
--- a/qemu/tests/cfg/hpt_max_page_size.cfg
+++ b/qemu/tests/cfg/hpt_max_page_size.cfg
@@ -1,0 +1,27 @@
+- hpt_max_page_size:
+    type = hpt_max_page_size
+    only ppc64 ppc64le
+    virt_test_type = qemu
+    required_qemu = [3.1.0,)
+    kill_vm = yes
+    machine_type_extra_params = "max-cpu-compat=power8"
+    # According to the case description, this test case is applicable to compatible guest (P8 guest).
+    variants:
+        - without_hugepage:
+        - with_hugepage:
+            setup_hugepages = yes
+            extra_params += " -mem-path /mnt/kvm_hugepage"
+    variants:
+        - 64k:
+            expected_value = ""
+            machine_type_extra_params += ",cap-hpt-max-page-size=64k"
+        - 16m:
+            expected_value = "16384"
+            only without_hugepage  # Due to product bug
+            machine_type_extra_params += ",cap-hpt-max-page-size=16M"
+            variants:
+                - tcg_mode: # setup hugepages but without mem backing file
+                    setup_hugepages = yes
+                    machine_type_extra_params += ",accel=tcg"
+                    disable_kvm = yes
+                    auto_cpu_model = yes

--- a/qemu/tests/hpt_max_page_size.py
+++ b/qemu/tests/hpt_max_page_size.py
@@ -1,0 +1,39 @@
+import logging
+import re
+
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test to guest-available hugepage sizes with explicit parameter.
+    Steps:
+    1) There are two options, with/without mem backing file,
+       if without mem backing, ignore the step 3.
+    2) System setup hugepages on host.
+    3) Mount this hugepage to /mnt/kvm_hugepage.
+    4) Boot up guest options with different cap-hpt-max-page-size,
+       and there are two modes with kvm or tcg.
+    5) Check output parameter don't include Hugepagesize,
+       when the cap-hpt-max-page-size is 64k.
+    6) Check output parameter the Hugepagesize is 16384,
+       when the cap-hpt-max-page-size is 16M.
+
+    :params test: QEMU test object.
+    :params params: Dictionary with the test parameters.
+    :params env: Dictionary with test environment.
+    """
+    def _check_meminfo(key):
+        meminfo = session.cmd_output("grep %s /proc/meminfo" % key)
+        actual_value = re.search(r'\d+', meminfo)
+        return actual_value.group(0) if actual_value else ""
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login()
+
+    error_context.context("Check output Hugepage size.", logging.info)
+    if _check_meminfo("Hugepagesize") != params["expected_value"]:
+        test.fail("The hugepage size doesn't match, "
+                  "please check meminfo: %s " % _check_meminfo("Huge"))


### PR DESCRIPTION
3 new cases:
1.Set cap-hpt-max-page-size=64k with hugepage
  to check hugepage value.
2.Set cap-hpt-max-page-size=64k without hugepage
  to check hugepage value.
3.Set cap-hpt-max-page-size=16m without hugepage
  and with TCG to check hugepage value.

ID: 1780874, 1783878, 1784328 
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>