### PR TITLE
Fix '${smp}' issue since vt can use vcpu_maxcpus to define smp

### DIFF
--- a/generic/tests/cfg/multi_queues_test.cfg
+++ b/generic/tests/cfg/multi_queues_test.cfg
@@ -36,11 +36,13 @@
                 client_path_win = "c:\\"
             variants:
                 - smp1:
+                    del vcpu_maxcpus
                     smp_fixed = 1
                     vcpu_cores_fixed = 1
                     vcpu_threads_fixed = 1
                     vcpu_sockets_fixed = 1
                 - smp4:
+                    del vcpu_maxcpus
                     smp_fixed = 4
                     queues = ${smp_fixed}
                     vhostfds_len = ${smp_fixed}
@@ -51,6 +53,7 @@
                         - multiple_netperf_session:
                             netperf_para_sessions = ${smp_fixed}
                 - max_queues:
+                    del vcpu_maxcpus
                     smp_fixed = 8
                     queues = ${smp_fixed}
                     vhostfds_len = ${smp_fixed}
@@ -58,6 +61,7 @@
                     vt_ulimit_nofile = 10240
                 - cpu_affinity:
                     #this test smp must equal queues.
+                    del vcpu_maxcpus
                     smp_fixed = 4
                     queues = ${smp_fixed}
                     vhostfds_len = ${smp_fixed}

--- a/generic/tests/cfg/ntttcp.cfg
+++ b/generic/tests/cfg/ntttcp.cfg
@@ -1,6 +1,7 @@
 - ntttcp:
     virt_test_type = qemu libvirt
     only Windows
+    smp ~= ${vcpu_maxcpus}
     queues = ${smp}
     type = ntttcp
     image_snapshot = yes

--- a/qemu/tests/cfg/iperf_test.cfg
+++ b/qemu/tests/cfg/iperf_test.cfg
@@ -29,9 +29,11 @@
             iperf_version = iperf-3.1.3
             host_iperf_file = ${iperf_version}.tar.gz
             Windows:
+                del vcpu_maxcpus
                 smp = 4
                 guest_iperf_file = ${iperf_version}.exe
                 iperf_deplist = 'cyggcc_s-1.dll,cygwin1.dll'
+            smp ~= ${vcpu_maxcpus}
             queues = ${smp}
             parallel_num = ${queues}
             iperf_test_duration = 60

--- a/qemu/tests/cfg/mq_enabled_chk.cfg
+++ b/qemu/tests/cfg/mq_enabled_chk.cfg
@@ -9,6 +9,7 @@
     image_snapshot = yes
     Linux:
         start_vm = no
+        del vcpu_maxcpus
         smp = 4
         queues_list = 8 4 2
     Windows:
@@ -16,6 +17,7 @@
         timeout = 360
         driver_name = "netkvm"
         type = boot_with_multiqueue
+        smp ~= ${vcpu_maxcpus}
         queues = ${smp}
         cdroms += " virtio"
         scp_count = 10
@@ -23,4 +25,3 @@
         filesize = 1024
         vt_ulimit_nofile = 10240
         clean_cmd = del
-

--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -8,11 +8,13 @@
     variants:
         - @default:
         - with_multiqueue:
+            smp ~= ${vcpu_maxcpus}
             queues = ${smp}
             vt_ulimit_nofile = 10240
             Windows:
                 # Windows product limit, it will fail when queues is too large
+                del vcpu_maxcpus
                 smp = 4
-                queues = 4
+                queues = ${smp}
                 i386:
                     nics_num = 8

--- a/qemu/tests/cfg/netkvm_cpu_mapping.cfg
+++ b/qemu/tests/cfg/netkvm_cpu_mapping.cfg
@@ -9,4 +9,5 @@
     timeout = 360
     driver_name = "netkvm"
     cdroms += " virtio"
+    smp ~= ${vcpu_maxcpus}
     queues = ${smp}


### PR DESCRIPTION
avocado-vt can use vcpu_maxcpus to define smp without using smp, this
will make some cases fail, such as 'queues = ${smp}', fix it to check both
smp and vcpu_maxcpus

ID: 1782698
Signed-off-by: Yihuang Yu <yihyu@redhat.com>