### PR TITLE
Added configuration for VM migration

### DIFF
--- a/qemu/tests/cfg/migration_with_remote.cfg
+++ b/qemu/tests/cfg/migration_with_remote.cfg
@@ -1,0 +1,27 @@
+# Network storage backends:
+#   iscsi_direct
+#   ceph
+# The following testing scenarios are covered:
+#   migrate VM on the same host
+#   migrate VM with postcopy on the same host
+
+- migration_with_remote_storage: install setup image_copy unattended_install.cdrom
+    only iscsi_direct ceph
+    virt_test_type = qemu
+    type = migration
+    migration_test_command = help
+    migration_bg_command = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"
+    migration_bg_check_command = pgrep tcpdump
+    migration_bg_kill_command = pkill -9 tcpdump
+    kill_vm = yes
+    ping_pong = 1
+    mig_timeout = 3600
+    pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
+    migration_protocol = "tcp"
+    variants:
+        - @default:
+        - with_post_copy:
+            migrate_inner_funcs = [('postcopy', 70)]
+            migrate_capabilities = "{'postcopy-ram': 'on'}"
+            mig_speed = 1b
+            pre_migrate = "mig_set_speed"


### PR DESCRIPTION
  1. iscsi&ceph images are used for OS images
  2. The following testing scenarios are covered:
     migrate VM on the same host
     migrate VM with postcopy on the same host

Signed-off-by: zhencliu <zhencliu@redhat.com>

ID: 1786232, 1786233