### PR TITLE
vioinput_enable: add new case for virtio-mouse/tablet device attached.

### DIFF
--- a/qemu/tests/cfg/vioinput_enable.cfg
+++ b/qemu/tests/cfg/vioinput_enable.cfg
@@ -1,4 +1,6 @@
 - vioinput_enable: install setup image_copy unattended_install.cdrom
+    required_qemu = [2.4.0, )
+    no Win2008..sp2
     virt_test_type = qemu
     type = driver_in_use
     inputs = input1
@@ -6,6 +8,7 @@
     driver_name = "vioinput"
     extra_driver_verify = "viohidkmdf hidclass.sys hidparse.sys"
     run_bg_flag = "before_bg_test"
+    del usb_devices
     variants:
         - with_shutdown:
             sub_test = shutdown
@@ -25,3 +28,21 @@
             key_table_file = key_to_keycode_win.json
             input_dev_type_input1 = keyboard
             run_bgstress = vioinput_keyboard
+        - device_mouse:
+            mice_name = "QEMU Virtio Mouse"
+            input_dev_type_input1 = mouse
+            tolerance = 40
+            run_bgstress = vioinput_mice
+            move_rate = 80
+            move_duration = 1
+            btns = "left right middle side extra"
+            scrolls = "wheel-up wheel-down"
+        - device_tablet:
+            mice_name = "QEMU Virtio Tablet"
+            input_dev_type_input1 = tablet
+            tolerance = 5
+            run_bgstress = vioinput_mice
+            move_rate = 80
+            move_duration = 1
+            btns = "left right middle side extra"
+            scrolls = "wheel-up wheel-down"


### PR DESCRIPTION
new case that do reboot/shutdown/system_rest/migrate
when virtio-mouse/tablet device attached.

id: 1786304, 1786302, 1786289, 1456182, 1456176, 1456177
Signed-off-by: Peixiu Hou <phou@redhat.com>