### PR TITLE
Add new case install_uninstall/downgrade_upgrade driver for virtio mouse/tablet device

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -189,8 +189,27 @@
             device_hwid = '"PCI\VEN_1AF4&DEV_1052"'
             inputs = input1
             input_dev_bus_type_input1 = virtio
+            del usb_devices
             variants:
                 - device_keyboard:
                     input_dev_type_input1 = keyboard
                     run_bgstress = "vioinput_keyboard"
                     key_table_file = key_to_keycode_win.json
+                - device_mouse:
+                    mice_name = "QEMU Virtio Mouse"
+                    input_dev_type_input1 = mouse
+                    tolerance = 40
+                    run_bgstress = vioinput_mice
+                    move_rate = 80
+                    move_duration = 1
+                    btns = "left right middle side extra"
+                    scrolls = "wheel-up wheel-down"
+                - device_tablet:
+                    mice_name = "QEMU Virtio Tablet"
+                    input_dev_type_input1 = tablet
+                    tolerance = 5
+                    run_bgstress = vioinput_mice
+                    move_rate = 80
+                    move_duration = 1
+                    btns = "left right middle side extra"
+                    scrolls = "wheel-up wheel-down"


### PR DESCRIPTION
Add 4 new cases:
win_virtio_driver_update_test..device_mouse..uninstall_install/downgrade_upgrade
win_virtio_driver_update_test..device_tablet..uninstall_install/downgrade_upgrade

id: 1786405, 1786406, 1786407, 1786408
Signed-off-by: Peixiu Hou <phou@redhat.com>