### PR TITLE
Added configuration for 'boot from a readonly iscsi image'

### DIFF
--- a/qemu/tests/cfg/remote_negative.cfg
+++ b/qemu/tests/cfg/remote_negative.cfg
@@ -1,0 +1,14 @@
+# Network storage backends:
+#   iscsi_direct ceph
+# The following testing scenarios are covered:
+#   Failed to boot VM from a readonly image
+
+- remote_storage_negative:
+    only iscsi_direct ceph
+    virt_test_type = qemu
+    variants:
+        - readonly_image:
+            only iscsi_direct
+            type = negative_create
+            start_vm = no
+            error_msg = "(LUN is write protected|Block node is read-only)"

--- a/qemu/tests/negative_create.py
+++ b/qemu/tests/negative_create.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from virttest import virt_vm
 from virttest import utils_net
@@ -28,7 +29,12 @@ def run(test, params, env):
         params["start_vm"] = "yes"
         env_process.preprocess_vm(test, params, env, params["main_vm"])
     except (virt_vm.VMError, utils_net.NetError) as err:
+        message = str(err)
         logging.debug("VM Failed to create. This was expected. Reason:\n%s",
-                      str(err))
+                      message)
+
+        error_msg = params.get("error_msg")
+        if error_msg and not re.search(error_msg, message, re.M | re.I):
+            test.fail("Can't find the expected error message: %s", error_msg)
     else:
         raise VMCreateSuccess()


### PR DESCRIPTION
negative_create.py is a negative test case that makes sure VM cannot be started, so we can use it for this test scenario;
Also, enhanced it with error message check, so that tc can check the expected error message from qemu.

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1786495 