### PR TITLE
block_with_iommu: Disable to verify bootable

### DIFF
--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -30,6 +30,7 @@
             images = "stg_iommu"
             image_name_stg_iommu = "images/storage_iommu"
             image_size_stg_iommu = 40G
+            image_verify_bootable = no
             force_create_image_stg_iommu = yes
             remove_image_image_stg_iommu = yes
             guest_port_unattended_install = 12323


### PR DESCRIPTION
Add "image_verify_bootable = no" in config file
to disable to verify the image whether is bootable.

ID: 1786545
Signed-off-by: Yongxue Hong <yhong@redhat.com>