### PR TITLE
Change scsi-disk to scsi-hd or scsi-cd

### DIFF
--- a/qemu/tests/cfg/device_option_check.cfg
+++ b/qemu/tests/cfg/device_option_check.cfg
@@ -40,7 +40,8 @@
                     ide, ahci:
                         force_drive_format = ide-drive
                     virtio_scsi, spapr_vscsi:
-                        force_drive_format = scsi-disk
+                        force_drive_format = scsi-hd
+                        force_drive_format_cd1 = scsi-cd
             variants:
                 - wwn_disk:
                     params_name = blk_extra_params_image1


### PR DESCRIPTION
scsi-disk is deprecated,
Change scsi-disk to scsi-hd or scsi-cd in device_option_check testing
ID:1787535 , 1782155
Signed-off-by: qingwangrh <qinwang@redhat.com>