### PR TITLE
image_creation_lock_release: Fix the wrong image name

### DIFF
--- a/qemu/tests/cfg/image_creation_lock_release.cfg
+++ b/qemu/tests/cfg/image_creation_lock_release.cfg
@@ -5,3 +5,4 @@
     create_image = no
     remove_image = yes
     images = "lock_test"
+    image_name_lock_test = "images/lock_test"


### PR DESCRIPTION
Change the name from defaul to the test image name.

ID: 1788817
Signed-off-by: Tingting Mao <timao@redhat.com>