### PR TITLE
block_devices_plug: Fix the order of hotplugging blockdev nodes

### DIFF
--- a/provider/block_devices_plug.py
+++ b/provider/block_devices_plug.py
@@ -236,7 +236,7 @@ class BlockDevicesPlug(object):
 
             for dev in reversed(devices_created):
                 if dev.get_qid().endswith(img):
-                    self._hotplugged_devs[img].insert(-1, dev)
+                    self._hotplugged_devs[img].insert(0, dev)
                     bus = dev.get_param('bus')
                     if bus:
                         bus_name = bus.rsplit('.')[0]


### PR DESCRIPTION
Failed to hotplug the format node since need to hotplug a protocol
node before it, so modify the order of hotplugging blockdev nodes.

ID: 1788350
Signed-off-by: Yongxue Hong <yhong@redhat.com>