### PR TITLE
block_hotplug: Fix fail to hotplug device

### DIFF
--- a/qemu/tests/block_hotplug.py
+++ b/qemu/tests/block_hotplug.py
@@ -73,9 +73,10 @@ def run(test, params, env):
         session = vm.wait_for_login(timeout=timeout)
         disks_before_plug = _find_all_disks(session)
         plug_devices = plug_devices if action == 'hotplug' else plug_devices[::-1]
-        for device in plug_devices:
-            if not getattr(vm.devices, 'simple_%s' % action)(device, vm.monitor)[1]:
-                test.fail("Failed to %s device '%s'." % (action, device))
+        for dev in plug_devices:
+            ret = getattr(vm.devices, 'simple_%s' % action)(dev, vm.monitor)
+            if ret[1] is False:
+                test.fail("Failed to %s device '%s', %s." % (action, dev, ret[0]))
 
         num = 1 if action == 'hotplug' else len(data_imgs)
         plugged_disks = wait_plug_disks(session, action, disks_before_plug, num)

--- a/qemu/tests/block_hotplug.py
+++ b/qemu/tests/block_hotplug.py
@@ -195,7 +195,7 @@ def run(test, params, env):
             run_sub_test(sub_test_before_unplug)
 
         plug_block_devices('unplug', unplug_devs)
-        unplug_devs.clear()
+        del unplug_devs[:]
 
         if sub_test_after_unplug:
             run_sub_test(sub_test_after_unplug)


### PR DESCRIPTION
Fix compatible with python2 & 3:
There is no attribute clear() for list type in
python2, so replace it with del.

Fix fail to hotplug device:
Judge whether the return of simple_hotplug is
False, since the return value is the string ""
when sending qmp command "__com.redhat_drive_add"
successfully.

ID: 1771278, 1771281
Signed-off-by: Yongxue Hong <yhong@redhat.com>