### PR TITLE
Snapshot to target with non-default cluster-size

### DIFF
--- a/provider/blockdev_snapshot_base.py
+++ b/provider/blockdev_snapshot_base.py
@@ -75,7 +75,6 @@ class BlockDevSnapshotTest(object):
             self.main_vm.destroy()
         if self.is_blockdev_mode():
             self.snapshot_image.base_tag = self.base_tag
-            self.snapshot_image.base_tag = self.base_tag
             self.snapshot_image.base_format = self.base_image.get_format()
             self.snapshot_image.base_image_filename = self.base_image.image_filename
             self.snapshot_image.rebase(self.snapshot_image.params)

--- a/qemu/tests/cfg/blockdev_snapshot.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot.cfg
@@ -22,3 +22,11 @@
         node = "drive_data"
         overlay = "drive_sn1"
         qemu_force_use_drive_expression = no
+    variants:
+        - @dst_default_cluster_size:
+        - dst_cluster_size_512:
+            image_cluster_size_sn1 = 512
+        - dst_cluster_size_2M:
+            timeout = 900
+            buf-size = 1024
+            image_cluster_size_sn1 = 2097152


### PR DESCRIPTION
blockdev_snapshot:add cfg to support snapshot to
non-default cluster-size target, and add rebase
mode "unsafe".

blockdev_snapshot_base:remove redundant code

Signed-off-by: Aihua Liang <aliang@redhat.com>

id:1790384,1790385