### PR TITLE
block_resize:Do not need to execute extend operation when disk size=2…

### DIFF
--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -158,6 +158,8 @@ def run(test, params, env):
             error_context.context("Extend disk to %s in guest"
                                   % block_size, logging.info)
             if os_type == 'windows':
+                if int(block_size) >= 2199023256000:
+                    test.error("The volume exceed the maximum clusters.")
                 drive.extend_volume(session, mpoint)
             else:
                 utils_disk.resize_partition_linux(session, partition, str(block_size))


### PR DESCRIPTION
1.Add a judgement for windows when block_size>=2T, no need to do extend.
ID: 1785990
Signed-off-by: Menghuan Li <menli@redhat.com>