### PR TITLE
block_resize: Cancel testing when resizing to 2T or 16T

### DIFF
--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -158,6 +158,9 @@ def run(test, params, env):
             error_context.context("Extend disk to %s in guest"
                                   % block_size, logging.info)
             if os_type == 'windows':
+                max_block_size = int(params["max_block_size"])
+                if int(block_size) >= max_block_size:
+                    test.cancel("Cancel the test for more than maximum %dB disk." % max_block_size)
                 drive.extend_volume(session, mpoint)
             else:
                 utils_disk.resize_partition_linux(session, partition, str(block_size))

--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -76,6 +76,9 @@
                 need_rescan = yes
                 disk_letter = I
                 disk_index = 1
+                max_block_size = 2199023255552
+                ovmf:
+                    max_block_size = 17592186044416
             virtio_scsi:
                 driver_name = vioscsi
             virtio_blk:

--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -9,6 +9,10 @@
     disk_change_ratio = "${extend_ratio} ${shrink_ratio}"
     accept_ratio = 0.005
     md5_file = md5.dat
+    Windows:
+        max_block_size = 2199023255552
+        ovmf:
+            max_block_size = 17592186044416
     iozone_path = "WIN_UTILS:\Iozone\iozone.exe"
     iozone_option = " -azR -r 64k -n 512M -g 1G -M -I -i 0 -i 1 -b iozone.xls -f %s:\testfile"
     dd_cmd = "dd if=/dev/urandom of=%s oflag=direct bs=1M count=10"


### PR DESCRIPTION
Cancel the testing when resizing to 2T or 16T on the windows bios guest
and 16T on the windows ovmf guest since they don't support to do it.

ID:1785990
Signed-off-by: Menghuan Li <menli@redhat.com>