### PR TITLE
qemu_img_info_while_vm_running: Support luks image

### DIFF
--- a/qemu/tests/cfg/qemu_img_info_while_running.cfg
+++ b/qemu/tests/cfg/qemu_img_info_while_running.cfg
@@ -15,5 +15,5 @@
             only qcow2
             boot_with_snapshot = yes
         - boot_and_info_same_img:
-            only raw
+            only raw luks
             create_snapshot = no

--- a/qemu/tests/qemu_img_info_while_vm_running.py
+++ b/qemu/tests/qemu_img_info_while_vm_running.py
@@ -16,7 +16,7 @@ def run(test, params, env):
 
     Verify it supports to get information of a running image.
     Including three tests:
-    1. Create a raw image.
+    1. Create a raw/luks image.
        Boot vm using this image.
        'qemu-info' the image.
     2. Create a base qcow2 image.


### PR DESCRIPTION
boot_and_info_same_img case

`qemu-img info` should support to get the info of a
running luks image.

ID: 1790784

Signed-off-by: Tingting Mao <timao@redhat.com>