### PR TITLE
balloon_check: Extend compare threshold for guest mem change

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -74,12 +74,17 @@ class BallooningTest(MemoryBaseTest):
         mmem = self.get_ballooned_memory()
         gmem = self.get_memory_status()
         gcompare_threshold = int(self.params.get("guest_compare_threshold", 100))
-        # for windows illegal test:set windows guest balloon in (1,100),free memory will less than 150M
+        guest_mem_ratio = self.params.get("guest_mem_ratio")
+        if guest_mem_ratio:
+            gcompare_threshold = max(gcompare_threshold,
+                                     float(guest_mem_ratio) * self.ori_mem)
+        # for windows illegal test:set windows guest balloon in (1,100),free
+        # memory of the OS shoul be as small as possible.
         if ballooned_mem >= self.ori_mem - 100:
             timeout = float(self.params.get("login_timeout", 600))
             session = self.vm.wait_for_login(timeout=timeout)
             try:
-                if self.get_win_mon_free_mem(session) > 150:
+                if self.get_win_mon_free_mem(session) > gcompare_threshold:
                     self.test.fail("Balloon_min test failed %s" % step)
             finally:
                 session.close()

--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -7,6 +7,9 @@
     balloon_dev_add_bus = yes
     iterations = 5
     free_mem_cmd = cat /proc/meminfo |grep MemFree
+    Windows:
+        guest_compare_threshold = 300
+        guest_mem_ratio = 0.025
     variants:
         - balloon_base:
         - balloon_oom:

--- a/qemu/tests/cfg/balloon_memhp.cfg
+++ b/qemu/tests/cfg/balloon_memhp.cfg
@@ -17,6 +17,7 @@
     Windows:
         driver_name = "balloon"
         guest_compare_threshold = 300
+        guest_mem_ratio = 0.025
         cdroms += " virtio"
         # Please change following cdrom_virtio to the right version
         # if necessary

--- a/qemu/tests/cfg/balloon_minimum.cfg
+++ b/qemu/tests/cfg/balloon_minimum.cfg
@@ -21,9 +21,14 @@
             guest_stable_threshold = 25
             repeat_times = 10
             check_guest_bsod = yes
+            Windows:
+                guest_compare_threshold = 150
+                x86_64:
+                    guest_mem_ratio = 0.025
         - boundary:
             run_sub_test_after_balloon = yes
             sub_test_after_balloon_evict = "boot"
             Windows:
                 guest_compare_threshold = 300
+                guest_mem_ratio = 0.025
             reboot_method = shell

--- a/qemu/tests/cfg/balloon_service.cfg
+++ b/qemu/tests/cfg/balloon_service.cfg
@@ -11,6 +11,7 @@
     Windows:
         driver_name = "balloon"
         guest_compare_threshold = 300
+        guest_mem_ratio = 0.025
         cdroms = "cd1 winutils virtio"
         # Please change following cdrom_virtio to the right version
         # if necessary
@@ -22,6 +23,7 @@
         status_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe status"
         run_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe -r"
         stop_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe -s"
+        check_mem_diff = 300
     repeat_times = 5
     base_path = "/machine/peripheral/"
     polling_property = "guest-stats-polling-interval"


### PR DESCRIPTION
1. 64 bit windows guest free mem is larger than 150M when balloon vm mem to boundary value;
2. Guest mem stats value got from qmp compare threshold 150M is not big enough for big mem windows guests, use a compare ratio instead
3. After each balloon operation, 300M is not big enough for large mem vm,  use a compare ratio instead.

ID: 1775459, 1772845, 1774850

Signed-off-by: lijin <lijin@redhat.com>