### PR TITLE
luks_convert: boot source image explicitly

### DIFF
--- a/qemu/tests/cfg/luks_convert.cfg
+++ b/qemu/tests/cfg/luks_convert.cfg
@@ -13,7 +13,8 @@
             sync_bin = WIN_UTILS:\Sync\sync64.exe /accepteula
         i386, i686:
             sync_bin = WIN_UTILS:\Sync\sync.exe /accepteula
-    convert_source = ${images}
+    images += " convert"
+    convert_source = image1
     tmp_file_check = yes
     variants:
         - @default:

--- a/qemu/tests/luks_convert.py
+++ b/qemu/tests/luks_convert.py
@@ -10,9 +10,13 @@ from provider import qemu_img_utils as img_utils
 
 def run(test, params, env):
     """Convert from/to luks image."""
+    root_dir = data_dir.get_data_dir()
+    convert_source = params["convert_source"]
+    convert_target = params["convert_target"]
     tmp_file_check = params.get("tmp_file_check", "yes") == "yes"
     if tmp_file_check:
-        vm = img_utils.boot_vm_with_images(test, params, env)
+        vm = img_utils.boot_vm_with_images(test, params, env,
+                                           (convert_source,))
         session = vm.wait_for_login()
         guest_temp_file = params["guest_temp_file"]
         md5sum_bin = params.get("md5sum_bin", "md5sum")
@@ -27,9 +31,6 @@ def run(test, params, env):
         session.close()
         vm.destroy()
 
-    root_dir = data_dir.get_data_dir()
-    convert_source = params["convert_source"]
-    convert_target = params["convert_target"]
     source_params = params.object_params(convert_source)
     target_params = params.object_params(convert_target)
     source = qemu_storage.QemuImg(source_params, root_dir, convert_source)


### PR DESCRIPTION
Include convert target image into `images` and boot explicitly from the
source image.

Signed-off-by: lolyu <lolyu@redhat.com>