### PR TITLE
TypeError: cannot use a string pattern on a bytes-like object

### DIFF
--- a/qemu/tests/block_stream_drop_backingfile.py
+++ b/qemu/tests/block_stream_drop_backingfile.py
@@ -107,7 +107,7 @@ def run(test, params, env):
             logging.info)
         cmd = "%s info %s" % (qemu_img, snapshots[1])
         if re.search("backing file",
-                     process.system_output(cmd, ignore_status=True)):
+                     process.system_output(cmd, ignore_status=True).decode('utf-8')):
             test.fail("should no backing-file in this step")
     finally:
         files = " ".join(snapshots)


### PR DESCRIPTION
block_stream_drop_backingfile: fix encoding issue in re.search()

Signed-off-by: meet-lucky <qdong@redhat.com>

id:1640052