### PR TITLE
Snapshot on guest under stress

### DIFF
--- a/provider/blockdev_snapshot_base.py
+++ b/provider/blockdev_snapshot_base.py
@@ -76,12 +76,14 @@ class BlockDevSnapshotTest(object):
         if self.is_blockdev_mode():
             self.snapshot_image.base_tag = self.base_tag
             self.snapshot_image.base_format = self.base_image.get_format()
-            self.snapshot_image.base_image_filename = self.base_image.image_filename
+            base_image_filename = self.base_image.image_filename
+            self.snapshot_image.base_image_filename = base_image_filename
             self.snapshot_image.rebase(self.snapshot_image.params)
         self.clone_vm.create()
         self.clone_vm.verify_alive()
-        self.mount_data_disks()
-        self.verify_data_file()
+        if self.base_tag != "image1":
+            self.mount_data_disks()
+            self.verify_data_file()
 
     def create_snapshot(self):
         if self.is_blockdev_mode():
@@ -145,7 +147,8 @@ class BlockDevSnapshotTest(object):
         if not self.main_vm.is_alive():
             self.main_vm.create()
         self.main_vm.verify_alive()
-        self.configure_data_disk()
+        if self.base_tag != "image1":
+            self.configure_data_disk()
         self.prepare_snapshot_file()
 
     def post_test(self):

--- a/qemu/tests/blockdev_snapshot_stress.py
+++ b/qemu/tests/blockdev_snapshot_stress.py
@@ -1,0 +1,39 @@
+import logging
+
+from virttest import utils_test
+from virttest import error_context
+
+from provider.blockdev_snapshot_base import BlockDevSnapshotTest
+
+
+class BlockdevSnapshotStressTest(BlockDevSnapshotTest):
+
+    @error_context.context_aware
+    def create_snapshot(self):
+        error_context.context("do snaoshot during running stress in guest",
+                              logging.info)
+        stress_test = utils_test.VMStress(self.main_vm, "stress", self.params)
+        stress_test.load_stress_tool()
+        super(BlockdevSnapshotStressTest, self).create_snapshot()
+
+
+def run(test, params, env):
+    """
+    Backup VM disk test when VM reboot
+
+    1) start VM with system disk
+    2) create target disk with qmp command
+    3) load stress in guest
+    4) do snapshot to target disk
+    5) shutdown VM
+    6) boot VM with target disk
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    base_image = params.get("images", "image1").split()[0]
+    params.update(
+        {"image_name_%s" % base_image: params["image_name"],
+         "image_format_%s" % base_image: params["image_format"]})
+    snapshot_stress = BlockdevSnapshotStressTest(test, params, env)
+    snapshot_stress.run_test()

--- a/qemu/tests/cfg/blockdev_snapshot_stress.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_stress.cfg
@@ -1,0 +1,16 @@
+- blockdev_snapshot_stress:
+    type = blockdev_snapshot_stress
+    virt_test_type = qemu
+    start_vm = yes
+    storage_type_default = "directory"
+    storage_pool = default
+    snapshot_tag = sn1
+    image_format_sn1 = qcow2
+    image_name_sn1 = images/sn1
+    device = "drive_image1"
+    base_tag = "image1"
+    rebase_mode = unsafe
+    Host_RHEL.m8:
+        node = "drive_image1"
+        overlay = "drive_sn1"
+        qemu_force_use_drive_expression = no


### PR DESCRIPTION
blockdev_snapshot_stress:do snapshot under stress,
and rebase_mode=unsafe to avoid a product bug.

blockdev_snapshot_base:add scenario for snapshot on
system disk.

Signed-off-by: Aihua Liang <aliang@redhat.com>

id:1793258