### PR TITLE
image_boot: disable image_boot

### DIFF
--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -2,6 +2,7 @@
     no Host_RHEL.m5, Host_RHEL.m6.u0, Host_RHEL.m6.u1, Host_RHEL.m6.u2
     virt_test_type = qemu
     type = boot_from_device
+    image_boot = no
     boot_menu = on
     enable_sga = yes
     boot_menu_key = "esc"

--- a/qemu/tests/cfg/seabios_strict.cfg
+++ b/qemu/tests/cfg/seabios_strict.cfg
@@ -2,6 +2,7 @@
     virt_test_type = qemu
     only i386, x86_64
     type = seabios_strict
+    image_boot = no
     boot_menu = on
     enable_sga = yes
     images = 'stg'


### PR DESCRIPTION
Disable image_boot to prevent interference with bootindex.

ID: 1781445

Signed-off-by: ybduan <yduan@redhat.com>