### PR TITLE
New case: Add iommu support for virtio balloon/rng/serial devices

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -57,6 +57,16 @@
             check_image = yes
         - balloon-stop_continue:
             sub_test_after_balloon = "stop_continue"
+        - iommu_enabled:
+            only q35
+            only balloon_evict_and_enlarge
+            no WinXP WinVista Win7 Win8 Win8.1 Win2000 Win2003
+            no Win2008 Win2008..r2 Win2012 Win2012..r2
+            virtio_dev_iommu_platform = on
+            enable_guest_iommu = yes
+            virtio_dev_ats = on
+            machine_type_extra_params = "kernel-irqchip=split"
+            extra_params = "-device intel-iommu,intremap=on,eim=on,device-iotlb=on"
     variants:
         - balloon_evict:
             # Disable balloon_base case as it not run any sub test
@@ -73,7 +83,7 @@
             balloon_type = enlarge
             balloon_type_evict = evict
         - balloon_evict_and_enlarge:
-            only balloon_base balloon_oom
+            only balloon_base balloon_oom iommu_enabled
             test_tags = "evict enlarge"
             balloon_type_evict = evict
             balloon_type_enlarge = enlarge

--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -24,3 +24,14 @@
             driver_name = virtio
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
+   variants:
+        - @default:
+        - iommu_enabled:
+            only q35
+            no WinXP WinVista Win7 Win8 Win8.1 Win2000 Win2003
+            no Win2008 Win2008..r2 Win2012 Win2012..r2
+            virtio_dev_iommu_platform = on
+            enable_guest_iommu = yes
+            virtio_dev_ats = on
+            machine_type_extra_params = "kernel-irqchip=split"
+            extra_params = "-device intel-iommu,intremap=on,eim=on,device-iotlb=on"

--- a/qemu/tests/cfg/virtio_serial_file_transfer.cfg
+++ b/qemu/tests/cfg/virtio_serial_file_transfer.cfg
@@ -51,6 +51,16 @@
             migration_protocol = "exec"
             migration_exec_cmd_src = "gzip -c > '%s'"
             migration_exec_cmd_dst = "gzip -c -d '%s'"
+        - iommu_enabled:
+            only q35
+            only unix_socket
+            no WinXP WinVista Win7 Win8 Win8.1 Win2000 Win2003
+            no Win2008 Win2008..r2 Win2012 Win2012..r2
+            virtio_dev_iommu_platform = on
+            enable_guest_iommu = yes
+            virtio_dev_ats = on
+            machine_type_extra_params = "kernel-irqchip=split"
+            extra_params = "-device intel-iommu,intremap=on,eim=on,device-iotlb=on"
     variants:
         - unix_socket:
         - tcp_socket:


### PR DESCRIPTION
Add 3 three new cases:
1. rng works when iommu_platform=on;
2. balloon function works when iommu_platform=on;
3. boot virtio-serial-pci with iommu_platform=on.

BZ: 1783820, 1783821, 1783822

Signed-off-by: Li Jin <lijin@redhat.com>