### PR TITLE
device_option_check: Support checking cdrom wwn option under s390x

### DIFF
--- a/qemu/tests/cfg/device_option_check.cfg
+++ b/qemu/tests/cfg/device_option_check.cfg
@@ -53,7 +53,7 @@
                     qtree_check_value = cd1
                     cmd_sg = sg_inq -p 0x83 `ls /dev/sr*`
                     cdrom_cd1 = isos/windows/winutils.iso
-                    pseries:
+                    pseries, s390x:
                         only default_drive_format
                         cdrom_cd1 = /tmp/new.iso
                         pre_command_noncritical = no


### PR DESCRIPTION
Modify the cfg file to support checking the wwn option of cdrom
under s390x platform

ID: 1800455
Signed-off-by: Nini Gu <ngu@redhat.com>