### PR TITLE
check_link_speed_duplex: change/delete default speed for guests

### DIFF
--- a/qemu/tests/cfg/check_link_speed_duplex.cfg
+++ b/qemu/tests/cfg/check_link_speed_duplex.cfg
@@ -2,7 +2,7 @@
     image_snapshot = yes
     type = check_link_speed_duplex
     tar_duplex = "full" 
-    default_tar_speed = 100000
+    default_tar_speed = 10000
     modify_tar_speed = 1000
     modify_speed_param = ",speed=${modify_tar_speed},duplex=${tar_duplex}"
     Windows:

--- a/qemu/tests/check_link_speed_duplex.py
+++ b/qemu/tests/check_link_speed_duplex.py
@@ -159,13 +159,16 @@ def run(test, params, env):
     tar_duplex = params.get("tar_duplex")
     modify_speed_param = params.get("modify_speed_param")
 
-    vm = env.get_vm(params["main_vm"])
-    session = vm.wait_for_login(timeout=timeout)
-    try:
-        run_test(session, default_tar_speed, tar_duplex)
-    finally:
-        session.close()
-    vm.destroy(gracefully=True)
+    # check default value only under windows guest
+    if os_type == "windows":
+        vm = env.get_vm(params["main_vm"])
+        session = vm.wait_for_login(timeout=timeout)
+        try:
+            run_test(session, default_tar_speed, tar_duplex)
+        finally:
+            session.close()
+        vm.destroy(gracefully=True)
+
     params["nic_extra_params"] = modify_speed_param
     env_process.preprocess_vm(test, params, env, params.get("main_vm"))
     vm = env.get_vm(params["main_vm"])


### PR DESCRIPTION
1 Change default speed for windows according to product change
2 Delete default speed check for linux guest

id:1789673

Signed-off-by: Yu Wang <wyu@redhat.com>