### PR TITLE
Add options to Bootstrap.sh

### DIFF
--- a/qemu/deps/playbook.yml
+++ b/qemu/deps/playbook.yml
@@ -8,6 +8,7 @@
     root_ca_url: "{{cert_url}}"
     ansible_ssh_pass: "{{guest_password}}"
     setup_bridge_sh: "{{setup_br_sh}}"
+    bs_options: "{{bootstrap_options}}"
     host_log_dir: "{{host_log_files_dir}}"
     cmd_line: "{{command_line}}"
     flag: True
@@ -47,7 +48,7 @@
         force: yes
 
     - name: Run bootstrap script
-      command: './Bootstrap.sh'
+      command: ./Bootstrap.sh {{bs_options}}
       args:
         chdir: '{{kar_local}}'
       register: bootstrap_result

--- a/qemu/tests/cfg/nested_test.cfg
+++ b/qemu/tests/cfg/nested_test.cfg
@@ -1,6 +1,7 @@
 - nested_test:
     kar_repo = <kar_repo_url>
     cert_url = <cert_ca_url>
+    nested_bs_options = ""
     no Host_RHEL.m7
     Host_RHEL.m8.u0, Host_RHEL.m8.u1:
         auto_cpu_model = no

--- a/qemu/tests/nested_test.py
+++ b/qemu/tests/nested_test.py
@@ -60,7 +60,10 @@ def run(test, params, env):
 
         guest_password = params.get("password")
 
+        bootstrap_options = params.get("nested_bs_options")
+
         kar_cmd = "python3 ./ConfigTest.py "
+
         test_type = params.get("test_type")
         if test_type:
             case_name = params.get("case_name")
@@ -82,6 +85,7 @@ def run(test, params, env):
         cert_url = params.get("cert_url")
 
         data = {"guest_password": guest_password,
+                "bootstrap_options": bootstrap_options,
                 "command_line": kar_cmd,
                 "setup_br_sh": setup_bridge_sh,
                 "host_log_files_dir": results_dir,


### PR DESCRIPTION

ID: 1802927

Add options for Bootstrap.sh and enable nested test cases to use avocado and tp-qemu stable build in gating. 

Signed-off-by: Qinghua Cheng <qcheng@redhat.com>