### PR TITLE
uefi_secureboot: make sure guest boot from image

### DIFF
--- a/qemu/tests/uefi_secureboot.py
+++ b/qemu/tests/uefi_secureboot.py
@@ -42,7 +42,7 @@ def run(test, params, env):
     params['kernel'] = ''
     params['initrd'] = ''
     params['kernel_params'] = ''
-    params['image_boot'] == 'yes'
+    params['image_boot'] = 'yes'
     vm = env.get_vm(params['main_vm'])
     if vm:
         vm.destroy()


### PR DESCRIPTION
Since edk2 does not support boot order, it needs boot index instead

ID: 1804633
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>