### PR TITLE
nested_test: Fix get L1 guest ip address failed issue

### DIFF
--- a/qemu/tests/nested_test.py
+++ b/qemu/tests/nested_test.py
@@ -39,7 +39,7 @@ def run(test, params, env):
         vms = get_live_vms(env)
         tmp_dir = virttest_data_dir.get_tmp_dir()
         file_name = "inventory_file"
-        ip_lst = list(map(lambda v: v.get_address(0), vms))
+        ip_lst = list(map(lambda v: v.wait_for_get_address(0, 240), vms))
         invent_file = open(os.path.join(tmp_dir, file_name), "w")
         invent_file.writelines(ip_lst)
         invent_file.close()


### PR DESCRIPTION
use vm.wait_for_get_address replace vm.get_address, and
set timeout value to 240s

id: 1804737
Signed-off-by: Yanan Fu <yfu@redhat.com>