### PR TITLE
New case of cluster_size_check with preallocation mode metadata

### DIFF
--- a/qemu/tests/cfg/cluster_size_check.cfg
+++ b/qemu/tests/cfg/cluster_size_check.cfg
@@ -16,6 +16,10 @@
             status_error = "no"
             # Cluster size must be a power of two between 512 and 2048k.
             cluster_size_set = "512 1K 2K 4K 8K 16K 32K default 128K 256K 512K 1M 2M"
+            variants:
+                - @default:
+                - preallocation_metadata:
+                    preallocated_cluster = metadata
         - negative_testing:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Creating with preallocation mode metadata and different cluster sizes.

ID: 1804556

Signed-off-by: Tingting Mao <timao@redhat.com>