### PR TITLE
qemu-guest-agent: bug fix of python bin in windows guest

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -106,7 +106,7 @@
             gagent_check_type = get_time
             get_guest_time_cmd = `command -v python python3 | head -1` -c "import time; print(int(time.time()))"
             Windows:
-                get_guest_time_cmd = python -c "import time; print(int(time.time()))"
+                get_guest_time_cmd = python2.7 -c "import time; print(int(time.time()))"
         - check_memory_leak:
             only Windows
             gagent_check_type = memory_leak
@@ -118,14 +118,14 @@
             gagent_check_type = set_time
             get_guest_time_cmd = `command -v python python3 | head -1` -c "import time; print(int(time.time()))"
             Windows:
-                get_guest_time_cmd = python -c "import time; print(int(time.time()))"
+                get_guest_time_cmd = python2.7 -c "import time; print(int(time.time()))"
             move_time_cmd = "date --rfc-3339=seconds --utc; date --set='now - 1 week' > /dev/null; date --rfc-3339=seconds --utc"
         - check_time_sync:
             only Windows
             gagent_check_type = time_sync
             image_snapshot = yes
             rtc_drift = none
-            get_guest_time_cmd = python -c "import time; print(int(time.time()))"
+            get_guest_time_cmd = python2.7 -c "import time; print(int(time.time()))"
             time_service_config = w32tm /config /manualpeerlist:"clock.redhat.com" /syncfromflags:manual /reliable:yes /update
             time_service_status_cmd = sc query w32time |findstr "RUNNING"
             time_service_stop_cmd = net stop w32time


### PR DESCRIPTION
python bin should be python2.7 in windows guest.
ID: 1805552
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>