### PR TITLE
savevm_loadvm: save VM and then load it while VM is running

### DIFF
--- a/qemu/tests/cfg/savevm_loadvm.cfg
+++ b/qemu/tests/cfg/savevm_loadvm.cfg
@@ -1,0 +1,6 @@
+- savevm_loadvm:
+    virt_test_type = qemu
+    type = savevm_loadvm
+    kill_vm_on_error = yes
+    kill_vm_gracefully = yes
+    kill_vm = yes

--- a/qemu/tests/savevm_loadvm.py
+++ b/qemu/tests/savevm_loadvm.py
@@ -1,0 +1,44 @@
+import logging
+
+from virttest import utils_misc
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Save VM while it's running, and then load it again.
+
+    1) Launch a VM.
+    2) Save VM via human monitor while VM is running. (unsafe)
+    3) Check if it exists in snapshots.
+    4) Load VM via human monitor.
+    5) Verify kernel and dmesg.
+    6) Delete snapshot after testing.
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+    snapshot_tag = "vm_" + utils_misc.generate_random_string(8)
+    os_type = params["os_type"]
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    vm.wait_for_login().close()
+    try:
+        error_context.base_context("Saving VM to %s" % snapshot_tag,
+                                   logging.info)
+        vm.monitor.human_monitor_cmd("savevm %s" % snapshot_tag)
+        vm_snapshots = vm.monitor.info("snapshots")
+        if snapshot_tag not in vm_snapshots:
+            test.fail("Failed to save VM to %s" % snapshot_tag)
+        error_context.context("Loading VM from %s" % snapshot_tag,
+                              logging.info)
+        vm.monitor.human_monitor_cmd("loadvm %s" % snapshot_tag)
+        if os_type == "linux":
+            vm.verify_kernel_crash()
+            vm.verify_dmesg()
+    finally:
+        if snapshot_tag in vm.monitor.info("snapshots"):
+            vm.monitor.human_monitor_cmd("delvm %s" % snapshot_tag)


### PR DESCRIPTION
After launch a VM, save the VM and load it while VM is running, verify
guest kernel and dmesg, qemu does not crash.

ID: 1807416
Signed-off-by: Yihuang Yu <yihyu@redhat.com>