### PR TITLE
system_reset_during_boot: add minimal waiting time before reset vm

### DIFF
--- a/qemu/tests/cfg/system_reset_during_boot.cfg
+++ b/qemu/tests/cfg/system_reset_during_boot.cfg
@@ -1,6 +1,7 @@
 - system_reset_during_boot:
     type = system_reset_bootable
     reset_times = 20
+    min_wait_time = 0
     kill_vm_on_error = yes
     get_boot_time = yes
     reset_during_boot = yes

--- a/qemu/tests/system_reset_bootable.py
+++ b/qemu/tests/system_reset_bootable.py
@@ -26,6 +26,7 @@ def run(test, params, env):
     reset_times = int(params.get("reset_times", 20))
     interval = int(params.get("reset_interval", 10))
     wait_time = int(params.get("wait_time_for_reset", 60))
+    min_wait_time = int(params.get("min_wait_time", 0))
     params["start_vm"] = "yes"
 
     if params.get("get_boot_time") == "yes":
@@ -35,7 +36,7 @@ def run(test, params, env):
         bootup_time = time.time() - vm.start_time
         if params.get("reset_during_boot") == "yes":
             interval = int(bootup_time)
-            wait_time = random.randint(0, int(bootup_time))
+            wait_time = random.randint(min_wait_time, int(bootup_time))
         vm.destroy()
 
     error_context.context("Boot the guest", logging.info)


### PR DESCRIPTION
some vm can't bootup when the wait_time is 0, add this params to
make this test more easier to control.

id: 1808203
Signed-off-by: Yanan Fu <yfu@redhat.com>