### PR TITLE
Remove configs with deprecated data plane

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -129,16 +129,3 @@
             drive_format_stg0 = scsi-hd
             drive_format_stg1 = scsi-hd
             get_disk_pattern = "^/dev/sd[a-z]*$"
-
-    variants:
-        - @default:
-        - data_plane:
-            no Host_RHEL.m6
-            only with_plug.with_system_reset.one_pci, block_scsi..with_plug.with_repetition.one_pci
-            iothreads = iothread0
-            block_virtio:
-                blk_extra_params_stg0 = "iothread=${iothreads}"
-            block_scsi:
-                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
-                bus_extra_params_image1 = "iothread=${iothreads}"
-                bus_extra_params_stg0 = "iothread=${iothreads}"

--- a/qemu/tests/cfg/block_hotplug_in_pause.cfg
+++ b/qemu/tests/cfg/block_hotplug_in_pause.cfg
@@ -18,6 +18,10 @@
         disk_op_cmd = "WIN_UTILS:\Iozone\iozone.exe -azR -r 64k -n 125M -g 512M -M -i 0"
         disk_op_cmd += " -i 1 -b %s:\iozone_test -f %s:\testfile"
         get_disk_cmd = "wmic diskdrive get index,size"
+        i440fx:
+            cd_format_cd1 = ide
+        q35:
+            cd_format_cd1 = ahci
 
     variants:
         - one_pci:
@@ -51,19 +55,3 @@
             stop_vm_before_hotplug = yes
             resume_vm_after_hotplug = no
             stop_vm_before_unplug = no
-    variants:
-        - @default:
-        - data_plane:
-            no Host_RHEL.m6
-            only virtio_blk, virtio_scsi
-            iothreads = iothread0
-            virtio_blk:
-                blk_extra_params_image1 = "iothread=${iothreads}"
-            virtio_scsi:
-                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
-                bus_extra_params = "iothread=${iothreads}"
-                Windows:
-                    i440fx:
-                        cd_format_cd1 = ide
-                    q35:
-                        cd_format_cd1 = ahci

--- a/qemu/tests/cfg/block_hotplug_negative.cfg
+++ b/qemu/tests/cfg/block_hotplug_negative.cfg
@@ -15,20 +15,8 @@
     force_create_image_stg0 = yes
     kill_vm_on_error = yes
     blk_extra_params_stg0 = "invalid_param=on"
-
-    variants:
-        - @default:
-        - data_plane:
-            no Host_RHEL.m6
-            only virtio_blk, virtio_scsi
-            iothreads = iothread0
-            virtio_blk:
-                blk_extra_params_image1 = "iothread=${iothreads}"
-            virtio_scsi:
-                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
-                bus_extra_params = "iothread=${iothreads}"
-                Windows:
-                    i440fx:
-                        cd_format_cd1 = ide
-                    q35:
-                        cd_format_cd1 = ahci
+    Windows:
+        i440fx:
+            cd_format_cd1 = ide
+        q35:
+            cd_format_cd1 = ahci

--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -92,14 +92,3 @@
                 tmp_md5_file = /tmp/tmp_md5_file
                 pre_command = "dd if=/dev/urandom of=${tmp_md5_file} oflag=direct bs=1M count=10"
                 post_command = "rm -rf ${tmp_md5_file}"
-    variants:
-        - @default:
-        - data_plane:
-            no Host_RHEL.m6
-            only virtio_blk virtio_scsi
-            iothreads = iothread0
-            virtio_blk:
-                blk_extra_params_stg += ",iothread=${iothreads}"
-            virtio_scsi:
-                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
-                bus_extra_params_stg = "iothread=${iothreads}"

--- a/qemu/tests/cfg/disk_extension.cfg
+++ b/qemu/tests/cfg/disk_extension.cfg
@@ -4,7 +4,6 @@
     type = disk_extension
     not_preprocess = yes
     wait_timeout = 60
-    iothreads = iothread0
     drive_werror = stop
     drive_rerror = stop
     tmpfs_folder = "/tmp/xtmpfs"
@@ -47,10 +46,8 @@
     variants:
         - with_virtio_blk:
             drive_format_stg1 = virtio
-            blk_extra_params_stg1 += ",iothread=${iothreads}"
         - with_virtio_scsi:
             drive_format_stg1 = scsi-hd
-            bus_extra_params += "iothread=${iothreads}"
     variants:
         - aio_native:
             image_aio_stg1 = native


### PR DESCRIPTION
id: 1808277

Related tests:
1. block_hotplug
2. block_hotplug_negative
3. block_hotplug_in_pause
4. block_resize
5. disk_extension

Signed-off-by: lolyu <lolyu@redhat.com>