### PR TITLE
Remove usage of 52lts compatiblity layer

### DIFF
--- a/qemu/tests/ksm_base.py
+++ b/qemu/tests/ksm_base.py
@@ -11,7 +11,6 @@ from avocado.utils import process
 from virttest import data_dir
 from virttest import error_context
 from virttest import utils_misc
-from virttest.compat_52lts import decode_to_text
 
 TMPFS_OVERHEAD = 0.0022
 
@@ -102,10 +101,10 @@ def run(test, params, env):
 
     query_cmd = re.sub("QEMU_PID", str(vm.process.get_pid()), query_cmd)
 
-    sharing_page_0 = decode_to_text(process.system_output(query_cmd,
-                                                          verbose=False,
-                                                          ignore_status=True,
-                                                          shell=True))
+    sharing_page_0 = process.run(query_cmd,
+                                 verbose=False,
+                                 ignore_status=True,
+                                 shell=True).stdout_text
     if query_regex:
         sharing_page_0 = re.findall(query_regex, sharing_page_0)[0]
 
@@ -118,10 +117,10 @@ def run(test, params, env):
     _execute_allocator(cmd, vm, session, fill_timeout)
     time.sleep(120)
 
-    sharing_page_1 = decode_to_text(process.system_output(query_cmd,
-                                                          verbose=False,
-                                                          ignore_status=True,
-                                                          shell=True))
+    sharing_page_1 = process.run(query_cmd,
+                                 verbose=False,
+                                 ignore_status=True,
+                                 shell=True).stdout_text
     if query_regex:
         sharing_page_1 = re.findall(query_regex, sharing_page_1)[0]
 
@@ -136,10 +135,10 @@ def run(test, params, env):
     _execute_allocator(cmd, vm, session, fill_timeout)
     time.sleep(120)
 
-    sharing_page_2 = decode_to_text(process.system_output(query_cmd,
-                                                          verbose=False,
-                                                          ignore_status=True,
-                                                          shell=True))
+    sharing_page_2 = process.run(query_cmd,
+                                 verbose=False,
+                                 ignore_status=True,
+                                 shell=True).stdout_text
     if query_regex:
         sharing_page_2 = re.findall(query_regex, sharing_page_2)[0]
 

--- a/qemu/tests/numa_memdev_options.py
+++ b/qemu/tests/numa_memdev_options.py
@@ -1,13 +1,13 @@
 import logging
 import re
 
+from avocado.utils import astring
 from avocado.utils import process
 
 from virttest import error_context
 from virttest import utils_misc
 from virttest import env_process
 from virttest.staging import utils_memory
-from virttest.compat_52lts import decode_to_text
 from virttest.utils_numeric import normalize_data_size
 
 
@@ -77,7 +77,7 @@ def check_memory_in_procfs(test, params, vm):
         mem_size = int(float(utils_misc.normalize_data_size(mem_size, "K")))
         smaps = process.system_output("grep -1 %d /proc/%d/smaps"
                                       % (mem_size, qemu_pid))
-        smaps = decode_to_text(smaps).strip()
+        smaps = astring.to_text(smaps).strip()
         mem_path = memdev_params.get("mem-path")
         if mem_path and (mem_path not in smaps):
             test.fail("memdev = %s: mem-path '%s' is not in smaps '%s'!"
@@ -85,7 +85,7 @@ def check_memory_in_procfs(test, params, vm):
         mem_start = smaps.split('-')[0]
         numa_maps = process.system_output("grep %s /proc/%d/numa_maps"
                                           % (mem_start, qemu_pid))
-        numa_maps = decode_to_text(numa_maps).strip()
+        numa_maps = astring.to_text(numa_maps).strip()
         if mem_path and (mem_path not in numa_maps):
             test.fail("memdev = %s: mem-path '%s' is not in numa_maps '%s'!"
                       % (mem_dev, mem_path, numa_maps))

--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -6,7 +6,6 @@ from avocado.utils import process
 from virttest import error_context
 from virttest import env_process
 from virttest import utils_misc
-from virttest.compat_52lts import decode_to_text
 
 
 @error_context.context_aware
@@ -41,8 +40,8 @@ def run(test, params, env):
             dmidecode_key = dmidecode_key.split()
             for key in dmidecode_key:
                 cmd = (dmidecode_exp % (smbios_type_number, key))
-                default_key_para = decode_to_text(process.system_output(
-                    cmd, shell=True).strip())
+                default_key_para = process.run(
+                    cmd, shell=True).stdout_text.strip()
                 smbios_key_para_set = params.object_params(sm_type).get(key,
                                                                         default_key_para)
                 smbios += ",%s='%s'" % (key.lower(), smbios_key_para_set)
@@ -69,8 +68,8 @@ def run(test, params, env):
     rhel_system_version = params.get('smbios_system_version') == 'rhel'
     if not rhel_system_version:
         re_pc_lt_2 = re.compile(r'^pc-(i440fx-)?[01].\d+$')
-        host_dmidecode_system_version = decode_to_text(
-            process.system_output("dmidecode -s system-version"))
+        host_dmidecode_system_version = process.run(
+            "dmidecode -s system-version").stdout_text
     for m_type in support_machine_types:
         if m_type in ("isapc", "xenfv", "xenpv"):
             continue
@@ -96,8 +95,8 @@ def run(test, params, env):
             for key in dmidecode_key:
                 cmd = (dmidecode_exp % (smbios_type_number, key))
                 smbios_get_para = session.cmd(cmd).strip()
-                default_key_para = decode_to_text(process.system_output(
-                    cmd, shell=True).strip())
+                default_key_para = process.run(
+                    cmd, shell=True).stdout_text.strip()
                 if params.get("smbios_type_disable", "no") == "no":
                     smbios_set_para = params.object_params(sm_type).get(key,
                                                                         default_key_para)

--- a/qemu/tests/timerdevice_host_time_back.py
+++ b/qemu/tests/timerdevice_host_time_back.py
@@ -5,7 +5,6 @@ import logging
 from avocado.utils import process
 
 from virttest import error_context
-from virttest.compat_52lts import decode_to_text
 
 
 @error_context.context_aware
@@ -37,7 +36,7 @@ def run(test, params, env):
 
     error_context.context("Check time difference between host and guest", logging.info)
     guest_timestr_ = session.cmd_output(epoch_time_cmd, timeout=120)
-    host_timestr_ = decode_to_text(process.system_output(epoch_time_cmd, shell=True))
+    host_timestr_ = process.run(epoch_time_cmd, shell=True).stdout_text
     host_epoch_time_, guest_epoch_time_ = map(lambda x: re.findall(r"epoch:\s+(\d+)", x)[0],
                                               [host_timestr_, guest_timestr_])
     real_difference_ = abs(int(host_epoch_time_) - int(guest_epoch_time_))
@@ -59,7 +58,7 @@ def run(test, params, env):
             session.close()
         except Exception:
             test.error("Guest error after set host system time back")
-        host_timestr = decode_to_text(process.system_output(epoch_time_cmd, shell=True))
+        host_timestr = process.run(epoch_time_cmd, shell=True).stdout_text
         host_epoch_time, guest_epoch_time = map(lambda x: re.findall(r"epoch:\s+(\d+)", x)[0],
                                                 [host_timestr, guest_timestr])
         real_difference = abs(int(host_epoch_time) - int(guest_epoch_time))

--- a/qemu/tests/timerdevice_time_jump_check.py
+++ b/qemu/tests/timerdevice_time_jump_check.py
@@ -2,7 +2,6 @@ import logging
 import time
 
 from virttest import error_context
-from virttest.compat_52lts import decode_to_text
 
 from avocado.utils import process
 
@@ -32,8 +31,8 @@ def run(test, params, env):
 
     error_context.context("Pin every vcpu to physical cpu", logging.info)
     host_cpu_cnt_cmd = params["host_cpu_cnt_cmd"]
-    host_cpu_num = decode_to_text(process.system_output(host_cpu_cnt_cmd,
-                                                        shell=True)).strip()
+    host_cpu_num = process.run(host_cpu_cnt_cmd,
+                               shell=True).stdout_text.strip()
     host_cpu_list = (_ for _ in range(int(host_cpu_num)))
     if len(vm.vcpu_threads) > int(host_cpu_num):
         host_cpu_list = []

--- a/qemu/tests/x86_cpu_model.py
+++ b/qemu/tests/x86_cpu_model.py
@@ -4,7 +4,6 @@ import json
 
 from avocado.utils import cpu, process
 from virttest import error_context, utils_misc, env_process
-from virttest.compat_52lts import decode_to_text
 
 
 @error_context.context_aware
@@ -28,10 +27,10 @@ def run(test, params, env):
                 '{"execute": "quit"}']
     cmd = "echo -e '{0}' | {1} -qmp stdio -vnc none -M none | grep return |"\
           "grep RAND91".format(r"\n".join(qmp_cmds), qemu_binary)
-    output = decode_to_text(process.system_output(cmd, timeout=10,
-                                                  ignore_status=True,
-                                                  shell=True,
-                                                  verbose=False))
+    output = process.run(cmd, timeout=10,
+                         ignore_status=True,
+                         shell=True,
+                         verbose=False).stdout_text
     out = json.loads(output)["return"]
 
     model = params["model"]


### PR DESCRIPTION
Drop the usage of 52lts compatibility layer to follow VT's roadmap.

Signed-off-by: Xu Han <xuhan@redhat.com>