### PR TITLE
win_sigverif: Fix 'sigverif logs are not created' error 

### DIFF
--- a/qemu/tests/win_sigverif.py
+++ b/qemu/tests/win_sigverif.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 
 from virttest import error_context
 from virttest import utils_test
@@ -22,6 +23,8 @@ def run(test, params, env):
 
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login()
+    vm.send_key('meta_l-d')
+    time.sleep(60)
 
     driver_name = params["driver_name"]
     session = utils_test.qemu.windrv_check_running_verifier(session, vm,


### PR DESCRIPTION
Add command to ensure guest on desktop and wait 60s to make
all popups pop up to eliminate the impact of popups on autoit.

ID:1797847

Signed-off-by: Menghuan Li menli@redhat.com