### PR TITLE
qemu_guest_agent: Update pattern to get "target_release"

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -172,7 +172,7 @@ class QemuGuestAgentTest(BaseVirtTest):
                               " stream." % virt_module_stream,
                               logging.info)
         # target release,such as 810,811
-        target_release = re.findall(r'rhel(\d+)-\d+', guest_name, re.I)[0]
+        target_release = re.findall(r'rhel(\d+)-\w+', guest_name, re.I)[0]
         # get tag pattern,such as module-virt-8.1-80101xxxxx
         if virt_module_stream == "rhel":
             # for slow train,didn't know 810 or 811.


### PR DESCRIPTION
Failed to get "target_release" on non-x86, update pattern to fix it.
- x86-64: rhel810-64
- ppc64le: rhel810-ppc64le
- aarch64: rhel810-aarch64

ID: 1811384
Signed-off-by: Yihuang Yu <yihyu@redhat.com>