### PR TITLE
input_event_proxy: change python_bin = 'python2' for windows

### DIFF
--- a/provider/input_event_proxy.py
+++ b/provider/input_event_proxy.py
@@ -490,7 +490,7 @@ class EventListenerWin(_EventListener):
 
     agent_source = os.path.join(DEP_DIR, 'input_event_win.py')
     agent_target = r'%TEMP%\input_event.py'
-    python_bin = 'python'
+    python_bin = 'python2'
 
     def _uninstall(self):
         cmd = ' '.join(('del', self.agent_target))


### PR DESCRIPTION
sometimes python_bin = 'python' does not work on windows os,
changed python_bin = 'python2'

id: 1811535
Signed-off-by: Peixiu Hou <phou@redhat.com>