### PR TITLE
Disable iothread explicitly for scsi-cd cases

### DIFF
--- a/qemu/tests/cfg/cdrom_test.cfg
+++ b/qemu/tests/cfg/cdrom_test.cfg
@@ -9,6 +9,11 @@
     tray_check_src = tray_open.py
     # wait before eject $cdrom (let OS initialize cdrom ...)
     workaround_eject_time = 5
+    virtio_scsi:
+        # disable iothread
+        iothread_scheme ?=
+        image_iothread ?=
+        iothreads ?=
     variants:
         - cdrom_default:
             cdrom_test_eject = yes

--- a/qemu/tests/cfg/change_media.cfg
+++ b/qemu/tests/cfg/change_media.cfg
@@ -8,6 +8,11 @@
     orig_img_name = /tmp/orig.iso
     new_img_name = /tmp/new.iso
     cdrom_cd1 = /tmp/orig.iso
+    virtio_scsi:
+        # disable iothread
+        iothread_scheme ?=
+        image_iothread ?=
+        iothreads ?=
     Linux:
         cd_mount_cmd = mount %s /mnt
         cd_umount_cmd = umount /mnt

--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -17,6 +17,11 @@
     chk_phy_blk_cmd = "cat /sys/block/%s/queue/physical_block_size"
     chk_log_blk_cmd = "cat /sys/block/%s/queue/logical_block_size"
     chk_blks_cmd_windows = "powershell "get-disk|format-list""
+    virtio_scsi:
+        # disable iothread
+        iothread_scheme ?=
+        iothreads ?=
+        image_iothread ?=
     variants:
         - extra_cdrom_ks:
             cdroms += " unattended"

--- a/qemu/tests/cfg/device_option_check.cfg
+++ b/qemu/tests/cfg/device_option_check.cfg
@@ -48,6 +48,11 @@
                     blk_extra_params_image1 = wwn=0x5000c50015ea71ad
                     qtree_check_value = image1
                 - wwn_cdrom:
+                    virtio_scsi:
+                        # disable iothread
+                        iothread_scheme ?=
+                        iothreads ?=
+                        image_iothread ?=
                     params_name = blk_extra_params_cd1
                     blk_extra_params_cd1 = wwn=0x5000c50015ea71ad
                     qtree_check_value = cd1

--- a/qemu/tests/cfg/eject_media.cfg
+++ b/qemu/tests/cfg/eject_media.cfg
@@ -9,6 +9,11 @@
     post_command += "rm -rf /tmp/orig.iso /tmp/new.iso /tmp/orig /tmp/new;"
     new_img_name = /tmp/new.iso
     cdrom_cd1 = /tmp/orig.iso
+    virtio_scsi:
+        # disable iothread
+        iothread_scheme ?=
+        iothreads ?=
+    image_iothread ?=
     variants:
         - force_eject:
             force_eject = yes

--- a/qemu/tests/cfg/ioeventfd.cfg
+++ b/qemu/tests/cfg/ioeventfd.cfg
@@ -5,6 +5,11 @@
     start_vm = no
     orig_ioeventfd = "ioeventfd=off"
     new_ioeventfd = "ioeventfd=on"
+    virtio_scsi:
+        # explicitly disable iothread
+        iothread_scheme ?=
+        image_iothread ?=
+        iothreads ?=
     variants dev_type:
         - @block:
             only virtio_blk virtio_scsi

--- a/qemu/tests/cfg/migration_with_block.cfg
+++ b/qemu/tests/cfg/migration_with_block.cfg
@@ -42,6 +42,10 @@
                     blk_extra_params_stg0 = "scsi=on,disable-legacy=off,disable-modern=on"
                     set_dst_params = "{'blk_extra_params_stg0': 'scsi=off,disable-legacy=off,disable-modern=on'}"
                 - with_change_cdrom:
+                    # explicitly disable iothread
+                    iothread_scheme ?=
+                    image_iothread ?=
+                    iothreads ?=
                     src_addition_desc = 'with cdrom'
                     dst_addition_desc = 'with new cdrom'
                     only virtio_scsi

--- a/qemu/tests/cfg/plug_cdrom.cfg
+++ b/qemu/tests/cfg/plug_cdrom.cfg
@@ -2,6 +2,10 @@
     only virtio_scsi
     virt_test_type = qemu
     type = plug_cdrom
+    # explicitly disable iothread
+    iothread_scheme ?=
+    image_iothread ?=
+    iothreads ?=
     cdroms = 'cd2'
     iso_name_cd2 = new
     cdrom_cd2 = /tmp/${iso_name_cd2}.iso

--- a/qemu/tests/cfg/virtio_scsi_cdrom.cfg
+++ b/qemu/tests/cfg/virtio_scsi_cdrom.cfg
@@ -20,9 +20,15 @@
     only x86_64, i386, ppc64, ppc64le
     only virtio_scsi, virtio_blk
     virtio_drive_letter = 'D'
+    virtio_scsi:
+        # disable iothread for scsi devices explicitly
+        iothread_scheme ?=
+        iothreads ?=
+        image_iothread ?=
     variants:
         - with_installation:
             cd_format_cd1 = scsi-cd
+            image_iothread_cd1 =
             i440fx:
                 Windows:
                     cd_format_unattended = ide
@@ -77,6 +83,7 @@
                     no WinXP Win2000 Win2003 WinVista
                     unattended_delivery_method = cdrom
                     cdroms += " unattended"
+                    image_iothread_unattended =
                     drive_index_unattended = 3
                     drive_index_cd1 = 1
             variants:


### PR DESCRIPTION
id: 1813792
Since scsi-cd is incompatible with iothread, adding configs to disable
iothread for scsi-cd related cases explicitly.

Signed-off-by: lolyu <lolyu@redhat.com>