### PR TITLE
Add 3 new cases

### DIFF
--- a/qemu/tests/boot_from_remote.py
+++ b/qemu/tests/boot_from_remote.py
@@ -1,0 +1,153 @@
+import logging
+import random
+import re
+import os
+
+from avocado.core import exceptions
+from avocado.utils import process
+
+from virttest import error_context
+from virttest import utils_misc
+from virttest import env_process
+from virttest import utils_numeric
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    The following testing scenarios are covered:
+        1) boot_with_debug
+        2) boot_with_local_image
+        3) boot_with_remote_images
+    Please refer to the specific case for details
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+    def _get_data_disk(session):
+        """ Get the data disk. """
+        extra_params = params["blk_extra_params_%s" %
+                              params['images'].split()[-1]]
+        drive_id = re.search(r"(serial|wwn)=(\w+)",
+                             extra_params, re.M).group(2)
+        return utils_misc.get_linux_drive_path(session, drive_id)
+
+    def _write_disk(session):
+        disk_op_cmd = params['disk_op_cmd']
+        if disk_op_cmd:
+            disk = _get_data_disk(session)
+            session.cmd(disk_op_cmd.format(disk=disk))
+
+    def _get_memory(pid):
+        cmd = "ps -o vsz,rss -p %s | tail -n1" % pid
+        out = process.system_output(cmd, shell=True).split()
+        return [int(i) for i in out]
+
+    def boot_with_debug():
+        """
+        Boot up a guest with debug level
+            1. from 'debug_level_low' to 'debug_level_high'
+            2. less than 'debug_level_low'
+            3. greater than 'debug_level_high'
+        VM can start up without any error
+        """
+        # valid debug levels
+        low = int(params["debug_level_low"])
+        high = int(params["debug_level_high"])
+        levels = [i for i in range(low, high+1)]
+
+        # invalid debug levels: [low-100, low) and [high+1, high+100)
+        levels.extend([random.choice(range(low-100, low)),
+                       random.choice(range(high+1, high+100))])
+
+        for level in levels:
+            logfile = utils_misc.get_log_filename("debug.level%s" % level)
+            params["gluster_debug"] = level
+            params["gluster_logfile"] = logfile
+            logging.info("debug level: %d, log: %s" % (level, logfile))
+
+            try:
+                env_process.preprocess_vm(test, params, env, params["main_vm"])
+                vm = env.get_vm(params["main_vm"])
+                vm.verify_alive()
+                if not os.path.exists(logfile):
+                    raise exceptions.TestFail("Failed to generate log file %s"
+                                              % logfile)
+                os.remove(logfile)
+            finally:
+                vm.destroy()
+
+    def boot_with_local_image():
+        """
+        Boot up a guest with a remote storage system image
+            as well as a local filesystem image
+        VM can start up without any error
+        """
+        try:
+            session = None
+            vm = env.get_vm(params["main_vm"])
+            vm.verify_alive()
+            tm = float(params.get("login_timeout", 240))
+            session = vm.wait_for_login(timeout=tm)
+
+            _write_disk(session)
+        finally:
+            if session:
+                session.close()
+            vm.destroy()
+
+    def boot_with_remote_images():
+        """
+        Boot up a guest with only one remote image,
+            record memory consumption(vsz, rss)
+        Boot up a guest with 4 remote images,
+            record memory consumption(vsz, rss)
+        The memory increased should not be greater than 'memory_diff'
+        """
+        try:
+            vm = env.get_vm(params["main_vm"])
+            vm.verify_alive()
+
+            # get vsz, rss when booting with one remote image
+            single_img_memory = _get_memory(vm.get_pid())
+            if not single_img_memory:
+                raise exceptions.TestError("Failed to get memory when "
+                                           "booting with one remote image.")
+            logging.debug("memory consumption(only one remote image): %s"
+                          % single_img_memory)
+
+            vm.destroy()
+
+            for img in params['images'].split()[1:]:
+                params['boot_drive_%s' % img] = 'yes'
+            env_process.preprocess_vm(test, params, env, params["main_vm"])
+            vm = env.get_vm(params["main_vm"])
+            vm.verify_alive()
+
+            # get vsz, rss when booting with 4 remote image
+            multi_img_memory = _get_memory(vm.get_pid())
+            if not multi_img_memory:
+                raise exceptions.TestError("Failed to get memory when booting"
+                                           " with several remote images.")
+            logging.debug("memory consumption(total 4 remote images): %s"
+                          % multi_img_memory)
+
+            diff = int(float(utils_numeric.normalize_data_size(
+                params['memory_diff'], order_magnitude="K")))
+            mem_diffs = [i-j for i, j in zip(multi_img_memory,
+                                             single_img_memory)]
+            if mem_diffs[0] > diff:
+                raise exceptions.TestFail(
+                    "vsz increased '%s', which was more than '%s'"
+                    % (mem_diffs[0], diff))
+            if mem_diffs[1] > diff:
+                raise exceptions.TestFail(
+                    "rss increased '%s', which was more than '%s'"
+                    % (mem_diffs[1], diff))
+        finally:
+            vm.destroy()
+
+    tc = params["scenario"]
+    fun = locals()[tc]
+    fun()

--- a/qemu/tests/cfg/remote_boot.cfg
+++ b/qemu/tests/cfg/remote_boot.cfg
@@ -1,0 +1,56 @@
+# Network storage backends:
+#   gluster_direct
+# The following testing scenarios are covered:
+#   - with_local_image
+#       boot from remote storage with a local image attached
+#   - with_remote_images
+#       boot VM with another 3 remote images, check if there
+#       is memory leak for qemu-kvm
+#   - with_debug
+#       boot VM with valid and invalid debug levels, make sure
+#       the VM can start up without any error
+
+- boot_from_remote_storage:
+    type = boot_from_remote
+    virt_test_type = qemu
+    bootindex_image1 = 0
+    variants:
+        - with_debug:
+            only gluster_direct
+            scenario = boot_with_debug
+            debug_level_low = 0
+            debug_level_high = 9
+        - with_local_image:
+            only gluster_direct
+            scenario = boot_with_local_image
+            images += " stg"
+            image_size_stg = 1G
+            image_name_stg = images/stg
+            enable_gluster_stg = no
+            remove_image_stg = yes
+            force_create_image_stg = yes
+            blk_extra_params_stg = "serial=TARGET_DISK0"
+            Host_RHEL.m6..ide:
+                blk_extra_params_stg = "wwn=0x5000123456789abc"
+            disk_op_cmd = 'dd if=/dev/urandom of={disk} bs=1M count=200 oflag=direct'
+        - with_remote_images:
+            only gluster_direct
+            only virtio_scsi virtio_blk
+            scenario = boot_with_remote_images
+            images += " stg1 stg2 stg3"
+            boot_drive_stg1 = no
+            boot_drive_stg2 = no
+            boot_drive_stg3 = no
+            image_name_stg1 = "images/stg1"
+            image_name_stg2 = "images/stg2"
+            image_name_stg3 = "images/stg3"
+            image_size_stg1 = 1G
+            image_size_stg2 = 1G
+            image_size_stg3 = 1G
+            remove_image_stg1 = yes
+            remove_image_stg2 = yes
+            remove_image_stg3 = yes
+            force_create_image_stg1 = yes
+            force_create_image_stg2 = yes
+            force_create_image_stg3 = yes
+            memory_diff = 100M


### PR DESCRIPTION
  1. use one glfs instance per volume
  2. Boot from glusterfs with attach device in local filesystem
  3. Controll libgfapi logging level

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1814483, 1814493, 1814492