### PR TITLE
vioinput_keyboard: Add 30s time sleep after listener start

### DIFF
--- a/qemu/tests/vioinput_keyboard.py
+++ b/qemu/tests/vioinput_keyboard.py
@@ -78,6 +78,7 @@ def key_tap_test(test, params, vm):
 
     error_context.context("Start event listener in guest", logging.info)
     listener = input_event_proxy.EventListener(vm)
+    time.sleep(30)
 
     console = graphical_console.GraphicalConsole(vm)
     for key in key_check_cfg.keys():


### PR DESCRIPTION
On win7 guest os, the time between listener starting and accept first key tap event is so short,
here add 30s sleep after listener starting, waiting the listener stable, then do key tap test continue.

id: 1811578
Signed-off-by: Peixiu Hou <phou@redhat.com>