### PR TITLE
umount_wipefs: add umount and wipefs steps

### DIFF
--- a/qemu/tests/cfg/format_disk.cfg
+++ b/qemu/tests/cfg/format_disk.cfg
@@ -22,6 +22,7 @@
     show_dev_cmd = "ls {0}"
     mount_cmd =  "mkdir -p /media && mount -t ${fs_type} {0} /media"
     show_mount_cmd = "mount | grep {0}"
+    wipefs_cmd = "wipefs -a {0}"
     umount_cmd = "umount {0}"
     testfile_name = "/media/format_disk-test.txt"
     writefile_cmd = "echo %s > %s"

--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -231,20 +231,19 @@
             drive_index_stg = 1
             create_image_stg = yes
             remove_image_stg = yes
-            image_size_stg = 10M
-            fdisk_string = "10 MB, 10485760 bytes"
-            format_timeout = 400
+            image_size_stg = 16G
             check_serial_option = yes
             check_removable_option = yes
             check_io_size_option = yes
             # The following parameters will be overridden in guest-os config files.
             create_partition_cmd = ""
-            format_cmd = "yes |mkfs $(readlink -f `ls /dev/disk/by-path/* | grep usb`)"
+            format_cmd = "yes | mkfs.ext4 {0}"
             list_disk_cmd = ""
             set_online_cmd = ""
-            chk_mount_cmd = "grep -qs $(readlink -f `ls /dev/disk/by-path/* | grep usb`) /proc/mounts"
-            mount_cmd =  "mount $(readlink -f `ls /dev/disk/by-path/* | grep usb`) /media"
-            umount_cmd = "umount $(readlink -f `ls /dev/disk/by-path/* | grep usb`)"
+            show_mount_cmd = "mount | grep {0}"
+            wipefs_cmd = "wipefs -a {0}"
+            mount_cmd =  "mkdir -p /media && mount {0} /media"
+            umount_cmd = "umount {0}"
             testfile_name = "/media/usb_storage-test.txt"
             writefile_cmd = "echo "set -e" > /media/md5chk.sh;"
             writefile_cmd += " out=%s;"
@@ -317,7 +316,6 @@
             force_create_image_image1 = no
             remove_image = yes
             remove_image_image1 = no
-            cmd_timeout = 1000
             stg_image_size = 1G
             stg_image_boot = no
             stg_image_format = qcow2


### PR DESCRIPTION
Add umount and wipefs steps before formatting in case the hard drive
contains a mounted filesystem.

ID: 1815053
Signed-off-by: ybduan <yduan@redhat.com>