### PR TITLE
fio_linux: Add fio installation timeout value to make it work on s390x

### DIFF
--- a/provider/storage_benchmark.py
+++ b/provider/storage_benchmark.py
@@ -342,11 +342,12 @@ class FioLinuxCfg(object):
         self.fio_path = '%s/bin/fio' % self.fio_inst
         scp_benckmark = attrgetter('scp_benckmark')
         unpack_file = attrgetter('unpack_file')
+        install_timeout = params.get_numeric('fio_install_timeout', 300)
         install = attrgetter('install')
         self.setups = {scp_benckmark: (params.get('username'), params.get('password'),
                                        host_path, self.download_path),
                        unpack_file: (TAR_UNPACK, self.download_path, self.fio_inst),
-                       install: (self.fio_inst, self.fio_inst)}
+                       install: (self.fio_inst, self.fio_inst, install_timeout)}
         self.setup_orders = (scp_benckmark, unpack_file, install)
 
 

--- a/qemu/tests/cfg/fio_linux.cfg
+++ b/qemu/tests/cfg/fio_linux.cfg
@@ -15,6 +15,8 @@
     fio_options += '${fio_default_options} --rw=randread;'
     fio_options += '${fio_default_options} --rw=randwrite;'
     fio_options += '${fio_default_options} --rw=randrw'
+    s390x:
+        fio_install_timeout = 600
     variants:
         - aio_native:
             image_aio_stg0 = native


### PR DESCRIPTION
1. storage_benchmark: Add code to transfer fio installation timeout value from cfg file
2. fio_linux: Add fio installation timeout value for s390x in the cfg file

ID: 1815458
Signed-off by: Nini Gu <ngu@redhat.com>