### PR TITLE
commit_snapshot_to_raw_backing: add switch for size check 

### DIFF
--- a/qemu/tests/cfg/commit_snapshot_to_raw_backing.cfg
+++ b/qemu/tests/cfg/commit_snapshot_to_raw_backing.cfg
@@ -21,6 +21,7 @@
     dd_total_size = "${dd_bs_val} * ${dd_bs_count} * 1024 ** 2"
     file_create_cmd = "dd if=/dev/urandom of=%s bs=${dd_bs_val}M count=${dd_bs_count}"
     guest_file_name = ${tmp_file_name}
+    snapshot_size_check_after_commit = yes
     Windows:
         guest_file_name = C:\testfile
         x86_64:


### PR DESCRIPTION
id: 1816522
if image is a block device, the size check will fail the case because
QEMU fails to get correct size info from block device. So add a switch
to enable tester to turn off the snapshot size check.

Signed-off-by: lolyu <lolyu@redhat.com>