### PR TITLE
Set rebase_mode unsafe for some storage_vm_migration cases

### DIFF
--- a/qemu/tests/cfg/blockdev_commit.cfg
+++ b/qemu/tests/cfg/blockdev_commit.cfg
@@ -33,6 +33,7 @@
     #mode = "absolute-paths"
     base_tag = sn1
     top_tag = sn3
+    rebase_mode = unsafe
     Host_RHEL.m8:
         node = ${device}
         qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_full_backup.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup.cfg
@@ -20,6 +20,7 @@
     sync = full
     source_images = src1
     target_images = dst1
+    rebase_mode = unsafe
     variants:
         - with_data_plane:
            only Host_RHEL

--- a/qemu/tests/cfg/blockdev_full_backup_multi_disks.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_multi_disks.cfg
@@ -29,6 +29,7 @@
     target_images = dst1 dst2
     type = blockdev_full_backup_simple
     backup_options = "sync"
+    rebase_mode = unsafe
     variants:
         - with_data_plane:
            only Host_RHEL

--- a/qemu/tests/cfg/blockdev_full_mirror.cfg
+++ b/qemu/tests/cfg/blockdev_full_mirror.cfg
@@ -22,6 +22,7 @@
     sync = full
     auto-dismiss = true
     auto-finalize = true
+    rebase_mode = unsafe
     variants:
         - with_data_plane:
            only Host_RHEL

--- a/qemu/tests/cfg/blockdev_snapshot.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot.cfg
@@ -17,6 +17,7 @@
     image_format_sn1 = qcow2
     device = "drive_data"
     format = qcow2
+    rebase_mode = unsafe
     #mode = "absolute-paths"
     Host_RHEL.m8:
         node = "drive_data"

--- a/qemu/tests/cfg/blockdev_stream.cfg
+++ b/qemu/tests/cfg/blockdev_stream.cfg
@@ -17,6 +17,7 @@
     image_format_sn1 = qcow2
     device = "drive_data"
     format = qcow2
+    rebase_mode = unsafe
     #mode = "absolute-paths"
     Host_RHEL.m8:
         node = "drive_data"


### PR DESCRIPTION
blockdev_snapshot:set rebase_mode unsafe
blockdev_commit:set rebase_mode unsafe
blockdev_stream:set rebase_mode unsafe
blockdev_full_mirror:set rebase_mode unsafe
blockdev_full_backup_multi_disks:set rebase mode unsafe

Signed-off-by: Aihua Liang <aliang@redhat.com>

id:1817908