### PR TITLE
Make cpu hotplug cases work on s390

### DIFF
--- a/provider/cpu_utils.py
+++ b/provider/cpu_utils.py
@@ -38,7 +38,8 @@ def get_guest_cpu_ids(session, os_type):
         return set()
     cmd = "grep processor /proc/cpuinfo"
     output = session.cmd_output(cmd)
-    return set(map(int, re.findall(r"(\d+)$", output, re.M)))
+    return set(map(int, re.findall(r"processor\s+(?::\s)?(\d+)",
+                                   output, re.M)))
 
 
 def check_guest_cpu_topology(session, os_type, cpuinfo):

--- a/qemu/tests/cfg/cpu_device_hotplug_during_boot.cfg
+++ b/qemu/tests/cfg/cpu_device_hotplug_during_boot.cfg
@@ -5,9 +5,11 @@
     qemu_sandbox = on
     vcpu_devices = vcpu1
     only Linux
+    no aarch64
     no ovmf
     no RHEL.6
     variants:
         - @only_plug:
         - with_unplug:
+            no s390x
             unplug_during_boot = yes

--- a/qemu/tests/cfg/cpu_device_hotpluggable.cfg
+++ b/qemu/tests/cfg/cpu_device_hotpluggable.cfg
@@ -1,9 +1,12 @@
 # Notes:
 #    For ppc64/ppc64le, please manually specify cpu_model in your environment
 - cpu_device_hotpluggable: install setup image_copy unattended_install.cdrom
-    only ppc64 ppc64le x86_64
+    no aarch64
     Windows:
-        no WinXP, WinVista, Win7, Win8, Win10, Win2000, Win2003
+        # TBD: Please update the list when new supported Win OS comes out
+        only Win2008, Win2012, Win2016, Win2019
+    Win2008, Win2012, s390x:
+        check_cpu_topology = no
     # ovmf does not support hotpluggable vCPU yet, this line will be removed
     # when it is fully supported.
     no ovmf
@@ -35,6 +38,8 @@
             hotplug:
                 Linux:
                     sub_test_after_migrate = reboot hotunplug
+                    s390x:
+                        sub_test_after_migrate = reboot
                 Windows:
                     sub_test_after_migrate = reboot
             hotunplug:
@@ -44,6 +49,8 @@
             pause_vm_before_hotplug = yes
             Linux:
                 sub_test_type = pause_resume
+            s390x:
+                del sub_test_type
         - with_online_offline:
             only hotplug
             only Linux
@@ -59,6 +66,7 @@
                 install_path = "C:\Program Files\JAM Software\HeavyLoad"
                 install_cmd = "start /wait %s:\HeavyLoadSetup.exe /verysilent"
         - with_numa:
+            no s390x
             only hotplug
             only multi_vcpu
             type = cpu_device_hotpluggable_with_numa
@@ -77,5 +85,6 @@
             vcpu_enable = no
         - hotunplug:
             only Linux
+            no s390x
             hotpluggable_test = hotunplug
             vcpu_enable = yes

--- a/qemu/tests/cfg/invalid_cpu_device_hotplug.cfg
+++ b/qemu/tests/cfg/invalid_cpu_device_hotplug.cfg
@@ -1,5 +1,5 @@
 - invalid_cpu_device_hotplug:
-    only x86_64 ppc64 ppc64le
+    no aarch64
     virt_test_type = qemu
     type = invalid_cpu_device_hotplug
     required_qemu = [2.6.0, )
@@ -16,8 +16,11 @@
                 error_desc = "core {0} already populated"
             x86_64:
                 Windows:
-                    no WinXP, WinVista, Win7, Win8, Win10, Win2000, Win2003
+                    # TBD: Please update the list when new supported Win OS comes out
+                    only Win2008, Win2012, Win2016, Win2019
                 error_desc = "CPU\[{0}\] with APIC ID \d+ exists"
+            s390x:
+                error_desc = "Unable to add CPU with core-id: {0}, it already exists"
         - invalid_id:
             execute_test = invalid_vcpu
             ppc64, ppc64le:
@@ -33,6 +36,9 @@
                     ppc64, ppc64le:
                         error_desc = "invalid core id {0}"
                         invalid_ids = 1 -1 -2
+                    s390x:
+                        error_desc = "Parameter 'core-id' expects uint32_t"
+                        invalid_ids = -1
                 - nr_threads:
                     invalid_property = nr-threads
                     only ppc64 ppc64le
@@ -44,3 +50,5 @@
                 error_desc = "core id {0} out of range"
             x86_64:
                 error_desc = "Invalid CPU {1}: {0} must be in range 0:{2}"
+            s390x:
+                error_desc = "Unable to add CPU with core-id: {0}, maximum core-id: {2}"

--- a/qemu/tests/cpu_device_hotpluggable.py
+++ b/qemu/tests/cpu_device_hotpluggable.py
@@ -113,6 +113,7 @@ def run(test, params, env):
     hotpluggable_test = params["hotpluggable_test"]
     verify_wait_timeout = params.get_numeric("verify_wait_timeout", 60)
     sub_test_type = params.get("sub_test_type")
+    check_cpu_topology = params.get_boolean("check_cpu_topology", True)
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
@@ -159,9 +160,9 @@ def run(test, params, env):
     if vm.is_alive():
         session = vm.wait_for_login(timeout=login_timeout)
         check_guest_cpu_count(expected_vcpus)
-        if (expected_vcpus == maxcpus and
-                not cpu_utils.check_guest_cpu_topology(session, os_type,
-                                                       vm.cpuinfo)):
-            session.close()
-            test.fail("CPU topology of guest is inconsistent with "
-                      "expectations.")
+        if expected_vcpus == maxcpus and check_cpu_topology:
+            if not cpu_utils.check_guest_cpu_topology(session, os_type,
+                                                      vm.cpuinfo):
+                session.close()
+                test.fail("CPU topology of guest is inconsistent with "
+                          "expectations.")


### PR DESCRIPTION
1. update pattern in `get_guest_cpu_ids` to make it work on s390
2. update to make some existing cpu hotplug cases work on s390
3. make a simple change so that some windows versions do not check cpu topology

Bug ID: 1817863, 1792104
Signed-off-by: Yihuang Yu <yihyu@redhat.com>