### PR TITLE
vioinput_hotplug: delete import module line to fix ci check failed issue

### DIFF
--- a/qemu/tests/vioinput_hotplug.py
+++ b/qemu/tests/vioinput_hotplug.py
@@ -2,9 +2,7 @@ import logging
 import time
 
 from virttest import error_context
-from virttest.qemu_devices import qdevices
 from provider import input_tests
-#from avocado.core import exceptions
 
 
 @error_context.context_aware


### PR DESCRIPTION
Due to there has a unused module on vioinpu_hotplug.py file,
many patch hit ci check failed issue, here delete it.

id:1820138
Signed-off-by: Peixiu Hou <phou@redhat.com>