### PR TITLE
qemu..migration: Run pre_migrate before each iteration and set_speed fixes

### DIFF
--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -199,11 +199,6 @@ def run(test, params, env):
                 test.error("migration bg check command failed")
             session2.close()
 
-            # run some functions before migrate start.
-            pre_migrate = get_functions(params.get("pre_migrate"), globals())
-            for func in pre_migrate:
-                func(vm, params, test)
-
             # Start stress test in guest.
             guest_stress_test = params.get("guest_stress_test")
             if guest_stress_test:
@@ -219,10 +214,14 @@ def run(test, params, env):
             target_mig_parameters = params.get("target_migrate_parameters", "None")
             target_mig_parameters = ast.literal_eval(target_mig_parameters)
             migrate_parameters = (mig_parameters, target_mig_parameters)
+            pre_migrate = get_functions(params.get("pre_migrate"), globals())
 
             # Migrate the VM
             ping_pong = params.get("ping_pong", 1)
             for i in range(int(ping_pong)):
+                # run some functions before migrate start
+                for func in pre_migrate:
+                    func(vm, params, test)
                 if i % 2 == 0:
                     logging.info("Round %s ping..." % str(i / 2))
                 else:

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -129,7 +129,7 @@ def run(test, params, env):
         vm.monitor.migrate_set_speed(mig_speed)
 
         cmd = ("%s/cpuflags-test --stressmem %d,%d" %
-               (os.path.join(install_path, "cpu_flags"),
+               (os.path.join(install_path, "cpu_flags", "src"),
                 vm_mem * 4, vm_mem / 2))
         logging.debug("Sending command: %s" % (cmd))
         session.sendline(cmd)

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -87,6 +87,8 @@ def run(test, params, env):
         last_transfer_mem = 0
         transfered_mem = 0
         mig_stat = Statistic()
+        while vm.monitor.get_migrate_progress() == 0:
+            pass
         for _ in range(30):
             o = vm.monitor.info("migrate")
             warning_msg = ("Migration already ended. Migration speed is"

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -139,7 +139,8 @@ def run(test, params, env):
         clonevm = vm.migrate(mig_timeout, mig_protocol,
                              not_wait_for_migration=True, env=env)
 
-        mig_speed = int(utils_misc.normalize_data_size(mig_speed, "M"))
+        mig_speed = int(float(
+            utils_misc.normalize_data_size(mig_speed, "M")))
 
         mig_stat = get_migration_statistic(vm)
 


### PR DESCRIPTION
With multiple ping_pong iterations I noticed the mig_set_speed does not actually work properly. It's because the migrate_set_speed needs to be issued before each iteration and not just once. I checked the currently existing pre_migrate functions and it looks like having them executed before each iteration makes sense so I'd like to propose doing that.

While testing this I noticed the "migration_with_speed_measurement" test is a bit broken, so added a few fixes.