### PR TITLE
Fixed bug about boot_order_check when run it with q35

### DIFF
--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -6,6 +6,7 @@
     kill_vm = yes
     boot_menu = on
     enable_sga = yes
+    devices_load_timeout = 10
     # we have QEMU machine with three NICs (virtio, e1000, rtl8139)
     # and two disks (default, IDE). firmware should try to boot from the bootindex=1
     # first. If this fails, it should try the bootindex=2 next, and so on.


### PR DESCRIPTION
Wait a time interval until get the device pci address

It needs more time to get the complete 'info pci' information, so wait a time interval to get the device pci address.

ID:1820473

Signed-off-by: Leidong Wang <leidwang@redhat.com>