### PR TITLE
blockdev_snapshot: add support for linux only

### DIFF
--- a/qemu/tests/cfg/blockdev_snapshot.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot.cfg
@@ -18,6 +18,7 @@
     device = "drive_data"
     format = qcow2
     rebase_mode = unsafe
+    only Linux
     #mode = "absolute-paths"
     Host_RHEL.m8:
         node = "drive_data"

--- a/qemu/tests/cfg/blockdev_snapshot_multi_disks.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_multi_disks.cfg
@@ -27,3 +27,4 @@
     image_format_sn1 = qcow2
     image_name_sn1 = images/sn1
     image_name_sn2 = images/sn2
+    only Linux

--- a/qemu/tests/cfg/blockdev_snapshot_reboot.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_reboot.cfg
@@ -10,6 +10,7 @@
     device = "drive_image1"
     base_tag = "image1"
     rebase_mode = unsafe
+    only Linux
     Host_RHEL.m8:
         node = "drive_image1"
         overlay = "drive_sn1"

--- a/qemu/tests/cfg/blockdev_snapshot_stop_cont.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_stop_cont.cfg
@@ -10,6 +10,7 @@
     device = "drive_image1"
     base_tag = "image1"
     rebase_mode = unsafe
+    only Linux
     Host_RHEL.m8:
         node = "drive_image1"
         overlay = "drive_sn1"

--- a/qemu/tests/cfg/blockdev_snapshot_stress.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_stress.cfg
@@ -10,6 +10,7 @@
     device = "drive_image1"
     base_tag = "image1"
     rebase_mode = unsafe
+    only Linux
     Host_RHEL.m8:
         node = "drive_image1"
         overlay = "drive_sn1"

--- a/qemu/tests/cfg/blockdev_stream.cfg
+++ b/qemu/tests/cfg/blockdev_stream.cfg
@@ -18,6 +18,7 @@
     device = "drive_data"
     format = qcow2
     rebase_mode = unsafe
+    only Linux
     #mode = "absolute-paths"
     Host_RHEL.m8:
         node = "drive_data"

--- a/qemu/tests/cfg/live_backup_add_bitmap.cfg
+++ b/qemu/tests/cfg/live_backup_add_bitmap.cfg
@@ -11,6 +11,7 @@
     bitmaps = bitmap0
     target_image_bitmap0 = stg
     shutdown_timeout = 360
+    only Linux
     variants:
         - with_qcow2:
             image_format_stg = qcow2


### PR DESCRIPTION
Add support for linux only on snapshot and stream cases

Signed-off-by: Aihua Liang <aliang@redhat.com>

id: 1825076