### PR TITLE
timedrift_adjust_time: add four timer device cases

### DIFF
--- a/qemu/tests/cfg/timedrift_adjust_time.cfg
+++ b/qemu/tests/cfg/timedrift_adjust_time.cfg
@@ -14,7 +14,14 @@
     host_epoch_time_cmd = 'epoch=$(date +%s); datetime=$(date);'
     host_epoch_time_cmd += 'echo "datetime: $datetime epoch: $epoch"'
     time_difference = 0
+    hwclock_time_command = "hwclock -u"
+    hwclock_time_filter_re = "(\d+-\d+-\d+ \d+:\d+:\d+).*"
+    hwclock_time_format = "%Y-%m-%d %H:%M:%S"
+    RHEL.6, RHEL.7:
+        hwclock_time_filter_re = "(\S+ \S+\s+\d+ \d+:\d+:\d+ \d+).*"
+        hwclock_time_format = "%a %b %d %H:%M:%S %Y"
     variants:
+        - no_adjust_clock:
         - adjust_host_clock:
             seconds_to_forward = 1800
             set_host_time_cmd = 'date -s "${seconds_to_forward} seconds"; hwclock -w'
@@ -41,13 +48,16 @@
                 rtc_base = localtime
     variants:
         - guest_pause_resume:
-            only adjust_host_clock
+            only no_adjust_clock adjust_host_clock
             vm_action = pause_resume
             sleep_seconds = 1800
-            time_difference = 3600
+            time_difference = 1800
+            time_difference_hwclock = 0
         - guest_reboot:
+            no no_adjust_clock
             vm_action = reboot
             time_difference = 0
+            time_difference_hwclock = 0
         - guest_s3:
             only adjust_host_clock
             vm_action = suspend_resume
@@ -61,10 +71,17 @@
         read_clock_source_cmd += "/clocksource0/current_clocksource"
         timedrift_adjust_time.guest_reboot.clock_vm.adjust_host_clock:
             time_difference = 1800
+            time_difference_hwclock = 1800
         timedrift_adjust_time.guest_s3.clock_vm.adjust_host_clock:
             time_difference = 1800
         timedrift_adjust_time.guest_s3.clock_host.adjust_host_clock:
             time_difference = 1800
+        timedrift_adjust_time.guest_pause_resume.clock_vm.no_adjust_clock:
+            time_difference = 1800
+            time_difference_hwclock = 1800
+        timedrift_adjust_time.guest_pause_resume.clock_vm.adjust_host_clock:
+            time_difference = 1800
+            time_difference_hwclock = 3600
     RHEL.6:
         timedrift_adjust_time.guest_reboot..adjust_guest_clock:
         time_difference = 1800
@@ -84,6 +101,8 @@
         timedrift_adjust_time.guest_reboot.clock_vm.adjust_host_clock:
             time_difference = 1800
         timedrift_adjust_time.guest_s3.clock_vm.adjust_host_clock:
+            time_difference = 1800
+        timedrift_adjust_time.guest_pause_resume..no_adjust_clock:
             time_difference = 1800
     Win7, Win2008:
         timedrift_adjust_time.guest_pause_resume.clock_host.adjust_host_clock:


### PR DESCRIPTION
Case 1:resume a paused VM with "-rtc base=localtime,clock=vm" (only windows)
Case 2:resume a paused VM with "-rtc base=localtime,clock=host" (only windows)
Case 3:resume a paused VM with "-rtc base=utc,clock=vm" (only linux)
Case 4:resume a paused VM with "-rtc base=utc,clock=host" (only linux)

bug id: 1825738, 1828028, 1828029, 1828030
Signed-off-by: yama <yama@redhat.com>