### PR TITLE
cd_bootindex: remove cdroms to avoid bootindex conflict

### DIFF
--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -27,6 +27,10 @@
     force_create_image_stg2 = yes
     remove_image_stg2 = yes
     nic_addr_filter = "%s.*?Bus\s+(\d+),\s+device\s+(\d+),\s+function\s+(\d+)"
+    # The default cdroms, which obtain bootindex automatically, would cause
+    # bootindex conflict in this case, so cleanup the default cdroms that are
+    # redundant for this case.
+    cdroms = ''
     variants:
         - bootorder0:
             # Some firmware has limitations on which devices can be considered for


### PR DESCRIPTION
ID: 1821606 
Signed-off-by: ybduan <yduan@redhat.com>