### PR TITLE
add timer device case

### DIFF
--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -50,6 +50,7 @@
         - boot_test:
             no RHEL.3 RHEL.4 RHEL.5 RHEL.6
             type = timerdevice_boot
+            start_vm = no
             i386, x86_64:
                 rtc_drift = slew
             timerdevice_drift_threshold = 3
@@ -87,19 +88,30 @@
                     only ppc64 ppc64le
                     timerdevice_clksource = "timebase"
             variants:
+                - without_host_load:
+                - with_host_load:
+                    login_timeout = 600
+                    only clock_host
+                    no clksource_tsc
+                    reboot_immediately:
+                        only Linux
+                    with_boot:
+                        repeat_nums = 6
+                        sleep_time = 600
+                    Linux:
+                        timerdevice_host_load_cmd = "for (( I=0; I<%s; I++ ));"
+                        timerdevice_host_load_cmd += " do taskset -c $I /bin/bash -c"
+                        timerdevice_host_load_cmd += " 'for ((;;)); do X=1; done &'; done"
+                        timerdevice_host_load_stop_cmd = "pkill -f 'do X=1'"
+                    Windows:
+                        stress_install_from_repo = "no"
+                        download_url_stress = 'stress/stress-1.0.4.tar.gz'
+                        timerdevice_host_load_cmd = "--cpu %s --io 4 --vm 2 --vm-bytes 256M"
+                        timerdevice_host_load_stop_cmd = "pkill -9 stress"
+            variants:
                 - with_boot:
                 - with_reboot:
                     timerdevice_reboot_test = yes
-                    variants:
-                        - without_host_load:
-                        - with_host_load:
-                            only Linux
-                            only clksource_kvm-clock..clock_host
-                            login_timeout = 600
-                            timerdevice_host_load_cmd = "for (( I=0; I<`grep processor /proc/cpuinfo"
-                            timerdevice_host_load_cmd += " | wc -l`; I++ )); do taskset -c $I /bin/bash -c"
-                            timerdevice_host_load_cmd += " 'for ((;;)); do X=1; done &'; done"
-                            timerdevice_host_load_stop_cmd = "pkill -f 'do X=1'"
                     variants:
                         - reboot_immediately:
                         - reboot_after_sleep:

--- a/qemu/tests/cfg/timerdevice.cfg
+++ b/qemu/tests/cfg/timerdevice.cfg
@@ -94,6 +94,7 @@
                         - without_host_load:
                         - with_host_load:
                             only Linux
+                            only clksource_kvm-clock..clock_host
                             login_timeout = 600
                             timerdevice_host_load_cmd = "for (( I=0; I<`grep processor /proc/cpuinfo"
                             timerdevice_host_load_cmd += " | wc -l`; I++ )); do taskset -c $I /bin/bash -c"
@@ -102,6 +103,7 @@
                     variants:
                         - reboot_immediately:
                         - reboot_after_sleep:
+                            only with_host_load
                             timerdevice_sleep_time = 3600
         - tscsync:
             only Linux


### PR DESCRIPTION
boot the guest with "-rtc base=utc,clock=host" when host 100% load (only linux)
boot the guest with "-rtc base=localtime,clock=host" when host 100% load (only windows)
reboot a guest with "-rtc base=localtime,clock=host" when host 100% load (only windows)

bug id: 1827016, 1836202, 1846824
Signed-off-by: yama <yama@redhat.com>