### PR TITLE
ansible_test: Add a basic ansible playbook test

### DIFF
--- a/qemu/tests/ansible_test.py
+++ b/qemu/tests/ansible_test.py
@@ -1,0 +1,82 @@
+import os
+import json
+import logging
+
+from avocado.utils import process
+from avocado.utils import software_manager
+
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Ansible playbook basic test:
+    1) Check ansible package exists
+    2) Launch the guest
+    3) Clone an ansible playbook repo
+    4) Generate the ansible-playbook command
+    5) Execute the playbook and verify the return status
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    sm = software_manager.SoftwareManager()
+    if not (sm.check_installed("ansible") or sm.install("ansible")):
+        test.cancel("ansible package install failed")
+
+    get_ip_timeout = params.get_numeric("get_ip_timeout")
+    guest_user = params["username"]
+    guest_passwd = params["password"]
+    ansible_callback_plugin = params.get("ansible_callback_plugin")
+    ansible_addl_opts = params.get("ansible_addl_opts", "")
+    ansible_ssh_extra_args = params["ansible_ssh_extra_args"]
+    ansible_extra_vars = params.get("ansible_extra_vars", "{}")
+    playbook_repo = params["playbook_repo"]
+    playbook_timeout = params.get_numeric("playbook_timeout")
+    playbook_dir = params.get("playbook_dir",
+                              os.path.join(test.workdir, "ansible_playbook"))
+    toplevel_playbook = os.path.join(playbook_dir, params["toplevel_playbook"])
+    # Use this directory to copy some logs back from the guest
+    test_harness_log_dir = test.logdir
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    guest_ip = vm.wait_for_get_address(0, get_ip_timeout)
+
+    logging.info("Cloning %s", playbook_repo)
+    process.run("git clone {src} {dst}".format(src=playbook_repo,
+                                               dst=playbook_dir), verbose=False)
+
+    error_context.base_context("Generate playbook related options.",
+                               logging.info)
+    extra_vars = {"ansible_ssh_extra_args": ansible_ssh_extra_args,
+                  "ansible_ssh_pass": guest_passwd,
+                  "test_harness_log_dir": test_harness_log_dir}
+    extra_vars.update(json.loads(ansible_extra_vars))
+
+    ansible_cmd_options = ["ansible-playbook",
+                           "-u {}".format(guest_user),
+                           "-i {},".format(guest_ip),
+                           "-e '{}'".format(json.dumps(extra_vars)),
+                           ansible_addl_opts,
+                           toplevel_playbook]
+    ansible_cmd = r" ".join(ansible_cmd_options)
+
+    error_context.context("Execute the ansible playbook.", logging.info)
+    env_vars = ({"ANSIBLE_STDOUT_CALLBACK": ansible_callback_plugin}
+                if ansible_callback_plugin else None)
+    logging.info("Command of ansible playbook: '%s'", ansible_cmd)
+    play_s, play_o = process.getstatusoutput(ansible_cmd,
+                                             timeout=playbook_timeout,
+                                             shell=False, env=env_vars)
+    ansible_log = "ansible_playbook-{}.log".format(vm.name)
+    with open(os.path.join(test_harness_log_dir, ansible_log), "w") as log_file:
+        log_file.write(play_o)
+        log_file.flush()
+
+    if play_s != 0:
+        test.fail("Ansible playbook execution failed, please check the {} "
+                  "for details.".format(ansible_log))
+    logging.info("Ansible playbook execution passed.")

--- a/qemu/tests/cfg/ansible_test.cfg
+++ b/qemu/tests/cfg/ansible_test.cfg
@@ -1,0 +1,12 @@
+- ansible_test:
+    type = ansible_test
+    virt_test_type = qemu
+    playbook_repo = "https://github.com/ansible/test-playbooks.git"
+    # Top level playbook file
+    toplevel_playbook = "site.yml"
+    get_ip_timeout = 300
+    playbook_timeout = 600
+    ansible_callback_plugin = debug
+    ansible_ssh_extra_args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    # Here we can define an extra set of variables for the playbook with json format
+    #ansible_extra_vars = '{"debug_msg": "Hello Ansible!", "force_handlers": true}'


### PR DESCRIPTION
Add an Ansible Playbook test case. The playbook will be cloned from the
git repository. You can write the required "play/role/task". In this
case, all the tasks you defined in the playbook will be executed from
the host via "ansible-playbook". You can do anything in the guest with
your playbook :)

ID: 1841419
Signed-off-by: Yihuang Yu <yihyu@redhat.com>