### PR TITLE
Support nvdimm.nvdimm_basic on pseries

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -5,7 +5,13 @@
     vm_mem_limit = 30G
     kill_vm_on_error = yes
     login_timeout = 240
-    only x86_64
+    only x86_64, ppc64le
+    ppc64le:
+        required_qemu = [5, )
+        only nvdimm_basic
+        # PowerPC guests need to create the persistent memory device manually so far
+        nvdimm_ns_create_cmd = "ndctl create-namespace"
+        dimm_extra_params = "label-size=256m"
     no Windows
     no RHEL.6 RHEL.5 RHEL.4 RHEL.3
     no RHEL.7.2 RHEL.7.1 RHEL.7.0

--- a/qemu/tests/nvdimm.py
+++ b/qemu/tests/nvdimm.py
@@ -152,6 +152,9 @@ def run(test, params, env):
             time.sleep(10)
             mems += target_mems
         error_context.context("Verify nvdimm in monitor and guest", logging.info)
+        nvdimm_ns_create_cmd = params.get("nvdimm_ns_create_cmd")
+        if nvdimm_ns_create_cmd:
+            nvdimm_test.run_guest_cmd(nvdimm_ns_create_cmd)
         nvdimm_test.verify_nvdimm(vm, mems)
         error_context.context("Format and mount nvdimm in guest", logging.info)
         nvdimm_test.mount_nvdimm()


### PR DESCRIPTION
Pseries supports nvdimm device since qemu-5.0, add the basic test case for it.

ID: 1829139
Signed-off-by: Yihuang Yu <yihyu@redhat.com>