### PR TITLE
cpu_device_hotplug_maximum: update case 'max_socket' and 'max_thread'

### DIFF
--- a/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
+++ b/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
@@ -17,6 +17,7 @@
         extra_params = "-device intel-iommu,intremap=on,eim=on"
     variants:
         - max_socket:
+            only Linux
             vcpu_sockets = 0
             vcpu_cores = 1
             vcpu_threads = 1
@@ -25,13 +26,11 @@
             vcpu_cores = 0
             vcpu_threads = 1
         - max_thread:
+            only ppc64 ppc64le
+            smp = 8
             vcpu_sockets = 1
-            vcpu_cores = 1
-            vcpu_threads = 0
-            ppc64, ppc64le:
-                smp = 8
-                vcpu_threads = 8
-                vcpu_cores = 0
+            vcpu_cores = 0
+            vcpu_threads = 8
     variants:
         - @default:
         - with_hugepages:


### PR DESCRIPTION
1. Disable windows guest for case 'max_socket'
2. Only enable case 'max_thread' on ppc platform
ID: 1834564, 1834570
Signed-off-by: Yumei Huang <yuhuang@redhat.com>