### PR TITLE
Add the nbd image export/access test cases

### DIFF
--- a/qemu/tests/boot_from_nbd_image.py
+++ b/qemu/tests/boot_from_nbd_image.py
@@ -1,0 +1,53 @@
+import socket
+
+from virttest import qemu_storage
+
+from avocado import fail_on
+
+from avocado.utils import process
+
+from provider import qemu_img_utils as img_utils
+
+from provider.nbd_image_export import QemuNBDExportImage
+
+
+def run(test, params, env):
+    """
+    1) Create a local raw/qcow2/luks image
+    2) Export it with qemu-nbd
+    3) Convert remote system image to the exported nbd image
+    4) Start VM from the exported image
+    5) Log into VM
+    """
+    def _convert_image():
+        source = params['images'].split()[0]
+        target = params['convert_target']
+        source_params = params.object_params(source)
+        target_params = params.object_params(target)
+        source_image = qemu_storage.QemuImg(source_params, None, source)
+
+        # Convert source to target
+        fail_on((process.CmdError,))(source_image.convert)(
+            target_params, None, skip_target_creation=True)
+
+    nbd_export = QemuNBDExportImage(params, params["local_image_tag"])
+    nbd_export.create_image()
+    nbd_export.export_image()
+
+    # we only export image with local nbd server
+    localhost = socket.gethostname()
+    params['nbd_server_%s' % params['convert_target']
+           ] = localhost if localhost else 'localhost'
+
+    vm = None
+    try:
+        _convert_image()
+        vm = img_utils.boot_vm_with_images(test, params, env,
+                                           (params['convert_target'],))
+        session = vm.wait_for_login(
+            timeout=params.get_numeric("login_timeout", 480))
+        session.close()
+    finally:
+        if vm:
+            vm.destroy()
+        nbd_export.stop_export()

--- a/qemu/tests/cfg/remote_boot.cfg
+++ b/qemu/tests/cfg/remote_boot.cfg
@@ -1,5 +1,8 @@
 # Network storage backends:
 #   gluster_direct
+#   nbd
+#   iscsi_direct
+#   ceph
 # The following testing scenarios are covered:
 #   - with_local_image
 #       boot from remote storage with a local image attached
@@ -9,12 +12,94 @@
 #   - with_debug
 #       boot VM with valid and invalid debug levels, make sure
 #       the VM can start up without any error
+#   - with_nbd_boot_image
+#       - xpt_raw_as_raw_format_raw
+#         create a raw image
+#         export the raw image in raw format
+#         convert system image to the exported image
+#         boot from the exported image in raw format
+#       - xpt_qcow2_as_raw_format_qcow2
+#         create a qcow2(full/falloc) image
+#         export the qcow2 image in raw format
+#         convert system image to the exported image
+#         boot from the exported image in qcow2 format
+#       - xpt_luks_as_raw_format_luks
+#         create a luks image
+#         export the luks image in raw format
+#         convert system image to the exported image
+#         boot from the exported image in luks format
+#       - xpt_qcow2_as_qcow2_format_raw
+#         create a qcow2(no preallocation) image
+#         export the qcow2 image in qcow2 format
+#         convert system image to the exported image
+#         boot from the exported image in raw format
+#       - xpt_luks_as_luks_format_raw
+#         create a luks image
+#         export the luks image in luks format
+#         convert system image to the exported image
+#         boot from the exported image in raw format
+#   - repeated_reboot
+#       repeated reboot testing
 
 - boot_from_remote_storage:
     type = boot_from_remote
     virt_test_type = qemu
     bootindex_image1 = 0
     variants:
+        - repeated_reboot:
+            only iscsi_direct ceph gluster_direct nbd
+            type = boot
+            reboot_count = 5
+            reboot_method = shell
+            login_timeout = 480
+        - with_nbd_boot_image:
+            only nbd
+            type = boot_from_nbd_image
+            start_vm = 'no'
+
+            # The following is specified for a local image 'stg0',
+            # used for qemu-nbd export with ip access
+            local_image_tag = 'stg0'
+            image_name_stg0 = images/stg0
+            images += ' ${local_image_tag}'
+            enable_nbd_stg0 = 'no'
+            storage_type_stg0 ='filesystem'
+            remove_image_stg0 = 'yes'
+            nbd_port_stg0 = 10850
+
+            # The following is specified for nbd image 'stg1',
+            # i.e. the exported 'stg0', used for nbd image accessing
+            convert_target = 'stg1'
+            nbd_port_stg1 = ${nbd_port_stg0}
+            variants:
+                - xpt_raw_as_raw_format_raw:
+                    image_format_stg1 = 'raw'
+                    image_format_stg0 = 'raw'
+                    nbd_export_format_stg0 = 'raw'
+                - xpt_qcow2_as_raw_format_qcow2:
+                    only Host_RHEL.m8 Host_RHEL.m7.u2 Host_RHEL.m7.u3
+                    image_format_stg1 = 'qcow2'
+                    image_format_stg0 = 'qcow2'
+                    nbd_export_format_stg0 = 'raw'
+                    variants:
+                        - falloc:
+                            preallocated = falloc
+                        - full:
+                            preallocated = full
+                - xpt_luks_as_raw_format_luks:
+                    image_format_stg1 = 'luks'
+                    image_format_stg0 = 'luks'
+                    nbd_export_format_stg0 = 'raw'
+                    image_secret = redhat
+                - xpt_qcow2_as_qcow2_format_raw:
+                    image_format_stg1 = 'raw'
+                    image_format_stg0 = 'qcow2'
+                    nbd_export_format_stg0 = 'qcow2'
+                - xpt_luks_as_luks_format_raw:
+                    image_format_stg1 = 'raw'
+                    image_format_stg0 = 'luks'
+                    nbd_export_format_stg0 = 'luks'
+                    image_secret = redhat
         - with_debug:
             only gluster_direct
             scenario = boot_with_debug

--- a/qemu/tests/cfg/remote_image_access.cfg
+++ b/qemu/tests/cfg/remote_image_access.cfg
@@ -1,0 +1,119 @@
+# Network storage backends:
+#   nbd
+#
+# The following testing scenarios are covered:
+#   - with_nmap
+#     Create a local image with qemu-img
+#     Export it with qemu-nbd
+#     Scan the port
+#   - with_guestfish
+#     Access system image with guestfish without booting up vm
+#   - with_qemu_io.drop_connection
+#     Create a local image with qemu-img
+#     Export it with qemu-nbd
+#     Access nbd image with qemu-io -c 'quit'
+#   - with_qemu_io.drop_sync
+#     Create a text file with echo
+#     Export it with qemu-nbd
+#     Access nbd image with qemu-io -c 'read'
+#   - with_unix_socket
+#     Clone system image with qemu-img
+#     Export it with qemu-nbd(unix socket access)
+#     Boot VM from the exported image
+#   - with_ncat
+#     Clone system image with qemu-img
+#     Add it into VM(without device driver)
+#     Export it with internal NBD server
+#     Access it with ncat
+#     Boot from the exported nbd image
+
+- access_with_remote_storage:
+    only nbd
+    virt_test_type = qemu
+    start_vm = 'no'
+
+    # The following is specified for a local image 'stg0',
+    # used for qemu-nbd export with ip access
+    local_image_tag = 'stg0'
+    image_name_stg0 = images/stg0
+    enable_nbd_stg0 = 'no'
+    storage_type_stg0 ='filesystem'
+    image_size_stg0 = '1G'
+    remove_image_stg0 = 'yes'
+    nbd_export_format_stg0 = 'raw'
+    nbd_port_stg0 = 10850
+
+    # The following is specified for nbd image 'stg1',
+    # i.e. the exported 'stg0', used for accessing the nbd image
+    nbd_image_tag = 'stg1'
+    nbd_port_stg1 = ${nbd_port_stg0}
+    variants:
+        - with_ncat:
+            type = remote_image_ncat_access
+            kill_vm = 'yes'
+            cmds_installed_host += ' ncat'
+
+            # ncat quits only if timeout
+            errmsg_check = 'Idle timeout expired'
+            nbd_export_writable = 'yes'
+            image_format_stg1 = 'raw'
+            variants:
+                - with_inet:
+                    ncat_cmd = 'ncat {localhost} ${nbd_port_stg1} -i 2'
+
+                    # for tcp(type=inet) only
+                    nbd_unix_socket = ''
+                - with_socket:
+                    # for socket(type=unix) only
+                    nbd_server_stg0 = ''
+                    nbd_server_stg1 = ''
+                    nbd_unix_socket_stg0 = /var/run/nbd_${nbd_image_tag}.sock
+                    nbd_unix_socket_stg1 = ${nbd_unix_socket_stg0}
+                    ncat_cmd = 'ncat -U ${nbd_unix_socket_stg1} -i 2'
+        - with_unix_socket:
+            type = remote_image_unix_socket_access
+            images += ' ${local_image_tag}'
+
+            # for socket(type=unix) only
+            nbd_server_stg0 = ''
+            nbd_server_stg1 = ''
+            nbd_unix_socket_stg0 = /var/run/nbd_${nbd_image_tag}.sock
+            nbd_unix_socket_stg1 = ${nbd_unix_socket_stg0}
+        - with_nmap:
+            type = remote_image_nmap_access
+            cmds_installed_host += ' nmap'
+            images = ${local_image_tag}
+            force_create_image_stg0 = 'yes'
+            msg_check = '${nbd_port_stg0}/tcp open'
+            nmap_cmd = 'nmap {localhost} -p ${nbd_port_stg1}'
+
+            # for tcp(type=inet) only
+            nbd_unix_socket = ''
+        - with_qemu_io:
+            type = remote_image_qemu_io_access
+            images = ${local_image_tag}
+            qemu_io_cmd = '{qemu_io} {tls_creds} {secret} {fmt} -c "{subcmd}" {filename}'
+            variants:
+                - drop_connection:
+                    qemu_io_subcmd = 'quit'
+                - drop_sync:
+                    image_format_stg0 = 'raw'
+                    image_format_stg1 = ${nbd_export_format_stg0}
+                    nbd_export_name_stg0 = nbd_image_stg
+                    nbd_export_name_stg1 = ${nbd_export_name_stg0}
+                    create_description_cmd_stg0 = 'printf %02048d'
+                    create_image_cmd_stg0 = 'echo "{desc}" > {filename}'
+                    count_bytes = '100'
+                    qemu_io_subcmd = 'read 0 ${count_bytes}'
+                    msg_check = 'read ${count_bytes}/${count_bytes} bytes'
+        - with_guestfish:
+            only raw qcow2
+            only Linux
+            type = remote_image_guestfish_access
+            start_vm = 'yes'
+            kill_vm = 'yes'
+            cmds_installed_host += ' guestfish'
+            msg_check = 'Access image without booting up vm'
+            guest_file_name = /tmp/guestfish.testfile
+            write_cmd = 'export LIBGUESTFS_BACKEND=direct; guestfish --format={fmt} -a {uri} -i sh "echo ${msg_check} > ${guest_file_name}"'
+            read_cmd = 'export LIBGUESTFS_BACKEND=direct; guestfish --format={fmt} -a {uri} -i sh "cat ${guest_file_name}"'

--- a/qemu/tests/cfg/remote_negative.cfg
+++ b/qemu/tests/cfg/remote_negative.cfg
@@ -1,17 +1,52 @@
 # Network storage backends:
-#   iscsi_direct gluster_direct
+#   iscsi_direct
+#   gluster_direct
+#   nbd
 # The following testing scenarios are covered:
-# readonly_image:
-#   Failed to boot VM from a readonly image
-# remote_server_disconnected:
-#   Make remote server inaccessible one by one
-#   (make sure that at least one server is accessible),
-#   qemu can access VM without any issue
+#   - readonly_image
+#     Failed to boot VM from a readonly image
+#   - remote_server_disconnected
+#     Make remote server inaccessible one by one
+#     (make sure that at least one server is accessible),
+#     qemu can access VM without any issue
+#   - long_export_name
+#     Export an image with long export name(4096 bytes)
+#     Accessing it with qemu-img can get proper error msg
 
 - remote_storage_negative:
     virt_test_type = qemu
     kill_vm = yes
     variants:
+        - long_export_name:
+            only nbd
+            type = nbd_long_export_name
+            start_vm = no
+
+            # local image to be exported
+            images = 'stg0'
+            image_name_stg0 = images/stg0
+            enable_nbd_stg0 = 'no'
+            storage_type_stg0 ='filesystem'
+            image_size_stg0 = '1G'
+            image_format_stg0 = 'raw'
+            force_create_image_stg0 = 'yes'
+            remove_image_stg0 = 'yes'
+            nbd_export_format_stg0 = 'raw'
+            nbd_port_stg0 = 10850
+
+            # nbd image to be accessed, i.e.
+            # the exported 'stg0'
+            nbd_image_tag = 'stg1'
+            nbd_port_stg1 = ${nbd_port_stg0}
+            image_format_stg1 = 'raw'
+            nbd_unix_socket = ''
+
+            create_export_name_cmd = printf %{length}d 1|tr ' ' a
+            max_export_name_len = 4096
+            access_export_name_lens = 4097 4000 4095
+            errmsg_check_4097 = 'export name too long to send to server'
+            errmsg_check_4000 = 'Requested export not available'
+            errmsg_check_4095 = 'Requested export not available'
         - readonly_image:
             only iscsi_direct
             type = negative_create

--- a/qemu/tests/nbd_long_export_name.py
+++ b/qemu/tests/nbd_long_export_name.py
@@ -1,0 +1,69 @@
+import socket
+
+from avocado.utils import process
+
+from virttest import qemu_storage
+from virttest import error_context
+
+from provider.nbd_image_export import QemuNBDExportImage
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Create a local file with qemu-img command
+    2) Export the file in raw format with qemu-nbd,
+       the length of export name is the max 4096
+    3) Access the exported nbd file with qemu-image,
+       3.1) export name is exactly the same as 2)
+       3.2) length of export name is 4097
+       3.3) length of export name is 4000
+       3.4) length of export name is 4095
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _make_export_name(length):
+        return process.run(
+            params['create_export_name_cmd'].format(length=length),
+            ignore_status=True,
+            shell=True
+        ).stdout.decode().strip()
+
+    tag = params["images"].split()[0]
+    params['nbd_export_name'] = _make_export_name(
+        params['max_export_name_len'])
+
+    nbd_export = QemuNBDExportImage(params, tag)
+    nbd_export.export_image()
+
+    nbd_image_tag = params['nbd_image_tag']
+    nbd_image_params = params.object_params(nbd_image_tag)
+    localhost = socket.gethostname()
+    nbd_image_params['nbd_server'] = localhost if localhost else 'localhost'
+    qemu_img = qemu_storage.QemuImg(nbd_image_params, None, nbd_image_tag)
+
+    try:
+        # Access image with the export name, just make sure
+        # qemu-img info can access image successfully
+        out = qemu_img.info()
+        if 'file format: raw' not in out:
+            test.fail('Failed to access image, output(%s)' % out)
+
+        # Access image with wrong export names
+        for length in params['access_export_name_lens'].split():
+            nbd_image_params['nbd_export_name'] = _make_export_name(length)
+            qemu_img = qemu_storage.QemuImg(nbd_image_params,
+                                            None, nbd_image_tag)
+
+            try:
+                out = qemu_img.info()
+            except process.CmdError as e:
+                if params['errmsg_check_%s' % length] not in str(e):
+                    test.fail('Failed to get export name(%s) from output(%s)'
+                              % (qemu_img.params['nbd_export_name'], out))
+            else:
+                test.fail('qemu-img should fail due to wrong export name')
+    finally:
+        nbd_export.stop_export()

--- a/qemu/tests/remote_image_guestfish_access.py
+++ b/qemu/tests/remote_image_guestfish_access.py
@@ -1,0 +1,57 @@
+import logging
+
+from avocado.utils import process
+
+from virttest import qemu_storage
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Start VM to make sure it's a bootable system image, shutdown VM
+    2) Write a file into the image by guestfish without booting up vm
+    3) Read the file and check the content is exactly what we write
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    image_tag = params.get("images").split()[0]
+    image_object = qemu_storage.QemuImg(params.object_params(image_tag),
+                                        None, image_tag)
+    if image_object.image_access:
+        test.cancel('Access remote image with tls-creds is '
+                    'not supported by guestfish, skip the test')
+
+    # Make sure the image holds an OS instance
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    try:
+        session = vm.wait_for_login(
+            timeout=params.get_numeric("login_timeout", 360))
+        session.close()
+    finally:
+        vm.destroy()
+
+    msg = params['msg_check']
+    testfile = params['guest_file_name']
+    write_cmd = params['write_cmd'].format(fmt=image_object.image_format,
+                                           uri=image_object.image_filename)
+    read_cmd = params['read_cmd'].format(fmt=image_object.image_format,
+                                         uri=image_object.image_filename)
+
+    logging.info("Write file '%s'" % testfile)
+    result = process.run(write_cmd, ignore_status=True, shell=True)
+    if result.exit_status != 0:
+        test.fail('Failed to write a file, error message: %s'
+                  % result.stderr.decode())
+
+    logging.info("Read file '%s'" % testfile)
+    result = process.run(read_cmd, ignore_status=True, shell=True)
+    if result.exit_status != 0:
+        test.fail('Failed to read a file, error message: %s'
+                  % result.stderr.decode())
+    elif result.stdout.decode().strip() != msg:
+        test.fail("Message '%s' mismatched with '%s'"
+                  % (msg, result.stdout.decode()))

--- a/qemu/tests/remote_image_ncat_access.py
+++ b/qemu/tests/remote_image_ncat_access.py
@@ -1,0 +1,89 @@
+import socket
+
+from avocado.utils import process
+
+from virttest import error_context
+from virttest import qemu_storage
+from virttest import storage
+from virttest import data_dir
+
+from provider.nbd_image_export import InternalNBDExportImage
+
+from provider import qemu_img_utils as img_utils
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Clone system image with qemu-img
+    2) Export the image with qemu internal NBD server
+    3) ncate ip -p port or ncat -U /socket/path
+    4) Boot from the exported nbd image
+    5) Log into VM
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _create_image():
+        result = qemu_storage.QemuImg(
+            params, None, params['images'].split()[0]).dd(
+                output=storage.get_image_filename(
+                    params.object_params(params["local_image_tag"]),
+                    data_dir.get_data_dir()
+                ),
+                bs=1024*1024
+            )
+
+        if result.exit_status != 0:
+            test.fail('Failed to clone the system image, error: %s'
+                      % result.stderr.decode())
+
+    def _start_vm_without_image():
+        params['images'] = ''
+        vm = None
+        try:
+            vm = img_utils.boot_vm_with_images(test, params, env)
+            vm.verify_alive()
+        finally:
+            # let VT remove it
+            params['images'] = ' %s' % params['local_image_tag']
+        return vm
+
+    def _make_ncat_cmd():
+        ncat = ''
+        if params.get('nbd_unix_socket_%s' % params['nbd_image_tag']):
+            ncat = params['ncat_cmd']
+        else:
+            localhost = socket.gethostname()
+            params['nbd_server'] = localhost if localhost else 'localhost'
+            ncat = params['ncat_cmd'].format(localhost=params['nbd_server'])
+        return ncat
+
+    _create_image()
+    vm = _start_vm_without_image()
+
+    nbd_export = InternalNBDExportImage(vm, params, params['local_image_tag'])
+    nbd_export.hotplug_tls()
+    nbd_export.hotplug_image()
+    nbd_export.export_image()
+    params['nbd_export_name'] = nbd_export.get_export_name()
+
+    ncat_cmd = _make_ncat_cmd()
+    result = process.run(ncat_cmd, ignore_status=True, shell=True)
+    if params['errmsg_check'] not in result.stderr.decode().strip():
+        test.fail('Failed to read message(%s) from output(%s)'
+                  % (params['errmsg_check'], result.stderr.decode()))
+
+    vm2 = None
+    try:
+        # Start another VM from the nbd exported image
+        vm2 = img_utils.boot_vm_with_images(test, params, env,
+                                            (params["nbd_image_tag"],),
+                                            'vm2')
+        session = vm2.wait_for_login(
+            timeout=params.get_numeric("login_timeout", 480))
+        session.close()
+    finally:
+        if vm2:
+            vm2.destroy()

--- a/qemu/tests/remote_image_nmap_access.py
+++ b/qemu/tests/remote_image_nmap_access.py
@@ -1,0 +1,44 @@
+import socket
+
+from avocado.utils import process
+
+from virttest import error_context
+
+from provider.nbd_image_export import QemuNBDExportImage
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Create a local raw file with qemu-img
+    2) Export the file in raw format with qemu-nbd
+    3) Scan the port with nmap
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    nbd_export = QemuNBDExportImage(params, params["local_image_tag"])
+    nbd_export.export_image()
+
+    h = socket.gethostname()
+    params['nbd_server_%s' % params["nbd_image_tag"]] = h if h else 'localhost'
+    nmap_cmd = params['nmap_cmd'].format(
+        localhost=params['nbd_server_%s' % params["nbd_image_tag"]])
+    try:
+        result = process.run(nmap_cmd, ignore_status=True, shell=True)
+        if result.exit_status != 0:
+            test.fail('Failed to execute nmap, error: %s'
+                      % result.stderr.decode())
+
+        nbd_export.list_exported_image(
+            params["nbd_image_tag"],
+            params.object_params(params["nbd_image_tag"])
+        )
+
+        if params.get('msg_check'):
+            if params['msg_check'] not in result.stdout.decode().strip():
+                test.fail('Failed to read message(%s) from output(%s)'
+                          % (params['msg_check'], result.stderr.decode()))
+    finally:
+        nbd_export.stop_export()

--- a/qemu/tests/remote_image_qemu_io_access.py
+++ b/qemu/tests/remote_image_qemu_io_access.py
@@ -1,0 +1,104 @@
+import socket
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import storage
+from virttest import qemu_storage
+from virttest import utils_misc
+from virttest import error_context
+
+from provider.nbd_image_export import QemuNBDExportImage
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Create a local file by echo command
+    2) Export the file in raw format with qemu-nbd
+    3) Access the exported nbd file by qemu-io
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _prepare():
+        tag = params["local_image_tag"]
+        image_params = params.object_params(tag)
+
+        if image_params.get('create_description_cmd'):
+            params['nbd_export_description_%s' % tag] = process.run(
+                image_params['create_description_cmd'],
+                ignore_status=True,
+                shell=True
+            ).stdout.decode().strip()
+
+        if image_params.get('create_image_cmd'):
+            params['create_image_cmd_%s' % tag] = image_params['create_image_cmd'].format(
+                desc=params['nbd_export_description_%s' % tag],
+                filename=storage.get_image_filename(image_params,
+                                                    data_dir.get_data_dir())
+            )
+
+        # update nbd image's server to the local host
+        localhost = socket.gethostname()
+        params['nbd_server_%s' % params["nbd_image_tag"]
+               ] = localhost if localhost else 'localhost'
+
+    def _get_tls_creds_obj(tag, params):
+        tls_str = '--object tls-creds-x509,id={t.aid},endpoint=client,dir={t.tls_creds}'
+        tls = storage.StorageAuth.auth_info_define_by_params(tag, params)
+        return tls_str.format(t=tls) if tls else ''
+
+    def _get_secret_obj(tag, params):
+        secret_str = '--object secret,id={s.aid},data={s.data}'
+        secret = storage.ImageSecret.image_secret_define_by_params(tag, params)
+        return secret_str.format(s=secret) if secret else ''
+
+    def _make_qemu_io_cmd():
+        nbd_image = params["nbd_image_tag"]
+        nbd_image_params = params.object_params(nbd_image)
+
+        nbd_image_filename = storage.get_image_filename(nbd_image_params, None)
+        nbd_image_format = '-f %s' % nbd_image_params['image_format']
+
+        tls_obj = _get_tls_creds_obj(nbd_image, nbd_image_params)
+        sec_obj = _get_secret_obj(nbd_image, nbd_image_params)
+        if tls_obj or sec_obj:
+            nbd_image_format = ''
+            nbd_image_filename = "'%s'" % qemu_storage.get_image_json(
+                nbd_image, nbd_image_params, None)
+
+        qemu_io = utils_misc.get_qemu_io_binary(params)
+        return params['qemu_io_cmd'].format(qemu_io=qemu_io,
+                                            tls_creds=tls_obj,
+                                            secret=sec_obj,
+                                            fmt=nbd_image_format,
+                                            subcmd=params['qemu_io_subcmd'],
+                                            filename=nbd_image_filename)
+
+    _prepare()
+
+    nbd_export = QemuNBDExportImage(params, params["local_image_tag"])
+    nbd_export.create_image()
+    nbd_export.export_image()
+
+    qemu_io_cmd = _make_qemu_io_cmd()
+
+    try:
+        result = process.run(qemu_io_cmd, ignore_status=True, shell=True)
+        if result.exit_status != 0:
+            test.fail('Failed to execute qemu-io, error: %s'
+                      % result.stderr.decode())
+
+        if params.get('msg_check'):
+            if params['msg_check'] not in result.stdout.decode().strip():
+                test.fail('Failed to read message(%s) from output(%s)'
+                          % (params['msg_check'], result.stderr.decode()))
+
+        nbd_export.list_exported_image(
+            params["nbd_image_tag"],
+            params.object_params(params["nbd_image_tag"])
+        )
+    finally:
+        nbd_export.stop_export()

--- a/qemu/tests/remote_image_unix_socket_access.py
+++ b/qemu/tests/remote_image_unix_socket_access.py
@@ -1,0 +1,62 @@
+import logging
+
+from virttest import data_dir
+from virttest import storage
+from virttest import qemu_storage
+from virttest import error_context
+
+from provider import qemu_img_utils as img_utils
+
+from provider.nbd_image_export import QemuNBDExportImage
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Clone the system image1 with qemu-img
+    2) Export the cloned image with qemu-nbd(type=unix)
+    3) Start VM from the exported image
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _prepare():
+        logging.info("Clone system image with qemu-img")
+        result = qemu_storage.QemuImg(
+            params, None, params['images'].split()[0]).dd(
+                output=storage.get_image_filename(
+                    params.object_params(params["local_image_tag"]),
+                    data_dir.get_data_dir()
+                ),
+                bs=1024*1024
+        )
+        if result.exit_status != 0:
+            test.fail('Failed to clone the system image, error: %s'
+                      % result.stderr.decode())
+
+        # Remove the image after test by avocado-vt
+        # params['images'] += ' %s' % params["local_image_tag"]
+
+    _prepare()
+
+    # local image to be exported
+    nbd_export = QemuNBDExportImage(params, params["local_image_tag"])
+    nbd_export.export_image()
+
+    session = None
+    logging.info("Start VM from the exported image")
+
+    try:
+        # Start VM from the nbd exported image
+        vm = img_utils.boot_vm_with_images(test, params, env,
+                                           (params["nbd_image_tag"],))
+        session = vm.wait_for_login(
+            timeout=int(params.get("login_timeout", 360)))
+        if not session:
+            test.fail('Failed to log into VM')
+    finally:
+        if session:
+            session.close()
+        vm.destroy()
+        nbd_export.stop_export()


### PR DESCRIPTION
    Add the nbd image export/access test cases
    
      1. access system image with guestfish without vm bootup
      2. access exported image with qemu-io
        2.1 drop sync testing
        2.2 drop connection testing
      3. scan the port of exported image with nmap
      4. access image with unix domain socket
      5. export image in nbd internal server, access it with ncat
        5.1 export it with unix socket
        5.2 export it with inet
      6. boot from nbd image in raw/qcow2/luks format
        6.1 export raw image as raw image, access it as raw image
        6.2 export qcow2(full/falloc) image as raw image, access it as qcow2 image
        6.3 export luks image as raw image, access it as luks image
        6.4 export qcow2 image as qcow2 image, access it as raw image
        6.5 export luks image as luks image, access it as raw image
      7. Export image with max length of export name
        7.1 access it with export name
        7.2 access it with wrong export name
      8. Repeated reboot
    
    Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>
ID: 1825932, 1845047, 1845084, 1845089, 1845093, 1845103, 1845106, 1845108, 1845532