### PR TITLE
qemu_guest_agent: bug fix of keyerror

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -254,7 +254,7 @@
             image_snapshot = yes
         - check_fsinfo:
             gagent_check_type = fsinfo
-            blk_extra_params = "serial=GAGENT_TEST"
+            blk_extra_params_image1 = "serial=GAGENT_TEST"
             cmd_get_disk = cat /proc/mounts |grep -v rootfs |awk '$2~/^\%s$/{print $1,$3}'
             Windows:
                 cmd_get_disk = wmic volume where "DriveLetter='%s'" get FileSystem,DeviceID |findstr /v /i FileSystem

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -2336,7 +2336,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         """
         session = self._get_session(params, None)
         self._open_session_list.append(session)
-        serial_num = params["blk_extra_params"].split("=")[1]
+        serial_num = params["blk_extra_params_image1"].split("=")[1]
 
         error_context.context("Check all file system info in a loop.", logging.info)
         fs_info_qga = self.gagent.get_fsinfo()
@@ -2373,6 +2373,9 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 logging.info("Disk name is %s which is expected." % disk_name_qga)
 
             error_context.context("Check serial number of some disk.", logging.info)
+            if fs_type_qga == "UDF" or fs_type_qga == "CDFS":
+                logging.info("Only check block disk's serial info, no cdrom.")
+                continue
             serial_qga = fs["disk"][0]["serial"]
             if not re.findall(serial_num, serial_qga):
                 test.fail("Serial name is not correct via qga.\n"


### PR DESCRIPTION
For fs info test, there is no need to
check cdrom's info, check the normal disk's
serial number is enough.
ID: 1808951
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>