### PR TITLE
set "image_boot = no" to prevent bootindex option from appearing

### DIFF
--- a/qemu/tests/cfg/seabios_order_once.cfg
+++ b/qemu/tests/cfg/seabios_order_once.cfg
@@ -4,6 +4,7 @@
     boot_menu = on
     start_vm =no
     enable_sga = yes
+    image_boot = no
     images = "stg"
     image_name_stg = "images/stg"
     image_size_stg = 100M


### PR DESCRIPTION
set "image_boot = no" to prevent bootindex option from appearing

ID：1836802

Signed-off-by: Leidong Wang <leidwang@redhat.com>