### PR TITLE
block_hotplug_in_pause: Fix failed to unplug device

### DIFF
--- a/qemu/tests/cfg/block_hotplug_in_pause.cfg
+++ b/qemu/tests/cfg/block_hotplug_in_pause.cfg
@@ -55,3 +55,5 @@
             stop_vm_before_hotplug = yes
             resume_vm_after_hotplug = no
             stop_vm_before_unplug = no
+            Windows:
+                resume_vm_after_hotplug = yes


### PR DESCRIPTION
The device will still in qtree if the vm is paused after unplug
the frontend device in the blockdev mode and can not unplug the
backend blockdev nodes, so check qtree after resume the vm and
unplug the backend devices.

ID: 1749697
Signed-off-by: Yongxue Hong <yhong@redhat.com>