### PR TITLE
block_with_iommu: New case to reload kernel with iommu

### DIFF
--- a/qemu/tests/block_with_iommu.py
+++ b/qemu/tests/block_with_iommu.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from virttest import cpu
 from virttest import error_context
@@ -13,11 +14,31 @@ def run(test, params, env):
         1. Add "intel_iommu=on" to kernel line of q35 guest.
         2. Boot a guest with virtio-scsi with iommu_platform=on.
         3. Verify IOMMU enabled in the guest.
+        4. Reload kernel then reboot guest.
 
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
+    :param test: QEMU test object.
+    :param params: Dictionary with the test parameters.
     :param env: Dictionary with test environment.
     """
+
+    def _get_boot_file(cmd_get_boot_file):
+        """Get the boot file."""
+        current_kernel = session.cmd_output(params.get('cmd_get_kernel_ver'))
+        boot_files = session.cmd_output(cmd_get_boot_file).splitlines()
+        if len(boot_files) > 1:
+            for boot_file in boot_files:
+                if current_kernel not in boot_file:
+                    return boot_file
+        return boot_files[0]
+
+    def reload_kernel(session):
+        """Reload kernel."""
+        error_context.context('Reload kernel.', logging.info)
+        vmlinuz = _get_boot_file(params.get('cmd_get_boot_vmlinuz'))
+        initrd = _get_boot_file(params.get('cmd_get_boot_initramfs'))
+        orig_cmdline = session.cmd_output(params.get('cmd_get_boot_cmdline'))
+        new_cmdline = re.sub(r'vmlinuz\S+', vmlinuz, orig_cmdline).strip()
+        session.cmd(params.get('reload_kernel_cmd') % (vmlinuz, initrd, new_cmdline))
 
     def verify_iommu_enabled():
         """ Verify whether the iommu is enabled. """
@@ -37,3 +58,7 @@ def run(test, params, env):
     vm.verify_alive()
     session = vm.wait_for_login(timeout=360)
     verify_iommu_enabled()
+
+    if params.get('reload_kernel_cmd'):
+        reload_kernel(session)
+        vm.reboot(session)

--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -18,6 +18,18 @@
             virtio_dev_disable_modern = off
             check_key_words = "DMAR: IOMMU enabled;"
             check_key_words += "DMAR: Intel(R) Virtualization Technology for Directed I/O"
+            variants:
+                - @default:
+                - reload_kernel:
+                    clone_master = yes
+                    master_images_clone = image1
+                    remove_image_image1 = yes
+                    force_reset_go_down_check = shell
+                    reload_kernel_cmd = 'kexec -l /boot/%s --initrd=/boot/%s --command-line="%s"'
+                    cmd_get_kernel_ver = uname -r
+                    cmd_get_boot_cmdline = cat /proc/cmdline
+                    cmd_get_boot_vmlinuz = ls /boot/ | grep vmlinuz | grep -vE rescue
+                    cmd_get_boot_initramfs = ls /boot/ | grep initramfs | grep -vE rescue
         - with_installation:
             type = unattended_install
             only Windows


### PR DESCRIPTION
New a case to use command kexec to reload kernel under
the IOMMU mode.

ID: 1822052
Signed-off-by: Yongxue Hong <yhong@redhat.com>