### PR TITLE
cdrom_block_size_check: Improve codes

### DIFF
--- a/qemu/tests/cfg/cdrom_block_size_check.cfg
+++ b/qemu/tests/cfg/cdrom_block_size_check.cfg
@@ -3,6 +3,8 @@
     start_vm = no
     test_cdroms = none
     cdrom_without_file = yes
+    excepted_qmp_err = "Device '${test_cdroms}' is locked and force was not specified, "
+    excepted_qmp_err += "wait for tray to open and try again"
     Linux:
         check_cdrom_size_cmd = cat /sys/block/sr0/size
         mount_cdrom_cmd = "mount %s %s"


### PR DESCRIPTION
Improve codes by following:
1. Add checking "DEVICE_TRAY_MOVED" event after eject cdrom
   and change cdrom.
2. Add checking whether the cdrom's tray opened after change
   cdrom.

ID: 1778666, 1645000
Signed-off-by: Yongxue Hong <yhong@redhat.com>