### PR TITLE
gluster_peers is a string in json

### DIFF
--- a/qemu/tests/remote_server_disconnected.py
+++ b/qemu/tests/remote_server_disconnected.py
@@ -1,6 +1,7 @@
 import os
 import netaddr
 import logging
+import json
 
 from avocado.utils import process
 
@@ -23,9 +24,10 @@ def run(test, params, env):
                             " socket is supported by now.")
 
     hosts = []
-    if params.get("enable_gluster") == "yes":
+    if params.get_boolean("enable_gluster"):
         hosts.append(params["gluster_server"])
-        hosts.extend(params.get("gluster_peers", "").split())
+        hosts.extend([peer['host'] for peer in json.loads(
+            params.get('gluster_peers', '[]')) if 'host' in peer])
 
     _check_hosts(hosts)
     hosts.pop()  # The last server should be accessible


### PR DESCRIPTION
gluster_peers now is defined as 
gluster_peers = '[{"host": "dell-per415-03.lab.eng.pek2.redhat.com"},{"host":"hp-z420-01.qe.lab.eng.nay.redhat.com"}]'
instead of
gluster_peers = dell-per415-03.lab.eng.pek2.redhat.com hp-z420-01.qe.lab.eng.nay.redhat.com

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1842766