### PR TITLE
hugepage_specify_node: fix 'NoneType' object has no attribute 'cleanup'

### DIFF
--- a/qemu/tests/hugepage_specify_node.py
+++ b/qemu/tests/hugepage_specify_node.py
@@ -63,7 +63,8 @@ def run(test, params, env):
             error_context.context("Setup huge pages for idle node%s." %
                                   idle_node, logging.info)
         params["setup_hugepages"] = "yes"
-        hp_config = test_setup.HugePageConfig(params).setup()
+        hp_config = test_setup.HugePageConfig(params)
+        hp_config.setup()
         params["qemu_command_prefix"] = "numactl --membind=%s" % node_id
         params["start_vm"] = "yes"
         env_process.preprocess_vm(test, params, env, params["main_vm"])


### PR DESCRIPTION
hp_config is an example of HugePageConfig().setup() method,
so there is no cleanup() object.
Change hp_config to an instance of HugePageConfig(),
so that hp_config contains both .setup() and .cleanup().

ID: 1839632
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>