### PR TITLE
Fix unattend install issue for cd-rom installtion

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -189,6 +189,11 @@
             boot_once = d
             medium = cdrom
             redirs += " unattended_install"
+            virtio_scsi:
+                # disable iothread
+                iothread_scheme ?=
+                iothreads ?=
+                image_iothread ?=
         # Install guest from http/ftp url
         - url:
             only Linux


### PR DESCRIPTION
The reason is scsi-cd can not attatched scsi bus which enabled
data plane.
ID:1844920
Signed-off-by: qingwangrh <qinwang@redhat.com>