### PR TITLE
usb_controller: restrict uhci/ehci controllers only cover boot/reboot cases

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -10,12 +10,14 @@
     # usb controllers
     variants:
         - piix3-uhci:
+            only usb_boot, usb_reboot
             usb_type_usbtest = piix3-usb-uhci
             usb_controller = uhci
             max_ports_usbtest = 2
             drive_format_stg = "usb1"
             no ppc64 ppc64le
         - piix4-uhci:
+            only usb_boot, usb_reboot
             usb_type_usbtest = piix4-usb-uhci
             usb_controller = uhci
             max_ports_usbtest = 2
@@ -23,6 +25,7 @@
             no ppc64 ppc64le
             no Windows
         - ich9-uhci:
+            only usb_boot, usb_reboot
             usb_type_usbtest = ich9-usb-uhci6
             usb_controller = uhci
             max_ports_usbtest = 2
@@ -30,6 +33,7 @@
             no ppc64 ppc64le
             no Host_RHEL.m6
         - ich9-ehci:
+            only usb_boot, usb_reboot
             usb_controller = ehci
             max_ports = 6
             drive_format_stg = "usb2"
@@ -45,6 +49,7 @@
                     only usb_hotplug..usb_negative_test, usb_multi_disk
                     usb_type = ich9-usb-ehci2
         - usb-ehci:
+            only usb_boot, usb_reboot
             usb_type_usbtest = usb-ehci
             usb_type = usb-ehci
             usb_controller = ehci
@@ -64,7 +69,7 @@
             no RHEL.5
             no Host_RHEL.m6, Host_RHEL.m7.u0, Host_RHEL.m7.u1
             no Host_RHEL.m7.u2, Host_RHEL.m7.u3
-            usb_type_usbtest = nec-usb-xhci
+            usb_type_usbtest = qemu-xhci
             usb_type = qemu-xhci
             usb_controller = xhci
             max_ports = 4


### PR DESCRIPTION
1.restrict uhci/ehci controllers only cover boot/reboot cases
2.correct usb_type_usbtest for qemu-xhci

ID: 1845007

Signed-off-by: ybduan <yduan@redhat.com>