### PR TITLE
qemu_guest_agent:bug fix of hotunplug blockdev dev

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -2074,7 +2074,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                         session, disk_index[0], image_size_stg0, "windows", labeltype="msdos")
             session.cmd(disk_write_cmd % mnt_point[0])
             error_context.context("Unplug the added disk", logging.info)
-            self.vm.devices.simple_unplug(devs[0], self.vm.monitor)
+            self.vm.devices.simple_unplug(devs[-1], self.vm.monitor)
         finally:
             if self.gagent.get_fsfreeze_status() == self.gagent.FSFREEZE_STATUS_FROZEN:
                 try:


### PR DESCRIPTION
Block devices' hotunplug method is changed for blockdev backend.
ID: 1839670
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>