### PR TITLE
Find unused loop device as image device

### DIFF
--- a/qemu/tests/cfg/disk_extension.cfg
+++ b/qemu/tests/cfg/disk_extension.cfg
@@ -7,7 +7,6 @@
     drive_werror = stop
     drive_rerror = stop
     tmpfs_folder = "/tmp/xtmpfs"
-    loop_device = /dev/loop6
     # Please keep consistent unit
     begin_size = 50M
     max_size = 500M
@@ -29,7 +28,6 @@
     remove_image_stg1 = no
     disk_serial = TARGET_DISK0
     blk_extra_params_stg1 += "serial=${disk_serial}"
-    image_name_stg1 = ${loop_device}
     image_format_stg1 = qcow2
     image_size_stg1 = ${max_size}
     Linux:

--- a/qemu/tests/disk_extension.py
+++ b/qemu/tests/disk_extension.py
@@ -69,6 +69,10 @@ def run(test, params, env):
     size_unit = params["increment_size"][-1]
     guest_cmd = params["guest_cmd"]
 
+    loop_device = process.run("losetup -f").stdout.decode().strip()
+    params["image_name_stg1"] = loop_device
+    params["loop_device"] = loop_device
+
     loop_device_backend_img_tag = params["loop_device_backend_img_tag"]
     loop_device_img_tag = params["loop_device_img_tag"]
 


### PR DESCRIPTION
Fix using  static /dev/loop6 issue.
ID:1846226
Signed-off-by: qingwangrh <qinwang@redhat.com>