### PR TITLE
When L1 guest starts up slow will get SCP error

### DIFF
--- a/qemu/tests/cfg/nested_test.cfg
+++ b/qemu/tests/cfg/nested_test.cfg
@@ -11,10 +11,12 @@
     type = nested_test
     test_type = testcase
     install_node = no
-    test_timeout = 3600
+    login_timeout = 360
     variants nested_test:
         - boot_l2:
             case_name = boot
             install_node = yes
+            test_timeout = 5400
         - check_cpu_model_l2:
             case_name = x86_cpu_model
+            test_timeout = 1800

--- a/qemu/tests/nested_test.py
+++ b/qemu/tests/nested_test.py
@@ -49,11 +49,13 @@ def run(test, params, env):
         return invent_file.name
 
     def copy_network_script(env):
+        login_timeout = params.get_numeric("login_timeout", 360)
         deps_dir = virttest_data_dir.get_deps_dir()
 
         file_name = os.path.basename(setup_bridge_sh)
         br_file = os.path.join(deps_dir, file_name)
         for vm in get_live_vms(env):
+            vm.wait_for_login(timeout=login_timeout)
             vm.copy_files_to(br_file, setup_bridge_sh)
 
     def generate_parameter_file(params):


### PR DESCRIPTION
Fix two timing related bugs:

Bug 1847824 - [KVM_AUTOTEST] When L1 guest starts up slow will get SCP error 
Bug 1822117 - [KVM_AUTOTEST] No test log for L1 guest when ansible cmd terminated as timeout.

ID: 1847824, 1822117
Signed-off-by: Qinghua Cheng <qcheng@redhat.com>