### PR TITLE
usb_negative: correct usb_reply_msg to validate usb_negative_test

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -311,13 +311,15 @@
                     Host_RHEL.m6:
                         # Now no output from monitor for negative test on Host_RHEL.m6
                         usb_reply_msg = ""
-                    usb_reply_msg = "Property 'usb-host.productid' doesn't take value"
+                    usb_reply_msg = "Property 'usb-host.productid' doesn't take value;"
                     usb_reply_msg += "Parameter 'productid' expects an int64 value or range;"
                     usb_reply_msg += "Parameter 'vendorid' expects an int64 value or range;"
                     usb_reply_msg += "productid out of range;"
                     usb_reply_msg += "vendorid out of range;"
                     usb_reply_msg += "Parameter 'productid' expects uint32_t;"
                     usb_reply_msg += "Parameter 'vendorid' expects uint32_t;"
+                    usb_reply_msg += "Parameter 'productid' expects uint64;"
+                    usb_reply_msg += "Parameter 'vendorid' expects uint64"
                     usb_host_device_list = "aaa:aaa,aaa:111,21231:11231333,11231333:21231,21231:1123132233,2123133:1123132233111,1123132233111:111"
                 - usb_check_isobufs:
                     usb_check_isobufs = "yes"

--- a/qemu/tests/usb_host.py
+++ b/qemu/tests/usb_host.py
@@ -48,6 +48,7 @@ def run(test, params, env):
         vm = env.get_vm(params["main_vm"])
         vm.verify_alive()
         session = vm.wait_for_login()
+        usb_reply_msg_list = params.get("usb_reply_msg").split(";")
         usb_host_device_list = params["usb_host_device_list"].split(",")
         for dev in usb_host_device_list:
             vid, pid = dev.split(":")
@@ -55,7 +56,6 @@ def run(test, params, env):
             monitor_add += ",vendorid=%s" % vid
             monitor_add += ",productid=%s" % pid
             reply = vm.monitor.cmd(monitor_add)
-            usb_reply_msg_list = params.get("usb_reply_msg").split(";")
             negative_flag = False
             for msg in usb_reply_msg_list:
                 if msg in reply:
@@ -65,7 +65,6 @@ def run(test, params, env):
                 test.fail("Could not get expected warning"
                           " msg in negative test, monitor"
                           " returns: '%s'" % reply)
-        vm.reboot()
         return
 
     device = params["usb_host_device"]


### PR DESCRIPTION
1.remove the semicolon at the end of usb_reply_msg.
  usb_negative_test becomes invalid with this semicolon.
2.update usb_reply_msg with latest info.
3.remove the reboot step at the end of usb_negative_test.

ID: 1849539

Signed-off-by: ybduan <yduan@redhat.com>