### PR TITLE
Adding backup/restore image action for driver_load testing

### DIFF
--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -3,6 +3,9 @@
     kill_vm_on_error = yes
     login_timeout = 240
     repeats = 1
+    Windows:
+        backup_image_before_testing = yes
+        restore_image_after_testing = yes
     variants:
         - with_nic:
             no e1000


### PR DESCRIPTION
This testing will break windows OS image.
It result in other test case failed on BSOD.
ID:1848937
Signed-off-by: qingwangrh <qinwang@redhat.com>