### PR TITLE
usb_host: add I/O operation for passthrough usb stick

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -309,6 +309,10 @@
                     no usb_negative_test
                     #usbdev_option_vendorid_usbhostdev = xxxx
                     #usbdev_option_productid_usbhostdev = xxxx
+                - with_hostbus_hostaddr:
+                    no usb_negative_test
+                    #usbdev_option_hostbus_usbhostdev = xxxx
+                    #usbdev_option_hostaddr_usbhostdev = xxxx
             variants:
                 - usb_normal_test:
                 - usb_negative_test:

--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -296,14 +296,23 @@
                     check_removable_option = no
                     check_io_size_option = no
         - usb_host:
-            # must configure which device should be used
-            #usb_host_device = "<vendorid>:<productid>"
             type = usb_host
             #XXX: Now usb_host doesn't support QMP monitor.
             # Limit it to human monitor only.
             monitor_type = human
             monitors = hmp1
             main_monitor = hmp1
+            usb_devices += " usbhostdev"
+            usb_type_usbhostdev = usb-host
+            variants options:
+                # must configure which device should be used
+                - @with_no_hostdev:
+                    usb_devices = ""
+                    only usb_negative_test
+                - with_vendorid_productid:
+                    no usb_negative_test
+                    #usbdev_option_vendorid_usbhostdev = xxxx
+                    #usbdev_option_productid_usbhostdev = xxxx
             variants:
                 - usb_normal_test:
                 - usb_negative_test:

--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -297,11 +297,7 @@
                     check_io_size_option = no
         - usb_host:
             type = usb_host
-            #XXX: Now usb_host doesn't support QMP monitor.
-            # Limit it to human monitor only.
-            monitor_type = human
-            monitors = hmp1
-            main_monitor = hmp1
+            only Linux
             usb_devices += " usbhostdev"
             usb_type_usbhostdev = usb-host
             variants options:

--- a/qemu/tests/usb_host.py
+++ b/qemu/tests/usb_host.py
@@ -1,11 +1,17 @@
 import re
+import os
+import time
 import logging
 
 from avocado.utils import process
 
 from virttest import error_context
+from virttest import utils_misc
 from virttest.qemu_devices import qdevices
 from virttest.qemu_monitor import QMPCmdError
+from virttest.utils_test import BackgroundTest
+
+from provider.storage_benchmark import generate_instance
 
 
 @error_context.context_aware
@@ -37,7 +43,7 @@ def run(test, params, env):
         vm.devices.simple_hotplug(dev, vm.monitor)
         session.cmd_status("sleep 2")
         session.cmd_status("udevadm settle")
-        messages_add = session.cmd("dmesg -c")
+        messages_add = session.cmd("dmesg")
         for line in messages_add.splitlines():
             logging.debug("[dmesg add] %s" % line)
         if messages_add.find(match_add) == -1:
@@ -59,6 +65,43 @@ def run(test, params, env):
             logging.debug("[dmesg del] %s" % line)
         if messages_del.find(match_del) == -1:
             test.fail("kernel didn't detect unplug")
+
+    def _get_usb_mount_point():
+        """ Get passthrough usb stick mount point """
+        dmesg_cmd = "dmesg | grep 'Attached SCSI removable disk'"
+        s, o = session.cmd_status_output(dmesg_cmd)
+        if s:
+            test.error("Fail to get passthrough usb stick in guest.")
+        dev = re.findall(r'\[(sd\w+)\]', o)[0]
+        mounts_cmd = "cat /proc/mounts | grep /dev/%s" % dev
+        s, o = session.cmd_status_output(mounts_cmd)
+        if s:
+            s, o = session.cmd_status_output('mount /dev/%s /mnt' % dev)
+            if s:
+                test.error("Fail to mount /dev/%s, output: %s" % (s, o))
+            mp = "/mnt"
+        else:
+            mp = re.findall(r'/dev/%s\d*\s+(\S+)\s+' % dev, o)[0]
+        return mp
+
+    def _usb_stick_io(mount_point, bg=False):
+        """
+        Do I/O operations on passthrough usb stick
+        """
+        error_context.context("Read and write on usb stick ", logging.info)
+        testfile = os.path.join(mount_point, 'testfile')
+        if bg:
+            iozone_cmd = params.get("iozone_cmd_bg", " -az -I -g 1g -f %s")
+            iozone_thread = BackgroundTest(iozone_test.run,
+                                           (iozone_cmd % testfile,))
+            iozone_thread.start()
+            if not utils_misc.wait_for(iozone_thread.is_alive, timeout=10):
+                test.fail("Fail to start the iozone background test.")
+            time.sleep(10)
+        else:
+            iozone_cmd = params.get("iozone_cmd",
+                                    " -a -I -r 64k -s 1m -i 0 -i 1 -f %s")
+            iozone_test.run(iozone_cmd % testfile)
 
     usb_params = {}
 
@@ -108,30 +151,42 @@ def run(test, params, env):
     match_add = "New USB device found, "
     match_add += "idVendor=%s, idProduct=%s" % (vendorid, productid)
     match_del = "USB disconnect"
+    usb_stick = "Mass Storage" in process.getoutput(lsusb_cmd)
 
     error_context.context("Log into guest", logging.info)
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     session = vm.wait_for_login()
 
-    usb_dev_verify()
-    usb_devs = get_usb_host_dev()
-    for dev in usb_devs:
-        usb_dev_unplug(dev)
-
-    repeat_times = int(params.get("usb_repeat_times", "1"))
-    for i in range(repeat_times):
-        msg = "Hotplug (iteration %d)" % (i+1)
-        usb_params["id"] = "usbhostdev%s" % i
-        if params.get("usb_check_isobufs", "no") == "yes":
-            # The value of isobufs could only be in '4, 8, 16'
-            isobufs = (2 << (i % 3 + 1))
-            usb_params["isobufs"] = isobufs
-            msg += ", with 'isobufs' option set to %d." % isobufs
-        error_context.context(msg, logging.info)
-        usb_dev = qdevices.QDevice("usb-host", usb_params)
-        usb_dev_hotplug(usb_dev)
+    try:
         usb_dev_verify()
-        usb_dev_unplug(usb_dev)
+        if usb_stick:
+            iozone_test = None
+            mount_point = _get_usb_mount_point()
+            iozone_test = generate_instance(params, vm, 'iozone')
+            _usb_stick_io(mount_point)
+        usb_devs = get_usb_host_dev()
+        for dev in usb_devs:
+            usb_dev_unplug(dev)
 
-    session.close()
+        repeat_times = int(params.get("usb_repeat_times", "1"))
+        for i in range(repeat_times):
+            msg = "Hotplug (iteration %d)" % (i+1)
+            usb_params["id"] = "usbhostdev%s" % i
+            if params.get("usb_check_isobufs", "no") == "yes":
+                # The value of isobufs could only be in '4, 8, 16'
+                isobufs = (2 << (i % 3 + 1))
+                usb_params["isobufs"] = isobufs
+                msg += ", with 'isobufs' option set to %d." % isobufs
+            error_context.context(msg, logging.info)
+            usb_dev = qdevices.QDevice("usb-host", usb_params)
+            usb_dev_hotplug(usb_dev)
+            usb_dev_verify()
+            if usb_stick:
+                mount_point = _get_usb_mount_point()
+                _usb_stick_io(mount_point, bg=True)
+            usb_dev_unplug(usb_dev)
+    finally:
+        if usb_stick and iozone_test:
+            iozone_test.clean()
+        session.close()


### PR DESCRIPTION
1.add I/O operation for passthrough usb stick
2.add hostbus and hostaddr options test for usb-host device
3.change to use QMP instead of HMP
4.boot up guest with a passthroughed usb device

ID: 1847777, 1847778, 1861177

Signed-off-by: ybduan <yduan@redhat.com>