### PR TITLE
block_devices_plug: Fix 2 hotplug issues

### DIFF
--- a/provider/block_devices_plug.py
+++ b/provider/block_devices_plug.py
@@ -379,7 +379,11 @@ class BlockDevicesPlug(object):
         """ Plug devices. """
         for img, devices in devices_dict.items():
             for device in devices:
-                args = (device, monitor) if bus is None else (device, monitor, bus)
+                args = (device, monitor)
+                if (isinstance(device, qdevices.QDevice) and
+                        bus is not None and
+                        self.vm.devices.is_pci_device(device['driver'])):
+                    args += (bus,)
                 _QMP_OUTPUT[device.get_qid()] = getattr(
                     self, '_%s_atomic' % action)(*args)
                 time.sleep(self._interval)

--- a/provider/block_devices_plug.py
+++ b/provider/block_devices_plug.py
@@ -275,6 +275,7 @@ class BlockDevicesPlug(object):
         with _LOCK:
             self.vm.devices.set_dirty()
 
+        qdev_out = ''
         if isinstance(device, qdevices.QDevice):
             dev_bus = device.get_param('bus')
             if bus is None:


### PR DESCRIPTION
1. block_devices_plug: Only assign bus for pci device when hotplug
    
    There are 2 issues:
    1. Only pci device should be assigned a bus when been hot plugged,
    -dirve/-blockdev should not have a bus.
    2. It should make sure that the device is a QDevice before check
    if it is pci device. -object for luks should be skipped.

2. block_devices_plug: Fix variable referenced before assignment

id: 1852685, 1852690
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>