### PR TITLE
Improve virtio_scsi_variants test cases efficiency

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -5,6 +5,7 @@
     remove_image = yes
     remove_image_image1 = no
     cmd_timeout = 1000
+    create_timeout = 1800
     black_list = C:
     vt_ulimit_nofile = 8192
     labeltype = mbr
@@ -54,7 +55,7 @@
                 Windows:
                     # The CD-ROM has occupied a driver letter.
                     stg_image_num = 23
-                stg_image_size = 5G
+                stg_image_size = 2G
                 stg_image_boot = no
                 Linux:
                     image_size_image1 = 20G
@@ -124,13 +125,13 @@
                                     stg_params += "drive_cache:writeback "
                 - multi_lun:
                     Linux:
-                        stg_params += "drive_port:range(0,16383,63) "
+                        stg_params += "drive_port:range(0,16383,127) "
                     Windows:
-                        stg_params += "drive_port:range(0,255,1) "
+                        stg_params += "drive_port:range(0,255,4) "
                         need_reboot = yes
                         need_shutdown = yes
                 - multi_scsiid_lun:
-                    stg_params += "drive_unit:range(0,255,1,3) "
+                    stg_params += "drive_unit:range(0,255,16,3) "
                     Linux:
                         stg_params += "drive_port:range(0,16383,8191) "
                     Windows:
@@ -139,9 +140,9 @@
                         need_shutdown = yes
                 - multi_bus_scsiid_lun:
                     ide, virtio_blk:
-                        stg_params += "drive_bus:range(0,15,1,9) "
+                        stg_params += "drive_bus:range(0,15,2,9) "
                     virtio_scsi:
-                        stg_params += "drive_bus:range(1,15,1,9) "
+                        stg_params += "drive_bus:range(1,15,2,9) "
                     stg_params += "drive_unit:range(0,255,127,3) "
                     Linux:
                         stg_params += "drive_port:range(0,16383,8191) "

--- a/qemu/tests/multi_disk.py
+++ b/qemu/tests/multi_disk.py
@@ -201,8 +201,9 @@ def run(test, params, env):
 
     error_context.context("Start the guest with those disks", logging.info)
     vm = env.get_vm(params["main_vm"])
-    vm.create(timeout=max(10, stg_image_num), params=params)
     login_timeout = int(params.get("login_timeout", 360))
+    create_timeout = int(params.get("create_timeout", 1800))
+    vm.create(timeout=create_timeout, params=params)
     session = vm.wait_for_login(timeout=login_timeout)
 
     n_repeat = int(params.get("n_repeat", "1"))
@@ -338,7 +339,7 @@ def run(test, params, env):
                     test.fail("Fail to shut down guest.")
                 error_context.context("Start the guest again.", logging.info)
                 vm = env.get_vm(params["main_vm"])
-                vm.create(params=params)
+                vm.create(timeout=create_timeout, params=params)
                 session = vm.wait_for_login(timeout=login_timeout)
             error_context.context("Delete partitions in guest.", logging.info)
             for disk in disks:


### PR DESCRIPTION
1.Increase vm monitor login timeout
2.Decrease disk number for virtio_scsi_variants
ID:1838891
Signed-off-by: qingwangrh <qinwang@redhat.com>