### PR TITLE
rng_iommu: update rng_bat.iommu_enabled

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -30,8 +30,19 @@
             only q35
             no WinXP WinVista Win7 Win8 Win8.1 Win2000 Win2003
             no Win2008 Win2008..r2 Win2012 Win2012..r2
+            no Host_RHEL.m7
             virtio_dev_iommu_platform = on
-            enable_guest_iommu = yes
             virtio_dev_ats = on
             machine_type_extra_params = "kernel-irqchip=split"
             extra_params = "-device intel-iommu,intremap=on,eim=on,device-iotlb=on"
+            variants:
+                - @default:
+                    Linux:
+                        enable_guest_iommu = no
+                - scenario1:
+                    only Linux
+                    enable_guest_iommu = yes
+                - scenario2:
+                    only Linux
+                    enable_guest_iommu = yes
+                    guest_iommu_option = pt


### PR DESCRIPTION
1.Not support RHEL 7 host.
2.Cover 3 iommu scenarios.

ID: 1853798

Signed-off-by: ybduan <yduan@redhat.com>