### PR TITLE
block_iscsi_lvm: Assign unattended delivery method explicitly

### DIFF
--- a/qemu/tests/cfg/block_iscsi_lvm.cfg
+++ b/qemu/tests/cfg/block_iscsi_lvm.cfg
@@ -56,6 +56,11 @@
     post_commands_iscsi += "${cmd_iscsi_delete_node},${cmd_iscsi_logout}"
     post_commands_lvm = "${cmd_remove_dm},${cmd_remove_pv},${cmd_remove_vg},${cmd_remove_lv}"
     post_command_noncritical = yes
+    ppc64le, ppc64:
+        # explicitly disable iothread
+        iothread_scheme ?=
+        image_iothread ?=
+        iothreads ?=
     variants:
         - with_scsi_hd:
             drive_format_image0 = scsi-hd

--- a/qemu/tests/cfg/block_iscsi_lvm.cfg
+++ b/qemu/tests/cfg/block_iscsi_lvm.cfg
@@ -76,6 +76,7 @@
             variants:
                 - extra_cdrom_ks:
                     no WinXP Win2000 Win2003 WinVista
+                    unattended_delivery_method = cdrom
                     cdroms += " unattended"
                     drive_index_unattended = 3
                     drive_index_cd1 = 1

--- a/qemu/tests/cfg/block_iscsi_lvm.cfg
+++ b/qemu/tests/cfg/block_iscsi_lvm.cfg
@@ -74,8 +74,7 @@
             ppc64le, ppc64:
                 cd_format_cd1 = scsi-cd
             i440fx:
-                Windows:
-                    cd_format_unattended = ide
+                cd_format_unattended = ide
             q35:
                 cd_format_unattended = ahci
             variants:


### PR DESCRIPTION
Assign unattended delivery method to cdrom explicitly in the
scenarios where unatteneded install guest OS form extra cdrom.

ID: 1838501
Signed-off-by: Yongxue Hong <yhong@redhat.com>