### PR TITLE
block_hotplug: Fix failed to insert scsi device into specified HBA

### DIFF
--- a/qemu/tests/block_hotplug.py
+++ b/qemu/tests/block_hotplug.py
@@ -175,9 +175,8 @@ def run(test, params, env):
     vm.verify_alive()
 
     for iteration in range(int(params.get("repeat_times", 3))):
-        data_imgs_devs = {img: create_block_devices(img) for img in data_imgs}
-        for index, img in enumerate(data_imgs_devs):
-            data_devs = data_imgs_devs[img]
+        for index, img in enumerate(data_imgs):
+            data_devs = create_block_devices(img)
             if need_plug:
                 new_disk = plug_block_devices('hotplug', data_devs).pop()
 

--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -128,4 +128,10 @@
         - block_scsi:
             drive_format_stg0 = scsi-hd
             drive_format_stg1 = scsi-hd
+                q35, arm64-pci:
+                    drive_bus_stg0 = 0
+                    drive_bus_stg1 = 1
+                    virtio_scsi:
+                        drive_bus_stg0 = 1
+                        drive_bus_stg1 = 2
             get_disk_pattern = "^/dev/sd[a-z]*$"


### PR DESCRIPTION
Failed to insert the SCSI device into the specified HBA controller
because that setting the params "drive_bus" is to specify the HBA
the controller then call method list_missing_named_buses of 
DevContainer to search HBA is used by iterating DevContainer.__buses 
list. But the __buses list didn't change after hotplugging since calling
images_define_by_params and calling simple_hotplug are not used by
matching way, so the __buses list is still using the same.

ID: 1771912
Signed-off-by: Yongxue Hong <yhong@redhat.com>