### PR TITLE
ansible_test: Log into the guest at first to ensure it is available

### DIFF
--- a/qemu/tests/ansible_test.py
+++ b/qemu/tests/ansible_test.py
@@ -43,7 +43,8 @@ def run(test, params, env):
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
-    guest_ip = vm.wait_for_get_address(0, get_ip_timeout)
+    vm.wait_for_login()
+    guest_ip = vm.get_address()
 
     logging.info("Cloning %s", playbook_repo)
     process.run("git clone {src} {dst}".format(src=playbook_repo,


### PR DESCRIPTION
Sometimes, guest can return its IP address before it is available, and
the ansible-playbook command failed to execute through ssh connection.
So log into the guest at first.

ID: 1858245
Signed-off-by: Yihuang Yu <yihyu@redhat.com>