### PR TITLE
win_irq_check: Remove vectors=0 scenarion in vioscsi driver

### DIFF
--- a/qemu/tests/cfg/win_irq_check.cfg
+++ b/qemu/tests/cfg/win_irq_check.cfg
@@ -87,12 +87,9 @@
                     no with_balloon, with_viorng
                     msi_cmd = "reg add "HKLM\System\CurrentControlSet\Enum\%s\Device Parameters\Interrupt Management\MessageSignaledInterruptProperties" /v MSISupported /d %d /t REG_DWORD /f"
                 - by_vectors:
-                    only with_vioscsi, with_viostor, with_netkvm
+                    only with_viostor, with_netkvm
                     vectors = 0
                     with_viostor:
                         virtio_blk:
                             blk_extra_params_image1 += ",vectors=${vectors}"
                         blk_extra_params_stg += ",vectors=${vectors}"
-                    with_vioscsi:
-                        bus_extra_params_image1 = "vectors=${vectors}"
-                        bus_extra_params_stg = "vectors=${vectors}"


### PR DESCRIPTION
Setting "vectors=0" for vioscsi driver since qemu product doesn't
support it, so we need to avoid trigger it.

ID: 1858148
Signed-off-by: Menghuan Li menli@redhat.com