### PR TITLE
QemuImg.create should take the image specified params as its argument

### DIFF
--- a/provider/nbd_image_export.py
+++ b/provider/nbd_image_export.py
@@ -53,9 +53,11 @@ class NBDExportImage(object):
             result = process.run(self._image_params['create_image_cmd'],
                                  ignore_status=True, shell=True)
         elif not self._image_params.get_boolean("force_create_image"):
-            _, result = qemu_storage.QemuImg(self._image_params,
-                                             data_dir.get_data_dir(),
-                                             self._tag).create(self._params)
+            _, result = qemu_storage.QemuImg(
+                self._image_params,
+                data_dir.get_data_dir(),
+                self._tag
+            ).create(self._image_params)
 
         if result.exit_status != 0:
             raise exceptions.TestFail('Failed to create image, error: %s'


### PR DESCRIPTION
Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>
ID: 1860029