### PR TITLE
The latest qemu version expected vhost test parameter is boolean

### DIFF
--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -86,7 +86,7 @@
         - vhost_nic:
             no Host_RHEL.m5
             only nic_virtio
-            netdev_extra_params_hotplug_nic1 = ",vhost=on"
+            netdev_extra_params_hotplug_nic1 = ",vhost=True"
             nics = ""
             extra_params += "-net none"
         - used_netdev:


### PR DESCRIPTION
1.Change vhost test parameter type to boolean
ID:1860240

Signed-off-by: Lei Yang <leiyang@redhat.com>