### PR TITLE
x86_cpu_flags: new case to test flag avx512_bf16

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -14,3 +14,8 @@
                 - memory_protection_key:
                     cpu_model_flags += ",+pku,check"
                     flags = "pku ospke"
+                - avx512_series_flags_5:
+                    # support RHEL.8.2.0 guest or later
+                    no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
+                    cpu_model_flags += ",+avx512-bf16"
+                    flags = "avx512_bf16"


### PR DESCRIPTION
ID: 1861283

depends on [avocado-framework/avocado-vt#2672](https://github.com/avocado-framework/avocado-vt/pull/2672)

Signed-off-by: Nana Liu <nanliu@redhat.com>