### PR TITLE
watchdog: check watchdog device need machine for aarch64

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -3,6 +3,8 @@
     enable_watchdog = yes
     start_vm = no
     type = watchdog
+    aarch64:
+        watchdog_type_check = " -M virt -watchdog '?'"
     variants:
         -i6300esb:
             no RHEL.4


### PR DESCRIPTION
The check cmd is "qemu-kvm  -M virt -watchdog '?'" for aarch64.

Signed-off-by: Chen Qun <kuhn.chenqun@huawei.com>