### PR TITLE
qmp_command: add qmp 'node-name' expect value for blockdev

### DIFF
--- a/qemu/tests/qmp_command.py
+++ b/qemu/tests/qmp_command.py
@@ -7,6 +7,7 @@ from avocado.utils import process
 
 from virttest import utils_misc
 from virttest import qemu_monitor
+from virttest.qemu_capabilities import Flags
 
 
 def run(test, params, env):
@@ -241,7 +242,10 @@ def run(test, params, env):
                 image_params = params.object_params(image)
                 image_format = image_params['image_format']
                 image_drive = "drive_%s" % image
-                image_info['device'] = image_drive
+                if vm.check_capability(Flags.BLOCKDEV):
+                    image_info['node-name'] = image_drive
+                else:
+                    image_info['device'] = image_drive
                 image_info['qdev'] = image
                 image_info['format'] = image_format
                 expect_o.append(image_info)


### PR DESCRIPTION
The disk device qemu command line has two configurations:
   1). blockdev config, eg:
       -blockdev node-name=file_image1,driver=file,filename=/var/**.qcow2
       -blockdev node-name=drive_image1,driver=qcow2,file=file_image1

   2). disk drive config, eg:
       -drive id=drive_image1,if=none,format=qcow2,file=/var/***.qcow2

If disk drive config, the expect value should be:
 {'device': 'drive_image1', 'qdev': 'image1', 'format': 'qcow2'}

If blockdev config, the expect value should be:
 {'node-name': 'drive_image1', 'qdev': 'image1', 'format': 'qcow2'}

Signed-off-by: Chen Qun <kuhn.chenqun@huawei.com>