### PR TITLE
Change image_chain to image_backup_chain for backup use

### DIFF
--- a/provider/blockdev_base.py
+++ b/provider/blockdev_base.py
@@ -161,7 +161,7 @@ class BlockdevBaseTest(object):
         error_context.context("Create target disk")
         for tag in self.params.objects("source_images"):
             image_params = self.params.object_params(tag)
-            for img in image_params.objects("image_chain"):
+            for img in image_params.objects("image_backup_chain"):
                 disk = self.target_disk_define_by_params(self.params, img)
                 disk.hotplug(self.main_vm)
                 self.trash.append(disk)

--- a/provider/blockdev_base.py
+++ b/provider/blockdev_base.py
@@ -56,6 +56,10 @@ class BlockdevBaseTest(object):
     def preprocess_data_disks(self):
         for tag in self.params.objects("source_images"):
             params = self.params.object_params(tag)
+            if params.get("force_create_image") == "yes":
+                # vt takes care of the image creation
+                continue
+
             if params.get("random_cluster_size") == "yes":
                 blacklist = list(
                     map(int, params.objects("cluster_size_blacklist")))

--- a/qemu/tests/blockdev_inc_backup_bitmap_mode_test.py
+++ b/qemu/tests/blockdev_inc_backup_bitmap_mode_test.py
@@ -23,7 +23,7 @@ class BlockdevIncreamentalBackupBitmapTest(blockdev_base.BlockdevBaseTest):
 
     def _init_arguments_by_params(self, tag):
         image_params = self.params.object_params(tag)
-        image_chain = image_params.objects("image_chain")
+        image_chain = image_params.objects("image_backup_chain")
         self.source_images.append("drive_%s" % tag)
         self.full_backups.append("drive_%s" % image_chain[0])
         self.inc_backups.append("drive_%s" % image_chain[1])
@@ -109,7 +109,7 @@ class BlockdevIncreamentalBackupBitmapTest(blockdev_base.BlockdevBaseTest):
 
     def _compare_image(self, src_tag):
         src_params = self.params.object_params(src_tag)
-        overlay_tag = src_params.objects("image_chain")[-1]
+        overlay_tag = src_params.objects("image_backup_chain")[-1]
         src_img = self.disk_define_by_params(self.params, src_tag)
         dst_img = self.disk_define_by_params(self.params, overlay_tag)
         result = src_img.compare_to(dst_img)

--- a/qemu/tests/blockdev_inc_backup_test.py
+++ b/qemu/tests/blockdev_inc_backup_test.py
@@ -21,14 +21,16 @@ class BlockdevIncreamentalBackupTest(blockdev_base.BlockdevBaseTest):
         self.rebase_targets = []
         for tag in params.objects('source_images'):
             image_params = params.object_params(tag)
-            image_chain = image_params.objects("image_chain")
+            image_chain = image_params.objects("image_backup_chain")
             self.source_images.append("drive_%s" % tag)
             self.full_backups.append("drive_%s" % image_chain[0])
             self.inc_backups.append("drive_%s" % image_chain[1])
             self.bitmaps.append("bitmap_%s" % tag)
             inc_img_tag = image_chain[-1]
             inc_img_params = params.object_params(inc_img_tag)
-            inc_img_params['image_chain'] = image_params['image_chain']
+
+            # rebase 'inc' image onto 'base' image, so inc's backing is base
+            inc_img_params['image_chain'] = image_params['image_backup_chain']
             inc_img = self.source_disk_define_by_params(
                 inc_img_params, inc_img_tag)
             target_func = partial(inc_img.rebase, params=inc_img_params)
@@ -94,7 +96,7 @@ class BlockdevIncreamentalBackupTest(blockdev_base.BlockdevBaseTest):
         clone_params = self.main_vm.params.copy()
         for tag in self.params.objects("source_images"):
             img_params = self.params.object_params(tag)
-            image_chain = img_params.objects('image_chain')
+            image_chain = img_params.objects('image_backup_chain')
             images = images.replace(tag, image_chain[-1])
         clone_params["images"] = images
         clone_vm = self.main_vm.clone(params=clone_params)

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_mode_test.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_mode_test.cfg
@@ -2,7 +2,7 @@
     type = blockdev_inc_backup_bitmap_mode_test
     virt_test_type = qemu
     images += " data"
-    image_chain_data = "base inc"
+    image_backup_chain_data = "base inc"
     backing_inc = base
     force_remove_image_image1 = no
     force_create_image_image1 = no

--- a/qemu/tests/cfg/blockdev_inc_backup_cluster_test.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_cluster_test.cfg
@@ -2,7 +2,7 @@
     type = blockdev_inc_backup_test
     virt_test_type = qemu
     images += " data"
-    image_chain_data = "base inc"
+    image_backup_chain_data = "base inc"
     force_remove_image_image1 = no
     force_create_image_image1 = no
     force_create_image_data = yes

--- a/qemu/tests/cfg/blockdev_inc_backup_test.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_test.cfg
@@ -2,7 +2,7 @@
     type = blockdev_inc_backup_test
     virt_test_type = qemu
     images += " data"
-    image_chain_data = "base inc"
+    image_backup_chain_data = "base inc"
     force_remove_image_image1 = no
     force_create_image_image1 = no
     force_create_image_data = yes
@@ -46,7 +46,7 @@
                 - @granularity_default:
         - multi_data_disks:
             images += " data2"
-            image_chain_data2 = "base2 inc2"
+            image_backup_chain_data2 = "base2 inc2"
             force_create_image_data2 = yes
             force_remove_image_data2 = yes
             image_size_data2 = 3G


### PR DESCRIPTION
  image_chain is used for showing the backing info between images

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1861951