### PR TITLE
cache_sizes_test: set parameter cache-size for system image

### DIFF
--- a/qemu/tests/cache_sizes_test.py
+++ b/qemu/tests/cache_sizes_test.py
@@ -22,7 +22,7 @@ def run(test, params, env):
     logging.info("Boot a guest up from initial image: %s, and create a"
                  " file %s on the disk.", initial_tag, file)
     for cache_size in cache_sizes:
-        params["drv_extra_params"] = "cache-size=%s" % cache_size
+        params["drv_extra_params_image1"] = "cache-size=%s" % cache_size
         vm = img_utils.boot_vm_with_images(test, params, env)
         session = vm.wait_for_login()
         guest_temp_file = params["guest_file_name"]


### PR DESCRIPTION
Since winutils iso will be added directly when testing it
with windows guest. And cache-size is a qcow2 option,
it cannot be given to any imgfmt but qcow2.
To avoid it, just set this parameter to system image.

ID: 1862315
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>