### PR TITLE
add new error message when creating large image over xfs filesystem

### DIFF
--- a/qemu/tests/cfg/create_large_raw_img.cfg
+++ b/qemu/tests/cfg/create_large_raw_img.cfg
@@ -11,7 +11,8 @@
         - over_xfs:
             file_sys = "xfs"
             image_size_large = 10240000T
-            err_info = "Image size must be less than 8 EiB!"
+            err_info = "Image size must be less than 8 EiB!;"
+            err_info = '${err_info}Invalid image size specified. Must be between 0 and 9223372036854775807.'
         - over_ext4:
             file_sys = "ext4"
             image_size_large = 16T


### PR DESCRIPTION
The following error messages should all work well.
1. Image size must be less than 8 EiB!
2. Invalid image size specified.
   Must be between 0 and 9223372036854775807.

ID: 1862381
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>