### PR TITLE
Add a new case, create luks format image with non utf8 secret

### DIFF
--- a/qemu/tests/cfg/qemu_img_negative.cfg
+++ b/qemu/tests/cfg/qemu_img_negative.cfg
@@ -1,7 +1,7 @@
 - qemu_img_negative:
-    only qcow2
     variants:
         - rebase:
+            only qcow2
             type = rebase_negative_test
             images = "base sn"
             image_name_base = "images/rebase_negative_base"
@@ -26,3 +26,14 @@
                     image_name_new = "images/rebase_negative_new"
                     create_image_new = no
                     rebase_list = "sn > new"
+        - luks_with_non_utf8_secret:
+            only luks
+            type = image_creation_luks_with_non_utf8_secret
+            start_vm = no
+            create_image = no
+            images = stg
+            err_info = "Data from secret\s+\w+\s+is not valid UTF-8"
+            echo_non_utf8_secret_cmd = "echo -n -e '\x3a\x3c\x3b\xff' > %s"
+            qemu_img_create_cmd = "qemu-img create -f luks --object secret,id=sec0,file=%s -o key-secret=sec0 %s 10M"
+            image_name_stg = "images/stg"
+            remove_image_stg = yes

--- a/qemu/tests/image_creation_luks_with_non_utf8_secret.py
+++ b/qemu/tests/image_creation_luks_with_non_utf8_secret.py
@@ -1,0 +1,41 @@
+import os
+import re
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import utils_misc
+
+
+def run(test, params, env):
+    """
+    Negative test.
+    Luks image creation with non_utf8_secret:
+    1. It should be failed to create the image.
+    2. The error information should be corret.
+       e.g. Data from secret sec0 is not valid UTF-8
+
+    :param test: Qemu test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+    image_stg_name = params["image_name_stg"]
+    root_dir = data_dir.get_data_dir()
+    image_stg_path = utils_misc.get_path(root_dir, image_stg_name)
+    if os.path.exists(image_stg_path):
+        os.remove(image_stg_path)
+    err_info = params["err_info"]
+    tmp_dir = data_dir.get_tmp_dir()
+    non_utf8_secret_file = os.path.join(tmp_dir, "non_utf8_secret")
+    non_utf8_secret = params["echo_non_utf8_secret_cmd"] % non_utf8_secret_file
+    process.run(non_utf8_secret, shell=True)
+    qemu_img_create_cmd = params["qemu_img_create_cmd"] % (non_utf8_secret_file,
+                                                           image_stg_path)
+    cmd_result = process.run(qemu_img_create_cmd,
+                             ignore_status=True, shell=True)
+    if os.path.exists(image_stg_path):
+        test.fail("The image '%s' should not exist. Since created"
+                  " it with non_utf8_secret." % image_stg_path)
+    if not re.search(err_info, cmd_result.stderr.decode(), re.I):
+        test.fail("Failed to get error information. The actual error "
+                  "information is %s." % cmd_result.stderr.decode())


### PR DESCRIPTION
1. It should be failed to create the image.
2. The error information should be corret.
   e.g. Data from secret sec0 is not valid UTF-8

ID: 1867037
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>