### PR TITLE
cpu_device_hotplug_maximum: Update unplug verification timeout

### DIFF
--- a/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
+++ b/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
@@ -7,7 +7,7 @@
     required_qemu = [2.6.0, )
     start_vm = no
     qemu_sandbox = on
-    allow_pcpu_overcommit = yes
+    allow_pcpu_overcommit = no
     # Require long time to reboot if CPU overcommit
     reboot_timeout = 360
     vcpu_maxcpus = 0

--- a/qemu/tests/cpu_device_hotplug_maximum.py
+++ b/qemu/tests/cpu_device_hotplug_maximum.py
@@ -72,6 +72,7 @@ def run(test, params, env):
     session = vm.wait_for_login()
     cpuinfo = vm.cpuinfo
     smp = cpuinfo.smp
+    vcpus_count = vm.params.get_numeric("vcpus_count")
 
     error_context.context("Hotplug all vCPU devices", logging.info)
     for vcpu_device in vcpu_devices:
@@ -93,7 +94,7 @@ def run(test, params, env):
 
     error_context.context("Hotunplug all vCPU devices", logging.info)
     for vcpu_device in reversed(vcpu_devices):
-        vm.hotunplug_vcpu_device(vcpu_device)
+        vm.hotunplug_vcpu_device(vcpu_device, 10 * vcpus_count)
     if not utils_misc.wait_for(lambda: vm.get_cpu_count() == smp,
                                verify_wait_timeout, first=5, step=10):
         logging.error(not_equal_text, vm.get_cpu_count(), smp)


### PR DESCRIPTION
1. Update unplug verification timeout
2. Set "allow_pcpu_overcommit = no" since overcommit on a single guest is not a positive scenario.

ID: 1867003
Signed-off-by: Yihuang Yu <yihyu@redhat.com>