### PR TITLE
timerdevice_tsc_enable: add one timer device case

### DIFF
--- a/qemu/tests/cfg/timerdevice_tsc_enable.cfg
+++ b/qemu/tests/cfg/timerdevice_tsc_enable.cfg
@@ -1,0 +1,13 @@
+- timerdevice_tsc_enable:
+    type = timerdevice_tsc_enable
+    only Linux
+    no Host_RHEL.m6 no Host_RHEL.m7
+    no RHEL.6 RHEL.7
+    cpu_model_flags += ",+invtsc"
+    clksrc_path = "/sys/devices/system/clocksource/clocksource0"
+    cur_clksrc_cmd = "cat ${clksrc_path}/current_clocksource"
+    avl_clksrc_cmd = "cat ${clksrc_path}/available_clocksource"
+    expect_cur_clk = "tsc"
+    expect_avl_clk = "tsc kvm-clock acpi_pm"
+    expect_tsc_flag = "nonstop_tsc"
+    check_tsc_flag_cmd = "lscpu | grep -o ${expect_tsc_flag}"

--- a/qemu/tests/timerdevice_tsc_enable.py
+++ b/qemu/tests/timerdevice_tsc_enable.py
@@ -1,0 +1,42 @@
+import logging
+
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Boot a guest with "-cpu host,+invtsc" or "-cpu $cpu_model,+invtsc".
+    2) Check current clocksource and available clocksource and nonstop_tsc flag
+    in guest.
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    timeout = float(params.get("login_timeout", 240))
+    session = vm.wait_for_login(timeout=timeout)
+
+    error_context.context("Check current cloclsource", logging.info)
+    cur_clksrc_cmd = params["cur_clksrc_cmd"]
+    current_clksrc = session.cmd_output_safe(cur_clksrc_cmd)
+    avl_clksrc_cmd = params["avl_clksrc_cmd"]
+    avl_clksrc = session.cmd_output_safe(avl_clksrc_cmd)
+    check_tsc_flag_cmd = params["check_tsc_flag_cmd"]
+    tsc_flag = session.cmd_status(check_tsc_flag_cmd)
+    expect_cur_clk = params["expect_cur_clk"]
+    expect_avl_clk = params["expect_avl_clk"]
+    expect_tsc_flag = params["expect_tsc_flag"]
+
+    if expect_cur_clk not in current_clksrc:
+        test.fail("Current clocksource is %s, the expected is %s." %
+                  (current_clksrc, expect_cur_clk))
+    if tsc_flag:
+        test.fail("Can not get expected flag: %s." % expect_tsc_flag)
+
+    if expect_avl_clk not in avl_clksrc:
+        test.fail("Available clocksources are %s, the exected are %s."
+                  % (avl_clksrc, expect_avl_clk))


### PR DESCRIPTION
enable TSC clocksource if invariant TSC is available (only linux
 after rhel8.1)

ID: 1868209
Signed-off-by: yama <yama@redhat.com>