### PR TITLE
valgrind_memalign: delete sandbox options

### DIFF
--- a/qemu/tests/cfg/valgrind_memalign.cfg
+++ b/qemu/tests/cfg/valgrind_memalign.cfg
@@ -7,6 +7,8 @@
     disable_kvm = yes
     enable-kvm = no
     start_vm = no
+    # bz 1800495, valgrind don't support "sandbox" option
+    del qemu_sandbox
     Ubuntu:
         valgrind_install_cmd = "apt-get install -y valgrind"
     s390x:


### PR DESCRIPTION
valgrind does not support sandbox options,refer bz 1800495

ID:1869981

Signed-off-by: Yiqian Wei <yiwei@redhat.com>