### PR TITLE
ppc_ic_mode_check: Add test cases to check ic-mode and kernel-irqchip

### DIFF
--- a/qemu/tests/cfg/ppc_ic_mode_check.cfg
+++ b/qemu/tests/cfg/ppc_ic_mode_check.cfg
@@ -1,0 +1,16 @@
+- ppc_ic_mode_check:
+    type = ppc_ic_mode_check
+    virt_test_type = qemu
+    only ppc64 ppc64le
+    required_qemu = [4, )
+    start_vm = no
+    variants ic_mode:
+        - xics:
+        - xive:
+            only RHEL.8
+    variants kernel_irqchip:
+        - in-kernel:
+            irqchip = on
+        - emulated:
+            irqchip = off
+    machine_type_extra_params += ,ic-mode=${ic_mode},kernel-irqchip=${irqchip}

--- a/qemu/tests/ppc_ic_mode_check.py
+++ b/qemu/tests/ppc_ic_mode_check.py
@@ -1,0 +1,48 @@
+import re
+import logging
+
+from virttest import error_context
+from virttest.virt_vm import VMCreateError
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Check the interrupt controller mode.
+
+    1) Launch a guest with kernel-irqchip=on/off and ic-mode=xics/xive.
+    2) Get pic info from human monitor and get interrupts info inside guest.
+    3) Check whether irqchip and ic-mode match what we set.
+
+    :param test: the test object.
+    :param params: the test params.
+    :param env: test environment.
+    """
+    ic_mode = params["ic_mode"]
+    kernel_irqchip = params["kernel_irqchip"]
+    params["start_vm"] = "yes"
+    vm = env.get_vm(params["main_vm"])
+
+    error_context.base_context("Try to create a qemu instance...", logging.info)
+    try:
+        vm.create(params=params)
+    except VMCreateError as e:
+        if re.search(r"kernel_irqchip requested but unavailable|"
+                     r"XIVE-only machines", e.output):
+            test.cancel(e.output)
+        raise
+    else:
+        vm.verify_alive()
+        session = vm.wait_for_login()
+
+    error_context.context("Get irqchip and ic-mode information.", logging.info)
+    pic_o = vm.monitor.info("pic")
+    irqchip_match = re.search(r"^irqchip: %s" % kernel_irqchip, pic_o, re.M)
+    ic_mode_match = session.cmd_status("grep %s /proc/interrupts"
+                                       % ic_mode.upper()) == 0
+
+    error_context.context("Check wherever irqchip/ic-mode match.", logging.info)
+    if not irqchip_match:
+        test.fail("irqchip does not match to '%s'." % kernel_irqchip)
+    elif not ic_mode_match:
+        test.fail("ic-mode does not match to '%s'." % ic_mode)


### PR DESCRIPTION
Launch a guest with "kernel-irqchip=on/off" and "ic-mode=xics/xive" and
then check them from human monitor and guest's interrupts information.

ID: 1870448, 1870450, 1870451, 1870452
Signed-off-by: Yihuang Yu <yihyu@redhat.com>