### PR TITLE
qmp_command: update the return value of device list propeties

### DIFF
--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -175,7 +175,9 @@
         - qmp_device-list-properties:
             qmp_cmd = "device-list-properties typename=virtio-balloon-pci"
             cmd_result_check = contain
-            cmd_return_value = "['command_serr_enable', 'multifunction']"
+            cmd_return_value = ['multifunction']
+            Host_RHEL.m7, Host_RHEL.m8.u0, Host_RHEL.m8.u1, Host_RHEL.m8.u2:
+                cmd_return_value = ['command_serr_enable', 'multifunction']            
             s390x:
                 qmp_cmd = "device-list-properties typename=virtio-balloon-ccw"
                 cmd_return_value = "['notify_on_empty', 'ioeventfd', 'any_layout', 'devno', 'indirect_desc', 'guest-stats', 'guest-stats-polling-interval', 'event_idx', 'virtio-backend', 'iommu_platform', 'deflate-on-oom', 'max_revision']"


### PR DESCRIPTION
In qemu-kvm-5.1 version, didn't find 'command_serr_enable',so remove it

ID: 1869992

Signed-off-by: Yiqian Wei <yiwei@redhat.com>