### PR TITLE
Fix windows guest installation issue with ovmf in case block_with_iommu

### DIFF
--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -48,6 +48,9 @@
             guest_port_unattended_install = 12323
             inactivity_watcher = error
             extra_params = "-device intel-iommu,device-iotlb=on,intremap"
+            ovmf:
+                restore_ovmf_vars = yes
+                send_key_at_install = ret
             variants:
                 - extra_cdrom_ks:
                     unattended_delivery_method = cdrom


### PR DESCRIPTION
Default not send key when run case block_with_iommu with ovmf that
cause the guest can not boot from CD.

ID: 1838944
Signed-off-by: Menghuan Li menli@redhat.com