### PR TITLE
qmp_event_notification: remove suspend and disk_suspend case

### DIFF
--- a/qemu/tests/cfg/qmp_event_notification.cfg
+++ b/qemu/tests/cfg/qmp_event_notification.cfg
@@ -11,7 +11,7 @@
     monitor_type_qmp2 = qmp
     variants:
         - from_guest:
-            only qmp_system_reset qmp_system_powerdown qmp_rtc_change qmp_watchdog qmp_suspend qmp_disk_suspend qmp_guest_panicked
+            only qmp_system_reset qmp_system_powerdown qmp_rtc_change qmp_watchdog qmp_guest_panicked
             event_cmd_type = guest_cmd
         - from_qmp:
             only qmp_quit qmp_system_reset qmp_system_powerdown
@@ -52,28 +52,6 @@
             no Windows, aarch64
             event_cmd = hwclock --systohc
             event_check = "RTC_CHANGE"
-        - qmp_suspend:
-            no Windows
-            usbs = ""
-            usb_devices = ""
-            event_cmd = pm-suspend
-            event_check = "SUSPEND"
-            event_cmd_options = "ignore_all_errors=True"
-            extra_params += " -global PIIX4_PM.disable_s3=0"
-            q35:
-                extra_params += " -global ICH9-LPC.disable_s3=0"
-            post_event_cmd = system_wakeup
-            post_event_cmd_type = qmp_cmd
-        - qmp_disk_suspend:
-            no Windows
-            usbs = ""
-            usb_devices = ""
-            event_cmd = pm-hibernate
-            event_check = "SUSPEND_DISK"
-            event_cmd_options = "ignore_all_errors=True"
-            extra_params += " -global PIIX4_PM.disable_s4=0"
-            q35:
-                extra_params += " -global ICH9-LPC.disable_s4=0"
         - qmp_watchdog:
             no Windows
             event_cmd = echo 0 > /dev/watchdog


### PR DESCRIPTION
S3/S4 (suspend/hybernate) of guests is not supported 
for rhel7 and rhel8,remove it

ID: 1870003

Signed-off-by: Yiqian Wei <yiwei@redhat.com>