### PR TITLE
cgroup.cpuset_cpus:ensure that different kernel use the correct cpu time

### DIFF
--- a/qemu/tests/cfg/cgroup.cfg
+++ b/qemu/tests/cfg/cgroup.cfg
@@ -64,6 +64,10 @@
             # cgroup_use_half_smp, cgroup_test_time, cgroup_limit, cgroup_cpuset, cgroup_verify
             cgroup_use_half_smp = 'yes'
             cgroup_test_time = 10
+            ##8.3 will cpu system time. prior to 8.3 will use cpu user time 
+            cpu_time_type = 2
+            Host_RHEL.m6,Host_RHEL.m7,Host_RHEL.m8.u0,Host_RHEL.m8.u1,Host_RHEL.m8.u2:
+                cpu_time_type = 0
             # cgroup_cpuset = [[None, '0,3', '1', '2', '1-2'],
             # cgroup_cpuset += [None, '0', '1', '0-1', '0-1']]
             # cgroup_verify = [[50, 100, 100, 50], [100, 100, 5, 5]]

--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -1185,6 +1185,7 @@ def run(test, params, env):
             sessions[-1].cmd("touch /tmp/cgroup-cpu-lock")
             sessions[-1].sendline(cmd)
 
+        cpu_time_type = params.get_numeric('cpu_time_type')
         try:
             logging.info("Test")
             for i in range(len(cpusets)):
@@ -1197,7 +1198,8 @@ def run(test, params, env):
                 _load = get_load_per_cpu()
                 time.sleep(test_time)
                 # Stats after test_time
-                stats.append(get_load_per_cpu(_load)[1:])
+                _load_diff = get_load_per_cpu(_load)
+                stats.append(list(map(list, zip(*_load_diff)))[cpu_time_type][1:])
 
             serial.cmd("rm -f /tmp/cgroup-cpu-lock")
             err = ""


### PR DESCRIPTION
Ensure that different kernel use the correct cpu time

1.RHEL8.3 will use cpu system time.

2.Prior to RHEL8.3 will use cpu user time.

id: 1875683

Signed-off-by: Xiangchun Fu <xfu@redhat.com>