### PR TITLE
migration: Support for setting migration parameters by migrate-set-parameters

### DIFF
--- a/multi_host_migration/tests/migration_multi_host_downtime_and_speed.py
+++ b/multi_host_migration/tests/migration_multi_host_downtime_and_speed.py
@@ -6,7 +6,10 @@ from autotest.client.shared import utils
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import virt_vm
+from virttest import qemu_migration
 from virttest.utils_test.qemu import migration
+from virttest.qemu_capabilities import Flags
+from virttest.utils_numeric import normalize_data_size
 
 
 @error.context_aware
@@ -96,7 +99,11 @@ def run(test, params, env):
             if self.is_src:
                 vm = env.get_vm(params["main_vm"])
                 error.context("Set downtime before migration.", logging.info)
-                vm.monitor.migrate_set_downtime(self.mig_downtime)
+                if vm.check_capability(Flags.MIGRATION_PARAMS):
+                    qemu_migration.set_migrate_parameter_downtime_limit(
+                            vm, self.mig_downtime * 1000)
+                else:
+                    vm.monitor.migrate_set_downtime(self.mig_downtime)
 
         @error.context_aware
         def post_migration_before_downtime(self, vm, cancel_delay, mig_offline,
@@ -127,7 +134,11 @@ def run(test, params, env):
                     break
                 except virt_vm.VMMigrateTimeoutError:
                     logging.info("Set downtime to %d seconds.", downtime)
-                    vm.monitor.migrate_set_downtime(downtime)
+                    if vm.check_capability(Flags.MIGRATION_PARAMS):
+                        qemu_migration.set_migrate_parameter_downtime_limit(
+                                vm, downtime * 1000)
+                    else:
+                        vm.monitor.migrate_set_downtime(downtime)
 
             try:
                 vm.wait_for_migration(self.mig_timeout)
@@ -154,7 +165,11 @@ def run(test, params, env):
                     vm.wait_for_migration(self.wait_mig_timeout)
                     break
                 except virt_vm.VMMigrateTimeoutError:
-                    vm.monitor.migrate_set_speed("%sB" % (mig_speed))
+                    if vm.check_capability(Flags.MIGRATION_PARAMS):
+                        qemu_migration.set_migrate_parameter_max_bandwidth(
+                                vm, int(normalize_data_size("%sB" % (mig_speed), 'B')))
+                    else:
+                        vm.monitor.migrate_set_speed("%sB" % (mig_speed))
 
             # Test migration status. If migration is not completed then
             # it kill program which creates guest load.

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -25,8 +25,10 @@ from virttest import gluster
 from virttest import env_process
 from virttest import data_dir
 from virttest import utils_test
+from virttest import qemu_migration
 from virttest.utils_test.qemu import migration
 from virttest.qemu_capabilities import Flags
+from virttest.utils_numeric import normalize_data_size
 
 
 @error_context.context_aware
@@ -956,7 +958,11 @@ def run(test, params, env):
 
             if self.is_src:  # Starts in source
                 vm = env.get_vm(self.vms[0])
-                vm.monitor.migrate_set_speed("1G")
+                if vm.check_capability(Flags.MIGRATION_PARAMS):
+                    return qemu_migration.set_migrate_parameter_max_bandwidth(
+                            vm, int(normalize_data_size("1G", 'B')))
+                else:
+                    vm.monitor.migrate_set_speed("1G")
                 session = vm.wait_for_login(timeout=login_timeout)
                 cdrom_dev_list = list_guest_cdroms(session)
                 logging.debug("cdrom_dev_list: %s", cdrom_dev_list)

--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -11,6 +11,9 @@ from virttest import utils_test
 from virttest import utils_package
 from virttest import error_context
 from virttest import qemu_monitor     # For MonitorNotSupportedMigCapError
+from virttest import qemu_migration
+from virttest.qemu_capabilities import Flags
+from virttest.utils_numeric import normalize_data_size
 
 
 # Define get_function-functions as global to allow importing from other tests
@@ -30,6 +33,9 @@ def get_functions(func_names, locals_dict):
 
 def mig_set_speed(vm, params, test):
     mig_speed = params.get("mig_speed", "1G")
+    if vm.check_capability(Flags.MIGRATION_PARAMS):
+        return qemu_migration.set_migrate_parameter_max_bandwidth(
+                vm, int(normalize_data_size(mig_speed, 'B')))
     return vm.monitor.migrate_set_speed(mig_speed)
 
 

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -5,6 +5,9 @@ import logging
 import time
 
 from virttest import utils_misc
+from virttest import qemu_migration
+from virttest.qemu_capabilities import Flags
+from virttest.utils_numeric import normalize_data_size
 
 from provider import cpuflags
 
@@ -126,7 +129,11 @@ def run(test, params, env):
         cpuflags.install_cpuflags_util_on_vm(test, vm, install_path,
                                              extra_flags="-msse3 -msse2")
 
-        vm.monitor.migrate_set_speed(mig_speed)
+        if vm.check_capability(Flags.MIGRATION_PARAMS):
+            qemu_migration.set_migrate_parameter_max_bandwidth(
+                    vm, int(normalize_data_size(mig_speed, 'B')))
+        else:
+            vm.monitor.migrate_set_speed(mig_speed)
 
         cmd = ("%s/cpuflags-test --stressmem %d,%d" %
                (os.path.join(install_path, "cpu_flags", "src"),

--- a/qemu/tests/vioser_in_use.py
+++ b/qemu/tests/vioser_in_use.py
@@ -8,6 +8,10 @@ from avocado.utils import process
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import error_context
+from virttest import qemu_migration
+
+from virttest.qemu_capabilities import Flags
+from virttest.utils_numeric import normalize_data_size
 
 from qemu.tests import virtio_serial_file_transfer
 from qemu.tests.timedrift_no_net import subw_guest_pause_resume  # pylint: disable=W0611
@@ -42,7 +46,12 @@ def live_migration_guest(test, params, vm, session):
     Run migrate_set_speed, then migrate guest.
     """
 
-    vm.monitor.migrate_set_speed(params.get("mig_speed", "1G"))
+    mig_speed = params.get("mig_speed", "1G")
+    if vm.check_capability(Flags.MIGRATION_PARAMS):
+        qemu_migration.set_migrate_parameter_max_bandwidth(
+                vm, int(normalize_data_size(mig_speed, 'B')))
+    else:
+        vm.monitor.migrate_set_speed(mig_speed)
     vm.migrate()
 
 


### PR DESCRIPTION
Some migration parameters are deprecated and replaced by other parameters after qemu-5.1.

1."migrate_set_downtime" is deprecated and replaced by "migrate_set_parameter":
2."migrate_set_speed" is deprecated and replaced by "migrate_set_parameter":

ID: 1845429
Signed-off-by: Yongxue Hong yhong@redhat.com