### PR TITLE
usb_redir: add usb-redir cases

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -81,7 +81,7 @@
     variants:
         - without_usb_hub:
         - with_usb_hub:
-            no usb_host, usb_multi_disk
+            no usb_host, usb_redir, usb_multi_disk
             no usb-ehci
             usb_devices += " hub1"
             usb_type_hub1 = usb-hub
@@ -111,7 +111,7 @@
     # usb devices
     variants:
         - @usb_nodev:
-            only usb_storage, usb_host, usb_multi_disk
+            only usb_storage, usb_host, usb_redir, usb_multi_disk
         - usb_kbd:
             Host_RHEL.m6:
                 no usb-ehci
@@ -338,6 +338,39 @@
                 - usb_multi_times:
                     no usb_negative_test
                     usb_repeat_times = 20
+        - usb_redir:
+            type = usb_redir
+            only Linux
+            usbredirdev_name = usbredir1
+            chardev_backend_usbredir1 = spicevmc
+            chardev_name_usbredir1 = usbredir
+            start_vm = no
+            # must configure which device should be used
+            #usbredir_vendorid = xxxx
+            #usbredir_productid = xxxx
+            variants option:
+                - @basic:
+                    display = spice
+                - with_bootindex:
+                    display = spice
+                    boot_menu = on
+                    enable_sga = yes
+                    boot_menu_key = "esc"
+                    Host_RHEL.m6:
+                        boot_menu_key = "f12"
+                    boot_menu_hint = "Press .*(F12|ESC) for boot menu"
+                    boot_entry_info = "Booting from Hard Disk..."
+                    usbdev_option_bootindex_usbredir1 = 0
+                - with_filter:
+                    display = spice
+                    variants policy:
+                        - allow:
+                            usbdev_option_filter_usbredir1 = "'-1:0x${usbredir_vendorid}:0x${usbredir_productid}:-1:1|-1:-1:-1:-1:0'"
+                        - deny:
+                            usbdev_option_filter_usbredir1 = "'-1:0x${usbredir_vendorid}:0x${usbredir_productid}:-1:0|-1:-1:-1:-1:1'"
+                - with_negative_config:
+                    display = spice
+                    usbredir_unconfigured_value = -1
         - usb_multi_disk:
             no piix3-uhci, piix4-uhci, ich9-uhci
             Host_RHEL.m6:

--- a/qemu/tests/usb_redir.py
+++ b/qemu/tests/usb_redir.py
@@ -1,0 +1,273 @@
+import logging
+import re
+import os
+
+from virttest import error_context
+from virttest import utils_misc
+from virttest import env_process
+from virttest.qemu_devices import qdevices
+from virttest.utils_params import Params
+
+from provider.storage_benchmark import generate_instance
+
+from avocado.utils import process
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Test usb redirection
+
+    1) Check host configurations
+    2) Preprocess VM
+    3) Start USB redirection via spice (optional)
+    4) Check the boot menu list (optional)
+    5) Check the redirected USB device in guest
+
+    :param test: QEMU test object
+    :param params: Dictionary with test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _host_config_check():
+        status = True
+        err_msg = ''
+        if option == "with_negative_config":
+            out = process.getoutput("dmesg")
+            pattern = r"usb (\d-\d(?:.\d)?):.*idVendor=%s, idProduct=%s"
+            pattern = pattern % (vendorid, productid)
+            obj = re.search(pattern, out, re.ASCII)
+            if not obj:
+                status = False
+                err_msg = "Fail to get the USB device info in host dmesg"
+                return (status, err_msg)
+            error_context.context("Make USB device unconfigured", logging.info)
+            unconfig_value = params["usbredir_unconfigured_value"]
+            cmd = "echo %s > /sys/bus/usb/devices/%s/bConfigurationValue"
+            cmd = cmd % (unconfig_value, obj.group(1))
+            logging.info(cmd)
+            s, o = process.getstatusoutput(cmd)
+            if s:
+                status = False
+                err_msg = "Fail to unconfig the USB device, output: %s" % o
+                return (status, err_msg)
+
+        if backend == 'spicevmc':
+            gui_group = "Server with GUI"
+            out = process.getoutput('yum group list --installed',
+                                    allow_output_check='stdout', shell=True)
+            obj = re.search(r"(Installed Environment Groups:.*?)^\S",
+                            out, re.S | re.M)
+            if not obj or gui_group not in obj.group(1):
+                gui_groupinstall_cmd = "yum groupinstall -y '%s'" % gui_group
+                s, o = process.getstatusoutput(gui_groupinstall_cmd, shell=True)
+                if s:
+                    status = False
+                    err_msg = "Fail to install '%s' on host, " % gui_group
+                    err_msg += "output: %s" % o
+                    return (status, err_msg)
+            virt_viewer_cmd = "rpm -q virt-viewer || yum install -y virt-viewer"
+            s, o = process.getstatusoutput(virt_viewer_cmd, shell=True)
+            if s:
+                status = False
+                err_msg = "Fail to install 'virt-viewer' on host, "
+                err_msg += "output: %s" % o
+                return (status, err_msg)
+        return (status, err_msg)
+
+    def _usbredir_preprocess():
+        def _generate_usb_redir_cmdline():
+            extra_params = ''
+            _backend = 'socket' if 'socket' in backend else backend
+            chardev_id = usbredir_params.get("chardev_id",
+                                             "chardev_%s" % usbredirdev_name)
+            chardev_params = Params({'backend': _backend, 'id': chardev_id})
+            if backend == 'spicevmc':
+                chardev_params['debug'] = usbredir_params.get('chardev_debug')
+                chardev_params['name'] = usbredir_params.get('chardev_name')
+            chardev = qdevices.CharDevice(chardev_params, chardev_id)
+            usbredir_dev = qdevices.QDevice('usb-redir',
+                                            aobject=usbredirdev_name)
+            usbredir_filter = usbredir_params.get("usbdev_option_filter")
+            usbredir_bootindex = usbredir_params.get("usbdev_option_bootindex")
+            usbredir_bus = usbredir_params.get("usb_bus")
+            usbredir_dev.set_param('id', 'usb-%s' % usbredirdev_name)
+            usbredir_dev.set_param('chardev', chardev_id)
+            usbredir_dev.set_param('filter', usbredir_filter)
+            usbredir_dev.set_param('bootindex', usbredir_bootindex)
+            usbredir_dev.set_param('bus', usbredir_bus)
+            extra_params += ' '.join([chardev.cmdline(),
+                                     usbredir_dev.cmdline()])
+            return extra_params
+        extra_params = _generate_usb_redir_cmdline()
+        params["extra_params"] = extra_params
+        if backend == 'spicevmc':
+            params["paused_after_start_vm"] = "yes"
+            del params["spice_password"]
+            del params["spice_addr"]
+            del params["spice_image_compression"]
+            del params["spice_zlib_glz_wan_compression"]
+            del params["spice_streaming_video"]
+            del params["spice_agent_mouse"]
+            del params["spice_playback_compression"]
+            del params["spice_ipv4"]
+        params["start_vm"] = "yes"
+        env_process.preprocess_vm(test, params, env, params["main_vm"])
+
+    def _start_spice_redirection():
+        def _rv_connection_check():
+            rv_pid = process.getoutput("pidof %s" % rv_binary)
+            spice_port = vm.get_spice_var('spice_port')
+            cmd = 'netstat -ptn | grep "^tcp.*127.0.0.1:%s.*ESTABLISHED %s.*"'
+            cmd = cmd % (spice_port, rv_pid)
+            s, o = process.getstatusoutput(cmd)
+            if s:
+                return False
+            logging.info("netstat output:\n%s", o)
+            return True
+        status = True
+        err_msg = ''
+        rv_binary_path = utils_misc.get_binary(rv_binary, params)
+        spice_port = vm.get_spice_var('spice_port')
+        rv_args = rv_binary_path + " spice://localhost:%s " % spice_port
+        rv_args += "--spice-usbredir-redirect-on-connect="
+        rv_args += "'-1,0x%s,0x%s,-1,1'" % (vendorid, productid)
+        rv_args += " > /dev/null 2>&1"
+        rv_thread = utils_misc.InterruptedThread(os.system, (rv_args,))
+        rv_thread.start()
+        if not utils_misc.wait_for(_rv_connection_check, timeout, 60):
+            status = False
+            err_msg = "Fail to establish %s connection" % rv_binary
+        return (status, err_msg)
+
+    def boot_check(info):
+        """
+        boot info check
+        """
+        return re.search(info, vm.serial_console.get_stripped_output())
+
+    def _usb_dev_verify():
+        error_context.context("Check USB device in guest", logging.info)
+        if session.cmd_status(lsusb_cmd):
+            return False
+        return True
+
+    def _kill_rv_proc():
+        s, o = process.getstatusoutput("pidof %s" % rv_binary)
+        if not s:
+            process.getoutput("killall %s" % rv_binary)
+
+    def _get_usb_mount_point():
+        """ Get redirected USB stick mount point """
+        dmesg_cmd = "dmesg | grep 'Attached SCSI removable disk'"
+        s, o = session.cmd_status_output(dmesg_cmd)
+        if s:
+            test.error("Fail to get redirected USB stick in guest.")
+        dev = re.findall(r'\[(sd\w+)\]', o)[0]
+        mounts_cmd = "cat /proc/mounts | grep /dev/%s" % dev
+        s, o = session.cmd_status_output(mounts_cmd)
+        if s:
+            s, o = session.cmd_status_output('mount /dev/%s /mnt' % dev)
+            if s:
+                test.error("Fail to mount /dev/%s, output: %s" % (dev, o))
+            mp = "/mnt"
+        else:
+            mp = re.findall(r'/dev/%s\d*\s+(\S+)\s+' % dev, o)[0]
+        return mp
+
+    def _usb_stick_io(mount_point):
+        """
+        Do I/O operations on passthrough USB stick
+        """
+        error_context.context("Read and write on USB stick ", logging.info)
+        testfile = os.path.join(mount_point, 'testfile')
+        iozone_cmd = params.get("iozone_cmd",
+                                " -a -I -r 64k -s 1m -i 0 -i 1 -f %s")
+        iozone_test.run(iozone_cmd % testfile)
+
+    usbredirdev_name = params["usbredirdev_name"]
+    usbredir_params = params.object_params(usbredirdev_name)
+    backend = usbredir_params.get('chardev_backend', 'spicevmc')
+    if backend not in ('spicevmc', 'tcp_socket'):
+        test.error("Unsupported char device backend type: %s" % backend)
+
+    option = params.get("option")
+    vendorid = params["usbredir_vendorid"]
+    productid = params["usbredir_productid"]
+    timeout = params.get("wait_timeout", 600)
+    lsusb_cmd = "lsusb -v -d %s:%s" % (vendorid, productid)
+    usb_stick = "Mass Storage" in process.getoutput(lsusb_cmd)
+    rv_binary = params.get('rv_binary', 'remote-viewer')
+
+    error_context.context("Check host configurations", logging.info)
+    s, o = _host_config_check()
+    if not s:
+        test.error(o)
+
+    if backend == 'spicevmc':
+        error_context.context("Preprocess VM", logging.info)
+        _usbredir_preprocess()
+        vm = env.get_vm(params["main_vm"])
+        vm.verify_alive()
+        error_context.context("Start USB redirection via spice", logging.info)
+        s, o = _start_spice_redirection()
+        if not s:
+            test.error(o)
+        vm.resume()
+
+    if option == "with_bootindex":
+        error_context.context("Check 'bootindex' option", logging.info)
+        boot_menu_hint = params["boot_menu_hint"]
+        boot_menu_key = params["boot_menu_key"]
+        if not utils_misc.wait_for(lambda: boot_check(boot_menu_hint),
+                                   timeout, 1):
+            test.fail("Could not get boot menu message")
+
+        # Send boot menu key in monitor.
+        vm.send_key(boot_menu_key)
+
+        output = vm.serial_console.get_stripped_output()
+        boot_list = re.findall(r"^\d+\. (.*)\s", output, re.M)
+        if not boot_list:
+            test.fail("Could not get boot entries list")
+        logging.info("Got boot menu entries: '%s'", boot_list)
+
+        bootindex = int(params["usbdev_option_bootindex_%s" % usbredirdev_name])
+        if "USB" not in boot_list[bootindex]:
+            test.fail("'bootindex' option of usb-redir doesn't take effect")
+
+        if usb_stick:
+            error_context.context("Boot from redirected USB stick",
+                                  logging.info)
+            boot_entry_info = params["boot_entry_info"]
+            vm.send_key(str(bootindex+1))
+            if not utils_misc.wait_for(lambda: boot_check(boot_entry_info),
+                                       timeout, 1):
+                test.fail("Could not boot from redirected USB stick")
+        return
+
+    error_context.context("Login to guest", logging.info)
+    session = vm.wait_for_login()
+
+    if params.get("policy") == "deny":
+        if _usb_dev_verify():
+            error_msg = "Redirected USB device can be found in guest"
+            error_msg += " while policy is deny"
+            test.fail(error_msg)
+        if backend == 'spicevmc':
+            _kill_rv_proc()
+        return
+
+    if not _usb_dev_verify():
+        test.fail("Can not find the redirected USB device in guest")
+
+    if usb_stick:
+        iozone_test = None
+        try:
+            mount_point = _get_usb_mount_point()
+            iozone_test = generate_instance(params, vm, 'iozone')
+            _usb_stick_io(mount_point)
+        finally:
+            if iozone_test:
+                iozone_test.clean()
+
+    session.close()


### PR DESCRIPTION
Add usb-redir device cases:
1. Basic functionality of USB redirection.
2. filter option of usb-redir device.
3. bootindex option of usb-redir device.
4. Host USB device negative configuration.

ID: 1876507, 1826129, 1876509, 1876510

Signed-off-by: ybduan <yduan@redhat.com>