### PR TITLE
Change the vcpu_maxcpus to be the same with smp number

### DIFF
--- a/qemu/tests/multi_vms_nics.py
+++ b/qemu/tests/multi_vms_nics.py
@@ -139,7 +139,8 @@ def run(test, params, env):
                    "pcus: %d, minimum of vcpus and vhost: %d" %
                    (host_cpu_count, (1 + vhost_count) * len(vms)))
     params['mem'] = host_mem // len(vms) * 1024
-    params['smp'] = host_cpu_count // len(vms) - vhost_count
+    params['smp'] = params['vcpu_maxcpus'] = \
+        host_cpu_count // len(vms) - vhost_count
     if params['smp'] % 2 != 0:
         params['vcpu_sockets'] = 1
     params["start_vm"] = "yes"


### PR DESCRIPTION
According to the case, sometimes we allocated the cpu number more than
the maxcpu supported in guest, so we add param['vcpu_maxcpus'] to set 
the value same.

ID:1872662

Signed-off-by: Boqiao Fu <bfu@redhat.com>