### PR TITLE
Make "tmpfs_size" able to set by cfg files to avoid lack of disk space

### DIFF
--- a/qemu/tests/cfg/numa.cfg
+++ b/qemu/tests/cfg/numa.cfg
@@ -19,3 +19,5 @@
             type = numa_stress
             del stress_args
             mem_ratio = 0.8
+            # Replace "count" in "dd commands" to avoid lack of disk space
+            #tmpfs_size = 1024

--- a/qemu/tests/numa_stress.py
+++ b/qemu/tests/numa_stress.py
@@ -83,10 +83,10 @@ def run(test, params, env):
     if test_count < len(host_numa_node.online_nodes):
         test_count = len(host_numa_node.online_nodes)
 
-    tmpfs_size = 0
+    tmpfs_size = params.get_numeric("tmpfs_size")
     for node in host_numa_node.nodes:
         node_mem = int(host_numa_node.read_from_node_meminfo(node, "MemTotal"))
-        if tmpfs_size < node_mem:
+        if tmpfs_size == 0:
             tmpfs_size = node_mem
     tmpfs_path = params.get("tmpfs_path", "tmpfs_numa_test")
     tmpfs_path = utils_misc.get_path(data_dir.get_tmp_dir(), tmpfs_path)


### PR DESCRIPTION
tmpfs_size could set by cfg files now and it will be equal with 
node_Memtotal only with default number 0

ID:1870570

Signed-off-by: Boqiao Fu <bfu@redhat.com>