### PR TITLE
virtio-fs: install viofs driver in Windows vm

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -102,3 +102,29 @@
                     input_dev_type_input1 = keyboard
                 - device_tablet:
                     input_dev_type_input1 = tablet
+        - with_viofs:
+            no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
+            no Win2008 Win7
+            virt_test_type = qemu
+            required_qemu = [4.2.0,)
+            filesystems = fs
+            fs_driver = virtio-fs
+            fs_source_type = mount
+            fs_source_dir = virtio_fs_test/
+            force_create_fs_source = yes
+            remove_fs_source = yes
+            fs_target = 'myfs'
+            fs_driver_props = {"queue-size": 1024}
+            mem = 4096
+            mem_devs = mem1
+            backend_mem_mem1 = memory-backend-file
+            mem-path_mem1 = /dev/shm
+            size_mem1 = 4G
+            use_mem_mem1 = no
+            share_mem = yes
+            guest_numa_nodes = shm0
+            numa_memdev_shm0 = mem-mem1
+            numa_nodeid_shm0 = 0
+            driver_name = viofs
+            device_name = "VirtIO FS Device"
+            device_hwid = '"PCI\VEN_1AF4&DEV_105A"'


### PR DESCRIPTION
Install viofs driver in a preinstalled windows guest.
ID: 1877701 
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>