### PR TITLE
Update some filters to let some earlier test cases can work on aarch64

### DIFF
--- a/qemu/tests/blockdev_commit_install.py
+++ b/qemu/tests/blockdev_commit_install.py
@@ -26,7 +26,7 @@ def run(test, params, env):
     def tag_for_install(vm, tag):
         if vm.serial_console:
             serial_output = vm.serial_console.get_output()
-            if tag in serial_output:
+            if serial_output and tag in serial_output:
                 return True
         logging.info("vm has not started yet")
         return False

--- a/qemu/tests/blockdev_snapshot_install.py
+++ b/qemu/tests/blockdev_snapshot_install.py
@@ -24,7 +24,7 @@ def run(test, params, env):
     def tag_for_install(vm, tag):
         if vm.serial_console:
             serial_output = vm.serial_console.get_output()
-            if tag in serial_output:
+            if serial_output and tag in serial_output:
                 return True
         logging.info("VM has not started yet")
         return False

--- a/qemu/tests/cfg/block_with_share_rw.cfg
+++ b/qemu/tests/cfg/block_with_share_rw.cfg
@@ -19,6 +19,8 @@
                     only virtio_blk
                     drive_format_stg = virtio
                 - with_usb_storage:
+                    aarch64:
+                        no Host_RHEL
                     usbs = " usbtest"
                     usb_bus = "usbtest.0"
                     variants:

--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -42,7 +42,7 @@
 
         - with_block:
             drive_format_image1 = ide
-            pseries:
+            pseries, aarch64:
                drive_format_image1 = scsi-hd
             q35:
                 drive_format_image1 = ahci
@@ -59,7 +59,7 @@
         - with_vioscsi:
             cd_format_fixed = ide
             drive_format_image1 = ide
-            pseries:
+            pseries, aarch64:
                cd_format_fixed = scsi-cd
                drive_format_image1 = virtio
             q35:

--- a/qemu/tests/cfg/multi_nics_hotplug.cfg
+++ b/qemu/tests/cfg/multi_nics_hotplug.cfg
@@ -12,7 +12,7 @@
         additional_operation = yes
     variants:
         - nic_8139:
-            no ppc64 ppc64le
+            only i386, x86_64
             pci_model = rtl8139
             nics = ""
             extra_params += "-net none"
@@ -23,19 +23,19 @@
             nics = ""
             extra_params += "-net none"
         - nic_e1000:
-            no ppc64 ppc64le
+            only i386, x86_64
             no RHEL.8
             pci_model = e1000
             nics = ""
             extra_params += "-net none"
         - nic_e1000e:
-            no ppc64 ppc64le
+            only i386, x86_64
             required_qemu = [2.6.0, )
             pci_model = e1000e
             nics = ""
             extra_params += "-net none"
         - combination:
-            no ppc64 ppc64le
+            only i386, x86_64
             pci_model = virtio-net-pci
             pci_model_hotplug_nic1 = rtl8139
             pci_model_hotplug_nic3 = e1000

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -34,7 +34,8 @@
             reboot_method = system_reset
     variants:
         - nic_8139:
-            no ppc64, ppc64le, s390x, q35
+            only i386, x86_64
+            no q35
             pci_model = rtl8139
         - nic_virtio:
             #TODO: Confirm this works with libvirt
@@ -44,12 +45,13 @@
             s390x:
                 pci_model = virtio-net-ccw
         - nic_e1000:
-            no ppc64, ppc64le, s390x, q35
+            only i386, x86_64
+            no q35
             RHEL:
                 only RHEL.6 RHEL.7
             pci_model = e1000
         - nic_e1000e:
-            no ppc64, ppc64le, s390x
+            only i386, x86_64
             pci_model = e1000e
     variants:
         - one_pci:

--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -272,7 +272,7 @@
         - check_fsinfo:
             gagent_check_type = fsinfo
             blk_extra_params_image1 = "serial=GAGENT_TEST"
-            cmd_get_disk = cat /proc/mounts |grep -v rootfs |awk '$2~/^\%s$/{print $1,$3}'
+            cmd_get_disk = cat /proc/mounts |grep -v rootfs |awk '$2~/^%s$/{print $1,$3}'
             Windows:
                 cmd_get_disk = wmic volume where "DriveLetter='%s'" get FileSystem,DeviceID |findstr /v /i FileSystem
         - check_nonexistent_cmd:

--- a/qemu/tests/cfg/qemu_option_check.cfg
+++ b/qemu/tests/cfg/qemu_option_check.cfg
@@ -10,13 +10,13 @@
         - e1000:
             RHEL:
                 only RHEL.6 RHEL.7
-            no ppc64,ppc64le,s390x
+            only i386, x86_64
             device_name = e1000
         - e1000e:
-            no ppc64,ppc64le,s390x
+            only i386, x86_64
             device_name = e1000e
         - rtl8139:
-            no ppc64,ppc64le,s390x
+            only i386, x86_64
             device_name = rtl8139
         - spapr-vlan:
             only ppc64,ppc64le

--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -179,6 +179,8 @@
             s390x:
                 qmp_cmd = "device-list-properties typename=virtio-balloon-ccw"
                 cmd_return_value = "['notify_on_empty', 'ioeventfd', 'any_layout', 'devno', 'indirect_desc', 'guest-stats', 'guest-stats-polling-interval', 'event_idx', 'virtio-backend', 'iommu_platform', 'deflate-on-oom', 'max_revision']"
+            aarch64:
+                cmd_return_value = "['multifunction', 'ats', 'notify_on_empty']"
         - qmp_query-command-line-options:
             qmp_cmd = "query-command-line-options"
             cmd_result_check = contain

--- a/qemu/tests/cfg/qmp_event_notification.cfg
+++ b/qemu/tests/cfg/qmp_event_notification.cfg
@@ -53,6 +53,8 @@
             event_cmd = hwclock --systohc
             event_check = "RTC_CHANGE"
         - qmp_watchdog:
+            aarch64:
+                no Host_RHEL
             no Windows
             event_cmd = echo 0 > /dev/watchdog
             event_check = "WATCHDOG"

--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -6,6 +6,10 @@
     kill_vm_on_error = yes
     usbs = " usbtest"
     usb_bus = "usbtest.0"
+    aarch64:
+        Host_RHEL:
+            only qemu-xhci
+            no usb_storage
 
     # usb controllers
     variants:

--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -19,6 +19,9 @@
     usb_mouse_for_guest = "QEMU USB Mouse"
     usb_kbd_for_guest = "QEMU USB Keyboard"
     usb_tablet_for_guest = "QEMU USB Tablet"
+    aarch64:
+        Host_RHEL:
+            only qemu-xhci
     Windows:
         chk_usb_info_cmd = 'wmic path Win32_USBControllerDevice get Dependent | find "USB"'
         # usb device info for Windows guest

--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -4,6 +4,7 @@
     start_vm = no
     type = watchdog
     aarch64:
+        no Host_RHEL
         watchdog_type_check = " -M virt -watchdog '?'"
     variants:
         -i6300esb:

--- a/qemu/tests/nic_hotplug.py
+++ b/qemu/tests/nic_hotplug.py
@@ -115,9 +115,10 @@ def run(test, params, env):
             root_port_id = bus.get_free_root_port()
             if root_port_id:
                 pci_add_cmd += ",bus=%s" % root_port_id
-                root_port = vm.devices.get_buses({"aobject": root_port_id})[0]
-                root_port.insert(qdevices.QBaseDevice(pci_model,
-                                                      aobject=device_id))
+                if used_sameid != "yes":
+                    root_port = vm.devices.get_buses({"aobject": root_port_id})[0]
+                    root_port.insert(qdevices.QBaseDevice(pci_model,
+                                                          aobject=device_id))
             else:
                 test.error("No free root port for device %s to plug."
                            % device_id)

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -2553,7 +2553,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             error_context.context("Check file system type of '%s' mount point." %
                                   mount_pt, logging.info)
             fs_type_qga = fs["type"]
-            cmd_get_disk = params["cmd_get_disk"] % mount_pt
+            cmd_get_disk = params["cmd_get_disk"] % mount_pt.replace("/", r"\/")
             disk_info_guest = session.cmd(cmd_get_disk).strip().split()
             fs_type_guest = disk_info_guest[1]
             if fs_type_qga != fs_type_guest:

--- a/qemu/tests/qmp_command.py
+++ b/qemu/tests/qmp_command.py
@@ -255,7 +255,8 @@ def run(test, params, env):
                 host_arch = host_arch[:5]
             expect_o = [{"arch": host_arch}]
         elif qmp_cmd == "query-machines":
-            vm_machines = params["machine_type"]
+            # Remove avocado machine type
+            vm_machines = params["machine_type"].split(':', 1)[-1]
             expect_o = [{'alias': vm_machines}]
         check_result(qmp_o, expect_o)
     elif result_check.startswith("post_"):


### PR DESCRIPTION
1. Update cfg files to drop some network-related test cases.
2. Fix "nic_hotplug.used_netdev.nic_virtio.default" failed on pcie bridge.
3. qmp_command: Update "qmp_device-list-properties" and "qmp_query-machines" to let them work on aarch64.
4. qmp_event_notification: Drop "qmp_watchdog" for aarch64 rhel guest
5. Pattern of "cmd_get_disk" cannot handle multiple '/' like '/boot/efi', update to fix this problem.
6. qemu-kvm provided by RHEL does not yet support watchdog on aarch64, drop these cases.
7. aarch64 does not support IDE bus, modify the drive format to use a supported bus.
8. blockdev_snapshot_install & blockdev_commit_install: session.get_output will return "None" if it excepts OSError, check "serial_output" at first to ensure it is not None.
9. Update cfg files to drop some usb-related test cases.

ID: 1878619, 1801498
Signed-off-by: Yihuang Yu <yihyu@redhat.com>