### PR TITLE
Modify boot_patterns and restrict qemu for cpu hotplug related cases

### DIFF
--- a/qemu/tests/cfg/cpu_device_hotplug_during_boot.cfg
+++ b/qemu/tests/cfg/cpu_device_hotplug_during_boot.cfg
@@ -1,5 +1,7 @@
 - cpu_device_hotplug_during_boot: cpu_device_hotpluggable
     required_qemu = [2.6.0, )
+    ppc64, ppc64le:
+        required_qemu = [2.12.0, )
     virt_test_type = qemu
     type = cpu_device_hotplug_during_boot
     qemu_sandbox = on

--- a/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
+++ b/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
@@ -5,6 +5,8 @@
     no RHEL.6
     only x86_64 ppc64 ppc64le
     required_qemu = [2.6.0, )
+    ppc64, ppc64le:
+        required_qemu = [2.12.0, )
     start_vm = no
     qemu_sandbox = on
     allow_pcpu_overcommit = no

--- a/qemu/tests/cfg/cpu_device_hotpluggable.cfg
+++ b/qemu/tests/cfg/cpu_device_hotpluggable.cfg
@@ -11,6 +11,8 @@
     # when it is fully supported.
     no ovmf
     required_qemu = [2.6.0, )
+    ppc64, ppc64le:
+        required_qemu = [2.12.0, )
     virt_test_type = qemu
     type = cpu_device_hotpluggable
     # Sleep for a while after vCPUs change, make guest stable

--- a/qemu/tests/cfg/invalid_cpu_device_hotplug.cfg
+++ b/qemu/tests/cfg/invalid_cpu_device_hotplug.cfg
@@ -3,6 +3,8 @@
     virt_test_type = qemu
     type = invalid_cpu_device_hotplug
     required_qemu = [2.6.0, )
+    ppc64, ppc64le:
+        required_qemu = [2.12.0, )
     # ovmf does not support hotpluggable vCPU yet
     no ovmf
     no RHEL.6

--- a/qemu/tests/cpu_device_hotplug_during_boot.py
+++ b/qemu/tests/cpu_device_hotplug_during_boot.py
@@ -21,7 +21,7 @@ def run(test, params, env):
     """
     vcpu_devices = params.objects("vcpu_devices")
     unplug_during_boot = params.get_boolean("unplug_during_boot")
-    boot_patterns = [r".*Linux version.*", r".*Kernel command line:.*"]
+    boot_patterns = [r".*Started udev Wait for Complete Device Initialization.*"]
     reboot_patterns = [r".*[Rr]ebooting.*", r".*[Rr]estarting system.*",
                        r".*[Mm]achine restart.*"]
 


### PR DESCRIPTION
1. cpu_device_hotplug_during_boot: Modify boot_patterns
2. Update required qemu version of CPU hotplug related test case for PPC

ID: 1834569
Signed-off-by: Yihuang Yu <yihyu@redhat.com>