### PR TITLE
Add cases to offline hotplugged vCPUs before hotunplug them

### DIFF
--- a/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
+++ b/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
@@ -37,3 +37,10 @@
         - with_hugepages:
             hugepage = yes
             extra_params += " -mem-path /mnt/kvm_hugepage"
+        - offline_vcpu:
+            only Linux
+            ppc64, ppc64le:
+                only max_thread
+            ! ppc64, ppc64le:
+                only max_core
+            offline_vcpu_after_hotplug = yes


### PR DESCRIPTION
1. Offline all hotplugged vCPUs before hotunplug them.
2. Hotunplug operations only in Linux guests.

ID: 1879456, 1881271
Signed-off-by: Yihuang Yu <yihyu@redhat.com>