### PR TITLE
Support running vtpm test cases on aarch64

### DIFF
--- a/qemu/tests/cfg/tpm_unattended_install.cfg
+++ b/qemu/tests/cfg/tpm_unattended_install.cfg
@@ -45,6 +45,9 @@
     ppc64le, ppc64:
         required_qemu= [5.0.0,)
         tpm_model_tpm0 = tpm-spapr
+    aarch64:
+        required_qemu= [5.1.0,)
+        tpm_model_tpm0 = tpm-tis-device
     tpm_type_tpm0 = emulator
     tpm_version_tpm0 = 2.0
     Windows:

--- a/qemu/tests/cfg/tpm_verify_device.cfg
+++ b/qemu/tests/cfg/tpm_verify_device.cfg
@@ -11,6 +11,8 @@
         required_qemu= [4.2.0,)
     ppc64le, ppc64:
         required_qemu= [5.0.0,)
+    aarch64:
+        required_qemu = [5.1.0,)
     Linux:
         check_cmd_names = dmesg ls
         cmd_dmesg = dmesg | grep -i tpm
@@ -33,6 +35,8 @@
             tpm_model_tpm0 = tpm-crb
             ppc64le, ppc64:
                 tpm_model_tpm0 = tpm-spapr
+            aarch64:
+                tpm_model_tpm0 = tpm-tis-device
             tpm_version_tpm0 = 2.0
             variants:
                 - @default:
@@ -60,6 +64,7 @@
                     master_images_clone = image1
                     remove_image_image1 = yes
         - with_passthrough:
+            no aarch64
             start_vm = no
             not_preprocess = yes
             cmd_check_tpm_device = ls /dev/tpm0


### PR DESCRIPTION
Support running tpm_verify_device and tpm_unattended_install on aarch64.

ID: 1882580
Signed-off-by: Yihuang Yu <yihyu@redhat.com>