### PR TITLE
softlockup: remove '-f' to avoid pkill other process unexpectedly

### DIFF
--- a/qemu/deps/softlockup/heartbeat_slu.py
+++ b/qemu/deps/softlockup/heartbeat_slu.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Heartbeat server/client to detect soft lockups
 """

--- a/qemu/tests/cfg/softlockup.cfg
+++ b/qemu/tests/cfg/softlockup.cfg
@@ -4,8 +4,8 @@
     type = softlockup
     stress_source = stress-1.0.4.tar.gz
     stress_setup_cmd = "cd %s && tar xvf stress-1.0.4.tar.gz && cd stress-1.0.4 && ./configure && make && cd src"
-    server_setup_cmd = "%s/heartbeat_slu.py --server --threshold %s --file %s --port %s --verbose --check-drift"
-    client_setup_cmd = "%s/heartbeat_slu.py --client --address %s --file %s --port %s --interval 1"
+    server_setup_cmd = "`command -v python python3 | head -1` %s/heartbeat_slu.py --server --threshold %s --file %s --port %s --verbose --check-drift"
+    client_setup_cmd = "`command -v python python3 | head -1` %s/heartbeat_slu.py --client --address %s --file %s --port %s --interval 1"
     stress_cmd  = "cd %s && cd stress-1.0.4 && cd src && nohup ./stress -c %s > /dev/null 2>&1&"
     kill_monitor_cmd = "ps aux | grep heart | grep -v grep | awk '{print$2}' | xargs kill -9 > /dev/null 2>&1"
     kill_stress_cmd = "pkill -9 stress > /dev/null 2>&1"

--- a/qemu/tests/cfg/softlockup.cfg
+++ b/qemu/tests/cfg/softlockup.cfg
@@ -8,7 +8,7 @@
     client_setup_cmd = "%s/heartbeat_slu.py --client --address %s --file %s --port %s --interval 1"
     stress_cmd  = "cd %s && cd stress-1.0.4 && cd src && nohup ./stress -c %s > /dev/null 2>&1&"
     kill_monitor_cmd = "ps aux | grep heart | grep -v grep | awk '{print$2}' | xargs kill -9 > /dev/null 2>&1"
-    kill_stress_cmd = "pkill -f stress > /dev/null 2>&1"
+    kill_stress_cmd = "pkill -9 stress > /dev/null 2>&1"
     drift_cmd = "tail -1 %s | awk '{print $7}'"
     monitor_log_file_server = /tmp/heartbeat_server.log
     monitor_log_file_client = /tmp/heartbeat_client.log


### PR DESCRIPTION
Without the option "-f", pkill only matched against the process
name. When "-f" is set, the full command line is used. It now
kills some other process that we need to keep running during the
test so remove it.

id: 1541729, 1869584
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>