### PR TITLE
resize_qemu_img: add preallocation support to resize image

### DIFF
--- a/qemu/tests/cfg/resize_qemu_img.cfg
+++ b/qemu/tests/cfg/resize_qemu_img.cfg
@@ -7,6 +7,16 @@
     images = "test"
     image_name_test = images/test
     variants:
+        - @default:
+        - with_preallocation:
+            variants:
+                - off:
+                    preallocation = off
+                - full:
+                    preallocation = full
+                - falloc:
+                    preallocation = falloc
+    variants:
         - increase_size:
             # These two params must be provided to calculate size changes.
             # You can change size_changes based on your cases.
@@ -16,3 +26,4 @@
             required_qemu = [2.12.0, )
             image_size_test = 10G
             size_changes = "-2G"
+            no full falloc


### PR DESCRIPTION
1. for increase size, add off, full and falloc
2. for shrink size, add off

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1883026