### PR TITLE
virtio-fs: support viofs driver for win driver case

### DIFF
--- a/qemu/tests/cfg/virtio_driver_sign_check.cfg
+++ b/qemu/tests/cfg/virtio_driver_sign_check.cfg
@@ -40,3 +40,27 @@
             tested_driver = "vioscsi"
         - with_viostor:
             tested_driver = "viostor"
+        - with_viofs:
+            no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
+            no Win2008 Win7
+            virt_test_type = qemu
+            required_qemu = [4.2.0,)
+            filesystems = fs
+            fs_driver = virtio-fs
+            fs_source_type = mount
+            fs_source_dir = virtio_fs_test/
+            force_create_fs_source = yes
+            remove_fs_source = yes
+            fs_target = 'myfs'
+            fs_driver_props = {"queue-size": 1024}
+            mem = 4096
+            mem_devs = mem1
+            backend_mem_mem1 = memory-backend-file
+            mem-path_mem1 = /dev/shm
+            size_mem1 = 4G
+            use_mem_mem1 = no
+            share_mem = yes
+            guest_numa_nodes = shm0
+            numa_memdev_shm0 = mem-mem1
+            numa_nodeid_shm0 = 0
+            tested_driver = viofs

--- a/qemu/tests/cfg/win_sigverif.cfg
+++ b/qemu/tests/cfg/win_sigverif.cfg
@@ -67,3 +67,28 @@
             input_dev_bus_type_input1 = virtio
             input_dev_type_input1 = mouse
             device_name = "VirtIO Input Driver"
+        - with_viofs:
+            no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
+            no Win2008 Win7
+            virt_test_type = qemu
+            required_qemu = [4.2.0,)
+            filesystems = fs
+            fs_driver = virtio-fs
+            fs_source_type = mount
+            fs_source_dir = virtio_fs_test/
+            force_create_fs_source = yes
+            remove_fs_source = yes
+            fs_target = 'myfs'
+            fs_driver_props = {"queue-size": 1024}
+            mem = 4096
+            mem_devs = mem1
+            backend_mem_mem1 = memory-backend-file
+            mem-path_mem1 = /dev/shm
+            size_mem1 = 4G
+            use_mem_mem1 = no
+            share_mem = yes
+            guest_numa_nodes = shm0
+            numa_memdev_shm0 = mem-mem1
+            numa_nodeid_shm0 = 0
+            driver_name = viofs
+            device_name = "VirtIO FS Device"


### PR DESCRIPTION
Support viofs driver in win_sigverify and virtio_driver_sign_check
test cases.
ID: 1883424, 1883427
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>