### PR TITLE
Modify cfgs to avoid hotplug/hot-unplug with spapr_vscsi devices

### DIFF
--- a/qemu/tests/cfg/block_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug.cfg
@@ -1,6 +1,7 @@
 - block_hotplug: install setup image_copy unattended_install.cdrom
     no RHEL.3.9
     no ide
+    no spapr_vscsi
     virt_test_type = qemu libvirt
     type = block_hotplug
     bootindex_image1 = 0

--- a/qemu/tests/cfg/block_hotplug_in_pause.cfg
+++ b/qemu/tests/cfg/block_hotplug_in_pause.cfg
@@ -1,5 +1,6 @@
 - block_hotplug_in_pause: install setup image_copy unattended_install.cdrom
     no ide
+    no spapr_vscsi
     virt_test_type = qemu libvirt
     type = block_hotplug_in_pause
     bootindex_image1 = 0

--- a/qemu/tests/cfg/block_hotplug_negative.cfg
+++ b/qemu/tests/cfg/block_hotplug_negative.cfg
@@ -4,6 +4,7 @@
 - block_hotplug_negative:
     no RHEL.3.9
     no ide
+    no spapr_vscsi
     virt_test_type = qemu
     type = block_hotplug_negative
     bootindex_image1 = 0

--- a/qemu/tests/cfg/hotplug_unplug_during_io_repeat.cfg
+++ b/qemu/tests/cfg/hotplug_unplug_during_io_repeat.cfg
@@ -1,6 +1,7 @@
 - hotplug_unplug_during_io_repeat:
     no RHEL.3.9
     no ide
+    no spapr_vscsi
     virt_test_type = qemu
     type = hotplug_unplug_during_io_repeat
     images += " stg0"

--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -14,6 +14,7 @@
     wait_after_hotplug = 10
     wait_between_unplugs = 2
     vt_ulimit_nofile = 8192
+    no spapr_vscsi
     ppc64le,ppc64:
         wait_between_unplugs = 20
     q35:


### PR DESCRIPTION
Cause spapr_vscsi devices not support to hotplug/hot-unplug, add
"no spapr_vscsi" in cfgs to avoid running those cases while doing hotplug
/hot-unplug

ID:1877658

Signed-off-by: Boqiao Fu <bfu@redhat.com>