### PR TITLE
usb_pci_ohci:add pci_ohci test cases for power

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -36,6 +36,13 @@
             drive_format_stg = "usb1"
             no ppc64 ppc64le
             no Host_RHEL.m6
+        - pci-ohci:
+            only usb_boot, usb_reboot
+            usb_type_usbtest = pci-ohci
+            usb_controller = ohci
+            max_ports_usbtest = 2
+            drive_format_stg = "usb1"
+            no x86_64
         - ich9-ehci:
             only usb_boot, usb_reboot
             usb_controller = ehci


### PR DESCRIPTION
add usb_boot and usb_reboot test cases of pci_ohci on  power

ID:1883774

Signed-off-by: MiriramDeng <mdeng@redhat.com>

It depends on https://github.com/avocado-framework/avocado-vt/pull/2784