### PR TITLE
storage_volume: Keep the same setting with libvirt when blockdev-add

### DIFF
--- a/provider/virt_storage/storage_volume.py
+++ b/provider/virt_storage/storage_volume.py
@@ -137,6 +137,10 @@ class StorageVolume(object):
                 self.format.set_param("backing", backing_node)
         self.format.set_param("file", self.protocol.get_param("node-name"))
 
+        # keep the same setting with libvirt when blockdev-add a format node
+        readonly = params.get("image_readonly", "off")
+        self.format.set_param("read-only", readonly)
+
     def refresh_protocol_by_params(self, params):
         if self.protocol.TYPE == "file":
             aio = params.get("image_aio", "threads")
@@ -144,6 +148,12 @@ class StorageVolume(object):
             self.protocol.set_param("aio", aio)
         else:
             raise NotImplementedError
+
+        # keep the same setting with libvirt when blockdev-add a protocol node
+        auto_readonly = params.get("image_auto_readonly", "on")
+        discard = params.get("image_discard_request", "unmap")
+        self.protocol.set_param("auto-read-only", auto_readonly)
+        self.protocol.set_param("discard", discard)
 
     def info(self):
         out = dict()


### PR DESCRIPTION
  1. protocol node: set "auto-read-only":true,"discard":"unmap"
  2. format node: set "read-only=false"
  3. The change should not take effect on all hotplug cases, but
     only on cases use storage_volume module, e.g. most storage
     vm migration cases, for the settings are not required, we
     should cover testing scenario without setting 1&2

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1882628