### PR TITLE
add "restorecon -Rv /" before guest-agent run fsfreeze

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -1895,6 +1895,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
     @error_context.context_aware
     def _action_before_fsfreeze(self, *args):
         session = self._get_session(self.params, None)
+        session.cmd("restorecon -Rv /", timeout=180)
         self._open_session_list.append(session)
 
     @error_context.context_aware
@@ -2750,6 +2751,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 test.error("Didn't find any disk_index except system disk.")
 
         error_context.context("Freeze fs.", logging.info)
+        session.cmd("restorecon -Rv /", timeout=180)
         self.gagent.fsfreeze()
 
         error_context.context("Umount fs or offline disk in guest.",


### PR DESCRIPTION
since guest-agent fail to set/check guest freeze status through guest-agent
socket, add "restorecon -Rv /" to avoid this issue

ID:1876731,1889312

Signed-off-by: Boqiao Fu <bfu@redhat.com>