### PR TITLE
block job with install: Add one keyword to detect install start

### DIFF
--- a/qemu/tests/blockdev_commit_install.py
+++ b/qemu/tests/blockdev_commit_install.py
@@ -1,6 +1,7 @@
 import time
 import logging
 import random
+import re
 
 from virttest import utils_test
 from virttest import utils_misc
@@ -26,7 +27,7 @@ def run(test, params, env):
     def tag_for_install(vm, tag):
         if vm.serial_console:
             serial_output = vm.serial_console.get_output()
-            if serial_output and tag in serial_output:
+            if serial_output and re.search(tag, serial_output, re.M):
                 return True
         logging.info("vm has not started yet")
         return False

--- a/qemu/tests/blockdev_mirror_install.py
+++ b/qemu/tests/blockdev_mirror_install.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import re
 import time
 
 from virttest import utils_test
@@ -19,7 +20,7 @@ class BlockdevMirrorVMInstallTest(BlockdevMirrorNowaitTest):
         out = self.main_vm.serial_console.get_output() \
             if self.main_vm.serial_console else None
         out = '' if out is None else out
-        return start_msg in out
+        return bool(re.search(start_msg, out, re.M))
 
     def _install_vm_in_background(self):
         """Install VM in background"""

--- a/qemu/tests/blockdev_snapshot_install.py
+++ b/qemu/tests/blockdev_snapshot_install.py
@@ -1,6 +1,7 @@
 import time
 import logging
 import random
+import re
 
 from virttest import utils_test
 from virttest import utils_misc
@@ -24,7 +25,7 @@ def run(test, params, env):
     def tag_for_install(vm, tag):
         if vm.serial_console:
             serial_output = vm.serial_console.get_output()
-            if serial_output and tag in serial_output:
+            if serial_output and re.search(tag, serial_output, re.M):
                 return True
         logging.info("VM has not started yet")
         return False

--- a/qemu/tests/blockdev_stream_install.py
+++ b/qemu/tests/blockdev_stream_install.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import re
 import time
 
 from virttest import utils_test
@@ -18,7 +19,7 @@ class BlockdevStreamVMInstallTest(BlockdevStreamNowaitTest):
         out = self.main_vm.serial_console.get_output() \
             if self.main_vm.serial_console else None
         out = '' if out is None else out
-        return start_msg in out
+        return bool(re.search(start_msg, out, re.M))
 
     def _install_vm_in_background(self):
         """Install VM in background"""

--- a/qemu/tests/cfg/blockdev_commit_install.cfg
+++ b/qemu/tests/cfg/blockdev_commit_install.cfg
@@ -38,3 +38,4 @@
     rebase_mode = unsafe
     qemu_force_use_drive_expression = no
     no RHEL.5 RHEL.6 RHEL.7 RHEL.8.1
+    tag_for_install_start = "Starting Login Service|Starting Update is Completed"

--- a/qemu/tests/cfg/blockdev_mirror_install.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_install.cfg
@@ -34,7 +34,7 @@
     image_format_mirror1 = qcow2
     image_name_mirror1 = mirror1
 
-    tag_for_install_start = "Starting Login Service"
+    tag_for_install_start = "Starting Login Service|Starting Update is Completed"
     rebase_mode = unsafe
 
     # Always access cd1 and unattended as local storage

--- a/qemu/tests/cfg/blockdev_snapshot_install.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_install.cfg
@@ -14,7 +14,7 @@
     cdroms += " unattended"
     index_enable = no
     kill_vm = yes
-    tag_for_install_start = "Starting Login Service"
+    tag_for_install_start = "Starting Login Service|Starting Update is Completed"
     storage_type_default = "directory"
     storage_pool = default
     snapshot_tag = sn1

--- a/qemu/tests/cfg/blockdev_stream_install.cfg
+++ b/qemu/tests/cfg/blockdev_stream_install.cfg
@@ -33,7 +33,7 @@
     image_format_datasn = qcow2
     image_name_datasn = datasn
 
-    tag_for_install_start = "Starting Login Service"
+    tag_for_install_start = "Starting Login Service|Starting Update is Completed"
     rebase_mode = unsafe
 
     # Always access cd1 and unattended as local storage


### PR DESCRIPTION
  blockdev_commit_install/blockdev_mirror_install
  blockdev_snapshot_install/blockdev_stream_install
  updated, please be noted that we have to add more
  keywords if the installation console logs changed

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1888498