### PR TITLE
Restore aavmf vars if needed

### DIFF
--- a/qemu/tests/cfg/blockdev_commit_install.cfg
+++ b/qemu/tests/cfg/blockdev_commit_install.cfg
@@ -21,6 +21,8 @@
     storage_type_default = "directory"
     storage_pool = default
     snapshot_tags = sn1 sn2 sn3 sn4
+    aarch64:
+        restore_aavmf_vars = yes
 
     image_name_sn1 = sn1
     image_format_sn1 = qcow2

--- a/qemu/tests/cfg/blockdev_mirror_install.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_install.cfg
@@ -30,6 +30,8 @@
     sync = full
     storage_pools = default
     storage_pool = default
+    aarch64:
+        restore_aavmf_vars = yes
 
     image_format_mirror1 = qcow2
     image_name_mirror1 = mirror1

--- a/qemu/tests/cfg/blockdev_snapshot_install.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_install.cfg
@@ -28,3 +28,5 @@
     overlay = "drive_sn1"
     qemu_force_use_drive_expression = no
     no RHEL.5 RHEL.6 RHEL.7 RHEL.8.0 RHEL8.1
+    aarch64:
+        restore_aavmf_vars = yes

--- a/qemu/tests/cfg/blockdev_stream_install.cfg
+++ b/qemu/tests/cfg/blockdev_stream_install.cfg
@@ -26,6 +26,8 @@
     shutdown_cleanly = no
     storage_pools = default
     storage_pool = default
+    aarch64:
+        restore_aavmf_vars = yes
 
     base_tag = image1
     node = "drive_image1"

--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -41,6 +41,8 @@
                 restore_ovmf_vars = yes
                 Windows:
                     send_key_at_install = ret
+            aarch64:
+                restore_aavmf_vars = yes
         - base:
             only 4096_4096
     variants:

--- a/qemu/tests/cfg/tpm_unattended_install.cfg
+++ b/qemu/tests/cfg/tpm_unattended_install.cfg
@@ -48,6 +48,7 @@
     aarch64:
         required_qemu= [5.1.0,)
         tpm_model_tpm0 = tpm-tis-device
+        restore_aavmf_vars = yes
     tpm_type_tpm0 = emulator
     tpm_version_tpm0 = 2.0
     Windows:


### PR DESCRIPTION
When the bootable disk has been recreated or the boot partition
is changed, better to recreate the aavmf vars as well.

ID: 1883407
Depends on: https://github.com/avocado-framework/avocado-vt/pull/2777
Signed-off-by: Yihuang Yu <yihyu@redhat.com>