### PR TITLE
x86_cpu_flags: test 5-level paging

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -35,6 +35,19 @@
                     flags = "arch_capabilities"
                     check_guest_cmd = "cat /sys/devices/system/cpu/vulnerabilities/mds | grep '%s'"
                     expect_items = 'Not affected'
+                - test_la57:
+                    # support RHEL.8 guest or later
+                    no RHEL.6 RHEL.7
+                    flags = "la57"
+                    check_guest_cmd = 'grep "address sizes" /proc/cpuinfo | uniq | grep "%s bits virtual"'
+                    variants:
+                        - with_la57:
+                            expect_items = 57
+                            cpu_model_flags = ",+la57"
+                        - without_la57:
+                            expect_items = 48
+                            cpu_model_flags = ",-la57"
+                            no_flags = "la57"
         - amd:
             only HostCpuVendor.amd
             variants:

--- a/qemu/tests/x86_cpu_flags.py
+++ b/qemu/tests/x86_cpu_flags.py
@@ -30,6 +30,8 @@ def run(test, params, env):
     error_context.context("Try to log into guest", logging.info)
     session = vm.wait_for_login()
     if params["os_type"] == "linux":
+        if params.get("no_flags", "") == flags:
+            flags = ""
         check_guest_cmd = params.get("check_guest_cmd")
         check_cpu_flags(params, flags, test, session)
         if check_guest_cmd:


### PR DESCRIPTION
ID: 1887656

Intel 5-level paging, it extends the size of
virtual addresses from 48 bits to 57 bits.

Signed-off-by: Nana Liu <nanliu@redhat.com>