### PR TITLE
new case to verify vm status when trigger crash

### DIFF
--- a/qemu/tests/cfg/verify_panic_status_with_pvpanic.cfg
+++ b/qemu/tests/cfg/verify_panic_status_with_pvpanic.cfg
@@ -1,0 +1,11 @@
+- verify_panic_status_with_pvpanic:
+    type = verify_panic_status_with_pvpanic
+    virt_test_type = qemu
+    monitors = 'qmp1'
+    monitor_type_qmp1 = qmp
+    stop_kdump_command = 'systemctl stop kdump'
+    trigger_crash = 'echo c > /proc/sysrq-trigger'
+    qmp_check_info = "guest-panicked"
+    disable_shutdown = yes
+    x86_64:
+        check_info = "dev: pvpanic"

--- a/qemu/tests/verify_panic_status_with_pvpanic.py
+++ b/qemu/tests/verify_panic_status_with_pvpanic.py
@@ -1,0 +1,42 @@
+import aexpect
+
+
+def run(test, params, env):
+    """
+    Verify the QMP even with -device pvpanic when trigger crash,this case will:
+
+    1) Start VM with pvpanic device.
+    2) Check if pvpanic device exists in guest.
+    3) Trigger crash in guest.
+    4) Check vm status with QMP.
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environmen.
+    """
+
+    stop_kdump_command = params["stop_kdump_command"]
+    trigger_crash = params["trigger_crash"]
+    qmp_check_info = params["qmp_check_info"]
+    check_info = params.get("check_info")
+    vm = env.get_vm(params["main_vm"])
+    session = vm.wait_for_login()
+
+    if check_info:
+        qtree_info = vm.monitor.info("qtree")
+        if check_info not in qtree_info:
+            test.fail("Not find pvpanic device in guest")
+
+    try:
+        session.cmd(stop_kdump_command)
+        session.cmd(trigger_crash, timeout=5)
+    except aexpect.ShellTimeoutError:
+        pass
+    else:
+        test.fail("Guest should crash.")
+    finally:
+        output = vm.monitor.get_status()
+        if qmp_check_info not in str(output):
+            test.fail("Guest status is not guest-panicked")
+        if session:
+            session.close()


### PR DESCRIPTION
verify_panic_status_with_pvpanic:new case to verify vm status when trigger crash

Verify the QMP even with -device pvpanic when trigger crash.

Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:1894818 