### PR TITLE
blockdev_mirror_hotunplug: hotunplug device when doing mirror

### DIFF
--- a/qemu/tests/blockdev_mirror_hotunplug.py
+++ b/qemu/tests/blockdev_mirror_hotunplug.py
@@ -1,0 +1,72 @@
+from virttest.qemu_monitor import QMPCmdError
+
+from provider.blockdev_mirror_nowait import BlockdevMirrorNowaitTest
+
+
+class BlockdevMirrorHotunplugTest(BlockdevMirrorNowaitTest):
+    """
+    Block mirror with hotunplug test
+    """
+
+    def hotunplug_frontend_devices(self):
+        """
+        device_del the frontend devices during mirroring,
+        the devices CAN be removed without any issue
+        """
+        def _device_del(device):
+            self.main_vm.monitor.cmd('device_del', {'id': device})
+            if 'qdev: %s' % device in self.main_vm.monitor.cmd("query-block"):
+                self.test.fail('Failed to hotunplug the frontend device')
+
+        list(map(_device_del, self._source_images))
+
+    def hotunplug_format_nodes(self):
+        """
+        blockdev-del the format nodes during mirroring,
+        the nodes CANNOT be removed for they are busy
+        """
+        def _blockdev_del(node):
+            try:
+                self.main_vm.monitor.cmd('blockdev-del', {'node-name': node})
+            except QMPCmdError as e:
+                err = self.params['block_node_busy_error'] % node
+                if err not in str(e):
+                    self.test.fail('Unexpected error: %s' % str(e))
+            else:
+                self.test.fail('blockdev-del succeeded unexpectedly')
+
+        list(map(_blockdev_del, self._source_nodes))
+
+    def do_test(self):
+        self.blockdev_mirror()
+        self.check_block_jobs_started(self._jobs)
+        self.hotunplug_frontend_devices()
+        self.hotunplug_format_nodes()
+        self.check_block_jobs_running(self._jobs)
+        self.wait_mirror_jobs_completed()
+        self.clone_vm_with_mirrored_images()
+        self.verify_data_files()
+
+
+def run(test, params, env):
+    """
+    Block mirror with hotunplug test
+
+    test steps:
+        1. boot VM with a 2G data disk
+        2. format the data disk and mount it
+        3. create a file
+        4. add a target disk for mirror to VM via qmp commands
+        5. do block-mirror with sync mode full
+        6. hotunplug the frontend device with device_del (OK)
+        7. hotunplug the format node with blockdev-del (ERROR)
+        8. check mirror continues and wait mirror done
+        9. restart VM with the mirror disk
+       10. check the file and its md5
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    mirror_test = BlockdevMirrorHotunplugTest(test, params, env)
+    mirror_test.run_test()

--- a/qemu/tests/cfg/blockdev_mirror_hotunplug.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_hotunplug.cfg
@@ -1,0 +1,50 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   Block mirror with hotunplug test
+#     The mirror image is a local fs image
+
+
+- blockdev_mirror_hotunplug:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_mirror_hotunplug
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    target_images = mirror1
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+    backup_options_data1 = sync speed
+    sync = full
+    speed_data1 = 90000000
+    tempfile_size = 1024M
+    storage_pools = default
+    storage_pool = default
+    rebase_mode = unsafe
+    block_node_busy_error = "Node '%s' is busy: block device is in use by block job: mirror"
+
+    image_size_data1 = 2G
+    image_size_mirror1 = ${image_size_data1}
+    image_format_data1 = qcow2
+    image_format_mirror1 = qcow2
+    image_name_data1 = data1
+    image_name_mirror1 = mirror1
+
+    nbd:
+        nbd_port_data1 = 10822
+        force_create_image_data1 = no
+        image_create_support_data1 = no
+    iscsi_direct:
+        lun_data1 = 1
+
+    # For local mirror images
+    storage_type_default = directory
+    enable_iscsi_mirror1 = no
+    enable_ceph_mirror1 = no
+    enable_gluster_mirror1 = no
+    enable_nbd_mirror1 = no
+    image_raw_device_mirror1 = no


### PR DESCRIPTION
  When doing blockdev-mirror, hotunplug the source image's
  frontend device with device-del, the mirror job should
  succeed without any error

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1894885