### PR TITLE
blockdev_mirror_ready_vm_down: vm poweroff when mirror job is ready

### DIFF
--- a/qemu/tests/blockdev_mirror_ready_vm_down.py
+++ b/qemu/tests/blockdev_mirror_ready_vm_down.py
@@ -1,0 +1,67 @@
+import time
+
+from provider import job_utils
+
+from provider.blockdev_mirror_nowait import BlockdevMirrorNowaitTest
+
+
+class BlockdevMirrorReadyVMDownTest(BlockdevMirrorNowaitTest):
+    """
+    VM poweroff when mirror job is ready
+    """
+
+    def poweroff_vm(self):
+        self.main_vm.monitor.system_powerdown()
+
+    def wait_mirror_jobs_ready(self):
+        def _wait_mirror_job_ready(jobid):
+            tmo = self.params.get_numeric('job_ready_timeout', 600)
+            job_utils.wait_until_job_status_match(self.main_vm, 'ready',
+                                                  jobid, tmo)
+        list(map(_wait_mirror_job_ready, self._jobs))
+
+    def wait_mirror_jobs_auto_completed(self):
+        """job completed automatically after vm poweroff"""
+        def _wait_mirror_job_completed(jobid):
+            tmo = self.params.get_numeric('job_completed_timeout', 200)
+            for i in range(tmo):
+                events = self.main_vm.monitor.get_events()
+                completed_events = [e for e in events if e.get(
+                    'event') == job_utils.BLOCK_JOB_COMPLETED_EVENT]
+                job_events = [e for e in completed_events if e.get(
+                    'data') and jobid in (e['data'].get('id'), e['data'].get('device'))]
+                if job_events:
+                    break
+                time.sleep(1)
+            else:
+                self.test.fail('job complete event never received in %s' % tmo)
+
+        list(map(_wait_mirror_job_completed, self._jobs))
+
+    def do_test(self):
+        self.blockdev_mirror()
+        self.wait_mirror_jobs_ready()
+        self.poweroff_vm()
+        self.wait_mirror_jobs_auto_completed()
+
+
+def run(test, params, env):
+    """
+    VM poweroff when mirror job is ready
+
+    test steps:
+        1. boot VM with 2G data disk
+        2. format the data disk and mount it
+        3. create a file
+        4. add a local fs image for mirror to VM via qmp commands
+        5. do blockdev-mirror
+        6. wait till mirror job is ready
+        7. poweroff vm
+        8. check mirror job completed
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    mirror_test = BlockdevMirrorReadyVMDownTest(test, params, env)
+    mirror_test.run_test()

--- a/qemu/tests/cfg/blockdev_mirror_ready_vm_down.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_ready_vm_down.cfg
@@ -1,0 +1,46 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   vm poweroff when mirror job is ready
+#     The mirror image is a local image(filesystem)
+
+
+- blockdev_mirror_ready_vm_down:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    qemu_force_use_drive_expression = no
+    type = blockdev_mirror_ready_vm_down
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    target_images = mirror1
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+    backup_options_data1 = sync
+    sync = full
+    storage_pools = default
+    storage_pool = default
+
+    image_size_data1 = 2G
+    image_size_mirror1 = ${image_size_data1}
+    image_format_data1 = qcow2
+    image_format_mirror1 = qcow2
+    image_name_data1 = data1
+    image_name_mirror1 = mirror1
+    rebase_mode = unsafe
+
+    nbd:
+        nbd_port_data1 = 10822
+        force_create_image_data1 = no
+        image_create_support_data1 = no
+    iscsi_direct:
+        lun_data1 = 1
+
+    # For local mirror images
+    storage_type_default = directory
+    enable_iscsi_mirror1 = no
+    enable_ceph_mirror1 = no
+    enable_gluster_mirror1 = no
+    enable_nbd_mirror1 = no
+    image_raw_device_mirror1 = no


### PR DESCRIPTION
  The job should complete automatically after vm poweroff

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1896238