### PR TITLE
virtio_fs_share_data: Add virtiofsd daemon extra parameters

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -44,6 +44,26 @@
     variants:
         - with_cache:
             variants:
+                - @default:
+                - @extra_parameters:
+                    no run_stress..extra_parameters
+                    variants:
+                        - lock_posix_off:
+                            fs_binary_extra_options += ",no_posix_lock"
+                        - lock_posix_on:
+                            fs_binary_extra_options += ",posix_lock"
+                    variants:
+                        - flock_on:
+                            fs_binary_extra_options += ",flock"
+                        - flock_off:
+                            fs_binary_extra_options += ",no_flock"
+                    variants:
+                        - xattr_on:
+                            fs_binary_extra_options += ",xattr"
+                        - xattr_off:
+                            fs_binary_extra_options += ",no_xattr"
+                        - @default:
+            variants:
                 - auto:
                     fs_binary_extra_options = " -o cache=auto"
                 - always:


### PR DESCRIPTION
Libvirt test virtiofsd daemon adds extra parameters.
So the qemu layer synchronizes these parameters.

ID: 1896214
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>