### PR TITLE
Add mirror job general operation test

### DIFF
--- a/provider/backup_utils.py
+++ b/provider/backup_utils.py
@@ -144,6 +144,8 @@ def blockdev_mirror_qmp_cmd(source, target, **extra_options):
         "buf-size",
         "on-source-error",
         "on-target-error",
+        "auto-finalize",
+        "auto-dismiss",
         "unmap"]
     arguments = copy_out_dict_if_exists(extra_options, options)
     arguments["device"] = source

--- a/qemu/tests/blockdev_mirror_simple.py
+++ b/qemu/tests/blockdev_mirror_simple.py
@@ -14,7 +14,19 @@ class BlockdevMirrorSimpleTest(BlockdevMirrorWaitTest):
     def __init__(self, test, params, env):
         self._set_granularity(params)
         self._set_bufsize(params)
+        self._set_auto_finalize(params)
+        self._set_auto_dismiss(params)
         super(BlockdevMirrorSimpleTest, self).__init__(test, params, env)
+
+    def _set_auto_finalize(self, params):
+        auto_finalize = params.get('auto_finalize')
+        if auto_finalize:
+            params['auto-finalize'] = auto_finalize
+
+    def _set_auto_dismiss(self, params):
+        auto_dismiss = params.get('auto_dismiss')
+        if auto_dismiss:
+            params['auto-dismiss'] = auto_dismiss
 
     def _set_granularity(self, params):
         granularities = params.objects("granularity_list")

--- a/qemu/tests/cfg/blockdev_mirror_simple.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_simple.cfg
@@ -9,6 +9,11 @@
 #     buf-size = count * granularity, when
 #     count is a random value from [1, 10], while
 #     granularity is a random value from (512, 64M)
+#   General mirror job operation test
+#     Enable/Disable auto-finalize/auto-dismiss explicitly,
+#     Note that both are enabled by default, and other block
+#     mirror tests have already covered the default setting
+
 
 - blockdev_mirror_simple:
     only Linux
@@ -68,3 +73,15 @@
                 - buf_size_random:
                     buf_size_factor_list = 2 3 4 5 6 7 8 9 10
                     backup_options_data1 += " buf-size"
+        - post_job_running:
+            backup_options_data1 = sync auto-finalize auto-dismiss
+            variants:
+                - auto_finalize_on:
+                    auto_finalize = on
+                - auto_finalize_off:
+                    auto_finalize = off
+            variants:
+                - auto_dismiss_on:
+                    auto_dismiss = on
+                - auto_dismiss_off:
+                    auto_dismiss = off


### PR DESCRIPTION
blockdev_mirror_simple: Add mirror job general operation test
    
      We cover the test by setting the following explicitly
      auto-finalize: true or false
      auto-dismiss: true or false
    
Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1897993