### PR TITLE
blockdev_mirror_base: fix node attached check after mirror job

### DIFF
--- a/provider/blockdev_mirror_base.py
+++ b/provider/blockdev_mirror_base.py
@@ -121,7 +121,7 @@ class BlockdevMirrorBaseTest(blockdev_base.BlockdevBaseTest):
     def _check_mirrored_block_node_attached(self, source_qdev, target_node):
         out = self.main_vm.monitor.query("block")
         for item in out:
-            if (item["qdev"] == source_qdev
+            if (source_qdev in item["qdev"]
                     and item["inserted"].get("node-name") == target_node):
                 break
         else:

--- a/qemu/tests/blockdev_stream_subchain.py
+++ b/qemu/tests/blockdev_stream_subchain.py
@@ -100,7 +100,7 @@ class BlockdevStreamSubChainTest(BlockDevStreamTest):
         """after block-stream, the backing chain: data->datasn1->dtasn3"""
         out = self.main_vm.monitor.query("block")
         for item in out:
-            if item["qdev"] == self.base_tag:
+            if self.base_tag in item["qdev"]:
                 backing = item["inserted"].get("backing_file")
                 if not backing:
                     self.test.fail("Failed to get backing_file for qdev %s"


### PR DESCRIPTION
  Different outputs of query-block command will show with different
  drive format(e.g. virtio-blk, scsi-hd):
  qdev: /machine/peripheral/data1/virtio-backend
  qdev: data1
  we have to apply the check code for all outputs

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1898011