### PR TITLE
Change the way of create snapshot to new method, also add cfg info

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -200,6 +200,27 @@
             gagent_check_type = fsfreeze
             gagent_fs_test_cmd = "echo foo > %s/foo"
             mountpoint_def = "/tmp"
+            virt_test_type = qemu
+            images += " data"
+            force_create_image_data = yes
+            start_vm = yes
+            storage_pools = default
+            storage_type_default = "directory"
+            storage_pool = default
+            base_tag = "data"
+            image_size_data = 100M
+            image_name_data = data
+            snapshot_tag = sn1
+            image_size_sn1 = 100M
+            image_name_sn1 = sn1
+            image_format_sn1 = qcow2
+            device = "drive_data"
+            snapshot_file = sn1
+            node = "drive_data"
+            overlay = "drive_sn1"
+            qemu_force_use_drive_expression = no
+            Host_RHEL.m7:
+                qemu_force_use_drive_expression = yes
             Windows:
                 gagent_fs_test_cmd = "echo 'fsfreeze test' > %s\test_file.txt"
                 mountpoint_def = "C:"


### PR DESCRIPTION
Cause we use "blockdev-snapshot" rather than "blockdev-snapshot-sync" from rhel8
Switch cmd command of creating snapshot to the new method

ID:1891927,1806380 

Signed-off-by: Boqiao Fu <bfu@redhat.com>