### PR TITLE
qemu_guest_agent_hotplug: Increase interval between operations

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent_hotplug.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent_hotplug.cfg
@@ -7,6 +7,7 @@
     gagent_name = "org.qemu.guest_agent.0"
     gagent_install_cmd = "yum install -y qemu-guest-agent"
     gagent_start_cmd = "service qemu-guest-agent start"
+    gagent_restart_cmd = "systemctl restart qemu-guest-agent"
     gagent_status_cmd = "service qemu-guest-agent status"
     gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
     gagent_check_type = sync

--- a/qemu/tests/qemu_guest_agent_hotplug.py
+++ b/qemu/tests/qemu_guest_agent_hotplug.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from virttest import error_context
 from virttest.qemu_devices import qdevices
@@ -50,6 +51,7 @@ def run(test, params, env):
     device.unplug(vm.monitor)
     device_status = device.verify_unplug("", vm.monitor)
     check_status_unplug(device_status, "virtserialport")
+    time.sleep(3)
     chardev.unplug(vm.monitor)
     chardev_status = chardev.verify_unplug("", vm.monitor)
     check_status_unplug(chardev_status, "socket")


### PR DESCRIPTION
Increase the interval between operations "device_del"
and "chardev-remove", original interval is too short to
execute "chardev-remove" successfully.

ID: 1899363
Signed-off-by: Dehan Meng <demeng@redhat.com>