### PR TITLE
qemu_guest_agent: Add quantity related to fsfreeze-hook

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -2383,7 +2383,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         cmd_get_hook_files = "rpm -ql qemu-guest-agent |grep fsfreeze-hook"
         hook_files = session.cmd_output(cmd_get_hook_files)
 
-        if len(hook_files.strip().split()) != 4:
+        if len(hook_files.strip().split()) != 5:
             test.fail("Fsfreeze hook files are missed, the output is"
                       " %s" % hook_files)
 


### PR DESCRIPTION
Because of bz-1738820, add soft link '/etc/qemu-kvm/fsfreeze-hook'
as new relation output that generated by the command
line 'rpm -ql qemu-guest-agent |grep fsfreeze-hook'.

ID: 1898836
Signed-off-by: Dehan Meng <demeng@redhat.com>