### PR TITLE
blockdev_stream_none_existed_overlay: Stream to a non-existed snapshot

### DIFF
--- a/qemu/tests/blockdev_stream_none_existed_overlay.py
+++ b/qemu/tests/blockdev_stream_none_existed_overlay.py
@@ -1,0 +1,42 @@
+from virttest.qemu_monitor import QMPCmdError
+
+from provider.blockdev_stream_base import BlockDevStreamTest
+
+
+class BlockdevStreamNoneExistedOverlay(BlockDevStreamTest):
+    """Do block-stream to an non-existed snapshot"""
+
+    def pre_test(self):
+        # vm will be started by VT, and no image will be created
+        pass
+
+    def post_test(self):
+        # vm will be stopped by VT, and no image will be removed
+        pass
+
+    def do_test(self):
+        try:
+            self.main_vm.monitor.cmd(
+                "block-stream",
+                {'device': self.params['none_existed_overlay_node']}
+            )
+        except QMPCmdError as e:
+            if self.params['error_msg'] not in str(e):
+                self.test.fail('Unexpected error: %s' % str(e))
+        else:
+            self.test.fail('block-stream succeeded unexpectedly')
+
+
+def run(test, params, env):
+    """
+    Do block-stream to an non-existed snapshot
+    test steps:
+        1. boot VM with a data image
+        2. do block-stream to an non-existed snapshot
+        3. check the proper error message should show out
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    stream_test = BlockdevStreamNoneExistedOverlay(test, params, env)
+    stream_test.run_test()

--- a/qemu/tests/cfg/blockdev_stream_none_existed_overlay.cfg
+++ b/qemu/tests/cfg/blockdev_stream_none_existed_overlay.cfg
@@ -1,0 +1,19 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   Do block stream to a non-existed snapshot image
+
+
+- blockdev_stream_none_existed_overlay:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = yes
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_stream_none_existed_overlay
+    virt_test_type = qemu
+    base_tag = image1
+    node = drive_image1
+    snapshot_tag = sn
+    none_existed_overlay_node = drive_${snapshot_tag}
+    error_msg = 'Cannot find device=${none_existed_overlay_node} nor node_name=${none_existed_overlay_node}'


### PR DESCRIPTION
  Do block-stream to a non-existed snapshot image

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1900975