### PR TITLE
numa_negative: Update memory size to avoid test cancel

### DIFF
--- a/qemu/tests/cfg/numa_negative.cfg
+++ b/qemu/tests/cfg/numa_negative.cfg
@@ -7,9 +7,9 @@
     start_vm = no
     smp = 2
     vcpu_maxcpus = ${smp}
-    mem = 2048M
+    mem = 4096M
     mem_devs = 'mem0 mem1'
-    size_mem = 1024M
+    size_mem = 2048M
     guest_numa_nodes = 'node0 node1'
     numa_memdev_node0 = mem-mem0
     numa_memdev_node1 = mem-mem1
@@ -27,7 +27,7 @@
             i386, x86_64:
                 negative_type = non-fatal
         - mem_mismatch:
-            mem = 3072
+            mem = 5120
             error_msg = "qemu-kvm: total memory for NUMA nodes \(0x[0-9A-Fa-f]+\)"
             error_msg += " should equal RAM size"
         - cpu_mismatch:
@@ -41,5 +41,5 @@
             error_msg = "Duplicate NUMA nodeid: 0"
         - mem_zero:
             size_mem_mem0 = 0M
-            size_mem_mem1 = 2048M
+            size_mem_mem1 = 4096M
             error_msg = "property 'size' of memory-backend-ram doesn't take value '0'"


### PR DESCRIPTION
Some windows guests have minimum memory restriction, which is 4G.
If memory size < 4G, tests will cancel. So update it.

ID: 1902164

Signed-off-by: Yumei Huang <yuhuang@redhat.com>