### PR TITLE
virtio-fs: new case about viofs driver

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -6,6 +6,8 @@
     login_timeout = 240
     image_snapshot = yes
     only Windows
+    cdroms += " virtio winutils"
+    virtio_win_media_type = iso
     sub_test = driver_load
     i386, i686:
         driver_load_cmd = "WIN_UTILS:\devcon\wnet_x86\devcon.exe enable @DRIVER_ID"
@@ -145,3 +147,42 @@
             python_bin = python2.7
             file_sender = guest
             target_process = ${python_bin}.exe
+        - with_viofs:
+            no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
+            no Win2008 Win7
+            virt_test_type = qemu
+            required_qemu = [4.2.0,)
+            filesystems = fs
+            fs_driver = virtio-fs
+            fs_source_type = mount
+            fs_source_dir = virtio_fs_test/
+            force_create_fs_source = yes
+            remove_fs_source = yes
+            fs_target = 'myfs'
+            fs_driver_props = {"queue-size": 1024}
+            mem = 4096
+            mem_devs = mem1
+            backend_mem_mem1 = memory-backend-file
+            mem-path_mem1 = /dev/shm
+            size_mem1 = 4G
+            use_mem_mem1 = no
+            share_mem = yes
+            guest_numa_nodes = shm0
+            numa_memdev_shm0 = mem-mem1
+            numa_nodeid_shm0 = 0
+            driver_name = viofs
+            target_process = fio.exe
+            run_bgstress = virtio_fs_share_data
+            driver_id_pattern = "(.*?):.*?VirtIO FS Device"
+            # install winfsp tool
+            i386, i686:
+                install_path = 'C:\Program Files'
+            x86_64:
+                install_path = 'C:\Program Files (x86)'
+            install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.7.20172.msi /qn'
+            check_installed_cmd = 'dir "%s" |findstr /I winfsp'
+            start_vfs_cmd = "start /b %s -d -1 -D C:\\viofs_log.txt"
+            check_virtiofs_cmd = 'wmic process where caption="virtiofs.exe" list brief'
+            fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
+            fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=600 --thread'
+            io_timeout = 700

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -213,3 +213,44 @@
                     move_duration = 1
                     btns = "left right middle side extra"
                     scrolls = "wheel-up wheel-down"
+        - with_viofs:
+            no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
+            no Win2008 Win7
+            virt_test_type = qemu
+            required_qemu = [4.2.0,)
+            filesystems = fs
+            fs_driver = virtio-fs
+            fs_source_type = mount
+            fs_source_dir = virtio_fs_test/
+            force_create_fs_source = yes
+            remove_fs_source = yes
+            fs_target = 'myfs'
+            fs_driver_props = {"queue-size": 1024}
+            mem = 4096
+            mem_devs = mem1
+            backend_mem_mem1 = memory-backend-file
+            mem-path_mem1 = /dev/shm
+            size_mem1 = 4G
+            use_mem_mem1 = no
+            share_mem = yes
+            guest_numa_nodes = shm0
+            numa_memdev_shm0 = mem-mem1
+            numa_nodeid_shm0 = 0
+            driver_name = viofs
+            device_name = "VirtIO FS Device"
+            device_hwid = '"PCI\VEN_1AF4&DEV_105A"'
+            target_process = fio.exe
+            run_bgstress = virtio_fs_share_data
+            driver_id_pattern = "(.*?):.*?VirtIO FS Device"
+            # install winfsp tool
+            i386, i686:
+                install_path = 'C:\Program Files'
+            x86_64:
+                install_path = 'C:\Program Files (x86)'
+            install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.7.20172.msi /qn'
+            check_installed_cmd = 'dir "%s" |findstr /I winfsp'
+            start_vfs_cmd = "start /b %s -d -1 -D C:\\viofs_log.txt"
+            check_virtiofs_cmd = 'wmic process where caption="virtiofs.exe" list brief'
+            fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
+            fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800 --thread'
+            io_timeout = 2000


### PR DESCRIPTION
1. Support install/uninstall virtio-fs driver(windows guest only)
2. Support upgrade/downgrade virtio-fs driver(windows guest only)
3. Support disable/Enable virtio-fs driver (windows guest only)

ID:1899833,1899834,1902160
Signed-off-by: Menghuan Li menli@redhat.com