### PR TITLE
blockdev_stream_forbidden_actions: Add qmp cmd test during stream

### DIFF
--- a/qemu/tests/blockdev_stream_forbidden_actions.py
+++ b/qemu/tests/blockdev_stream_forbidden_actions.py
@@ -1,0 +1,96 @@
+from virttest import data_dir
+from virttest.qemu_monitor import QMPCmdError
+
+from provider.blockdev_stream_nowait import BlockdevStreamNowaitTest
+from provider.virt_storage.storage_admin import sp_admin
+
+
+class BlockdevStreamForbiddenActionsTest(BlockdevStreamNowaitTest):
+    """Do qmp commands during block-stream"""
+
+    def __init__(self, test, params, env):
+        super(BlockdevStreamForbiddenActionsTest, self).__init__(test,
+                                                                 params,
+                                                                 env)
+        self._snapshot_images = self.params.objects("snapshot_images")
+        self._trash = []
+
+    def prepare_snapshot_file(self):
+        """hotplug all snapshot images"""
+        def _disk_define_by_params(tag):
+            params = self.params.copy()
+            params.setdefault("target_path", data_dir.get_data_dir())
+            return sp_admin.volume_define_by_params(tag, params)
+
+        for tag in self._snapshot_images:
+            disk = _disk_define_by_params(tag)
+            disk.hotplug(self.main_vm)
+            self._trash.append(disk)
+
+    def post_test(self):
+        list(map(sp_admin.remove_volume, self._trash))
+
+    def commit(self):
+        self.main_vm.monitor.cmd(
+            "block-commit", {'device': self._top_device}
+        )
+
+    def resize(self):
+        self.main_vm.monitor.cmd(
+            "block_resize",
+            {'node-name': self._top_device, 'size': 1024*1024*1024}
+        )
+
+    def mirror(self):
+        self.main_vm.monitor.cmd(
+            "blockdev-mirror",
+            {'device': self._top_device,
+             'target': self.params['overlay_node'], 'sync': 'full'}
+        )
+
+    def snapshot(self):
+        self.main_vm.monitor.cmd(
+            "blockdev-snapshot",
+            {'node': self._top_device, 'overlay': self.params['overlay_node']}
+        )
+
+    def stream(self):
+        self.main_vm.monitor.cmd("block-stream", {'device': self._top_device})
+
+    def do_forbidden_actions(self):
+        """Run the qmp commands one by one, all should fail"""
+        for action in self.params.objects('forbidden_actions'):
+            error_msg = self.params['error_msg_%s' % action]
+            f = getattr(self, action)
+            try:
+                f()
+            except QMPCmdError as e:
+                if error_msg not in str(e):
+                    self.test.fail('Unexpected error: %s' % str(e))
+            else:
+                self.test.fail('Unexpected qmp command success')
+
+    def do_test(self):
+        self.create_snapshot()
+        self.blockdev_stream()
+        self.do_forbidden_actions()
+        self.main_vm.monitor.cmd("block-job-set-speed",
+                                 {'device': self._job, 'speed': 0})
+        self.wait_stream_job_completed()
+
+
+def run(test, params, env):
+    """
+    Basic block stream test with stress
+    test steps:
+        1. boot VM with a data image
+        2. add snapshot images
+        3. take snapshots(data->sn1)
+        4. do block-stream
+        5. do some qmp commands, all should fail
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    stream_test = BlockdevStreamForbiddenActionsTest(test, params, env)
+    stream_test.run_test()

--- a/qemu/tests/cfg/blockdev_stream_forbidden_actions.cfg
+++ b/qemu/tests/cfg/blockdev_stream_forbidden_actions.cfg
@@ -1,0 +1,63 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   mirror/commit/resize/live snapshot/stream action should be forbidden during stream
+#     The snapshot images are local fs images
+
+
+- blockdev_stream_forbidden_actions:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    qemu_force_use_drive_expression = no
+    type = blockdev_stream_forbidden_actions
+    virt_test_type = qemu
+    start_vm = yes
+    kill_vm = yes
+    images += " data"
+    node = drive_data
+    top_device_node = drive_datasn1
+    overlay_node = drive_datasn2
+    base_tag = data
+    snapshot_tag = datasn1
+    speed = 1024
+    auto_dismiss = off
+    remove_image_data = yes
+    force_create_image_data = yes
+    snapshot_images = datasn1 datasn2
+    storage_pools = default
+    storage_pool = default
+    storage_type_default = directory
+    forbidden_actions = snapshot stream mirror commit resize
+    error_msg_snapshot = "Node '${top_device_node}' is busy: block device is in use by block job: stream"
+    error_msg_stream = "Node '${top_device_node}' is busy: block device is in use by block job: stream"
+    error_msg_mirror = "Need a root block node"
+    error_msg_commit = "Need a root block node"
+    error_msg_resize = "Device '(null)' is in use"
+
+    image_size_data = 2G
+    image_size_datasn1 = ${image_size_data}
+    image_size_datasn2 = ${image_size_data}
+    image_name_data = data
+    image_name_datasn1 = datasn1
+    image_name_datasn2 = datasn2
+    image_format_data = qcow2
+    image_format_datasn1 = qcow2
+    image_format_datasn2 = qcow2
+
+    nbd:
+        nbd_port_data = 10822
+        force_create_image_data = no
+    iscsi_direct:
+        lun_data = 1
+
+    # For the local snapshot images
+    enable_iscsi_datasn2 = no
+    enable_iscsi_datasn1 = no
+    enable_ceph_datasn2 = no
+    enable_ceph_datasn1 = no
+    enable_gluster_datasn2 = no
+    enable_gluster_datasn1 = no
+    enable_nbd_datasn2 = no
+    enable_nbd_datasn1 = no
+    image_raw_device_datasn2 = no
+    image_raw_device_datasn2 = no


### PR DESCRIPTION
  mirror/commit/resize/live snapshot/stream action should be forbidden
  when doing block-stream

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1904988