### PR TITLE
slof_next_entry: Add a case to check the next_entry on guest

### DIFF
--- a/qemu/tests/cfg/slof_next_entry.cfg
+++ b/qemu/tests/cfg/slof_next_entry.cfg
@@ -1,0 +1,9 @@
+- slof_next_entry:
+    virt_test_type = qemu
+    type = slof_next_entry
+    only ppc64 ppc64le
+    only Linux
+    clone_master = yes
+    master_images_clone = image1
+    remove_image_image1 = yes
+    get_kernel_list_cmd = 'find /boot/ -regex ".*/vmlinuz-[1-9]+.*$(arch)"'

--- a/qemu/tests/slof_next_entry.py
+++ b/qemu/tests/slof_next_entry.py
@@ -1,0 +1,91 @@
+import logging
+
+from virttest import error_context
+
+from provider import slof
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Verify that next-entry will get unset after reboot.
+
+    Step:
+     1) Check if any error info in output of SLOF during booting.
+     2) Ensure the guest has at least two kernel versions.
+     3) Set a boot next entry and check it.
+     4) Reboot guest, check the kernel version and value of next_entry.
+     5) Reboot guest again, continue to check the kernel version.
+
+    :param test: Qemu test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+
+    def get_kernels_info():
+        """ Get detailed information about each kernel version in the guest. """
+        kernels_info = {}
+        for kernel in kernel_list:
+            grubby_info = session.cmd_output("grubby --info=%s" % kernel,
+                                             print_func=logging.info)
+            entry_dict = dict((item.replace('"', '').split("=", 1)
+                               for item in grubby_info.splitlines()))
+            kernels_info[int(entry_dict.pop("index"))] = entry_dict
+        return kernels_info
+
+    def check_kernel_version(k_index):
+        """ Check whether the kernel version matches the kernel index. """
+        current_kernel = session.cmd_output("uname -r").strip()
+        if guest_kernels[k_index]["kernel"].split("-", 1)[1] != current_kernel:
+            logging.debug("The current kernel version is: %s", current_kernel)
+            test.fail("The current kernel version is different from expected")
+        logging.info("The kernel version matches the kernel index")
+
+    get_kernel_list_cmd = params["get_kernel_list_cmd"]
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    error_context.base_context("Check the output of SLOF.", logging.info)
+    content = slof.wait_for_loaded(vm, test)[0]
+    slof.check_error(test, content)
+    session = vm.wait_for_login()
+
+    logging.info("Ensure the guest has at least two kernel versions")
+    kernel_list = session.cmd_output(get_kernel_list_cmd).splitlines()
+    if len(kernel_list) < 2:
+        test.cancel("This test requires at least two kernel versions in the "
+                    "guest")
+    if session.cmd_output("grubby --default-index").strip() != "0":
+        logging.info("Ensure that the default kernel index of the guest is 0.")
+        session.cmd("grubby --set-default-index=0")
+        session = vm.reboot()
+
+    guest_kernels = get_kernels_info()
+    error_context.context("Set a next boot entry other than the default one and"
+                          " check it", logging.info)
+    next_entry = guest_kernels[1]["title"]
+    session.cmd("grub2-reboot '%s'" % next_entry)
+    grub_env = dict((item.split("=", 1) for item in
+                     session.cmd_output("grub2-editenv list").splitlines()))
+    grub_next_entry = grub_env["next_entry"]
+    if grub_next_entry != next_entry:
+        logging.debug("The 'next_entry' is: %s", grub_next_entry)
+        test.fail("The next boot entry is not expected as we set")
+
+    error_context.base_context("Reboot guest, check the kernel version and "
+                               "'next_entry'", logging.info)
+    session = vm.reboot(session)
+    grub_env = dict((item.split("=", 1) for item in
+                     session.cmd_output("grub2-editenv list").splitlines()))
+    check_kernel_version(1)
+    grub_next_entry = grub_env["next_entry"]
+    if grub_next_entry:
+        logging.debug("The 'next_entry' is: %s", grub_next_entry)
+        test.fail("The 'next_entry' did not return to empty after reboot")
+
+    error_context.context("Reboot guest again to check the kernel version")
+    session = vm.reboot(session)
+    check_kernel_version(0)
+
+    session.close()
+    vm.destroy(gracefully=True)


### PR DESCRIPTION
Next_entry will be cleared after reboot, grub-reboot sets the default
boot menu entry for the next boot, but not further boots after that.

ID: 1907294
Signed-off-by: Yihuang Yu <yihyu@redhat.com>