### PR TITLE
blockdev_inc_backup_bitmap_vm_crash_reboot: bitmap exists after crash

### DIFF
--- a/qemu/tests/blockdev_inc_backup_bitmap_vm_crash_reboot.py
+++ b/qemu/tests/blockdev_inc_backup_bitmap_vm_crash_reboot.py
@@ -1,0 +1,71 @@
+import aexpect
+
+from provider.block_dirty_bitmap import get_bitmap_by_name
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+from provider.job_utils import get_event_by_condition
+
+
+class BlockdevIncbkBitmapExistAfterVMCrashReboot(BlockdevLiveBackupBaseTest):
+    """bitmap still exist after vm reboot caused by crash"""
+
+    def check_bitmap_existed(self):
+        """
+        bitmap should exist after vm reboot.
+        No need compare bitmap count with the original, for an
+        active bitmap's count can be changed after reboot
+        """
+        bitmaps = list(map(
+            lambda n, b: get_bitmap_by_name(self.main_vm, n, b),
+            self._source_nodes, self._bitmaps))
+        if not all(list(map(lambda b: b and b['status'] == 'active'
+                            and b['count'] >= 0, bitmaps))):
+            self.test.fail('bitmap should still exist after vm crash.')
+
+    def trigger_vm_crash(self):
+        session = self.main_vm.wait_for_login(
+            timeout=self.params.get_numeric('login_timeout', 300))
+        try:
+            session.cmd(self.params['trigger_crash_cmd'], timeout=5)
+        except aexpect.ShellTimeoutError:
+            pass
+        else:
+            self.test.error('Error occurred when triggering vm crash')
+        finally:
+            session.close()
+
+    def wait_till_vm_reboot(self):
+        session = self.main_vm.wait_for_login(
+            timeout=self.params.get_numeric('login_timeout', 360))
+        session.close()
+
+    def check_vm_reset_event(self):
+        tmo = self.params.get_numeric('vm_reset_timeout', 60)
+        if get_event_by_condition(self.main_vm, 'RESET', tmo) is None:
+            self.test.fail('Failed to reset VM after triggering crash')
+
+    def do_test(self):
+        self.do_full_backup()
+        self.trigger_vm_crash()
+        self.check_vm_reset_event()
+        self.wait_till_vm_reboot()
+        self.check_bitmap_existed()
+
+
+def run(test, params, env):
+    """
+    bitmap still exist after vm reboot caused by crash
+
+    test steps:
+        1. boot VM with a 2G data disk
+        2. format data disk and mount it, create a file
+        3. add target disks for backup to VM via qmp commands
+        4. do full backup and add non-persistent bitmap
+        5. trigger vm crash
+        6. check bitmap still existed after vm reboot
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkBitmapExistAfterVMCrashReboot(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_vm_crash_reboot.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_vm_crash_reboot.cfg
@@ -1,0 +1,42 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   bitmap exists after vm reboot caused by crash
+#     The backup images are local images(filesystem)
+
+- blockdev_inc_backup_bitmap_vm_crash_reboot:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_bitmap_vm_crash_reboot
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    image_backup_chain_data1 = base
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+    storage_pools = default
+    storage_pool = default
+    storage_type_default = directory
+    full_backup_options = '{"sync": "full"}'
+    trigger_crash_cmd = 'echo c > /proc/sysrq-trigger'
+    iscsi_direct:
+        # for iscsi network storage, we have to set panic, or vm cannot reset
+        trigger_crash_cmd = 'echo 10 > /proc/sys/kernel/panic && echo c > /proc/sysrq-trigger'
+
+    image_size_data1 = 2G
+    image_size_base = ${image_size_data1}
+    image_format_data1 = qcow2
+    image_format_base = qcow2
+    image_name_data1 = data1
+    image_name_base = base
+
+    nbd:
+        nbd_port_data1 = 10822
+        force_create_image_data1 = no
+        image_create_support_data1 = no
+        remove_image_data1 = no
+    iscsi_direct:
+        lun_data1 = 1


### PR DESCRIPTION
  Add a non-persistent bitmap, then trigger vm crash,
  check bitmap still existed after vm reboot

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1910337