### PR TITLE
qemu-guest-agent: Add new case for operate ssh-pub-keys into guest.

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -454,6 +454,22 @@
             get_container_ver_cmd = "podman inspect qemu-guest-agent | grep %s"
             # Please define create_container_cmd before this test:
             # create_container_cmd = podman create --name qemu-guest-agent --network xxx --privileged --volume xxx:xxx --pull missing qemu-guest-agent:xxx
+        - gagent_ssh_public_key_injection:
+            only Linux
+            guest_user = "fedora"
+            guest_user_passwd = "redhat"
+            guest_homepath = /home/${guest_user}
+            gagent_check_type = ssh_public_key_injection
+            cmd_add_user_set_passwd = useradd ${guest_user} && echo ${guest_user_passwd} | passwd --stdin ${guest_user}
+            set_setenforce = "setenforce %s"
+            cmd_remove_user = userdel -rf ${guest_user}
+            cmd_clean_keys = rm -rf ~/.ssh/*
+            ssh_keygen_cmd =  "ssh-keygen -t rsa -P "" -f ~/.ssh/id_rsa"
+            add_line_at_end = "echo >> ${guest_homepath}/.ssh/authorized_keys"
+            cmd_get_guestkey = "cat ${guest_homepath}/.ssh/authorized_keys"
+            cmd_get_hostkey = "cat ~/.ssh/id_rsa.pub"
+            cmd_del_key_file = "rm -rf ${guest_homepath}/.ssh/authorized_keys"
+            test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls /home
     variants:
         - virtio_serial:
             gagent_serial_type = virtio


### PR DESCRIPTION
operation includes guest-ssh-add-authorized-keys, 
*-remove-*, *-get-*, and reset ssh keys" for host can 
login guest via ssh without passwd.

ID: 1906644
Signed-off-by: Dehan Meng <demeng@redhat.com>