### PR TITLE
blockdev_inc_backup_bitmap_with_hotplug: bitmap with hotplug

### DIFF
--- a/qemu/tests/blockdev_inc_backup_bitmap_with_hotplug.py
+++ b/qemu/tests/blockdev_inc_backup_bitmap_with_hotplug.py
@@ -1,0 +1,76 @@
+from virttest.utils_misc import wait_for
+
+from provider.block_dirty_bitmap import get_bitmaps, get_bitmap_by_name
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+
+
+class BlockdevIncbkAddBitmapToHotplugImg(BlockdevLiveBackupBaseTest):
+    """Add bitmap to hot-plugged image"""
+
+    def check_bitmap_count_gt_zero(self):
+        """count of bitmaps should be 0"""
+        bitmaps = list(map(
+            lambda n, b: get_bitmap_by_name(self.main_vm, n, b),
+            self._source_nodes, self._bitmaps))
+        if not all(list(map(lambda b: b and b['count'] > 0, bitmaps))):
+            self.test.fail('bitmap count should be greater than 0.')
+
+    def hotplug_data_disk(self):
+        tag = self._source_images[0]
+        self._devices = self.main_vm.devices.images_define_by_params(
+            tag, self.params.object_params(tag), 'disk')
+        for dev in self._devices:
+            ret = self.main_vm.devices.simple_hotplug(
+                dev, self.main_vm.monitor)
+            if not ret[1]:
+                self.test.fail("Failed to hotplug '%s': %s."
+                               % (dev, ret[0]))
+
+    def prepare_main_vm(self):
+        super(BlockdevIncbkAddBitmapToHotplugImg, self).prepare_main_vm()
+        self.hotplug_data_disk()
+
+    def unplug_data_disk(self):
+        """Unplug device and its format node"""
+        for dev in self._devices[-1:-3:-1]:
+            out = dev.unplug(self.main_vm.monitor)
+            if not wait_for(
+                    lambda: dev.verify_unplug(out, self.main_vm.monitor),
+                    first=1, step=5, timeout=30):
+                self.test.fail('Failed to unplug device')
+
+    def check_bitmap_gone(self):
+        out = self.main_vm.monitor.cmd("query-block")
+        bitmaps = get_bitmaps(out)
+        if not all([len(l) == 0 for l in bitmaps.values()]):
+            self.test.fail("bitmap found unexpectedly after unplug")
+
+    def do_test(self):
+        self.do_full_backup()
+        self.generate_inc_files()
+        self.check_bitmap_count_gt_zero()
+        self.unplug_data_disk()
+        self.check_bitmap_gone()
+
+
+def run(test, params, env):
+    """
+    Add disabled bitmaps test
+
+    test steps:
+        1. boot VM
+        2. hot-plugged a 2G data disk
+           format data disk and mount it, create a file
+        3. add target disks for backup to VM via qmp commands
+        4. do full backup and add a bitmap to the hot-plugged data disk
+        5. create another file
+        6. check bitmap count should be greater than 0
+        7. hot-unplug data disk(device and format node)
+        8. check bitmap gone(not in output of query-block)
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkAddBitmapToHotplugImg(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_hotplug.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_hotplug.cfg
@@ -1,0 +1,36 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   Add bitmap to a hot-plugged image
+#     The backup images are local images(filesystem)
+
+- blockdev_inc_backup_bitmap_with_hotplug:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_bitmap_with_hotplug
+    virt_test_type = qemu
+    source_images = data1
+    image_backup_chain_data1 = base
+    remove_image_data1 = yes
+    force_create_image_data1 = no
+    storage_pools = default
+    storage_pool = default
+    storage_type_default = directory
+    full_backup_options = '{"sync": "full"}'
+
+    image_size_data1 = 2G
+    image_size_base = ${image_size_data1}
+    image_format_data1 = qcow2
+    image_format_base = qcow2
+    image_name_data1 = data1
+    image_name_base = base
+
+    nbd:
+        nbd_port_data1 = 10822
+        image_create_support_data1 = no
+        remove_image_data1 = no
+    iscsi_direct:
+        lun_data1 = 1


### PR DESCRIPTION
  Add bitmap to a hot-plugged image, then unplug the image,
  bitmap should be gone.

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1911275