### PR TITLE
qemu-guest-agent: Add command 'guest-get-disk' for checking disks info

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -286,6 +286,18 @@
             Windows:
                 cmd_get_disk = wmic volume where "DeviceID='%s'" get FileSystem,DeviceID |findstr /v /i FileSystem
                 cmd_get_disk_usage = wmic volume where "DriveLetter='%s'" get Capacity,FreeSpace |findstr /v /i FreeSpace
+        - check_get_disks:
+            only Linux
+            gagent_check_type = get_disks
+            force_create_image_stg0 = yes
+            remove_image_stg0 = yes
+            images += " stg0"
+            image_name_stg0 = images/storage0
+            image_size_stg0 = 1G
+            get_rawdisk_guest_cmd = lsblk -p|grep disk|awk '{print$1}'
+            diskinfo_guest_cmd = 'lsblk -Jp -o KNAME,PKNAME,TYPE | grep %s|awk "NR==1"'
+            rawdisk_info_guest_cmd = 'lsblk -Jp -o KNAME,TYPE | grep %s|awk "NR==1"'
+            cmd_get_disk_alias = 'lsblk -o NAME %s |grep -v NAME'
         - check_nonexistent_cmd:
             gagent_check_type = nonexistent_cmd
             wrong_cmd = "system_reset"


### PR DESCRIPTION
Add command 'guest-get-disk' for checking disk_name,
disk_dependencies, disk_partition, disk_alias(lvm only).

ID: 1906654
Signed-off-by: Dehan Meng <demeng@redhat.com>