### PR TITLE
cpu_device_hotpluggable: Add a workaround for win2016 guest

### DIFF
--- a/provider/win_wora.py
+++ b/provider/win_wora.py
@@ -1,0 +1,34 @@
+"""
+windows workaround functions.
+
+"""
+import logging
+import re
+
+from virttest import error_context
+from virttest import utils_misc
+
+
+@error_context.context_aware
+def modify_driver(params, session):
+    """
+    Add a workaround for win2016 guest to solve the issue that
+    "HID Button over Interrupt Driver" does occupy hot-added cpu's driver,
+    cause the system cannot detected new added cpu, need modify the driver.
+    issue details please refer to:
+    https://support.huawei.com/enterprise/zh/doc/EDOC1100034211/5ba99a60.
+    """
+    devcon_path = utils_misc.set_winutils_letter(session,
+                                                 params["devcon_path"])
+    dev_hwid = params["dev_hwid"]
+    chk_cmd = '%s find %s' % (devcon_path, dev_hwid)
+    chk_pat = r'ACPI\\ACPI0010.*\: Generic Bus'
+    if not re.search(chk_pat, session.cmd(chk_cmd)):
+        error_context.context("Install 'HID Button over Interrupt Driver' "
+                              "to Generic Bus", logging.info)
+        inst_cmd = '%s install %s %s' % (devcon_path,
+                                         params["driver_inf_file"],
+                                         dev_hwid)
+        if session.cmd_status(inst_cmd, timeout=60):
+            logging.error("'HID Button over Interrupt Driver' modify failed")
+    logging.info("'HID Button over Interrupt Driver' modify finished")

--- a/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
+++ b/qemu/tests/cfg/cpu_device_hotplug_maximum.cfg
@@ -19,6 +19,13 @@
         machine_type_extra_params = "kernel-irqchip=split"
         intel_iommu = yes
         virtio_dev_iommu_platform = on
+    Win2016:
+        # Set a workaround for win2016 guest
+        workaround_need = yes
+        devcon_dir = "win7_amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dir}\devcon.exe"
+        driver_inf_file = "C:\Windows\INF\machine.inf"
+        dev_hwid = '"ACPI\VEN_ACPI&DEV_0010"'
     variants:
         - max_socket:
             only Linux

--- a/qemu/tests/cfg/cpu_device_hotpluggable.cfg
+++ b/qemu/tests/cfg/cpu_device_hotpluggable.cfg
@@ -7,6 +7,13 @@
         only Win2008, Win2012, Win2016, Win2019
     Win2008, Win2012, s390x:
         check_cpu_topology = no
+    Win2016:
+        # Set a workaround for win2016 guest
+        workaround_need = yes
+        devcon_dir = "win7_amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dir}\devcon.exe"
+        driver_inf_file = "C:\Windows\INF\machine.inf"
+        dev_hwid = '"ACPI\VEN_ACPI&DEV_0010"'
     required_qemu = [2.6.0, )
     ppc64, ppc64le:
         required_qemu = [2.12.0, )

--- a/qemu/tests/cfg/invalid_cpu_device_hotplug.cfg
+++ b/qemu/tests/cfg/invalid_cpu_device_hotplug.cfg
@@ -11,6 +11,13 @@
     qemu_sandbox = on
     vcpu_devices = vcpu1
     monitor_type = qmp
+    Win2016:
+        # Set a workaround for win2016 guest
+        workaround_need = yes
+        devcon_dir = "win7_amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dir}\devcon.exe"
+        driver_inf_file = "C:\Windows\INF\machine.inf"
+        dev_hwid = '"ACPI\VEN_ACPI&DEV_0010"'
     variants:
         - in_use_id:
             execute_test = in_use_vcpu

--- a/qemu/tests/cpu_device_hotplug_maximum.py
+++ b/qemu/tests/cpu_device_hotplug_maximum.py
@@ -10,6 +10,7 @@ from virttest import utils_qemu
 from virttest.utils_version import VersionInterval
 
 from provider import cpu_utils
+from provider import win_wora
 
 
 @error_context.context_aware
@@ -73,6 +74,9 @@ def run(test, params, env):
     cpuinfo = vm.cpuinfo
     smp = cpuinfo.smp
     vcpus_count = vm.params.get_numeric("vcpus_count")
+
+    if params.get_boolean("workaround_need"):
+        win_wora.modify_driver(params, session)
 
     error_context.context("Check the number of guest CPUs after startup",
                           logging.info)

--- a/qemu/tests/cpu_device_hotpluggable.py
+++ b/qemu/tests/cpu_device_hotpluggable.py
@@ -7,6 +7,7 @@ from virttest import utils_misc
 from virttest.virt_vm import VMDeviceCheckError
 
 from provider import cpu_utils
+from provider import win_wora
 
 
 @error_context.context_aware
@@ -134,10 +135,14 @@ def run(test, params, env):
     else:
         pluggable_vcpu_dev = vcpu_devices[::-1]
 
+    if params.get_boolean("workaround_need"):
+        win_wora.modify_driver(params, session)
+
     if params.get("pause_vm_before_hotplug", "no") == "yes":
         error_context.context("Pause guest before %s" % hotpluggable_test,
                               logging.info)
         vm.pause()
+
     error_context.context("%s all vcpu devices" % hotpluggable_test,
                           logging.info)
     for vcpu_dev in pluggable_vcpu_dev:

--- a/qemu/tests/cpu_device_hotpluggable_with_numa.py
+++ b/qemu/tests/cpu_device_hotpluggable_with_numa.py
@@ -6,6 +6,7 @@ from virttest import error_context
 from virttest import utils_package
 
 from provider import cpu_utils
+from provider import win_wora
 
 
 @error_context.context_aware
@@ -74,6 +75,9 @@ def run(test, params, env):
                           logging.info)
     vm.create(params=params)
     session = vm.wait_for_login(timeout=login_timeout)
+
+    if params.get_boolean("workaround_need"):
+        win_wora.modify_driver(params, session)
 
     error_context.context("Check the number of guest CPUs after startup",
                           logging.info)

--- a/qemu/tests/cpu_device_hotpluggable_with_stress.py
+++ b/qemu/tests/cpu_device_hotpluggable_with_stress.py
@@ -4,6 +4,7 @@ import random
 import logging
 
 from provider import cpu_utils
+from provider import win_wora
 
 from virttest import arch
 from virttest import error_context
@@ -49,6 +50,9 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     session = vm.wait_for_login(timeout=login_timeout)
+
+    if params.get_boolean("workaround_need"):
+        win_wora.modify_driver(params, session)
 
     error_context.context("Check the number of guest CPUs after startup",
                           logging.info)

--- a/qemu/tests/invalid_cpu_device_hotplug.py
+++ b/qemu/tests/invalid_cpu_device_hotplug.py
@@ -8,6 +8,7 @@ from virttest import error_context
 from virttest.qemu_monitor import QMPCmdError
 
 from provider import cpu_utils
+from provider import win_wora
 
 
 @error_context.context_aware
@@ -122,7 +123,10 @@ def run(test, params, env):
     error_desc = params["error_desc"]
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
-    vm.wait_for_login()
+    session = vm.wait_for_login()
+
+    if params.get_boolean("workaround_need"):
+        win_wora.modify_driver(params, session)
 
     error_context.context("Check the number of guest CPUs after startup",
                           logging.info)
@@ -139,3 +143,4 @@ def run(test, params, env):
                              "invalid_vcpu": hotplug_invalid_vcpu,
                              "out_of_range_vcpu": hotplug_outofrange_vcpu}
     invalid_hotplug_tests[params["execute_test"]]()
+    session.close()


### PR DESCRIPTION
For win2016 guest, there is a exist microsoft issue:
https://support.huawei.com/enterprise/zh/doc/EDOC1100034211/5ba99a60
In order to workaround the known issue, add install driver of
"HID Button over Interrupt Driver" steps before cpu hotplugged.

id: 1822451
Signed-off-by: Peixiu Hou <phou@redhat.com>