### PR TITLE
Disable rhel 7 in discard test

### DIFF
--- a/qemu/tests/cfg/block_discard_hotplug.cfg
+++ b/qemu/tests/cfg/block_discard_hotplug.cfg
@@ -11,13 +11,14 @@
     drv_extra_params_stg1 += "discard=unmap"
     guest_mount_point = "/home/test"
     guest_test_file = "${guest_mount_point}/test.img"
-    guest_format_command = "mkdir -p ${guest_mount_point};mkfs.ext4 {0} && mount {0} ${guest_mount_point}"
+    guest_format_command = "mkdir -p ${guest_mount_point};yes|mkfs.ext4 {0} && mount {0} ${guest_mount_point}"
     guest_dd_command = "dd if=/dev/zero of=${guest_test_file}"
     guest_rm_command = "rm -rf ${guest_test_file};sync"
     guest_fstrim_command = "fstrim ${guest_mount_point}"
     variants:
       - local_file:
           no luks
+          no RHEL.7
           force_create_image_stg1 = yes
           image_size_stg1 = 1G
           image_name_stg1 = images/stg1

--- a/qemu/tests/cfg/virtio_blk_with_discard_write_zeroes.cfg
+++ b/qemu/tests/cfg/virtio_blk_with_discard_write_zeroes.cfg
@@ -14,6 +14,7 @@
     cmd_dd += "dd if={0} of=/dev/null bs=1M count=900 iflag=direct"
     variants:
         - all_enabled:
+            no RHEL.7
             blk_extra_params_stg0 += ",discard=on,write-zeroes=on"
             attributes_checked = "{'discard': 'true', 'write-zeroes': 'true'}"
             check_cmd_discard = "blkdiscard {0} && echo "PASS" || echo "FAIL""


### PR DESCRIPTION
Due to fstrim and blkdiscard command is not support
in RHEL.7 for the discard disk.

ID:1915189,1875212
Signed-off-by: qingwangrh <qinwang@redhat.com>