### PR TITLE
Replace 'isAlive' with 'is_alive' for threading.Thread

### DIFF
--- a/generic/tests/nic_promisc.py
+++ b/generic/tests/nic_promisc.py
@@ -51,7 +51,7 @@ def run(test, params, env):
 
         error.context("Perform file transfer while turning nic promisc on/off",
                       logging.info)
-        while transfer_thread.isAlive():
+        while transfer_thread.is_alive():
             set_nic_promisc_onoff(session_serial)
     except Exception:
         transfer_thread.join(suppress_exception=True)

--- a/generic/tests/nicdriver_unload.py
+++ b/generic/tests/nicdriver_unload.py
@@ -39,7 +39,7 @@ def run(test, params, env):
         Check whether all threads have finished
         """
         for thread in threads:
-            if thread.isAlive():
+            if thread.is_alive():
                 return False
             else:
                 continue
@@ -50,7 +50,7 @@ def run(test, params, env):
         Check whether all threads is alive
         """
         for thread in threads:
-            if not thread.isAlive():
+            if not thread.is_alive():
                 return False
             else:
                 continue

--- a/generic/tests/ntttcp.py
+++ b/generic/tests/ntttcp.py
@@ -178,7 +178,7 @@ def run(test, params, env):
     try:
         bg = utils_misc.InterruptedThread(receiver, ())
         bg.start()
-        if bg.isAlive():
+        if bg.is_alive():
             sender()
             bg.join(suppress_exception=True)
         else:

--- a/multi_host_migration/tests/migration_multi_host_with_file_transfer.py
+++ b/multi_host_migration/tests/migration_multi_host_with_file_transfer.py
@@ -160,7 +160,7 @@ def run(test, params, env):
         def _run_and_migrate(self, bg, end_event, sync, migrate_count):
             bg.start()
             try:
-                while bg.isAlive():
+                while bg.is_alive():
                     logging.info("File transfer not ended, starting"
                                  " a round of migration...")
                     sync.sync(True, timeout=d_transfer_timeout)

--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -318,7 +318,7 @@ class BlockCopy(object):
                 fun = getattr(self, test)
                 bg = utils_misc.InterruptedThread(fun)
                 bg.start()
-                if bg.isAlive():
+                if bg.is_alive():
                     self.processes.append(bg)
 
     def job_finished(self):

--- a/qemu/tests/live_snapshot_runtime.py
+++ b/qemu/tests/live_snapshot_runtime.py
@@ -29,7 +29,7 @@ class LiveSnapshotRuntime(live_snapshot_basic.LiveSnapshot):
                 fun = getattr(self, test)
                 bg = utils_misc.InterruptedThread(fun)
                 bg.start()
-                if bg.isAlive():
+                if bg.is_alive():
                     self.create_snapshot()
                     bg.join()
 

--- a/qemu/tests/migration_with_file_transfer.py
+++ b/qemu/tests/migration_with_file_transfer.py
@@ -47,7 +47,7 @@ def run(test, params, env):
         def run_and_migrate(bg):
             bg.start()
             try:
-                while bg.isAlive():
+                while bg.is_alive():
                     logging.info("File transfer not ended, starting a round of "
                                  "migration...")
                     if migrate_between_vhost_novhost == "yes":

--- a/qemu/tests/migration_with_reboot.py
+++ b/qemu/tests/migration_with_reboot.py
@@ -49,7 +49,7 @@ def run(test, params, env):
             vm.reboot, kwargs={'session': session, 'timeout': login_timeout})
         bg.start()
         try:
-            while bg.isAlive():
+            while bg.is_alive():
                 for func in pre_migrate:
                     func(vm, params, test)
                 vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay,

--- a/qemu/tests/nic_bonding.py
+++ b/qemu/tests/nic_bonding.py
@@ -82,7 +82,7 @@ def run(test, params, env):
             vm.copy_files_to, (host_path, guest_path))
         transfer_thread.start()
         try:
-            while transfer_thread.isAlive():
+            while transfer_thread.is_alive():
                 for ifname in ifnames:
                     session_serial.cmd(link_set_cmd % (ifname, "down"))
                     time.sleep(random.randint(1, 30))
@@ -103,7 +103,7 @@ def run(test, params, env):
         try:
             nic_num = len(ifnames)
             up_index = 0
-            while transfer_thread.isAlive():
+            while transfer_thread.is_alive():
                 nic_indexes = list(range(nic_num))
                 up_index = up_index % nic_num
                 session_serial.cmd(link_set_cmd % (ifnames[up_index], "up"))

--- a/qemu/tests/qemu_guest_agent_snapshot.py
+++ b/qemu/tests/qemu_guest_agent_snapshot.py
@@ -43,7 +43,7 @@ class QemuGuestAgentSnapshotTest(QemuGuestAgentBasicCheckWin):
 
     @error_context.context_aware
     def _action_after_fsfreeze(self, *args):
-        if self.bg.isAlive():
+        if self.bg.is_alive():
             image_tag = self.params.get("image_name", "image1")
             image_params = self.params.object_params(image_tag)
             snapshot_test = LiveSnapshot(self.test, self.params,

--- a/qemu/tests/sr_iov_irqbalance.py
+++ b/qemu/tests/sr_iov_irqbalance.py
@@ -302,7 +302,7 @@ def run(test, params, env):
                         msg += "Just now: %s" % post_irq_nums_dict
                         test.fail(msg)
     finally:
-        if bg_stress.isAlive():
+        if bg_stress.is_alive():
             bg_stress.join(suppress_exception=True)
         else:
             logging.warn("Background stress test already finished")

--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -576,7 +576,7 @@ def run(test, params, env):
                     err += "main(vmdied), "
                 _transfered = []
                 for i in range(no_threads):
-                    if not threads[i].isAlive():
+                    if not threads[i].is_alive():
                         err += "main(th%s died), " % threads[i]
                     _transfered.append(threads[i].idx)
                 if (_transfered == transferred and
@@ -597,7 +597,7 @@ def run(test, params, env):
             workaround_unfinished_threads = False
             logging.debug('Joining %s', threads[0])
             threads[0].join(5)
-            if threads[0].isAlive():
+            if threads[0].is_alive():
                 logging.error('Send thread stuck, destroing the VM and '
                               'stopping loopback test to prevent autotest '
                               'freeze.')
@@ -609,7 +609,7 @@ def run(test, params, env):
             for thread in threads[1:]:
                 logging.debug('Joining %s', thread)
                 thread.join(5)
-                if thread.isAlive():
+                if thread.is_alive():
                     workaround_unfinished_threads = True
                     logging.debug("Unable to destroy the thread %s", thread)
                 tmp += "%d, " % thread.idx
@@ -625,7 +625,7 @@ def run(test, params, env):
             guest_worker.safe_exit_loopback_threads([send_pt], recv_pts)
 
             for thread in threads:
-                if thread.isAlive():
+                if thread.is_alive():
                     vm.destroy()
                     del threads[:]
                     test.error("Not all threads finished.")
@@ -967,9 +967,9 @@ def run(test, params, env):
                      (4 + no_repeats * (intr_time + test_time)))
         # Lets transfer some data before the interruption
         time.sleep(2)
-        if not threads[0].isAlive():
+        if not threads[0].is_alive():
             test.fail("Sender thread died before interruption.")
-        if not threads[0].isAlive():
+        if not threads[0].is_alive():
             test.fail("Receiver thread died before interruption.")
 
         # 0s interruption without any measurements
@@ -991,14 +991,14 @@ def run(test, params, env):
                 for _ in range(10):
                     time.sleep(test_time)
                     logging.debug('Transfered data2: %s', threads[1].idx)
-                    if count == threads[1].idx and threads[1].isAlive():
+                    if count == threads[1].idx and threads[1].is_alive():
                         logging.warn('No data received after %ds, extending '
                                      'test_time', test_time)
                     else:
                         break
                 threads[1].reload_loss_idx()
-                if count == threads[1].idx or not threads[1].isAlive():
-                    if not threads[1].isAlive():
+                if count == threads[1].idx or not threads[1].is_alive():
+                    if not threads[1].is_alive():
                         logging.error('RecvCheck thread stopped unexpectedly.')
                     if count == threads[1].idx:
                         logging.error(
@@ -1030,7 +1030,7 @@ def run(test, params, env):
         funcatexit.unregister(env, params.get('type'), __set_exit_event)
         workaround_unfinished_threads = False
         threads[0].join(5)
-        if threads[0].isAlive():
+        if threads[0].is_alive():
             workaround_unfinished_threads = True
             logging.error('Send thread stuck, destroing the VM and '
                           'stopping loopback test to prevent autotest freeze.')
@@ -1038,7 +1038,7 @@ def run(test, params, env):
         for thread in threads[1:]:
             logging.debug('Joining %s', thread)
             thread.join(5)
-            if thread.isAlive():
+            if thread.is_alive():
                 workaround_unfinished_threads = True
                 logging.debug("Unable to destroy the thread %s", thread)
         if not err:     # Show only on success
@@ -1060,7 +1060,7 @@ def run(test, params, env):
         guest_worker.safe_exit_loopback_threads([send_pt], [recv_pt])
 
         for thread in threads:
-            if thread.isAlive():
+            if thread.is_alive():
                 vm.destroy()
                 del threads[:]
                 test.error("Not all threads finished.")
@@ -1365,7 +1365,7 @@ def run(test, params, env):
                               tmp[:-2])
                 i += 1
                 time.sleep(2)
-            if not threads[0].isAlive():
+            if not threads[0].is_alive():
                 if EXIT_EVENT.isSet():
                     test.fail("Exit event emitted, check the log "
                               "for send/recv thread failure.")
@@ -1374,7 +1374,7 @@ def run(test, params, env):
                     test.fail("Send thread died unexpectedly in "
                               "migration %d" % (j + 1))
             for i in range(0, len(ports[1:])):
-                if not threads[i + 1].isAlive():
+                if not threads[i + 1].is_alive():
                     EXIT_EVENT.set()
                     test.fail("Recv thread %d died unexpectedly in "
                               "migration %d" % (i, (j + 1)))
@@ -1397,7 +1397,7 @@ def run(test, params, env):
         # Send thread might fail to exit when the guest stucks
         workaround_unfinished_threads = False
         threads[0].join(5)
-        if threads[0].isAlive():
+        if threads[0].is_alive():
             workaround_unfinished_threads = True
             logging.error('Send thread stuck, destroing the VM and '
                           'stopping loopback test to prevent autotest freeze.')
@@ -1407,7 +1407,7 @@ def run(test, params, env):
 
         for thread in threads[1:]:
             thread.join(5)
-            if thread.isAlive():
+            if thread.is_alive():
                 workaround_unfinished_threads = True
                 logging.debug("Unable to destroy the thread %s", thread)
             tmp += "%d, " % thread.idx
@@ -1425,7 +1425,7 @@ def run(test, params, env):
         guest_worker.safe_exit_loopback_threads([ports[0]], ports[1:])
 
         for thread in threads:
-            if thread.isAlive():
+            if thread.is_alive():
                 vm.destroy()
                 del threads[:]
                 test.error("Not all threads finished.")

--- a/qemu/tests/win_nics_teaming.py
+++ b/qemu/tests/win_nics_teaming.py
@@ -66,7 +66,7 @@ def run(test, params, env):
             vm.copy_files_to, (host_path, guest_path))
         transfer_thread.start()
         try:
-            while transfer_thread.isAlive():
+            while transfer_thread.is_alive():
                 for ifname in ifnames:
                     session_serial.cmd(netsh_set_cmd % (ifname, "disable"))
                     time.sleep(random.randint(1, 30))
@@ -87,7 +87,7 @@ def run(test, params, env):
         try:
             nic_num = len(ifnames)
             index = 0
-            while transfer_thread.isAlive():
+            while transfer_thread.is_alive():
                 index = index % nic_num
                 for i in range(nic_num):
                     session_serial.cmd(netsh_set_cmd % (ifnames[i], "enable"))


### PR DESCRIPTION
threading.Thread.isAlive() has been removed in python 3.9,
and is_alive() has been supported since python 2.6

id: 1916085
Signed-off-by: Yanan Fu <yfu@redhat.com>