### PR TITLE
Fix lspci output change issue for vsock device

### DIFF
--- a/qemu/tests/cfg/vsock.cfg
+++ b/qemu/tests/cfg/vsock.cfg
@@ -12,5 +12,9 @@
             vsocks = ''
             addr_pattern = '\d\d:\d\d\.\d'
             device_pattern = 'Communication controller: Red Hat.* Device'
+            q35: 
+              device_pattern = 'Communication controller: Red Hat.* Virtio socket'
+              RHEL.7, RHEL.8.1, RHEL.8.2:
+                device_pattern = 'Communication controller: Red Hat.* Device'
         - migration_with_vsock:
             type = migration_with_vsock


### PR DESCRIPTION
Fix lspci output change issue for vsock device when machine_type=q35.

ID: 1916620

Signed-off-by: Qinghua Cheng <qcheng@redhat.com>