### PR TITLE
commit_with_backing: save file under '/var/tmp' instead of '/tmp'

### DIFF
--- a/qemu/tests/cfg/commit_with_backing.cfg
+++ b/qemu/tests/cfg/commit_with_backing.cfg
@@ -12,7 +12,7 @@
     image_format_sn2 = qcow2
     image_size_sn2 = ""
     backing_chain = yes
-    guest_tmp_filename = "/tmp/%s"
+    guest_tmp_filename = "/var/tmp/%s"
     backup_image_before_testing = yes
     restore_image_after_testing = yes
     Windows:

--- a/qemu/tests/cfg/rebase_second_snapshot_to_base.cfg
+++ b/qemu/tests/cfg/rebase_second_snapshot_to_base.cfg
@@ -17,7 +17,7 @@
     # the cmdline will not have specified size option
     image_size_sn1 = ""
     image_size_sn2 = ""
-    guest_tmp_filename = "/tmp/%s"
+    guest_tmp_filename = "/var/tmp/%s"
     rebase_mode = "safe"
     backup_image_before_testing = yes
     restore_image_after_testing = yes


### PR DESCRIPTION
For some os, '/tmp' is wiped whenever the system reboots where as
'/var/tmp' gets preserved across reboot

id: 1914129
Signed-off-by: Yanan Fu <yfu@redhat.com>