### PR TITLE
qemu_guest_agent: Use 'mkdir -p' to avoid file exists issue

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -78,7 +78,7 @@
         - check_powerdown:
             gagent_check_type = powerdown
             journal_file = /var/log/journal
-            cmd_prepared_and_restart_journald = "mkdir ${journal_file} && chgrp systemd-journal ${journal_file} && chmod g+s ${journal_file} && systemctl restart systemd-journald"
+            cmd_prepared_and_restart_journald = "mkdir -p ${journal_file} && chgrp systemd-journal ${journal_file} && chmod g+s ${journal_file} && systemctl restart systemd-journald"
             cmd_query_log = "journalctl -e | grep -6 -i 'core-dump'"
         - check_reboot:
             gagent_check_type = reboot


### PR DESCRIPTION
id: 1917804
Signed-off-by: Yanan Fu <yfu@redhat.com>