### PR TITLE
x86_cpu_model: delete Icelake-Client since qemu 5.2.0

### DIFF
--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -57,10 +57,12 @@
             no_flags = "hle rtm"
         - Icelake-Client:
             only HostCpuVendor.intel
+            required_qemu = (, 5.2.0)
             flags = "wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512_bitalg avx512_vpopcntdq"
             model_pattern = "Intel Core Processor \(Icelake%s\)"
         - Icelake-Client-noTSX:
             only HostCpuVendor.intel
+            required_qemu = (, 5.2.0)
             flags = "wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512_bitalg avx512_vpopcntdq"
             model_pattern = "Intel Core Processor \(Icelake%s\)"
             no_flags = "hle rtm"


### PR DESCRIPTION
ID: 1912198

'Icelake-Client' CPU Models are deprecated since 5.2.0

Signed-off-by: Nana Liu <nanliu@redhat.com>