### PR TITLE
Fix the issue of VM can not start

### DIFF
--- a/qemu/tests/cfg/multi_vms_with_stress.cfg
+++ b/qemu/tests/cfg/multi_vms_with_stress.cfg
@@ -14,3 +14,10 @@
     stress_cmd = ${stress_bin} --cpu 4 --io 4 --vm 2 --vm-bytes 128M &
     pre_command = "mkdir -p ${stress_inst_dir}"
     post_command = "killall -9 stress; rm -rf ${stress_inst_dir}"
+    ovmf:
+        smp = 1
+        vcpu_maxcpus = 1
+        vcpu_sockets = 1
+        vcpu_dies = 1
+        vcpu_cores = 1
+        vcpu_threads = 1


### PR DESCRIPTION
multi_vms_with_stress: Fix the issue of VM can not start
Since on some machines with poor performance, the CPU resources
are not allocated enough, which causes the VM to fail to start.
Therefore, set the 'smp' value to 1

Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:1869517,1874383