### PR TITLE
ppc_nested_compat: negative test that launch a compat mode nested guest

### DIFF
--- a/qemu/tests/cfg/ppc_nested_compat.cfg
+++ b/qemu/tests/cfg/ppc_nested_compat.cfg
@@ -1,0 +1,9 @@
+- ppc_nested_compat:
+    type = ppc_nested_compat
+    vt_test_type = qemu
+    only ppc64le
+    no Host_RHEL.6 Host_RHEL.7
+    kvm_probe_module_parameters = "nested=1"
+    start_vm = no
+    error_msg = "Nested KVM-HV only supported on POWER9"
+    machine_type_extra_params = cap-nested-hv=on,max-cpu-compat=power8

--- a/qemu/tests/ppc_nested_compat.py
+++ b/qemu/tests/ppc_nested_compat.py
@@ -1,0 +1,38 @@
+import re
+import logging
+
+from virttest import error_context
+from virttest.virt_vm import VMCreateError
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    qemu should be terminated when launching an L1 guest with
+    "cap-nested-hv=on,max-cpu-compat=power8".
+
+    1) Launch a guest with "cap-nested-hv=on,max-cpu-compat=power8".
+    2) Check whether qemu terminates.
+    3) Check whether the qemu output is as expected.
+
+    :param test: Qemu test object.
+    :param params: the test params.
+    :param env: test environment.
+    """
+
+    params['start_vm'] = 'yes'
+    error_msg = params['error_msg']
+    vm = env.get_vm(params['main_vm'])
+
+    error_context.base_context('Try to create a qemu instance...', logging.info)
+    try:
+        vm.create(params=params)
+    except VMCreateError as e:
+        if not re.search(error_msg, e.output):
+            logging.error(e.output)
+            test.error('The error message could not be searched at qemu '
+                       'outputs.')
+        logging.info('qemu terminated with the expected error message.')
+    else:
+        test.fail('The qemu instance should not be launched with '
+                  '"cap-nested-hv=on" and "max-cpu-compat=power8".')


### PR DESCRIPTION
Launch a qemu instance with power8 compat mode and cap-nested-hv=on,
qemu will terminate and prompt that it does not support.

ID: 1918598
Signed-off-by: Yihuang Yu <yihyu@redhat.com>