### PR TITLE
throttle_operation_test:fix no free root port issue

### DIFF
--- a/qemu/tests/cfg/throttle_operation_test.cfg
+++ b/qemu/tests/cfg/throttle_operation_test.cfg
@@ -68,6 +68,8 @@
               image_throttle_group_stg4 = "group2"
               throttle_group_member_group1 = "stg1 stg2 stg3"
               throttle_group_member_group2 = "stg4"
+              q35:
+                pcie_extra_root_port = 3
         - negative:
               throttle_groups = "group1"
               operation = negative_test


### PR DESCRIPTION
It need to apply enough pcie_extra_root_port for the
hotplug operation under q35.

ID:1920799
Signed-off-by: qingwangrh <qinwang@redhat.com>