### PR TITLE
Enable autopep8 style check in travis CI

### DIFF
--- a/generic/tests/shutdown.py
+++ b/generic/tests/shutdown.py
@@ -31,8 +31,8 @@ def run(test, params, env):
         vm = env.get_vm(params["main_vm"])
         vm.verify_alive()
         session = vm.wait_for_login(timeout=timeout)
-        error_context.base_context("shutting down the VM %s/%s" % (i + 1,
-                                   shutdown_count), logging.info)
+        error_context.base_context("shutting down the VM %s/%s" %
+                                   (i + 1, shutdown_count), logging.info)
         if params.get("setup_runlevel") == "yes":
             error_context.context("Setup the runlevel for guest", logging.info)
             utils_test.qemu.setup_runlevel(params, session)

--- a/generic/tests/whql_hck_client_install.py
+++ b/generic/tests/whql_hck_client_install.py
@@ -48,7 +48,7 @@ def run_whql_hck_client_install(test, params, env):
         session.cmd(cmd, timeout=600)
 
     error_context.context(("Setting up auto logon for user '%s'" %
-                          client_username), logging.info)
+                           client_username), logging.info)
     cmd = ('reg add '
            '"HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\winlogon"'
            ' /v "%s" /d "%s" /t REG_SZ /f')
@@ -66,7 +66,7 @@ def run_whql_hck_client_install(test, params, env):
 
     install_cmd = params["install_cmd"]
     error_context.context(("Installing HCK client (timeout=%ds)" %
-                          install_timeout), logging.info)
+                           install_timeout), logging.info)
     session.cmd(install_cmd, timeout=install_timeout)
     reboot_timeout = login_timeout + 1500
     session = vm.reboot(session, timeout=reboot_timeout)

--- a/provider/cpu_utils.py
+++ b/provider/cpu_utils.py
@@ -11,6 +11,7 @@ class VMStressBinding(VMStress):
     """
     Run stress tool on VMs, and bind the process to the specified cpu
     """
+
     def __init__(self, vm, params, stress_args=""):
         super(VMStressBinding, self).__init__(vm, "stress", params,
                                               stress_args=stress_args)

--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -73,7 +73,8 @@ class BallooningTest(MemoryBaseTest):
         error_context.context("Check memory status %s" % step, logging.info)
         mmem = self.get_ballooned_memory()
         gmem = self.get_memory_status()
-        gcompare_threshold = int(self.params.get("guest_compare_threshold", 100))
+        gcompare_threshold = int(self.params.get("guest_compare_threshold",
+                                                 100))
         guest_mem_ratio = self.params.get("guest_mem_ratio")
         if guest_mem_ratio:
             gcompare_threshold = max(gcompare_threshold,
@@ -92,9 +93,10 @@ class BallooningTest(MemoryBaseTest):
             guest_ballooned_mem = abs(gmem - self.ori_gmem)
             if (abs(mmem - self.ori_mem) != ballooned_mem or
                     (abs(guest_ballooned_mem - ballooned_mem) > gcompare_threshold)):
-                self.error_report(step, self.ori_mem - ballooned_mem, mmem, gmem)
+                self.error_report(step, self.ori_mem - ballooned_mem, mmem,
+                                  gmem)
                 raise exceptions.TestFail("Balloon test failed %s" % step)
-        return (mmem, gmem)
+        return mmem, gmem
 
     def enable_polling(self, device_path):
         """
@@ -105,7 +107,8 @@ class BallooningTest(MemoryBaseTest):
         polling_interval = int(self.params.get("polling_interval", 2))
         sleep_time = int(self.params.get("polling_sleep_time", 20))
         error_context.context("Enable polling", logging.info)
-        self.vm.monitor.qom_set(device_path, "guest-stats-polling-interval", polling_interval)
+        self.vm.monitor.qom_set(device_path, "guest-stats-polling-interval",
+                                polling_interval)
         time.sleep(sleep_time)
 
     def get_memory_stat(self, device_path):
@@ -132,7 +135,7 @@ class BallooningTest(MemoryBaseTest):
             guest_mem = self.get_vm_mem(self.vm)
         memory_stat_qmp = "%sB" % memory_stat_qmp
         memory_stat_qmp = int(float(utils_misc.normalize_data_size(
-                                   memory_stat_qmp, order_magnitude="M")))
+            memory_stat_qmp, order_magnitude="M")))
         mem_diff = float(abs(guest_mem - memory_stat_qmp))
         if ((mem_diff / guest_mem) > check_mem_ratio and
                 mem_diff > check_mem_diff):
@@ -181,7 +184,8 @@ class BallooningTest(MemoryBaseTest):
             self.vm.balloon(new_mem)
             self.env["balloon_test"] = 1
         except Exception as e:
-            if self.params.get('illegal_value_check', 'no') == 'no' and new_mem != self.get_ballooned_memory():
+            if (self.params.get('illegal_value_check', 'no') == 'no'
+                    and new_mem != self.get_ballooned_memory()):
                 raise exceptions.TestFail("Balloon memory fail with error"
                                           " message: %s" % e)
         if new_mem > self.ori_mem:
@@ -196,9 +200,9 @@ class BallooningTest(MemoryBaseTest):
             compare_mem = new_mem
 
         balloon_timeout = float(self.params.get("balloon_timeout", 480))
-        status = utils_misc.wait_for((lambda: compare_mem ==
-                                      self.get_ballooned_memory()),
-                                     balloon_timeout)
+        status = utils_misc.wait_for((
+            lambda: compare_mem == self.get_ballooned_memory()),
+            balloon_timeout)
         if status is None:
             raise exceptions.TestFail("Failed to balloon memory to expect"
                                       " value during %ss" % balloon_timeout)
@@ -277,14 +281,16 @@ class BallooningTest(MemoryBaseTest):
             self.vm.balloon(1)
             balloon_timeout = self.params.get("balloon_timeout", 900)
             self.wait_for_balloon_complete(balloon_timeout)
-            used_size = min((self.get_ballooned_memory() + balloon_buffer), max_size)
+            used_size = min((self.get_ballooned_memory() + balloon_buffer),
+                            max_size)
             self.vm.balloon(max_size)
             self.wait_for_balloon_complete(balloon_timeout)
             self.ori_gmem = self.get_memory_status()
         else:
             vm_total = self.get_memory_status()
             vm_mem_free = self.get_free_mem()
-            used_size = min((self.ori_mem - vm_mem_free + balloon_buffer), max_size)
+            used_size = min((self.ori_mem - vm_mem_free + balloon_buffer),
+                            max_size)
         if balloon_type == "enlarge":
             min_size = self.current_mmem
         elif balloon_type == "evict":
@@ -320,7 +326,8 @@ class BallooningTest(MemoryBaseTest):
         ballooned_memory = self.ori_mem - expect_mem
         if ballooned_memory < 0 or ballooned_memory == self.ori_mem:
             ballooned_memory = 0
-        mmem, gmem = self.memory_check("after %s memory" % tag, ballooned_memory)
+        mmem, gmem = self.memory_check("after %s memory" % tag,
+                                       ballooned_memory)
         self.current_mmem = mmem
         self.current_gmem = gmem
         if (params_tag.get("run_sub_test_after_balloon", "no") == "yes" and
@@ -335,7 +342,8 @@ class BallooningTest(MemoryBaseTest):
                 expect_mem = self.ori_mem
 
             sleep_before_check = int(self.params.get("sleep_before_check", 0))
-            timeout = int(self.params.get("balloon_timeout", 100)) + sleep_before_check
+            timeout = (int(self.params.get("balloon_timeout", 100)) +
+                       sleep_before_check)
             ballooned_mem = abs(self.ori_mem - expect_mem)
             msg = "Wait memory balloon back after "
             msg += params_tag['sub_test_after_balloon']
@@ -403,6 +411,7 @@ class BallooningTestWin(BallooningTest):
     """
     Windows memory ballooning test
     """
+
     def _balloon_post_action(self):
         """
         Wait for guest memory goes into stable status
@@ -451,7 +460,8 @@ class BallooningTestWin(BallooningTest):
         status, output = session.cmd_status_output(cmd)
         if status == 0:
             free = "%s" % re.findall(r"\d+\.\d+", output)[2]
-            free = float(utils_misc.normalize_data_size(free, order_magnitude="M"))
+            free = float(utils_misc.normalize_data_size(free,
+                                                        order_magnitude="M"))
             return int(free)
         else:
             self.test.fail("Failed to get windows guest free memory")
@@ -579,12 +589,12 @@ def run(test, params, env):
         elif params_tag.get('expect_memory_ratio'):
             expect_mem = int(balloon_test.ori_mem *
                              float(params_tag.get('expect_memory_ratio')))
-        #set evict illegal value to "0" for both linux and windows
+        # set evict illegal value to "0" for both linux and windows
         elif params_tag.get('illegal_value_check', 'no') == 'yes':
             if tag == 'evict':
                 expect_mem = 0
             else:
-                expect_mem = int(balloon_test.ori_mem+random.uniform(1, 1000))
+                expect_mem = int(balloon_test.ori_mem + random.uniform(1, 1000))
         else:
             balloon_type = params_tag['balloon_type']
             min_sz, max_sz = balloon_test.get_memory_boundary(balloon_type)

--- a/qemu/tests/block_hotplug_in_pause.py
+++ b/qemu/tests/block_hotplug_in_pause.py
@@ -116,10 +116,12 @@ def run(test, params, env):
                             if not node.verify_unplug(
                                     node.unplug(vm.monitor), vm.monitor):
                                 raise DeviceUnplugError(
-                                        node, "Failed to unplug blockdev node.", vm.devices)
+                                    node, "Failed to unplug blockdev node.",
+                                    vm.devices)
                             vm.devices.remove(node, True if isinstance(
-                                    node, qdevices.QBlockdevFormatNode) else False)
-                            if not isinstance(node, qdevices.QBlockdevFormatNode):
+                                node, qdevices.QBlockdevFormatNode) else False)
+                            if not isinstance(node,
+                                              qdevices.QBlockdevFormatNode):
                                 format_node.del_child_node(node)
                     else:
                         vm.devices.remove(drive)
@@ -139,7 +141,8 @@ def run(test, params, env):
         for dev in reversed(device_list):
             out = dev.unplug(vm.monitor)
             if out:
-                test.fail("Failed to unplug device '%s'.Ouptut:\n%s" % (dev, out))
+                test.fail("Failed to unplug device '%s'.Ouptut:\n%s" % (dev,
+                                                                        out))
 
         if verify_del_event:
             verify_deleted_event(device_list)
@@ -163,9 +166,10 @@ def run(test, params, env):
         """
         logging.info("Check block device in guest after %s." % plug_tag)
         pause = float(params.get("virtio_block_pause", 30.0))
-        status = utils_misc.wait_for(lambda: len(get_plug_unplug_disks(disks,
-                                     find_disk(session, get_disk_cmd))) == blk_num,
-                                     pause)
+        status = utils_misc.wait_for(
+            lambda: len(
+                get_plug_unplug_disks(
+                    disks, find_disk(session, get_disk_cmd))) == blk_num, pause)
         disks = get_plug_unplug_disks(disks, find_disk(session, get_disk_cmd))
         if not status:
             test.fail("Failed to %s device to guest, expected: %d,"
@@ -188,7 +192,8 @@ def run(test, params, env):
         for item in index_sizes:
             did, size = item.split()
             drive_letter = utils_disk.configure_empty_windows_disk(session,
-                                                                   did, size + "B")
+                                                                   did,
+                                                                   size + "B")
             windows_drive_letters.extend(drive_letter)
 
     def rw_disk_in_guest(session, plug_disks, iteration):
@@ -249,15 +254,18 @@ def run(test, params, env):
                 if devs:
                     device_list.extend(devs)
 
-            if is_vm_paused and params.get("resume_vm_after_hotplug", "yes") == "yes":
+            if is_vm_paused and params.get("resume_vm_after_hotplug",
+                                           "yes") == "yes":
                 error_context.context("Resume vm after hotplug")
                 vm.resume()
                 is_vm_paused = False
 
-                block_check_in_guest(session, disks_before_plug, blk_num, get_disk_cmd)
+                block_check_in_guest(session, disks_before_plug, blk_num,
+                                     get_disk_cmd)
                 if params.get("disk_op_cmd"):
                     plug_disks = get_plug_unplug_disks(disks_before_plug,
-                                                       find_disk(session, get_disk_cmd))
+                                                       find_disk(session,
+                                                                 get_disk_cmd))
                     rw_disk_in_guest(session, plug_disks, iteration)
 
         else:

--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -90,7 +90,7 @@ def run(test, params, env):
     data_image_dev = vm.get_block({'file': data_image_filename})
     img = QemuImg(data_image_params, data_dir.get_data_dir(), data_image)
     block_virtual_size = json.loads(img.info(force_share=True,
-                                    output="json"))["virtual-size"]
+                                             output="json"))["virtual-size"]
 
     session = vm.wait_for_login(timeout=timeout)
 
@@ -132,8 +132,10 @@ def run(test, params, env):
                     block_size), 'M').split(".")[0]
                 drive.shrink_volume(session, mpoint, shr_size)
             else:
-                utils_disk.resize_filesystem_linux(session, partition, str(block_size))
-                utils_disk.resize_partition_linux(session, partition, str(block_size))
+                utils_disk.resize_filesystem_linux(session, partition,
+                                                   str(block_size))
+                utils_disk.resize_partition_linux(session, partition,
+                                                  str(block_size))
 
         error_context.context("Change disk size to %s in monitor"
                               % block_size, logging.info)
@@ -160,16 +162,20 @@ def run(test, params, env):
             if os_type == 'windows':
                 max_block_size = int(params["max_block_size"])
                 if int(block_size) >= max_block_size:
-                    test.cancel("Cancel the test for more than maximum %dB disk." % max_block_size)
+                    test.cancel(
+                        "Cancel the test for more than maximum %dB disk." %
+                        max_block_size)
                 drive.extend_volume(session, mpoint)
             else:
-                utils_disk.resize_partition_linux(session, partition, str(block_size))
+                utils_disk.resize_partition_linux(session, partition,
+                                                  str(block_size))
                 utils_disk.resize_filesystem_linux(session, partition,
                                                    utils_disk.SIZE_AVAILABLE)
         global current_size
         current_size = 0
         if not wait.wait_for(lambda: verify_disk_size(session, os_type,
-                             disk), 20, 0, 1, "Block Resizing"):
+                                                      disk), 20, 0, 1,
+                             "Block Resizing"):
             test.fail("Block size get from guest is not same as expected.\n"
                       "Reported: %s\nExpect: %s\n" % (current_size, block_size))
         session = vm.reboot(session=session)

--- a/qemu/tests/dump_guest_memory.py
+++ b/qemu/tests/dump_guest_memory.py
@@ -190,7 +190,8 @@ def run(test, params, env):
     if check_dump == "True":
         # query dump status and wait for dump completed
         utils_misc.wait_for(lambda: execute_qmp_cmd(query_qmp_cmd,
-                            query_cmd_return_value), dump_file_timeout)
+                                                    query_cmd_return_value),
+                            dump_file_timeout)
         check_dump_file()
         os.remove(dump_file)
 

--- a/qemu/tests/mlock_basic.py
+++ b/qemu/tests/mlock_basic.py
@@ -10,6 +10,7 @@ class MlockBasic(object):
     """
     Base class for mlock test
     """
+
     def __init__(self, test, params, env):
         self.test = test
         self.params = params

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -405,13 +405,16 @@ class QemuGuestAgentTest(BaseVirtTest):
                 logging.info("qemu-ga is not installed or need to update.")
                 self.gagent_install(session, self.vm)
 
-            if self._check_ga_service(session, params.get("gagent_status_cmd")):
+            if self._check_ga_service(
+                    session, params.get("gagent_status_cmd")):
                 logging.info("qemu-ga service is already running.")
             else:
                 logging.info("qemu-ga service is not running.")
                 self.gagent_start(session, self.vm)
 
-            args = [params.get("gagent_serial_type"), params.get("gagent_name")]
+            args = [
+                params.get("gagent_serial_type"),
+                params.get("gagent_name")]
             self.gagent_create(params, self.vm, *args)
 
     def run_once(self, test, params, env):
@@ -443,7 +446,9 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param env: Dictionary with test environment.
         """
         repeats = int(params.get("repeat_times", 1))
-        logging.info("Repeat install/uninstall qemu-ga pkg for %s times" % repeats)
+        logging.info(
+            "Repeat install/uninstall qemu-ga pkg for %s times" %
+            repeats)
 
         if not self.vm:
             self.vm = self.env.get_vm(params["main_vm"])
@@ -471,7 +476,9 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param env: Dictionary with test environment.
         """
         repeats = int(params.get("repeat_times", 1))
-        logging.info("Repeat stop/restart qemu-ga service for %s times" % repeats)
+        logging.info(
+            "Repeat stop/restart qemu-ga service for %s times" %
+            repeats)
 
         if not self.vm:
             self.vm = self.env.get_vm(params["main_vm"])
@@ -499,7 +506,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param params: Dictionary with the test parameters
         :param env: Dictionary with test environmen.
         """
-        error_context.context("Check guest agent command 'guest-sync'", logging.info)
+        error_context.context("Check guest agent command 'guest-sync'",
+                              logging.info)
         self.gagent.sync()
 
     @error_context.context_aware
@@ -531,6 +539,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param params: Dictionary with the test parameters
         :param env: Dictionary with test environmen.
         """
+
         def _gagent_check_shutdown(self):
             self.__gagent_check_shutdown(self.gagent.SHUTDOWN_MODE_POWERDOWN)
             if not utils_misc.wait_for(self.vm.is_dead, self.vm.REBOOT_TIMEOUT):
@@ -547,7 +556,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             env_process.preprocess_vm(test, params, env, params["main_vm"])
             self.vm = env.get_vm(params["main_vm"])
             session = self.vm.wait_for_login(timeout=int(params.get("login_timeout",
-                                             360)))
+                                                                    360)))
 
             error_context.context("Check if guest-agent crash after reboot.",
                                   logging.info)
@@ -649,7 +658,9 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             test.fail("Failed to set the new password for guest")
 
         finally:
-            error_context.context("Reset back the password of guest", logging.info)
+            error_context.context(
+                "Reset back the password of guest",
+                logging.info)
             self.gagent.set_user_password(old_password, username=ga_username)
 
     @error_context.context_aware
@@ -1165,7 +1176,9 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         params["drv_extra_params_%s" % test_image] = "discard=on"
         params["images"] = " ".join([params["images"], test_image])
 
-        error_context.context("boot guest with disk '%s'" % disk_name, logging.info)
+        error_context.context(
+            "boot guest with disk '%s'" %
+            disk_name, logging.info)
         env_process.preprocess_vm(test, params, env, vm_name)
 
         self.initialize(test, params, env)
@@ -1175,7 +1188,9 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         device_name = get_guest_discard_disk(session)
         self.gagent_setsebool_value('on', params, self.vm)
 
-        error_context.context("format disk '%s' in guest" % device_name, logging.info)
+        error_context.context(
+            "format disk '%s' in guest" %
+            device_name, logging.info)
         format_disk_cmd = params["format_disk_cmd"]
         format_disk_cmd = format_disk_cmd.replace("DISK", device_name)
         session.cmd(format_disk_cmd)
@@ -1190,7 +1205,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         write_disk_cmd = params["write_disk_cmd"]
         session.cmd(write_disk_cmd)
 
-        error_context.context("Delete the file created before on disk", logging.info)
+        error_context.context("Delete the file created before on disk",
+                              logging.info)
         delete_file_cmd = params["delete_file_cmd"]
         session.cmd(delete_file_cmd)
 
@@ -1324,7 +1340,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             if_index = 0
             for interface in ret_list:
                 if "hardware-address" in interface and \
-                                interface["hardware-address"] == mac_addr:
+                        interface["hardware-address"] == mac_addr:
                     interface_name = interface["name"]
                     break
                 if_index += 1
@@ -1460,14 +1476,18 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         gagent = self.gagent
         gagent.fsfreeze()
         try:
-            for mode in (gagent.SHUTDOWN_MODE_POWERDOWN, gagent.SHUTDOWN_MODE_REBOOT):
+            for mode in (gagent.SHUTDOWN_MODE_POWERDOWN,
+                         gagent.SHUTDOWN_MODE_REBOOT):
                 try:
                     gagent.shutdown(mode)
                 except guest_agent.VAgentCmdError as detail:
-                    if not re.search('guest-shutdown has been disabled', str(detail)):
-                        test.fail("This is not the desired information: ('%s')" % str(detail))
+                    if not re.search('guest-shutdown has been disabled',
+                                     str(detail)):
+                        test.fail("This is not the desired information: ('%s')"
+                                  % str(detail))
                 else:
-                    test.fail("agent shutdown command shouldn't succeed for freeze FS")
+                    test.fail("agent shutdown command shouldn't succeed for "
+                              "freeze FS")
         finally:
             try:
                 gagent.fsthaw(check_status=False)
@@ -1578,7 +1598,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self.gagent.guest_file_seek(ret_handle, 0, 0)
         self._read_check(ret_handle, "he", 2)
 
-        logging.info("Seek the position to file beginning, offset is 2, and read 2 bytes.")
+        logging.info("Seek the position to file beginning, offset is 2, and "
+                     "read 2 bytes.")
         self.gagent.guest_file_seek(ret_handle, 2, 0)
         self._read_check(ret_handle, "ll", 2)
 
@@ -1984,7 +2005,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                         test.fail("When exitcode is 0, should not return"
                                   " error data.")
                     else:
-                        test.fail("There is no output with capture_output is true.")
+                        test.fail(
+                            "There is no output with capture_output is true.")
                 else:
                     if "out-data" in result:
                         test.fail("When exitcode is 1, should not return"
@@ -1995,7 +2017,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                         logging.info("The guest cmd failed,"
                                      "the error info is:\n%s" % err_data)
                     else:
-                        test.fail("There is no output with capture_output is true.")
+                        test.fail("There is no output with capture_output is "
+                                  "true.")
             else:
                 # for windows guest,no matter what exitcode is,
                 #  the return key is out-data
@@ -2042,7 +2065,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         else:
             test.fail("Should not success for invalid cmd.")
 
-        error_context.context("Execute guest cmd with wrong args.", logging.info)
+        error_context.context("Execute guest cmd with wrong args.",
+                              logging.info)
         if params.get("os_type") == "linux":
             guest_cmd = "cd"
             guest_cmd_args = "/tmp/qga_empty_dir"
@@ -2369,7 +2393,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             """
             Get the new added disks by comparing two disk lists.
             """
-            disk = list(set(disks_after_plug).difference(set(disks_before_plug)))
+            disk = list(
+                set(disks_after_plug).difference(set(disks_before_plug)))
             return disk
 
         session = self._get_session(params, self.vm)
@@ -2394,8 +2419,11 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             pause = float(params.get("virtio_block_pause", 10.0))
             error_context.context("Format and write disk", logging.info)
             if params.get("os_type") == "linux":
-                new_disks = utils_misc.wait_for(lambda: get_new_disk(disks_before_plug.keys(),
-                                                utils_disk.get_linux_disks(session, True).keys()), pause)
+                new_disks = utils_misc.wait_for(
+                    lambda: get_new_disk(
+                        disks_before_plug.keys(),
+                        utils_disk.get_linux_disks(session, True).keys()),
+                    pause)
                 if not new_disks:
                     test.fail("Can't detect the new hotplugged disks in guest")
                 try:
@@ -2409,11 +2437,14 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 disk_index = utils_misc.wait_for(
                     lambda: utils_disk.get_windows_disks_index(session, image_size_stg0), 120)
                 if disk_index:
-                    logging.info("Clear readonly for disk and online it in windows guest.")
-                    if not utils_disk.update_windows_disk_attributes(session, disk_index):
+                    logging.info("Clear readonly for disk and online it in "
+                                 "windows guest.")
+                    if not utils_disk.update_windows_disk_attributes(
+                            session, disk_index):
                         test.error("Failed to update windows disk attributes.")
                     mnt_point = utils_disk.configure_empty_disk(
-                        session, disk_index[0], image_size_stg0, "windows", labeltype="msdos")
+                        session, disk_index[0], image_size_stg0, "windows",
+                        labeltype="msdos")
             session.cmd(disk_write_cmd % mnt_point[0])
             error_context.context("Unplug the added disk", logging.info)
             self.vm.devices.simple_unplug(devs[-1], self.vm.monitor)
@@ -2422,7 +2453,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 try:
                     self.gagent.fsthaw(check_status=False)
                 except guest_agent.VAgentCmdError as detail:
-                    if not re.search("fsfreeze is limited up to 10 seconds", str(detail)):
+                    if not re.search("fsfreeze is limited up to 10 seconds",
+                                     str(detail)):
                         test.error("guest-fsfreeze-thaw cmd failed with:"
                                    "('%s')" % str(detail))
             self.vm.verify_alive()
@@ -2614,12 +2646,14 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         error_context.context("Remove qga.service.", logging.info)
         self.gagent_uninstall(session, self.vm)
 
-        error_context.context("Check qga.service after removing it.", logging.info)
+        error_context.context("Check qga.service after removing it.",
+                              logging.info)
         try:
             if self._check_ga_service(session, params.get("gagent_status_cmd")):
                 test.fail("QGA service should be removed.")
         finally:
-            error_context.context("Recover test env that start qga.", logging.info)
+            error_context.context("Recover test env that start qga.",
+                                  logging.info)
             self.gagent_install(session, self.vm)
             self.gagent_start(session, self.vm)
             self.gagent_verify(params, self.vm)
@@ -2637,7 +2671,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                               logging.info)
         session = self._get_session(self.params, None)
         self._open_session_list.append(session)
-        iozone_cmd = utils_misc.set_winutils_letter(session, params["iozone_cmd"])
+        iozone_cmd = utils_misc.set_winutils_letter(session,
+                                                    params["iozone_cmd"])
         session.cmd(iozone_cmd, timeout=360)
         error_context.context("Freeze the FS.", logging.info)
         try:
@@ -2647,11 +2682,13 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                              " VSS provider", str(detail)):
                 test.fail("guest-fsfreeze-freeze cmd failed with:"
                           "('%s')" % str(detail))
-        if self.gagent.verify_fsfreeze_status(self.gagent.FSFREEZE_STATUS_FROZEN):
+        if self.gagent.verify_fsfreeze_status(
+                self.gagent.FSFREEZE_STATUS_FROZEN):
             try:
                 self.gagent.fsthaw(check_status=False)
             except guest_agent.VAgentCmdError as detail:
-                if not re.search("fsfreeze is limited up to 10 seconds", str(detail)):
+                if not re.search("fsfreeze is limited up to 10 seconds",
+                                 str(detail)):
                     test.error("guest-fsfreeze-thaw cmd failed with:"
                                "('%s')" % str(detail))
 
@@ -2699,14 +2736,16 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         error_context.context("Freeze fs.", logging.info)
         self.gagent.fsfreeze()
 
-        error_context.context("Check VSS Provider status after fsfreeze.", logging.info)
+        error_context.context("Check VSS Provider status after fsfreeze.",
+                              logging.info)
         check_vss_info("query", "STATE", "RUNNING")
 
         error_context.context("Thaw fs.", logging.info)
         try:
             self.gagent.fsthaw()
         except guest_agent.VAgentCmdError as detail:
-            if not re.search("fsfreeze is limited up to 10 seconds", str(detail)):
+            if not re.search("fsfreeze is limited up to 10 seconds",
+                             str(detail)):
                 test.error("guest-fsfreeze-thaw cmd failed with:"
                            "('%s')" % str(detail))
 
@@ -2766,7 +2805,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 else:
                     # Disk 'C:' and '/' used space usage have a floating interval,
                     # so set a safe value '10485760'.
-                    logging.info("Need to check the floating interval for C: or /.")
+                    logging.info("Need to check the floating interval for C: "
+                                 "or /.")
                     if diff_used_qgaguest > 10485760:
                         test.fail("File System floating interval is too large,"
                                   "Something must go wrong.")
@@ -2778,7 +2818,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self._open_session_list.append(session)
         serial_num = params["blk_extra_params_image1"].split("=")[1]
 
-        error_context.context("Check all file system info in a loop.", logging.info)
+        error_context.context("Check all file system info in a loop.",
+                              logging.info)
         fs_info_qga = self.gagent.get_fsinfo()
         for fs in fs_info_qga:
             device_id = fs["name"]
@@ -2794,14 +2835,16 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 # volume is not supported.
                 check_usage_qga_guest(mount_pt)
             else:
-                logging.info("'%s' disk usage statistic is not supported" % mount_pt)
+                logging.info("'%s' disk usage statistic is not supported" %
+                             mount_pt)
 
-            error_context.context("Check file system type of '%s' mount point." %
-                                  mount_pt, logging.info)
+            error_context.context("Check file system type of '%s' mount point."
+                                  % mount_pt, logging.info)
             fs_type_qga = fs["type"]
             cmd_get_disk = params["cmd_get_disk"] % mount_pt.replace("/", r"\/")
             if params["os_type"] == "windows":
-                cmd_get_disk = params["cmd_get_disk"] % device_id.replace("\\", r"\\")
+                cmd_get_disk = params["cmd_get_disk"] % device_id.replace("\\",
+                                                                          r"\\")
             disk_info_guest = session.cmd(cmd_get_disk).strip().split()
             fs_type_guest = disk_info_guest[1]
             if fs_type_qga != fs_type_guest:
@@ -2809,23 +2852,27 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                           "from guest-agent is %s.\nfrom guest os is %s."
                           % (fs_type_qga, fs_type_guest))
             else:
-                logging.info("File system type is %s which is expected." % fs_type_qga)
+                logging.info("File system type is %s which is expected." %
+                             fs_type_qga)
 
             error_context.context("Check disk name.", logging.info)
             disk_name_qga = fs["name"]
             disk_name_guest = disk_info_guest[0]
             if params["os_type"] == "linux":
                 if not re.findall(r'^/\w*/\w*$', disk_name_guest):
-                    disk_name_guest = session.cmd("readlink %s" % disk_name_guest).strip()
+                    disk_name_guest = session.cmd("readlink %s" %
+                                                  disk_name_guest).strip()
                 disk_name_guest = disk_name_guest.split('/')[-1]
             if disk_name_qga != disk_name_guest:
                 test.fail("Device name doesn't match.\n"
                           "from guest-agent is %s.\nit's from guest os is %s."
                           % (disk_name_qga, disk_name_guest))
             else:
-                logging.info("Disk name is %s which is expected." % disk_name_qga)
+                logging.info("Disk name is %s which is expected." %
+                             disk_name_qga)
 
-            error_context.context("Check serial number of some disk.", logging.info)
+            error_context.context("Check serial number of some disk.",
+                                  logging.info)
             if fs_type_qga == "UDF" or fs_type_qga == "CDFS":
                 logging.info("Only check block disk's serial info, no cdrom.")
                 continue
@@ -2835,7 +2882,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                           "from guest-agent is %s.\n"
                           "but it should include %s." % (serial_qga, serial_num))
             else:
-                logging.info("Serial number is %s which is expected." % serial_qga)
+                logging.info("Serial number is %s which is expected." %
+                             serial_qga)
 
     @error_context.context_aware
     def gagent_check_nonexistent_cmd(self, test, params, env):
@@ -3179,9 +3227,10 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             device_id = device_address["device-id"]
             vendor_id = device_address["vendor-id"]
 
-            filter_name = "friendlyname" if "Ethernet" in driver_name \
-                else "devicename"
-            check_driver_cmd = check_driver_cmd_org % (filter_name, driver_name)
+            filter_name = ("friendlyname" if "Ethernet" in driver_name else
+                           "devicename")
+            check_driver_cmd = check_driver_cmd_org % (
+                filter_name, driver_name)
 
             driver_info_guest = session.cmd_output(check_driver_cmd)
             # check driver date
@@ -3504,6 +3553,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
     """
     Qemu guest agent test class for windows guest.
     """
+
     def __init__(self, test, params, env):
         QemuGuestAgentBasicCheck.__init__(self, test, params, env)
         self.gagent_guest_dir = params.get("gagent_guest_dir", "")
@@ -3533,7 +3583,8 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
 
             error_context.context("Download qemu-ga.msi from website and copy "
                                   "it to guest.", logging.info)
-            process.system(gagent_download_cmd, float(params.get("login_timeout", 360)))
+            process.system(
+                gagent_download_cmd, float(params.get("login_timeout", 360)))
             if not os.path.exists(gagent_host_path):
                 test.error("qemu-ga.msi is not exist, maybe it is not "
                            "successfully downloaded ")
@@ -3548,7 +3599,8 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
         elif self.gagent_src_type == "virtio-win":
             vol_virtio_key = "VolumeName like '%virtio-win%'"
             vol_virtio = utils_misc.get_win_disk_vol(session, vol_virtio_key)
-            qemu_ga_pkg_path = r"%s:\%s\%s" % (vol_virtio, "guest-agent", qemu_ga_pkg)
+            qemu_ga_pkg_path = r"%s:\%s\%s" % (vol_virtio, "guest-agent",
+                                               qemu_ga_pkg)
         else:
             test.error("Only support 'url' and 'virtio-win' method to "
                        "download qga installer now.")
@@ -3685,7 +3737,8 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
             try:
                 self.gagent.fsthaw()
             except guest_agent.VAgentCmdError as detail:
-                if re.search("fsfreeze is limited up to 10 seconds", str(detail)):
+                if re.search("fsfreeze is limited up to 10 seconds",
+                             str(detail)):
                     logging.info("FS is thaw as it's limited up to 10 seconds.")
                 else:
                     test.fail("guest-fsfreeze-thaw cmd failed with:"

--- a/qemu/tests/qemu_guest_agent_hotplug.py
+++ b/qemu/tests/qemu_guest_agent_hotplug.py
@@ -8,7 +8,6 @@ from qemu.tests.qemu_guest_agent import run as guest_agent_run
 
 @error_context.context_aware
 def run(test, params, env):
-
     """
     hotplug guest agent device
 

--- a/qemu/tests/qemu_img_map_unaligned_image.py
+++ b/qemu/tests/qemu_img_map_unaligned_image.py
@@ -30,7 +30,7 @@ def run(test, params, env):
         """Verify qemu-img map's output."""
         logging.info("Verify the dumped mete-data of the unaligned image.")
         expected = [{"start": 0, "length": str_len, "depth": 0,
-                    "zero": False, "data": True, "offset": 0},
+                     "zero": False, "data": True, "offset": 0},
                     {"start": str_len, "length": 512 - (str_len % 512),
                      "depth": 0, "zero": True, "data": False,
                      "offset": str_len}]

--- a/qemu/tests/remote_block_resize.py
+++ b/qemu/tests/remote_block_resize.py
@@ -67,7 +67,7 @@ def run(test, params, env):
         test.error("Cannot find device to resize.")
 
     block_virtual_size = json.loads(img.info(force_share=True,
-                                    output="json"))["virtual-size"]
+                                             output="json"))["virtual-size"]
 
     session = vm.wait_for_login(timeout=timeout)
     disk = sorted(utils_disk.get_linux_disks(session).keys())[0]
@@ -90,7 +90,8 @@ def run(test, params, env):
             session = vm.reboot(session=session)
 
         if not wait.wait_for(lambda: verify_disk_size(session, os_type,
-                             disk), 20, 0, 1, "Block Resizing"):
+                                                      disk), 20, 0, 1,
+                             "Block Resizing"):
             test.fail("The current block size is not the same as expected.\n")
 
     session.close()

--- a/qemu/tests/usb_device_check_negative.py
+++ b/qemu/tests/usb_device_check_negative.py
@@ -23,7 +23,7 @@ def run(test, params, env):
     logging.info("starting vm according to the usb topology")
     error_info = params["error_info"]
     error_context.context(("verify [%s] is reported by QEMU..." %
-                          error_info), logging.info)
+                           error_info), logging.info)
     try:
         env_process.process(test, params, env,
                             env_process.preprocess_image,

--- a/qemu/tests/usb_redir.py
+++ b/qemu/tests/usb_redir.py
@@ -96,7 +96,7 @@ def run(test, params, env):
             usbredir_dev.set_param('bootindex', usbredir_bootindex)
             usbredir_dev.set_param('bus', usbredir_bus)
             extra_params += ' '.join([chardev.cmdline(),
-                                     usbredir_dev.cmdline()])
+                                      usbredir_dev.cmdline()])
             return extra_params
         extra_params = _generate_usb_redir_cmdline()
         params["extra_params"] = extra_params
@@ -239,7 +239,7 @@ def run(test, params, env):
             error_context.context("Boot from redirected USB stick",
                                   logging.info)
             boot_entry_info = params["boot_entry_info"]
-            vm.send_key(str(bootindex+1))
+            vm.send_key(str(bootindex + 1))
             if not utils_misc.wait_for(lambda: boot_check(boot_entry_info),
                                        timeout, 1):
                 test.fail("Could not boot from redirected USB stick")

--- a/qemu/tests/vioser_in_use.py
+++ b/qemu/tests/vioser_in_use.py
@@ -69,7 +69,7 @@ def kill_host_serial_pid(params, vm):
     simultaneously.
     """
     port_path = virtio_serial_file_transfer.get_virtio_port_property(
-            vm, params["file_transfer_serial_port"])[1]
+        vm, params["file_transfer_serial_port"])[1]
 
     host_process = 'ps aux | grep "serial_host_send_receive.py"'
     host_process = process.system_output(host_process,
@@ -95,13 +95,14 @@ def run_bg_test(test, params, vm, sender="both"):
     error_context.context("Run serial transfer test in background",
                           logging.info)
     stress_thread = utils_misc.InterruptedThread(
-            virtio_serial_file_transfer.transfer_data, (params, vm),
-            {"sender": sender})
+        virtio_serial_file_transfer.transfer_data, (params, vm),
+        {"sender": sender})
     stress_thread.start()
 
     check_bg_timeout = float(params.get('check_bg_timeout', 120))
     if not utils_misc.wait_for(lambda: driver_in_use.check_bg_running(vm,
-                               params), check_bg_timeout, 0, 1):
+                                                                      params),
+                               check_bg_timeout, 0, 1):
         test.fail("Backgroud test is not alive!")
     return stress_thread
 

--- a/qemu/tests/win_sigverif.py
+++ b/qemu/tests/win_sigverif.py
@@ -43,7 +43,8 @@ def run(test, params, env):
         test.error(output)
 
     if not utils_misc.wait_for(lambda: system.file_exists(session,
-                               sigverif_log), 180, 0, 5):
+                                                          sigverif_log),
+                               180, 0, 5):
         test.error("sigverif logs are not created")
 
     try:

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,3 +1,4 @@
 virtualenv==1.9.1
 inspektor==0.5.2
 autotest==0.16.2; python_version < '3.0'
+autopep8==1.5.4


### PR DESCRIPTION
Inspektor has the ability to use autopep8 transparently (if installed),
add autopep8 in requirements-travis.txt to enable this ability.

Refer to: avocado-framework/avocado#4394
ID: 1921754
Signed-off-by: Yihuang Yu <yihyu@redhat.com>