### PR TITLE
blockdev_inc_backup_xpt_allocation_depth: Allocation export test

### DIFF
--- a/qemu/tests/blockdev_inc_backup_xpt_allocation_depth.py
+++ b/qemu/tests/blockdev_inc_backup_xpt_allocation_depth.py
@@ -1,0 +1,119 @@
+import json
+import socket
+
+from avocado.utils import process
+
+from virttest.qemu_storage import filename_to_file_opts
+from virttest.utils_misc import get_qemu_img_binary
+
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+from provider.nbd_image_export import InternalNBDExportImage
+from provider.nbd_image_export import QemuNBDExportImage
+
+
+class BlockdevIncbkXptAllocDepth(BlockdevLiveBackupBaseTest):
+    """Allocation depth export test"""
+
+    def __init__(self, test, params, env):
+        super(BlockdevIncbkXptAllocDepth, self).__init__(test, params, env)
+        self._base_image, self._snapshot_image = self.params.objects(
+            'image_backup_chain')
+        localhost = socket.gethostname()
+        self.params['nbd_server'] = localhost if localhost else 'localhost'
+        self._nbd_image_obj = self.source_disk_define_by_params(
+            self.params, self.params['nbd_image_tag'])
+        self._block_export_uid = self.params.get('block_export_uid')
+        self._nbd_export = None
+        self._is_exported = False
+
+    def _init_nbd_export(self, tag):
+        self._nbd_export = InternalNBDExportImage(
+            self.main_vm, self.params, tag
+        ) if self._block_export_uid else QemuNBDExportImage(
+            self.params, tag
+        )
+
+    def _start_nbd_export(self, tag):
+        if self._block_export_uid is not None:
+            # export local image with block-export-add
+            self._nbd_export.start_nbd_server()
+            self._nbd_export.add_nbd_image('drive_%s' % tag)
+        else:
+            # export local image with qemu-nbd
+            # we should stop vm and rebase sn onto base
+            if self.main_vm.is_alive():
+                self.main_vm.destroy()
+                self._rebase_sn_onto_base()
+            self._nbd_export.export_image()
+        self._is_exported = True
+
+    def _rebase_sn_onto_base(self):
+        disk = self.source_disk_define_by_params(self.params,
+                                                 self._snapshot_image)
+        disk.rebase(params=self.params)
+
+    def post_test(self):
+        self.stop_export()
+        super(BlockdevIncbkXptAllocDepth, self).post_test()
+
+    def stop_export(self):
+        """stop nbd export"""
+        if self._is_exported:
+            self._nbd_export.stop_export()
+            self._is_exported = False
+
+    def export_image(self, tag):
+        """export image from nbd server"""
+        self._init_nbd_export(tag)
+        self._start_nbd_export(tag)
+
+    def check_allocation_depth_from_export(self, zero, data):
+        """
+        check allocation depth from output of qemu-img map
+            local(base image): zero: false, data: false
+            backing(snapshot): zero: true, data: true
+        """
+        opts = filename_to_file_opts(self._nbd_image_obj.image_filename)
+        opts[self.params['dirty_bitmap_opt']] = 'qemu:allocation-depth'
+        map_cmd = '{qemu_img} map --output=json {args}'.format(
+            qemu_img=get_qemu_img_binary(self.params),
+            args="'json:%s'" % json.dumps(opts)
+        )
+
+        result = process.run(map_cmd, ignore_status=False, shell=True)
+        for item in json.loads(result.stdout.decode().strip()):
+            if item['zero'] is zero and item['data'] is data:
+                break
+        else:
+            self.test.fail(
+                'Failed to get "zero": %s, "data": %s' % (zero, data))
+
+    def do_test(self):
+        self.do_full_backup()
+        self.export_image(self._base_image)
+        self.check_allocation_depth_from_export(zero=False, data=False)
+        self.stop_export()
+        self.export_image(self._snapshot_image)
+        self.check_allocation_depth_from_export(zero=True, data=True)
+
+
+def run(test, params, env):
+    """
+    Allocation depth export test.
+
+    test steps:
+        1. boot VM with a data image
+        2. create fs on the data image and create a file
+        3. hotplug a 'base' image, then hotplug a 'sn' image(base->sn)
+        4. do full backup (from data image to base image)
+        5. export 'base' with allocation depth
+        6. check allocation depth info (local: zero: false, data: false)
+        7. export 'sn' with allocation depth
+        8. check allocation depth info (backing: zero: true, data: true)
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkXptAllocDepth(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_xpt_allocation_depth.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_xpt_allocation_depth.cfg
@@ -1,0 +1,67 @@
+# Storage backends:
+#   filesystem
+# The following testing scenario is covered:
+#   Export allocation depth with qemu-nbd
+#   Export allocation depth with block-export-add
+#       base -> sn(exported): backing should be checked
+#       inc(exported): local should be checked
+#       backing: "zero":true,  "data":true
+#       local: "zero":false, "data":false
+# Note:
+#   The images to be exported are local fs images
+
+
+- blockdev_inc_backup_xpt_allocation_depth:
+    only Linux
+    only filesystem
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_xpt_allocation_depth
+    virt_test_type = qemu
+    images += ' data1'
+    image_backup_chain = base sn
+    storage_pools = default
+    storage_pool = default
+    storage_type_default = directory
+    full_backup_options = '{"sync": "full"}'
+    image_chain = ${image_backup_chain}
+    rebase_mode = unsafe
+
+    source_images = data1
+    image_size_data1 = 2G
+    image_name_data1 = data1
+    image_format_data1 = qcow2
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+
+    # base is a local image to be exported
+    image_format_base = qcow2
+    image_name_base = base
+    image_size_base = ${image_size_data1}
+
+    # sn is a local snapshot image(base->sn) to be exported
+    backing_sn = base
+    image_format_sn = qcow2
+    image_name_sn = sn
+    image_size_sn = ${image_size_data1}
+
+    # settings for nbd export
+    nbd_port = 10850
+    nbd_export_name = nbdimage
+    nbd_allocation_exported = yes
+
+    # settings for the access to the exported image
+    nbd_image_tag = nbdimage
+    nbd_port_nbdimage = ${nbd_port}
+    nbd_export_name_nbdimage = ${nbd_export_name}
+    enable_nbd_nbdimage = yes
+    storage_type_nbdimage = nbd
+    dirty_bitmap_opt = x-dirty-bitmap
+
+    variants:
+        - with_qemu_nbd:
+            nbd_export_format = qcow2
+        - with_block_export:
+            block_export_uid = nbdimage_uid
+            block_export_writable = no


### PR DESCRIPTION
  Export allocation depth with qemu-nbd and block-export-add

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1922947, 1922948