### PR TITLE
Mount correct device when restarting vm with target images

### DIFF
--- a/provider/blockdev_backup_base.py
+++ b/provider/blockdev_backup_base.py
@@ -97,6 +97,7 @@ class BlockdevBackupBaseTest(object):
     def verify_data_files(self):
         session = self.clone_vm.wait_for_login()
         try:
+            backup_utils.refresh_mounts(self.disks_info, self.params, session)
             for tag, info in self.disks_info.items():
                 logging.debug("mount target disk in VM!")
                 utils_disk.mount(info[0], info[1], session=session)

--- a/provider/blockdev_stream_base.py
+++ b/provider/blockdev_stream_base.py
@@ -13,9 +13,9 @@ class BlockDevStreamTest(BlockDevSnapshotTest):
         self._top_device = "drive_%s" % self.snapshot_tag
         self._init_stream_options()
         if self.base_tag == self.params.objects("images")[0]:
-            self.disks_info.append(
-                ["system", self.params.get("mnt_on_sys_dsk", "/var/tmp")]
-            )
+            self.disks_info[self.base_tag] = [
+                "system", self.params.get("mnt_on_sys_dsk", "/var/tmp")
+            ]
 
     def _init_stream_options(self):
         if self.params.get("speed"):
@@ -37,10 +37,10 @@ class BlockDevStreamTest(BlockDevSnapshotTest):
                 self.params["block_stream_timeout"])
 
     def snapshot_test(self):
-        for info in self.disks_info:
+        for info in self.disks_info.values():
             self.generate_tempfile(info[1], filename="base")
         self.create_snapshot()
-        for info in self.disks_info:
+        for info in self.disks_info.values():
             self.generate_tempfile(info[1], filename="sn1")
 
     def blockdev_stream(self):

--- a/qemu/tests/blockdev_inc_backup_test.py
+++ b/qemu/tests/blockdev_inc_backup_test.py
@@ -5,6 +5,7 @@ from functools import partial
 from avocado.utils import memory
 
 from virttest import utils_misc
+from virttest import qemu_monitor
 
 from provider import backup_utils
 from provider import blockdev_base
@@ -76,7 +77,7 @@ class BlockdevIncreamentalBackupTest(blockdev_base.BlockdevBaseTest):
                     self.inc_backups,
                     self.bitmaps,
                     **extra_options)
-            except AssertionError:
+            except qemu_monitor.QMPCmdError:
                 return
             self.test.fail('expect incremental backup job(s) failed')
         else:

--- a/qemu/tests/blockdev_mirror_multiple_blocks.py
+++ b/qemu/tests/blockdev_mirror_multiple_blocks.py
@@ -1,32 +1,9 @@
-import re
-
-from virttest import utils_disk
-from virttest import utils_misc
-
 from provider.blockdev_mirror_parallel import BlockdevMirrorParallelTest
 
 
 class BlockdevMirrorMultipleBlocksTest(BlockdevMirrorParallelTest):
     """do block-mirror for multiple disks in parallel"""
-
-    def _get_data_disk_info(self, tag, session):
-        """Get the disk id and size by serial or wwn in linux"""
-        disk_params = self.params.object_params(tag)
-        extra_params = disk_params["blk_extra_params"]
-        drive_id = re.search(r"(serial|wwn)=(\w+)", extra_params, re.M).group(2)
-        drive_path = utils_misc.get_linux_drive_path(session, drive_id)
-        return drive_path[5:], disk_params["image_size"]
-
-    def format_data_disk(self, tag):
-        session = self.main_vm.wait_for_login()
-        try:
-            disk_id, disk_size = self._get_data_disk_info(tag, session)
-            mnt = utils_disk.configure_empty_linux_disk(session,
-                                                        disk_id,
-                                                        disk_size)[0]
-            self.disks_info[tag] = ["/dev/%s1" % disk_id, mnt]
-        finally:
-            session.close()
+    pass
 
 
 def run(test, params, env):

--- a/qemu/tests/blockdev_snapshot_multi_disks.py
+++ b/qemu/tests/blockdev_snapshot_multi_disks.py
@@ -39,16 +39,15 @@ class BlockdevSnapshotMultiDisksTest(BlockDevSnapshotTest):
                     assert disk_id, "Disk not found in guest!"
                     mount_point = utils_disk.configure_empty_linux_disk(
                         session, disk_id, disk_size)[0]
-                    self.disks_info.append([
-                        r"/dev/%s1" %
-                        disk_id, mount_point])
+                    self.disks_info[snapshot_tag] = [r"/dev/%s1" % disk_id,
+                                                     mount_point]
                 else:
                     disk_id = utils_disk.get_windows_disks_index(
                         session, disk_size)
                     driver_letter = utils_disk.configure_empty_windows_disk(
                         session, disk_id, disk_size)[0]
                     mount_point = r"%s:\\" % driver_letter
-                    self.disks_info.append([disk_id, mount_point])
+                    self.disks_info[snapshot_tag] = [disk_id, mount_point]
             finally:
                 session.close()
 

--- a/qemu/tests/blockdev_stream_multiple_blocks.py
+++ b/qemu/tests/blockdev_stream_multiple_blocks.py
@@ -1,8 +1,4 @@
-import re
 import logging
-
-from virttest import utils_disk
-from virttest import utils_misc
 
 from provider import backup_utils
 
@@ -23,26 +19,6 @@ class BlockdevStreamMultipleBlocksTest(BlockdevStreamParallelTest,
         self.disks_info = {}  # tag, [dev, mount_point]
         self.files_info = {}  # tag, [file, file...]
         self.trash = []
-
-    def _get_data_disk_info(self, tag, session):
-        """Get the disk id and size by serial or wwn in linux"""
-        disk_params = self.params.object_params(tag)
-        extra_params = disk_params["blk_extra_params"]
-        drive_id = re.search(r"(serial|wwn)=(\w+)",
-                             extra_params, re.M).group(2)
-        drive_path = utils_misc.get_linux_drive_path(session, drive_id)
-        return drive_path[5:], disk_params["image_size"]
-
-    def format_data_disk(self, tag):
-        session = self.main_vm.wait_for_login()
-        try:
-            disk_id, disk_size = self._get_data_disk_info(tag, session)
-            mnt = utils_disk.configure_empty_linux_disk(session,
-                                                        disk_id,
-                                                        disk_size)[0]
-            self.disks_info[tag] = ["/dev/%s1" % disk_id, mnt]
-        finally:
-            session.close()
 
     def generate_inc_files(self):
         """create another file on data disks"""

--- a/qemu/tests/blockdev_stream_subchain.py
+++ b/qemu/tests/blockdev_stream_subchain.py
@@ -21,7 +21,7 @@ class BlockdevStreamSubChainTest(BlockDevStreamTest):
 
     def snapshot_test(self):
         """create one snapshot, create one new file"""
-        self.generate_tempfile(self.disks_info[0][1],
+        self.generate_tempfile(self.disks_info[self.base_tag][1],
                                filename="base",
                                size=self.params["tempfile_size"])
 
@@ -34,7 +34,7 @@ class BlockdevStreamSubChainTest(BlockDevStreamTest):
                 "drive_%s" % chain[idx]
             )
 
-            self.generate_tempfile(self.disks_info[0][1],
+            self.generate_tempfile(self.disks_info[self.base_tag][1],
                                    filename=chain[idx],
                                    size=self.params["tempfile_size"])
 

--- a/qemu/tests/cfg/blockdev_mirror_multiple_blocks.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_multiple_blocks.cfg
@@ -55,9 +55,8 @@
 
     blk_extra_params_data1 = "serial=DATA_DISK1"
     blk_extra_params_data2 = "serial=DATA_DISK2"
-    Host_RHEL.m6..ide:
-        blk_extra_params_data1 = "wwn=0x5000123456789abc"
-        blk_extra_params_data2 = "wwn=0x5000123456789cba"
+    blk_extra_params_mirror1 = ${blk_extra_params_data1}
+    blk_extra_params_mirror2 = ${blk_extra_params_data2}
 
     # For local mirror images
     storage_type_default = directory

--- a/qemu/tests/cfg/blockdev_stream_multiple_blocks.cfg
+++ b/qemu/tests/cfg/blockdev_stream_multiple_blocks.cfg
@@ -59,9 +59,8 @@
 
     blk_extra_params_data1 = "serial=DATA_DISK1"
     blk_extra_params_data2 = "serial=DATA_DISK2"
-    Host_RHEL.m6..ide:
-        blk_extra_params_data1 = "wwn=0x5000123456789abc"
-        blk_extra_params_data2 = "wwn=0x5000123456789cba"
+    blk_extra_params_data1sn = ${blk_extra_params_data1}
+    blk_extra_params_data2sn = ${blk_extra_params_data2}
 
     # For local snapshot images
     storage_type_default = directory


### PR DESCRIPTION
  When starting vm with target images(such as:
  mirror/backup/snapshot images) as its data images on RHEL9,
  device node name may change, e.g.
    data1 -> /dev/sdb in VM (start VM with data1)
    data1 -> mirror1 (do block-mirror)
    mirror1 -> /dev/sda in VM (restart VM with mirror1)

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1918878