### PR TITLE
boot_nic_with_iommu: Only enable iommu capability on network device

### DIFF
--- a/qemu/tests/cfg/boot_nic_with_iommu.cfg
+++ b/qemu/tests/cfg/boot_nic_with_iommu.cfg
@@ -10,8 +10,8 @@
             enable_guest_iommu = yes
     only virtio_net
     type = boot_nic_with_iommu
-    virtio_dev_disable_legacy = on
-    virtio_dev_disable_modern = off
-    virtio_dev_iommu_platform = on
-    virtio_dev_ats = on
+    nic_extra_params += ",disable-legacy=on,disable-modern=off,iommu_platform=on,ats=on"
+    aarch64:
+        machine_type_extra_params += ",iommu=smmuv3"
+        nic_extra_params += ",iommu_platform=on,ats=on"
     vhostforce = on


### PR DESCRIPTION
1. In order to avoid the impact of enabling iommu on other devices, only enable iommu capability for the virtual network device.
2. Add the machine type extra params for aarch64.

ID: 1925875
Signed-off-by: Yihuang Yu <yihyu@redhat.com>