### PR TITLE
Block commit with top is an non-existed snapshot

### DIFF
--- a/qemu/tests/blockdev_commit_non_existed_node.py
+++ b/qemu/tests/blockdev_commit_non_existed_node.py
@@ -6,7 +6,7 @@ from provider import backup_utils
 from provider.blockdev_commit_base import BlockDevCommitTest
 
 
-class BlockdevCommitNonExistedBase(BlockDevCommitTest):
+class BlockdevCommitNonExistedNode(BlockDevCommitTest):
 
     def commit_snapshots(self):
         device = self.params.get("device_tag")
@@ -15,9 +15,14 @@ class BlockdevCommitNonExistedBase(BlockDevCommitTest):
         self.device_node = self.get_node_name(device)
         options = ["base-node", "top-node", "speed"]
         arguments = self.params.copy_from_keys(options)
-        arguments["base-node"] = self.params["none_existed_base"]
-        device = self.get_node_name(snapshot_tags[-1])
-        arguments["top-node"] = device
+        if self.params.get("none_existed_base"):
+            arguments["base-node"] = self.params["none_existed_base"]
+            device = self.get_node_name(snapshot_tags[-1])
+            arguments["top-node"] = device
+        if self.params.get("none_existed_top"):
+            arguments["base-node"] = self.get_node_name(device)
+            device = self.get_node_name(snapshot_tags[-1])
+            arguments["top-node"] = self.params["none_existed_top"]
         commit_cmd = backup_utils.block_commit_qmp_cmd
         cmd, args = commit_cmd(device, **arguments)
         try:
@@ -50,5 +55,5 @@ def run(test, params, env):
     5. check QMPCmdError data
     """
 
-    block_test = BlockdevCommitNonExistedBase(test, params, env)
+    block_test = BlockdevCommitNonExistedNode(test, params, env)
     block_test.run_test()

--- a/qemu/tests/cfg/blockdev_commit_non_existed_node.cfg
+++ b/qemu/tests/cfg/blockdev_commit_non_existed_node.cfg
@@ -1,5 +1,5 @@
-- blockdev_commit_non_existed_base:
-    type = blockdev_commit_non_existed_base
+- blockdev_commit_non_existed_node:
+    type = blockdev_commit_non_existed_node
     virt_test_type = qemu
     only Linux
     images += " data"
@@ -21,5 +21,9 @@
     device_tag = "data"
     rebase_mode = unsafe
     qemu_force_use_drive_expression = no
-    none_existed_base = sn0
     qmp_error_msg = "'desc': 'Cannot find device= nor node_name=sn0'"
+    variants:
+        - none_existed_base:
+            none_existed_base = sn0
+        - none_existed_top:
+            none_existed_top = sn0


### PR DESCRIPTION
blockdev_commit_non_existed_node: Block commit test

Block commit with base is an non-existed snapshot in snapshot
chain. When do live commit, specify an non-existed snapshot
in snapshot chain as top, qemu-kvm should prompt error.

Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:1931265