### PR TITLE
nvdimm: Enable "reflink=0 with non-RHEL.7 guests

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -27,7 +27,7 @@
     pre_command = "dd if=/dev/zero of=${nv_backend} bs=1M count=1024"
     dev_path = /dev/pmem0
     format_command = "mkfs.xfs -f ${dev_path}"
-    RHEL.8:
+    ! RHEL.7:
         format_command += " -m reflink=0"
     mount_command = "mount -o dax ${dev_path} ${mount_dir}"
     post_command = "rm -rf ${nv_backend}"

--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -5,14 +5,17 @@
     vm_mem_limit = 30G
     kill_vm_on_error = yes
     login_timeout = 240
-    only x86_64, ppc64le
+    only x86_64, ppc64le, aarch64
     ppc64le:
         required_qemu = [5, )
         only nvdimm_basic nvdimm_negative nvdimm_nvml nvdimm_redis
-        no RHEL.7 RHEL.6 RHEL.5 RHEL.4 RHEL.3
+        no RHEL.7
         # PowerPC guests need to create the persistent memory device manually so far
         nvdimm_ns_create_cmd = "ndctl create-namespace"
         dimm_extra_params = "label-size=256M"
+    aarch64:
+        only nvdimm_basic nvdimm_hotplug nvdimm_negative.align_illegal
+        no RHEL.7
     no Windows
     no RHEL.6 RHEL.5 RHEL.4 RHEL.3
     no RHEL.7.2 RHEL.7.1 RHEL.7.0


### PR DESCRIPTION
1. The reflink and dax options are mutually exclusive which causes the mount to fail. Force "reflink=0" when formatting XFS system.
2. Move aarch64 out of the unsupported list and remove some duplicate versions on non-x86 platforms on L12.


ID: 1931442
Signed-off-by: Yihuang Yu <yihyu@redhat.com>