### PR TITLE
boot_order_check: use get() to obtain 'desc' element.

### DIFF
--- a/qemu/tests/boot_order_check.py
+++ b/qemu/tests/boot_order_check.py
@@ -29,7 +29,7 @@ def run(test, params, env):
             if dev['qdev_id'] == dev_id:
                 device_found = dev
                 break
-            elif dev['class_info']['desc'] == 'PCI bridge':
+            elif dev['class_info'].get('desc') == 'PCI bridge':
                 pci_bridge_devices = dev['pci_bridge'].get('devices')
                 if not pci_bridge_devices:
                     continue


### PR DESCRIPTION
Some device representation has no 'desc' element.
Change to use get() to obtain it.

ID: 1931792

Signed-off-by: ybduan <yduan@redhat.com>