### PR TITLE
dump_guest_memory: adjust the value of dump_file_timeout.

### DIFF
--- a/qemu/tests/cfg/dump_guest_memory.cfg
+++ b/qemu/tests/cfg/dump_guest_memory.cfg
@@ -4,7 +4,7 @@
     no Windows
     monitors = 'qmp1'
     monitor_type_qmp1 = qmp
-    dump_file_timeout = 30
+    dump_file_timeout = 90
     dump_file = "/home/dump"
     crash_script = "/home/crash.cmd"
     x86_64:


### PR DESCRIPTION
Adjust the value of dump_file_timeout to wait dump file
generated completed.

Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:1925951