### PR TITLE
Drop some timer device test cases on aarch64

### DIFF
--- a/generic/tests/cfg/timerclock.cfg
+++ b/generic/tests/cfg/timerclock.cfg
@@ -4,10 +4,12 @@
     qemu_stop = off
     variants:
         - monotonic_time:
+            no aarch64
             type = monotonic_time
         - rtc:
             type = rtc
         - tsc:
+            no aarch64
             type = tsc
             tsc_test_name = tsc_before_rhel8
             RHEL.8:

--- a/qemu/tests/cfg/timedrift_adjust_time.cfg
+++ b/qemu/tests/cfg/timedrift_adjust_time.cfg
@@ -2,6 +2,8 @@
     no WinXp, Win2000, Win2003, WinVista
     virt_test_type = qemu libvirt
     clock_source = 'kvm-clock'
+    aarch64:
+        clock_source = 'arch_sys_counter'
     qemu_stop = off
     type = timedrift_adjust_time
     tolerance = 5.0

--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -46,6 +46,7 @@
                     only Linux
                     nmi_cmd = "guest: echo '1' > /proc/sys/kernel/sysrq && echo '0' > /proc/sys/kernel/panic && service kdump stop; echo 'c' > /proc/sysrq-trigger"
         - hotplug_vcpu:
+            no aarch64
             type = timedrift_check_when_hotplug_vcpu
             start_vm = yes
             vcpu_sockets = 2
@@ -56,6 +57,7 @@
             drift_threshold = 3
         - non_event:
             only RHEL
+            no aarch64
             type = timedrift_check_non_event
             start_vm = yes
             monitor_type = qmp

--- a/qemu/tests/cfg/timerdevice_tsc_enable.cfg
+++ b/qemu/tests/cfg/timerdevice_tsc_enable.cfg
@@ -1,6 +1,7 @@
 - timerdevice_tsc_enable:
     type = timerdevice_tsc_enable
     only Linux
+    only i386, x86_64
     no Host_RHEL.m6 no Host_RHEL.m7
     no RHEL.6 RHEL.7
     cpu_model_flags += ",+invtsc"


### PR DESCRIPTION
aarch64 only supports `arch_sys_counter` clock and some timer device test cases have platform limitations, drop them on aarch64.

ID: 1919843, 1932762
Signed-off-by: Yihuang Yu <yihyu@redhat.com>