### PR TITLE
dump_guest_memory: Fix no vmcoreinfo device on aarch64

### DIFF
--- a/qemu/tests/cfg/dump_guest_memory.cfg
+++ b/qemu/tests/cfg/dump_guest_memory.cfg
@@ -7,7 +7,7 @@
     dump_file_timeout = 90
     dump_file = "/home/dump"
     crash_script = "/home/crash.cmd"
-    x86_64:
+    x86_64, aarch64:
         extra_params = "-device vmcoreinfo"
     variants:
         - with_detach_params:


### PR DESCRIPTION
Fix no vmcoreinfo device on aarch64

ID: 1933921
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>