### PR TITLE
cpu_utils: rename check_guest_cpu_topology to make it clear

### DIFF
--- a/provider/cpu_utils.py
+++ b/provider/cpu_utils.py
@@ -54,7 +54,7 @@ def get_guest_cpu_ids(session, os_type):
                                    output, re.M)))
 
 
-def check_guest_cpu_topology(session, os_type, cpuinfo):
+def check_if_vm_vcpu_topology_match(session, os_type, cpuinfo):
     """
     check the cpu topology of the guest.
 

--- a/qemu/tests/cpu_device_hotplug_maximum.py
+++ b/qemu/tests/cpu_device_hotplug_maximum.py
@@ -95,10 +95,10 @@ def run(test, params, env):
         test.fail(mismatch_text)
 
     error_context.context("Check CPU topology of guest", logging.info)
-    if not cpu_utils.check_guest_cpu_topology(session, os_type, cpuinfo):
+    if not cpu_utils.check_if_vm_vcpu_topology_match(session, os_type, cpuinfo):
         test.fail("CPU topology of guest is not as expected.")
     session = vm.reboot(session, timeout=reboot_timeout)
-    if not cpu_utils.check_guest_cpu_topology(session, os_type, cpuinfo):
+    if not cpu_utils.check_if_vm_vcpu_topology_match(session, os_type, cpuinfo):
         test.fail("CPU topology of guest is not as expected after reboot.")
 
     if os_type == "linux":

--- a/qemu/tests/cpu_device_hotpluggable.py
+++ b/qemu/tests/cpu_device_hotpluggable.py
@@ -165,8 +165,8 @@ def run(test, params, env):
         session = vm.wait_for_login(timeout=login_timeout)
         check_guest_cpu_count()
         if vm.get_cpu_count() == maxcpus and check_cpu_topology:
-            if not cpu_utils.check_guest_cpu_topology(session, os_type,
-                                                      vm.cpuinfo):
+            if not cpu_utils.check_if_vm_vcpu_topology_match(session, os_type,
+                                                             vm.cpuinfo):
                 session.close()
                 test.fail("CPU topology of guest is inconsistent with "
                           "expectations.")

--- a/qemu/tests/cpu_topology_test.py
+++ b/qemu/tests/cpu_topology_test.py
@@ -6,7 +6,7 @@ from avocado.utils import cpu
 from virttest import error_context
 from virttest import env_process
 
-from provider.cpu_utils import check_guest_cpu_topology
+from provider.cpu_utils import check_if_vm_vcpu_topology_match
 
 
 @error_context.context_aware
@@ -69,7 +69,8 @@ def run(test, params, env):
                 raise
         vm = env.get_vm(vm_name)
         session = vm.wait_for_login()
-        check_guest_cpu_topology(session, os_type, vm.cpuinfo)
+        if not check_if_vm_vcpu_topology_match(session, os_type, vm.cpuinfo):
+            test.fail('CPU topology of guest is incorrect.')
         if params.get('check_siblings_cmd'):
             check('sibling', vcpu_threads * vcpu_cores, 'check_siblings_cmd')
         vm.destroy()


### PR DESCRIPTION
The function name "check_guest_cpu_topology" is easy to confuse, rename
it to "is_guest_cpu_topology_matched" and correct all calls to it.

ID: 1934429
Signed-off-by: Yihuang Yu <yihyu@redhat.com>