### PR TITLE
blockdev_commit_specify_node: block commit with specify node

### DIFF
--- a/qemu/tests/blockdev_commit_specify_node.py
+++ b/qemu/tests/blockdev_commit_specify_node.py
@@ -1,0 +1,60 @@
+import logging
+
+from virttest.qemu_monitor import QMPCmdError
+
+from provider import backup_utils
+from provider.blockdev_commit_base import BlockDevCommitTest
+
+
+class BlockdevCommitSpecifyNode(BlockDevCommitTest):
+
+    def commit_snapshots(self):
+        device = self.params.get("device_tag")
+        device_params = self.params.object_params(device)
+        snapshot_tags = device_params["snapshot_tags"].split()
+        self.device_node = self.get_node_name(device)
+        options = ["base-node", "top-node", "speed"]
+        arguments = self.params.copy_from_keys(options)
+        test_scenario = self.params["test_scenario"]
+        if test_scenario == 'base_same_with_top':
+            arguments["base-node"] = self.get_node_name(snapshot_tags[-2])
+            arguments["top-node"] = self.get_node_name(snapshot_tags[-2])
+            device = self.get_node_name(snapshot_tags[-1])
+        if test_scenario == 'parent_as_top_child_as_base':
+            arguments["base-node"] = self.get_node_name(snapshot_tags[-2])
+            arguments["top-node"] = self.get_node_name(snapshot_tags[0])
+            device = self.get_node_name(snapshot_tags[-1])
+        commit_cmd = backup_utils.block_commit_qmp_cmd
+        cmd, args = commit_cmd(device, **arguments)
+        try:
+            self.main_vm.monitor.cmd(cmd, args)
+        except QMPCmdError as e:
+            logging.info("Error message is %s", e.data)
+            if self.params.get("error_msg") not in str(e.data):
+                self.test.fail("Error message not as expected")
+        else:
+            self.test.fail("Block commit should fail with %s,but "
+                           "block commit succeeded unexpectedly"
+                           % self.params.get("error_msg"))
+
+    def run_test(self):
+        self.pre_test()
+        try:
+            self.commit_snapshots()
+        finally:
+            self.post_test()
+
+
+def run(test, params, env):
+    """
+    Block commit with specified top and base node
+
+    1. boot guest with data disk
+    2. create snapshot and save file in snapshot
+    3. specify node by test requirement
+    4. do live commit
+    5. check QMPCmdError data
+    """
+
+    block_test = BlockdevCommitSpecifyNode(test, params, env)
+    block_test.run_test()

--- a/qemu/tests/cfg/blockdev_commit_specify_node.cfg
+++ b/qemu/tests/cfg/blockdev_commit_specify_node.cfg
@@ -1,0 +1,42 @@
+- blockdev_commit_specify_node:
+    type = blockdev_commit_specify_node
+    virt_test_type = qemu
+    only Linux
+    images += " data"
+    force_create_image_data = yes
+    remove_image_data = yes
+    start_vm = yes
+    kill_vm = yes
+    storage_pools = default
+    storage_type_default = "directory"
+    storage_pool = default
+    image_size_data = 500M
+    image_name_data = data
+    snapshot_tags_data = sn1 sn2 sn3 sn4
+
+    image_size_sn1 = 500M
+    image_name_sn1 = sn1
+    image_format_sn1 = qcow2
+
+    image_size_sn2 = 500M
+    image_name_sn2 = sn2
+    image_format_sn2 = qcow2
+
+    image_size_sn3 = 500M
+    image_name_sn3 = sn3
+    image_format_sn3 = qcow2
+
+    image_size_sn4 = 500M
+    image_name_sn4 = sn4
+    image_format_sn4 = qcow2
+
+    device_tag = "data"
+    rebase_mode = unsafe
+    qemu_force_use_drive_expression = no
+    variants:
+        - base_same_with_top:
+            test_scenario = base_same_with_top
+            error_msg = "'desc': 'cannot commit an image into itself'"
+        - parent_as_top_child_as_base:
+            test_scenario = parent_as_top_child_as_base
+            error_msg = "'drive_sn3' is not in this backing file chain"


### PR DESCRIPTION
1.Block commit with based and top is the same.
2.Block commit with parent as top and child as base.

Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:1934957,1934955