### PR TITLE
blockdev_mirror_remote_server_down: Stop remote server while mirroring

### DIFF
--- a/provider/nbd_image_export.py
+++ b/provider/nbd_image_export.py
@@ -143,11 +143,21 @@ class QemuNBDExportImage(NBDExportImage):
 
     def suspend_export(self):
         if self._nbd_server_pid is not None:
+            logging.info("Suspend qemu-nbd by sending SIGSTOP")
             try:
                 os.kill(self._nbd_server_pid, signal.SIGSTOP)
             except Exception as e:
                 logging.warning("Error occurred when suspending"
                                 "nbd server: %s", str(e))
+
+    def resume_export(self):
+        if self._nbd_server_pid is not None:
+            logging.info("Resume qemu-nbd by sending SIGCONT")
+            try:
+                os.kill(self._nbd_server_pid, signal.SIGCONT)
+            except Exception as e:
+                logging.warning("Error occurred when resuming nbd server: %s",
+                                str(e))
 
 
 class InternalNBDExportImage(NBDExportImage):

--- a/qemu/tests/blockdev_mirror_remote_server_down.py
+++ b/qemu/tests/blockdev_mirror_remote_server_down.py
@@ -1,0 +1,100 @@
+import socket
+
+from provider.blockdev_mirror_nowait import BlockdevMirrorNowaitTest
+from provider.nbd_image_export import QemuNBDExportImage
+
+
+class BlockdevMirrorRemoteServerDownTest(BlockdevMirrorNowaitTest):
+    """
+    Suspend/resume remote storage service while doing blockdev-mirror
+    """
+
+    def __init__(self, test, params, env):
+        localhost = socket.gethostname()
+        params['nbd_server_%s' % params['nbd_image_tag']] = localhost \
+            if localhost else 'localhost'
+        self.nbd_export = QemuNBDExportImage(params,
+                                             params["local_image_tag"])
+        super(BlockdevMirrorRemoteServerDownTest, self).__init__(test,
+                                                                 params,
+                                                                 env)
+
+    def _create_local_image(self):
+        image_params = self.params.object_params(
+            self.params['local_image_tag'])
+        local_image = self.source_disk_define_by_params(
+            image_params, self.params['local_image_tag'])
+        local_image.create(image_params)
+        self.trash.append(local_image)
+
+    def prepare_test(self):
+        try:
+            self._create_local_image()
+            self.nbd_export.export_image()
+            super(BlockdevMirrorRemoteServerDownTest, self).prepare_test()
+        except Exception:
+            self.clean_images()
+            raise
+
+    def add_target_data_disks(self):
+        """Mirror image is an exported nbd image"""
+
+        tag = self._target_images[0]
+        devices = self.main_vm.devices.images_define_by_params(
+            tag, self.params.object_params(tag), 'disk')
+        devices.pop()
+
+        for dev in devices:
+            ret = self.main_vm.devices.simple_hotplug(dev,
+                                                      self.main_vm.monitor)
+            if not ret[1]:
+                self.test.fail("Failed to hotplug '%s': %s."
+                               % (dev, ret[0]))
+
+    def clean_images(self):
+        self.nbd_export.stop_export()
+        super(BlockdevMirrorRemoteServerDownTest, self).clean_images()
+
+    def do_test(self):
+        self.blockdev_mirror()
+        self.check_block_jobs_started(
+            self._jobs, self.params.get_numeric('job_started_timeout', 10))
+        self.nbd_export.suspend_export()
+        try:
+            self.check_block_jobs_paused(
+                self._jobs,
+                self.params.get_numeric('job_paused_interval', 30)
+            )
+        finally:
+            self.nbd_export.resume_export()
+        self.main_vm.monitor.cmd("block-job-set-speed",
+                                 {'device': self._jobs[0], 'speed': 0})
+        self.wait_mirror_jobs_completed()
+        self.check_mirrored_block_nodes_attached()
+        self.clone_vm_with_mirrored_images()
+        self.verify_data_files()
+
+
+def run(test, params, env):
+    """
+    Suspend/resume remote storage service while doing blockdev-mirror
+
+    test steps:
+        1. boot VM with 2G data disk
+        2. format the data disk and mount it
+        3. create a file
+        4. create a local image and export it with qemu-nbd
+        5. hotplug the exported image as the mirror target
+        6. do blockdev-mirror
+        7. suspend qemu-nbd
+        8. check mirror job paused
+        9. resume qemu-nbd
+       10. wait till mirror job done
+       11. restart vm with mirror image and check files
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    mirror_test = BlockdevMirrorRemoteServerDownTest(test, params, env)
+    mirror_test.run_test()

--- a/qemu/tests/cfg/blockdev_mirror_remote_server_down.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_remote_server_down.cfg
@@ -1,0 +1,61 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   Do blockdev-mirror, suspend/resume remote storage service
+#     The mirror image is a on nfs
+
+
+- blockdev_mirror_remote_server_down:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_mirror_remote_server_down
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    target_images = mirror1
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+    backup_options_data1 = sync speed
+    sync = full
+    speed = 50000000
+    tempfile_size = 200M
+    image_size_data1 = 2G
+    image_format_data1 = qcow2
+    image_name_data1 = data1
+
+    nbd:
+        nbd_port_data1 = 10822
+        force_create_image_data1 = no
+        image_create_support_data1 = no
+        remove_image_data1 = no
+    iscsi_direct:
+        lun_data1 = 1
+
+    # Settings for a local fs image 'data',
+    # which will be exported by qemu-nbd
+    local_image_tag = data
+    image_size_data = ${image_size_data1}
+    image_name_data = data
+    image_format_data = qcow2
+    preallocated_data = falloc
+    nbd_port_data = 10810
+    nbd_export_format_data = raw
+    nbd_server_tls_creds_data = ''
+    enable_iscsi_data = no
+    enable_ceph_data = no
+    enable_gluster_data = no
+    enable_nbd_data = no
+    image_raw_device_data = no
+
+    # Settings for nbd image 'mirror1',
+    # i.e. the exported 'data'
+    nbd_image_tag = mirror1
+    enable_nbd_mirror1 = yes
+    storage_type_mirror1 = nbd
+    nbd_port_mirror1 = ${nbd_port_data}
+    force_create_image_mirror1 = no
+    image_create_support_mirror1 = no
+    image_format_mirror1 = ${image_format_data}


### PR DESCRIPTION
Stop nfs service while mirroring, then start nfs service to resume
mirroring

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1934985