### PR TITLE
blockdev_inc_backup_bitmap_not_exist: Incbk with non-existed bitmap

### DIFF
--- a/qemu/tests/blockdev_inc_backup_bitmap_not_exist.py
+++ b/qemu/tests/blockdev_inc_backup_bitmap_not_exist.py
@@ -1,0 +1,47 @@
+from virttest.qemu_monitor import QMPCmdError
+
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+
+
+class BlockdevIncbkNonExistedBitmap(BlockdevLiveBackupBaseTest):
+    """Do incremental backup with a non-existed bitmap"""
+
+    def prepare_test(self):
+        self.prepare_main_vm()
+        self.add_target_data_disks()
+
+    def do_incremental_backup(self):
+        try:
+            self.main_vm.monitor.cmd(
+                'blockdev-backup',
+                {'device': self._source_nodes[0],
+                 'target': self._full_bk_nodes[0],
+                 'bitmap': self.params['non_existed_bitmap'],
+                 'sync': 'incremental'}
+            )
+        except QMPCmdError as e:
+            if self.params['error_msg'] not in str(e):
+                self.test.fail('Unexpected error: %s' % str(e))
+        else:
+            self.test.fail('blockdev-backup succeeded unexpectedly')
+
+    def do_test(self):
+        self.do_incremental_backup()
+
+
+def run(test, params, env):
+    """
+    Do incremental backup with a non-existed bitmap
+
+    test steps:
+        1. boot VM
+        2. hot-plug the backup image
+        3. Do incremental backup with a non-existed bitmap, proper
+           error message should output
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkNonExistedBitmap(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_not_exist.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_not_exist.cfg
@@ -1,0 +1,26 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   Do incremental backup with a non-existed bitmap
+# Note:
+#   The backup image is a local fs image
+
+
+- blockdev_inc_backup_bitmap_not_exist:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_bitmap_not_exist
+    virt_test_type = qemu
+    source_images = image1
+    image_backup_chain_image1= inc
+    image_format_inc = qcow2
+    image_name_inc = inc
+    storage_pools = default
+    storage_pool = default
+    storage_type_default = directory
+    full_backup_options = '{"persistent": "on"}'
+    non_existed_bitmap = bitmap0
+    error_msg = Bitmap '${non_existed_bitmap}' could not be found


### PR DESCRIPTION
Do incremental backup with a non-existed bitmap

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1936303