### PR TITLE
blockdev_inc_backup_target_not_exist: Incbk with non-existed target

### DIFF
--- a/qemu/tests/blockdev_inc_backup_target_not_exist.py
+++ b/qemu/tests/blockdev_inc_backup_target_not_exist.py
@@ -1,0 +1,54 @@
+from virttest.qemu_monitor import QMPCmdError
+
+from provider.block_dirty_bitmap import block_dirty_bitmap_add
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+
+
+class BlockdevIncbkNonExistedTarget(BlockdevLiveBackupBaseTest):
+    """Do incremental backup with a non-existed target"""
+
+    def add_bitmap(self):
+        kargs = {'bitmap_name': self._bitmaps[0],
+                 'target_device': self._source_nodes[0],
+                 'persistent': 'off', 'disabled': 'off'}
+        block_dirty_bitmap_add(self.main_vm, kargs)
+
+    def prepare_test(self):
+        self.prepare_main_vm()
+        self.add_bitmap()
+
+    def do_incremental_backup(self):
+        try:
+            self.main_vm.monitor.cmd(
+                'blockdev-backup',
+                {'device': self._source_nodes[0],
+                 'target': self.params['non_existed_target'],
+                 'bitmap': self._bitmaps[0],
+                 'sync': 'incremental'}
+            )
+        except QMPCmdError as e:
+            if self.params['error_msg'] not in str(e):
+                self.test.fail('Unexpected error: %s' % str(e))
+        else:
+            self.test.fail('blockdev-backup succeeded unexpectedly')
+
+    def do_test(self):
+        self.do_incremental_backup()
+
+
+def run(test, params, env):
+    """
+    Do incremental backup with a non-existed target
+
+    test steps:
+        1. boot VM
+        2. hot-plug the backup image
+        3. Do incremental backup with a non-existed target, proper
+           error message should output
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkNonExistedTarget(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_target_not_exist.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_target_not_exist.cfg
@@ -1,0 +1,21 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   Do incremental backup with a non-existed target node
+# Note:
+#   The backup image is a local fs image
+
+
+- blockdev_inc_backup_target_not_exist:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_target_not_exist
+    virt_test_type = qemu
+    source_images = image1
+    image_backup_chain_image1= inc
+    full_backup_options = {"persistent": "off", "disabled": "off"}
+    non_existed_target = target_node
+    error_msg = Cannot find device=${non_existed_target} nor node_name=${non_existed_target}


### PR DESCRIPTION
Do incremental backup with a non-existed target node

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1936317