### PR TITLE
blockdev_inc_backup_without_bitmap: Incbk without a bitmap

### DIFF
--- a/qemu/tests/blockdev_inc_backup_without_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_without_bitmap.py
@@ -1,0 +1,45 @@
+from virttest.qemu_monitor import QMPCmdError
+
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+
+
+class BlockdevIncbkWithoutBitmap(BlockdevLiveBackupBaseTest):
+    """Do incremental backup without bitmap"""
+
+    def prepare_test(self):
+        self.prepare_main_vm()
+        self.add_target_data_disks()
+
+    def do_incremental_backup(self):
+        job_list = [{'type': 'blockdev-backup',
+                     'data': {'device': self._source_nodes[0],
+                              'target': self._full_bk_nodes[0],
+                              'sync': 'incremental'}}]
+        try:
+            self.main_vm.monitor.transaction(job_list)
+        except QMPCmdError as e:
+            if self.params['error_msg'] not in str(e):
+                self.test.fail('Unexpected error: %s' % str(e))
+        else:
+            self.test.fail('blockdev-backup succeeded unexpectedly')
+
+    def do_test(self):
+        self.do_incremental_backup()
+
+
+def run(test, params, env):
+    """
+    Do incremental backup without bitmap
+
+    test steps:
+        1. boot VM
+        2. hot-plug the backup image
+        3. Do incremental backup without bitmap, proper
+           error message should output
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkWithoutBitmap(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_without_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_without_bitmap.cfg
@@ -1,0 +1,25 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   Do incremental backup without bitmap
+# Note:
+#   The backup image is a local fs image
+
+
+- blockdev_inc_backup_without_bitmap:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_without_bitmap
+    virt_test_type = qemu
+    source_images = image1
+    image_backup_chain_image1= inc
+    image_format_inc = qcow2
+    image_name_inc = inc
+    storage_pools = default
+    storage_pool = default
+    storage_type_default = directory
+    full_backup_options = {}
+    error_msg = must provide a valid bitmap name for 'incremental' sync mode


### PR DESCRIPTION
Do incremental backup without a bitmap in a transaction

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1936354