### PR TITLE
blockdev_inc_backup_inconsistent_bitmap: Inconsistent bitmap test

### DIFF
--- a/qemu/tests/blockdev_inc_backup_inconsistent_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_inconsistent_bitmap.py
@@ -1,0 +1,129 @@
+import signal
+
+from virttest.data_dir import get_data_dir
+from virttest.qemu_monitor import QMPCmdError
+from virttest.utils_misc import kill_process_tree
+
+from provider.block_dirty_bitmap import block_dirty_bitmap_add
+from provider.block_dirty_bitmap import block_dirty_bitmap_remove
+from provider.block_dirty_bitmap import get_bitmap_by_name
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+
+
+class BlockdevIncbkInconsistentBitmap(BlockdevLiveBackupBaseTest):
+    """Inconsistent bitmap tests"""
+
+    def __init__(self, test, params, env):
+        super(BlockdevIncbkInconsistentBitmap, self).__init__(
+            test, params, env)
+        self._data_image_obj = self.source_disk_define_by_params(
+            self.params, self._source_images[0])
+        self.test_scenario = getattr(self, self.params['test_scenario'])
+
+    def prepare_test(self):
+        self.preprocess_data_disks()
+        self.prepare_main_vm()
+        self.prepare_data_disks()
+
+    def add_persistent_bitmap(self):
+        kargs = {'bitmap_name': self._bitmaps[0],
+                 'target_device': self._source_nodes[0],
+                 'persistent': 'on'}
+        block_dirty_bitmap_add(self.main_vm, kargs)
+
+    def is_image_bitmap_existed(self):
+        out = self._data_image_obj.info()
+        return out and self._bitmaps[0] in out
+
+    def check_bitmap_status(self, status):
+        bitmap = get_bitmap_by_name(self.main_vm, self._source_nodes[0],
+                                    self._bitmaps[0])
+        if bitmap is None:
+            self.test.fail('Failed to get bitmap %s' % self._bitmaps[0])
+        elif status != bitmap.get('status'):
+            self.test.fail('bitmap status changed')
+
+    def kill_qemu_and_start_vm(self):
+        """Forcely killing qemu-kvm can make bitmap inconsistent"""
+
+        kill_process_tree(self.main_vm.get_pid(), signal.SIGKILL, timeout=20)
+        self.main_vm.create()
+        self.main_vm.verify_alive()
+
+    def powerdown_and_start_vm(self):
+        self.main_vm.monitor.system_powerdown()
+        if not self.main_vm.wait_for_shutdown(
+                self.params.get_numeric("shutdown_timeout", 360)):
+            self.test.fail("Failed to poweroff vm")
+        self.main_vm.create()
+        self.main_vm.verify_alive()
+
+    def handle_bitmap_with_qmp_cmd(self):
+        """Failed to clear/enable/disable an inconsistent bitmap"""
+
+        forbidden_actions = ['block-dirty-bitmap-disable',
+                             'block-dirty-bitmap-enable',
+                             'block-dirty-bitmap-clear']
+        for action in forbidden_actions:
+            try:
+                self.main_vm.monitor.cmd(action,
+                                         {'node': self._source_nodes[0],
+                                          'name': self._bitmaps[0]})
+            except QMPCmdError as e:
+                error_msg = self.params['error_msg'] % self._bitmaps[0]
+                if error_msg not in str(e):
+                    self.test.fail('Unexpected error: %s' % str(e))
+            else:
+                self.test.fail('%s completed unexpectedly' % action)
+
+    def remove_bitmap_with_qmp_cmd(self):
+        """Removing an inconsistent bitmap should succeed"""
+
+        block_dirty_bitmap_remove(self.main_vm, self._source_nodes[0],
+                                  self._bitmaps[0])
+        bitmap = get_bitmap_by_name(self.main_vm, self._source_nodes[0],
+                                    self._bitmaps[0])
+        if bitmap is not None:
+            self.test.fail('Failed to remove bitmap %s' % self._bitmaps[0])
+
+    def repair_bitmap_with_qemu_img(self):
+        """Repair an inconsistent bitmap with qemu-img should succeed"""
+
+        self.main_vm.destroy()
+        if not self.is_image_bitmap_existed():
+            self.test.fail('Persistent bitmap should exist in image')
+        self._data_image_obj.check(self._data_image_obj.params,
+                                   get_data_dir())
+        if self.is_image_bitmap_existed():
+            self.test.fail('Persistent bitmap should be removed from image')
+
+    def do_test(self):
+        self.add_persistent_bitmap()
+        self.generate_inc_files(filename='inc')
+        self.powerdown_and_start_vm()
+        self.check_bitmap_status(status='active')
+        self.kill_qemu_and_start_vm()
+        self.check_bitmap_status(status='inconsistent')
+        self.test_scenario()
+
+
+def run(test, params, env):
+    """
+    Inconsistent bitmap tests
+
+    test steps:
+        1. boot VM with a 2G data disk
+        2. add persistent bitmap, dd a file
+        3. restart VM, then kill qemu-kvm
+        4. restart VM, check bitmap is inconsistent
+        5. Do some tests:
+            5.1 clearing/enabling/disabling an inconsistent bitmap should fail
+            5.2 removing an inconsistent bitmap should succeed
+            5.3 removing an inconsistent bitmap with qemu-img should succeed
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkInconsistentBitmap(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_inconsistent_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_inconsistent_bitmap.cfg
@@ -1,0 +1,36 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, gluster_direct
+# The following testing scenario is covered:
+#   enable/disable/clear/remove an inconsistent bitmap with qmp command
+#   remove an inconsistent bitmap with qemu-img --repair
+
+
+- blockdev_inc_backup_inconsistent_bitmap:
+    only Linux
+    only filesystem iscsi_direct ceph gluster_direct
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_inconsistent_bitmap
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    image_backup_chain_data1 = base
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+    full_backup_options = {}
+
+    image_size_data1 = 2G
+    image_format_data1 = qcow2
+    image_name_data1 = data1
+    iscsi_direct:
+        lun_data1 = 1
+
+    variants:
+        - remove_bitmap_with_qmp_cmd:
+            test_scenario = remove_bitmap_with_qmp_cmd
+        - repair_bitmap_with_qemu_img:
+            test_scenario = repair_bitmap_with_qemu_img
+        - handle_bitmap_with_qmp_cmd:
+            test_scenario = handle_bitmap_with_qmp_cmd
+            error_msg = Bitmap '%s' is inconsistent and cannot be used


### PR DESCRIPTION
Clearing/Enabling/Disabling an inconsistent bitmap should fail,
removing an inconsistent bitmap should succeed.

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1937172, 1937281, 1937283