### PR TITLE
virtio-fs: Add a checkpoint of the mount virtiofs target

### DIFF
--- a/qemu/tests/virtio_fs_multi_vms.py
+++ b/qemu/tests/virtio_fs_multi_vms.py
@@ -134,7 +134,8 @@ def run(test, params, env):
                 error_context.context(
                     "%s: Mount the virtiofs target %s to %s inside guest." %
                     (vm, fs_target, fs_dest), logging.info)
-                utils_disk.mount(fs_target, fs_dest, 'virtiofs', session=session)
+                if not utils_disk.mount(fs_target, fs_dest, 'virtiofs', session=session):
+                    test.fail('Mount virtiofs target failed.')
             else:
                 virtio_fs_disk_label = fs_target
                 error_context.context("%s: Get Volume letter of virtio fs"

--- a/qemu/tests/virtio_fs_readonly.py
+++ b/qemu/tests/virtio_fs_readonly.py
@@ -33,7 +33,8 @@ def run(test, params, env):
 
     error_context.context("Mount the virtiofs target with read-only to "
                           "the destination directory inside guest.", logging.info)
-    utils_disk.mount(fs_target, fs_dest, 'virtiofs', 'ro', session=session)
+    if not utils_disk.mount(fs_target, fs_dest, 'virtiofs', 'ro', session=session):
+        test.fail('Mount virtiofs target failed.')
 
     try:
         error_context.context("Create file under the destination "

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -162,7 +162,8 @@ def run(test, params, env):
                 error_context.context("Mount virtiofs target %s to %s inside"
                                       " guest." % (fs_target, fs_dest),
                                       logging.info)
-                utils_disk.mount(fs_target, fs_dest, 'virtiofs', session=session)
+                if not utils_disk.mount(fs_target, fs_dest, 'virtiofs', session=session):
+                    test.fail('Mount virtiofs target failed.')
 
         else:
             error_context.context("Start virtiofs service in guest.", logging.info)


### PR DESCRIPTION
The mount virtiofs target failed due to a new product issue, so a special test
point was added. When the mount fails, subsequent tests will not be performed.

ID: 1937607
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>