### PR TITLE
blockdev_inc_backup_bitmap_size: Estimate bitmap size

### DIFF
--- a/provider/block_dirty_bitmap.py
+++ b/provider/block_dirty_bitmap.py
@@ -75,6 +75,8 @@ def block_dirty_bitmap_add(vm, bitmap_params):
                 item: False}, "default": {
                 item: None}}
     kargs = dict(node=target_device, name=bitmap)
+    if bitmap_params.get('bitmap_granularity'):
+        kargs['granularity'] = bitmap_params['bitmap_granularity']
     for item in ["persistent", "disabled"]:
         kargs.update(mapping[item][bitmap_params.get(item, "default")])
     vm.monitor.block_dirty_bitmap_add(**kargs)
@@ -231,7 +233,7 @@ def handle_block_dirty_bitmap_transaction(vm, disabled_params=None,
         bitmap_data = {"node": added_params['bitmap_device_node'],
                        "name": added_params['bitmap_name']}
         if added_params.get('bitmap_granularity'):
-            bitmap_data['granularity'] = added_params['granularity']
+            bitmap_data['granularity'] = added_params['bitmap_granularity']
 
         mapping = {'on': True, 'yes': True, 'off': False, 'no': False}
         if added_params.get('bitmap_persistent'):

--- a/qemu/tests/blockdev_inc_backup_bitmap_size.py
+++ b/qemu/tests/blockdev_inc_backup_bitmap_size.py
@@ -1,0 +1,70 @@
+import json
+
+from avocado.utils import process
+
+from virttest.utils_numeric import normalize_data_size
+
+from provider.block_dirty_bitmap import block_dirty_bitmap_add
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+
+
+class BlockdevIncbkBitmapSizeTest(BlockdevLiveBackupBaseTest):
+    """Estimate bitmaps size"""
+
+    def __init__(self, test, params, env):
+        super(BlockdevIncbkBitmapSizeTest, self).__init__(test, params, env)
+        self._granularities = self.params.objects('granularity_list')
+
+    def add_bitmaps(self):
+        args = {'target_device': self._source_nodes[0], 'persistent': 'on'}
+        if self._granularities:
+            for granularity in self._granularities:
+                g = int(normalize_data_size(granularity, "B"))
+                args.update({'bitmap_name': 'bitmap_%s' % g,
+                             'bitmap_granularity': g})
+                block_dirty_bitmap_add(self.main_vm, args)
+        else:
+            max_len = self.params.get_numeric('max_bitmap_name_len')
+            for i in range(self.params.get_numeric('bitmap_count')):
+                l = max_len - len(str(i))
+                args['bitmap_name'] = process.run(
+                    self.params['create_bitmap_name_cmd'].format(length=l),
+                    ignore_status=True, shell=True
+                ).stdout.decode().strip() + str(i)
+                block_dirty_bitmap_add(self.main_vm, args)
+
+    def measure_bitmaps_size(self):
+        img = self.source_disk_define_by_params(self.params,
+                                                self._source_images[0])
+        o = img.measure(self.params['target_fmt'], output='json').stdout_text
+        if o:
+            info = json.loads(o)
+            if info.get(self.params['check_keyword'], 0) <= 0:
+                self.test.fail('Failed to get bitmap size')
+        else:
+            self.test.error('Failed to measure a qcow2 image')
+
+    def prepare_test(self):
+        self.prepare_main_vm()
+
+    def do_test(self):
+        self.add_bitmaps()
+        self.main_vm.destroy()
+        self.measure_bitmaps_size()
+
+
+def run(test, params, env):
+    """
+    Estimate bitmaps size
+
+    test steps:
+        1. boot VM with a 2G data disk
+        2. add bitmaps with default granularity or different granularities
+        3. measure bitmaps size with qemu-img
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkBitmapSizeTest(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_size.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_size.cfg
@@ -1,0 +1,35 @@
+# Storage backends:
+#   filesystem
+# The following testing scenario is covered:
+#   Estimate space utilization of bitmaps
+
+
+- blockdev_inc_backup_bitmap_size:
+    only Linux
+    only filesystem
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_bitmap_size
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    image_backup_chain_data1 = full
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+    full_backup_options = {}
+    image_size_data1 = 2G
+    image_format_data1 = qcow2
+    image_name_data1 = data1
+    create_bitmap_name_cmd = printf %{length}d 1|tr ' ' a
+    check_keyword = bitmaps
+    target_fmt = qcow2
+
+    variants:
+        - with_default_granularity:
+            max_bitmap_name_len = 1023
+            bitmap_count = 10
+        - with_different_granularity:
+            image_cluster_size_data1 = 512
+            granularity_list = 512 1K 2K 4K 8K 16K 32K 64K 128K 256K 512K
+            granularity_list += ' 1M 2M 4M 8M 16M 32M 64M 128M 256M 512M 1G 2G'


### PR DESCRIPTION
Add bitmap with the default granularity
Add bitmap with different granularities
Estimate space utilization for bitmaps

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1939307, 1939308