### PR TITLE
blockdev_inc_backup_nospace_with_bitmap_mode: Bimap mode test

### DIFF
--- a/qemu/tests/blockdev_inc_backup_nospace_with_bitmap_mode.py
+++ b/qemu/tests/blockdev_inc_backup_nospace_with_bitmap_mode.py
@@ -1,0 +1,98 @@
+from time import sleep
+
+from provider.block_dirty_bitmap import get_bitmap_by_name
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+from provider.job_utils import BLOCK_JOB_COMPLETED_EVENT
+from provider.job_utils import get_event_by_condition
+
+
+class BlockdevIncbkIncNospaceWithSyncMode(BlockdevLiveBackupBaseTest):
+    """
+    Do incremental backup to an image without enough space,
+    set bitmap mode to: on-success or always, check bitmap count
+    """
+
+    def __init__(self, test, params, env):
+        super(BlockdevIncbkIncNospaceWithSyncMode, self).__init__(test,
+                                                                  params,
+                                                                  env)
+        self._inc_bitmap_mode = params["inc_bitmap_mode"]
+        self._inc_bk_nodes = ["drive_%s" % t for t in self._target_images]
+
+    def _get_bitmap_count(self):
+        # let's wait some time to sync bitmap count, for on ppc the count
+        # failed to be synced immediately after creating a new file
+        sleep(10)
+
+        bm = get_bitmap_by_name(self.main_vm, self._source_nodes[0],
+                                self._bitmaps[0])
+        if bm:
+            if bm.get("count", 0) <= 0:
+                self.test.fail("Count of bitmap should be greater than 0")
+            return bm["count"]
+        else:
+            self.test.fail("Failed to get bitmap")
+
+    def do_incremental_backup(self):
+        self.count_before_incbk = self._get_bitmap_count()
+        self.inc_job_id = "job_%s" % self._inc_bk_nodes[0]
+        args = {"device": self._source_nodes[0],
+                "target": self._inc_bk_nodes[0],
+                "sync": "bitmap",
+                "job-id": self.inc_job_id,
+                "bitmap": self._bitmaps[0],
+                "bitmap-mode": self._inc_bitmap_mode}
+        self.main_vm.monitor.cmd("blockdev-backup", args)
+
+    def check_no_space_error(self):
+        tmo = self.params.get_numeric('job_completed_timeout', 360)
+        cond = {'device': self.inc_job_id}
+        event = get_event_by_condition(self.main_vm,
+                                       BLOCK_JOB_COMPLETED_EVENT,
+                                       tmo, **cond)
+        if event:
+            if event['data'].get('error') != self.params['error_msg']:
+                self.test.fail('Unexpected error: %s'
+                               % event['data'].get('error'))
+        else:
+            self.test.fail('Failed to get BLOCK_JOB_COMPLETED event')
+
+    def check_bitmap_count(self):
+        count_after_incbk = self._get_bitmap_count()
+        if self._inc_bitmap_mode == "on-success":
+            if self.count_before_incbk != count_after_incbk:
+                self.test.fail("Count of bitmap changed after inc-backup")
+        elif self._inc_bitmap_mode == "always":
+            if self.count_before_incbk <= count_after_incbk:
+                self.test.fail("Count of bitmap not changed after inc-backup")
+
+    def do_test(self):
+        self.do_full_backup()
+        self.generate_inc_files()
+        self.do_incremental_backup()
+        self.check_no_space_error()
+        self.check_bitmap_count()
+
+
+def run(test, params, env):
+    """
+    Do incremental backup to an image without enough space
+
+    test steps:
+        1. boot VM with a 2G data disk
+        2. format data disk and mount it, create a file
+        3. add target disks for backup to VM via qmp commands, note
+           that space of incremental backup image is less then 110M
+        4. do full backup and add non-persistent bitmap
+        5. create another file (size 110M)
+        6. do inc bakcup to an image without enough space,
+           check no enough space error
+           bitmap-mode=always, count should be less than before
+           bitmap-mode=on-success, count should be the same as before
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_test = BlockdevIncbkIncNospaceWithSyncMode(test, params, env)
+    inc_test.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_nospace_with_bitmap_mode.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_nospace_with_bitmap_mode.cfg
@@ -1,0 +1,61 @@
+# Storage backends:
+#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
+# The following testing scenario is covered:
+#   Do incremental backup with bitmap:on-success/always
+#     The backup images are local images(filesystem)
+#     No enough space for incremental backup image
+
+
+- blockdev_inc_backup_nospace_with_bitmap_mode:
+    only Linux
+    only filesystem iscsi_direct ceph nbd gluster_direct
+    start_vm = no
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_nospace_with_bitmap_mode
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    image_backup_chain_data1 = full inc
+    backing_inc = full
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+    inc_path = /tmp/tmp_target_path
+    storage_pools = pool1 pool2
+    storage_type_pool1 = directory
+    storage_type_pool2 = directory
+    target_path_pool2 = ${inc_path}
+    full_backup_options = {"sync": "full"}
+    tempfile_size = 110M
+    error_msg = No space left on device
+
+    image_size_data1 = 2G
+    image_size_full = ${image_size_data1}
+    image_size_inc = ${image_size_data1}
+    image_format_data1 = qcow2
+    image_format_full = qcow2
+    image_format_inc = qcow2
+    image_name_data1 = data1
+    image_name_full = full
+    image_name_inc = inc
+    storage_pool_full = pool1
+    storage_pool_inc = pool2
+
+    tmp_image_file = /tmp/tmp_image_file
+    pre_command = "mkdir -p ${inc_path} && dd if=/dev/urandom of=${tmp_image_file} bs=1M count=100 &&"
+    pre_command += " mkfs.ext4 ${tmp_image_file} && mount -o loop ${tmp_image_file} ${inc_path}"
+    post_command = "umount -f ${inc_path} && rm -rf ${tmp_image_file} ${inc_path}"
+    pre_command_timeout = 30
+    post_command_timeout = 30
+
+    nbd:
+        force_create_image_data1 = no
+        nbd_port_data1 = 10822
+        image_create_support_data1 = no
+    iscsi_direct:
+        lun_data1 = 1
+
+    variants:
+        - on_success:
+            inc_bitmap_mode = on-success
+        - always:
+            inc_bitmap_mode = always


### PR DESCRIPTION
Do incremental backup to an image without enough space,
bitmap-mode=always, count of bitmap should be less then before
bitmap-mode=on-success, count of bitmap should be the same

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1940019, 1940020