### PR TITLE
Add adaption for ioeventfd on s390x

### DIFF
--- a/qemu/tests/cfg/ioeventfd.cfg
+++ b/qemu/tests/cfg/ioeventfd.cfg
@@ -33,6 +33,8 @@
                         iozone_options = '-azR -r 64k -n 1G -g 4G -M -I -i 0 -i 1 -b iozone.xls -f c:\testfile'
                 - check_property:
                     compare_fd = yes
+                    s390x:
+                        dev_id = 'virtio_scsi_ccw0'
         - virtio_serial:
             compare_fd = yes
             serials += " vs1"

--- a/qemu/tests/ioeventfd.py
+++ b/qemu/tests/ioeventfd.py
@@ -75,7 +75,7 @@ def run(test, params, env):
             dev_id = 'image1'
         elif params['drive_format'] == 'scsi-hd':
             params['bus_extra_params_image1'] = ioeventfd
-            dev_id = 'virtio_scsi_pci0'
+            dev_id = params.get('dev_id', 'virtio_scsi_pci0')
         return dev_id
 
     def _dd_test(session):


### PR DESCRIPTION
Virtual_block: modify the way of getting dev_id so that it could adapt
on s390x

ID:1940320

Signed-off-by: Boqiao Fu <bfu@redhat.com>