### PR TITLE
qemu.test: qemu_img_negative.snapshot

### DIFF
--- a/qemu/tests/cfg/qemu_img_negative.cfg
+++ b/qemu/tests/cfg/qemu_img_negative.cfg
@@ -37,3 +37,31 @@
             qemu_img_create_cmd = "qemu-img create -f luks --object secret,id=sec0,file=%s -o key-secret=sec0 %s 10M"
             image_name_stg = "images/stg"
             remove_image_stg = yes
+        - snapshot:
+            only qcow2
+            type = snapshot_negative_test
+            start_vm = no
+            create_image = no
+            variants:
+                - with_incorrect_format:
+                    test_scenario = run_cmd_with_incorrect_format
+                    images = stg
+                    image_name_stg = "images/stg"
+                    image_format_stg = raw
+                    image_size_stg = 1G
+                    remove_image_stg = yes
+                    err_info = "Image is not in qcow2 format"
+                    cmd_with_incorrect_format = "qemu-img create -f qcow2 sn.qcow2 -b %s -F qcow2;"
+                    cmd_with_incorrect_format += "qemu-img create -f qcow2 sn.qcow2 -b %s -o backing_fmt=qcow2;"
+                    cmd_with_incorrect_format += "qemu-img create -f qcow2 sn.qcow2 -o backing_file=%s -o backing_fmt=qcow2;"
+                    cmd_with_incorrect_format += "qemu-img create -f qcow2 sn.qcow2 -o backing_file=%s -F qcow2"
+                - with_non_existing_backing_file:
+                    test_scenario = run_cmd_with_non_existing_backing_file
+                    err_info = "(Could not open 'base.qcow2': No such file or directory|Could not open backing image)"
+                    cmd_with_non_existing_backing_file = "qemu-img create -f qcow2 -F qcow2 -b base.qcow2 sn.qcow2;"
+                    cmd_with_non_existing_backing_file += "qemu-img create -f qcow2 -F qcow2 -b base.qcow2 sn.qcow2 1G;"
+                    cmd_with_non_existing_backing_file += "qemu-img create -f qcow2 sn.qcow2 -b ssh://xen/"
+                - with_empty_string_for_backing_file:
+                    test_scenario = run_cmd_with_empty_string_for_backing_file
+                    err_info = "Expected backing file name, got empty string"
+                    cmd_with_empty_string_for_backing_file = "qemu-img create -f qcow2 -b '' foo"

--- a/qemu/tests/snapshot_negative_test.py
+++ b/qemu/tests/snapshot_negative_test.py
@@ -1,0 +1,60 @@
+import re
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest.qemu_storage import QemuImg
+
+
+def run(test, params, env):
+    """
+    Negative test.
+    Verify that qemu-img supports to check the options used for
+    creating external snapshot, and raise accurate error when
+    specifying a wrong option.
+    1. It should be failed to create the snapshot when specifying
+       a wrong format for backing file.
+    2. It should be failed to create the snapshot when specifying
+       a non-existing backing file.
+    3. It should be failed to create the snapshot when specifying
+       an empty string for backing file.
+
+    :param test: Qemu test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+
+    def _check_command(cmds):
+        """run the command and check the output"""
+        cmds = cmds.split(";")
+        for qemu_img_cmd in cmds:
+            if qemu_img_cmd_agrs:
+                qemu_img_cmd %= qemu_img_cmd_agrs
+            cmd_result = process.run(qemu_img_cmd, ignore_status=True,
+                                     shell=True)
+            if not re.search(err_info, cmd_result.stderr.decode(), re.I | re.M):
+                test.fail("Failed to get error information. The actual error "
+                          "information is %s." % cmd_result.stderr.decode())
+
+    def run_cmd_with_incorrect_format():
+        cmds = params.get("cmd_with_incorrect_format")
+        _check_command(cmds)
+
+    def run_cmd_with_non_existing_backing_file():
+        cmds = params.get("cmd_with_non_existing_backing_file")
+        _check_command(cmds)
+
+    def run_cmd_with_empty_string_for_backing_file():
+        cmds = params.get("cmd_with_empty_string_for_backing_file")
+        _check_command(cmds)
+
+    qemu_img_cmd_agrs = ""
+    image_stg = params["images"]
+    if image_stg == "stg":
+        root_dir = data_dir.get_data_dir()
+        stg = QemuImg(params.object_params(image_stg), root_dir, image_stg)
+        stg.create(stg.params)
+        qemu_img_cmd_agrs = stg.image_filename
+    err_info = params["err_info"]
+    test_scenario = params["test_scenario"]
+    locals()[test_scenario]()


### PR DESCRIPTION
1. add case "qemu_img_negative.snapshot.with_incorrect_format"
2. add case "qemu_img_negative.snapshot.with_non_existing_backing_file"
3. add case "qemu_img_negative.snapshot.with_empty_string_for_backing_file"

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1941355