### PR TITLE
virtio_net_dpdk: update case for new rhel product

### DIFF
--- a/qemu/tests/cfg/virtio_net_dpdk.cfg
+++ b/qemu/tests/cfg/virtio_net_dpdk.cfg
@@ -30,10 +30,10 @@
     vhost_nic1 =
     vhost_nic2 = vhost=on
     nettype_nic2 = macvtap
-    netdst_nic2 = shell:ip link | sed -n '/90:e2:ba:7d:33:3d/{g;1!p;};h'|awk -F': ' '{print $2}'|head -1
+    netdst_nic2 = shell:ip link | sed -n '/00:1b:21:8e:b2:b9/{g;1!p;};h'|awk -F': ' '{print $2}'|head -1
     nic_extra_params_nic2 =
     pf_filter_re = 82599
-    device_name_nic3 = shell:ip link | sed -n '/90:e2:ba:7d:33:3c/{g;1!p;};h'|awk -F': ' '{print $2}'|head -1
+    device_name_nic3 = shell:ip link | sed -n '/00:1b:21:8e:b2:b8/{g;1!p;};h'|awk -F': ' '{print $2}'|head -1
     vf_filter_re = "Virtual Function"
     device_driver = vfio-pci
     pci_assignable_nic3 = vf
@@ -41,7 +41,7 @@
     pci_assignable_nic1 = no
     pre_command = echo 8 > /sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages
     pre_command += ; modprobe vfio; modprobe vfio-pci
-    pre_command += ; echo 2 > /sys/class/net/enp6s0f0/device/sriov_numvfs
+    pre_command += ; dev=`ip link | sed -n '/00:1b:21:8e:b2:b8/{g;1!p;};h'|awk -F': ' '{print $2}'|head -1` ; echo 2 > /sys/class/net/$dev/device/sriov_numvfs
     post_command = modprobe -r ixgbe; modprobe ixgbe
     #intel-iommu device
     extra_params = " -object memory-backend-file,id=mem,size=8G,mem-path=/dev/hugepages,share=on -numa node,memdev=mem -mem-prealloc "
@@ -60,7 +60,7 @@
     kernel_extra_params_add = "default_hugepagesz=1G"
 
     #generator host configuration
-    generator = 10.73.8.4
+    generator = 10.73.114.95
     username_generator = root
     password_generator = kvmautotest
     shell_client_generator = ssh
@@ -73,9 +73,10 @@
     env_hugepages_cmd = echo 8 >  /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
     env_pkg = tuned-profiles-cpu-partitioning dpdk dpdk-devel dpdk-tools
     nic_driver = Virtio 82599
-    nic1_dpdk_driver = /usr/lib64/librte_pmd_virtio.so
-    nic2_dpdk_driver = /usr/lib64/librte_pmd_ixgbe.so
+    nic1_dpdk_driver = /usr/lib64/dpdk-pmds/librte_net_virtio.so.21.0
+    nic2_dpdk_driver = /usr/lib64/dpdk-pmds/librte_net_ixgbe.so.21.0
+    whitelist_option = -a
     moongen_pkg = MoonGen.zip
-    moongen_dpdk_nic = 0000:05:00.0 0000:05:00.1
+    moongen_dpdk_nic = 0000:3b:00.0 0000:3b:00.1
     testpmd_exec = start_testpmd.py
     testpmd_queues = 1


### PR DESCRIPTION
1. "/usr/bin/testpmd" is replaced with "/usr/bin/dpdk-testpmd"
2. -w is deprecated, use -a instead
3. "dpdk-devbind" is replaced with "dpdk-devbind.py"
4. update virtio_net_dpdk.cfg since hardware was changed

Signed-off-by: Wenli Quan <wquan@redhat.com>

id:1941440