### PR TITLE
virtio-fs: fix nfs mount failed

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -170,10 +170,10 @@
                         - with_nfs_source:
                             start_vm = no
                             force_create_fs_source = no
-                            export_dir_fs1 = /tmp/virtio_fs1_test_nfs
-                            export_dir_fs2 = /tmp/virtio_fs2_test_nfs
-                            nfs_mount_src_fs1 = 127.0.0.1:/tmp/virtio_fs1_test_nfs
-                            nfs_mount_src_fs2 = 127.0.0.1:/tmp/virtio_fs2_test_nfs
+                            export_dir_fs1 = /mnt/virtio_fs1_test_nfs
+                            export_dir_fs2 = /mnt/virtio_fs2_test_nfs
+                            nfs_mount_src_fs1 = 127.0.0.1:/mnt/virtio_fs1_test_nfs
+                            nfs_mount_src_fs2 = 127.0.0.1:/mnt/virtio_fs2_test_nfs
                             setup_local_nfs = yes
                             nfs_mount_options = rw
                             export_options = 'rw,insecure,no_root_squash,async'


### PR DESCRIPTION
In the latest version of rhel, tmp is a tmpfs and
cannot be used as a mount dir. So modify it to the /mnt dir.

ID: 1940744
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>