### PR TITLE
qemu_guest_agent: Add situation for windows to get disks info.

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -308,7 +308,6 @@
                 cmd_get_disk = wmic volume where "DeviceID='%s'" get FileSystem,DeviceID |findstr /v /i FileSystem
                 cmd_get_disk_usage = wmic volume where "DriveLetter='%s'" get Capacity,FreeSpace |findstr /v /i FreeSpace
         - check_get_disks:
-            only Linux
             no Host_RHEL.m6 Host_RHEL.m7
             no Host_RHEL.m8.u0 Host_RHEL.m8.u1 Host_RHEL.m8.u2 Host_RHEL.m8.u3
             gagent_check_type = get_disks
@@ -321,6 +320,8 @@
             diskinfo_guest_cmd = 'lsblk -Jp -o KNAME,PKNAME,TYPE | grep %s|awk "NR==1"'
             rawdisk_guest_cmd = 'lsblk -Jp -o KNAME,TYPE | grep %s|awk "NR==1"'
             cmd_get_disk_alias = 'lsblk -o NAME %s |grep -v NAME'
+            Windows:
+                cmd_get_diskinfo = wmic diskdrive where "DeviceID='%s'" get Name | findstr /v /i Name
         - check_nonexistent_cmd:
             gagent_check_type = nonexistent_cmd
             wrong_cmd = "system_reset"


### PR DESCRIPTION
qemu_guest_agent: Add situation for windows to get disks info

1. qemu_guest_agent.py: Add conditions to filter windows.
2. qemu_guest_agent.cfg: Add cmd to get disks info in windows.

ID: 1937188
Signed-off-by: Dehan Meng <demeng@redhat.com>