### PR TITLE
 Add virtio-net-ccw support for s390x

### DIFF
--- a/qemu/tests/cfg/multi_nics_hotplug.cfg
+++ b/qemu/tests/cfg/multi_nics_hotplug.cfg
@@ -22,6 +22,11 @@
                 pci_model = virtio
             nics = ""
             extra_params += "-net none"
+            s390x:
+            ''' virtio-net-ccw is not a kind of pci device, but
+            more convinient to use pci_model here
+            '''
+                pci_model = virtio-net-ccw
         - nic_e1000:
             only Host_RHEL.m6, Host_RHEL.m7
             only i386, x86_64
@@ -48,3 +53,8 @@
             pci_model = virtio-net-pci
             device_id_hotplug_nic2 = hotplug_nic1
             device_id_hotplug_nic1 = hotplug_nic2
+            s390x:
+            ''' virtio-net-ccw is not a kind of pci device, but
+            more convinient to use pci_model here
+            '''
+                pci_model = virtio-net-ccw


### PR DESCRIPTION
virtual-network: add pci_model "virtio-net-ccw" for s390x

ID:1942866

Signed-off-by: Boqiao Fu <bfu@redhat.com>