### PR TITLE
qemu_guest_agent: check and install vioser during Setup for windows

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -1,6 +1,7 @@
 - qemu_guest_agent: install setup image_copy unattended_install.cdrom single_driver_install.with_vioserial
     only Fedora, RHEL, Windows
     no Fedora.8, Fedora.9, Fedora.10, Fedora.11, Fedora.12, Fedora.13, Fedora.14, Fedora.15
+    check_vioser = no
     type = qemu_guest_agent
     gagent_name = "org.qemu.guest_agent.0"
     gagent_install_cmd = "yum install -y qemu-guest-agent"
@@ -22,14 +23,21 @@
     # Please update your file share web server url before test
     download_root_url = <your_server_url>
     Windows:
+        check_vioser = yes
         gagent_src_type = url
         cdroms += " virtio"
         cdrom_virtio = isos/windows/virtio-win.iso
         ga_username = "Administrator"
         i386:
+            devcon_dirname += "x86"
             qemu_ga_pkg = qemu-ga-x86.msi
         x86_64:
+            devcon_dirname += "amd64"
             qemu_ga_pkg = qemu-ga-x64.msi
+        cert_files = ""
+        devcon_dirname = "win7_"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        cmd_serial_driver_install = '${devcon_path} updateni %s %s'
         gagent_host_path = "/tmp/${qemu_ga_pkg}"
         gagent_download_cmd = "wget https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-qemu-ga/${qemu_ga_pkg} -O ${gagent_host_path}"
         gagent_guest_dir = "C:\qemu-ga"
@@ -475,12 +483,18 @@
     variants:
         - virtio_serial:
             gagent_serial_type = virtio
+            virtio_win_media_type = iso
+            driver_name_serial = vioser
+            device_hwid_serial = '"PCI\VEN_1AF4&DEV_1003" "PCI\VEN_1AF4&DEV_1043"'
+            cmd_check_serial = 'driverquery /V |findstr /i "virtioserial"'
+            cert_files = 'trustedpublisher=WIN_UTILS:\redhat.cer'
             serials += " org.qemu.guest_agent.0"
             serial_type_org.qemu.guest_agent.0 = "virtserialport"
         - isa_serial:
             # isa-serial is only supported on x86
             only i386, x86_64
             gagent_serial_type = isa
+            check_vioser = no
             serials += " org.qemu.guest_agent.0"
             gagent_start_cmd = "pgrep qemu-ga || qemu-ga -d -m isa-serial -p /dev/ttyS1 -l /var/log/qemu-ga/qemu-ga.log -v"
             gagent_status_cmd = "pgrep qemu-ga"


### PR DESCRIPTION
Add steps to check and install vioser during setup phase for qga
on windows guest.
1. qemu_guest_agent.py: add method to check/install vioser
2. qemu_guest_agent.cfg: add some params.

ID: 1737332
Signed-off-by: Dehan Meng <demeng@redhat.com>