### PR TITLE
HOTFIX: Fix the latest pylint version causing the CI check to fail

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,4 +1,6 @@
 virtualenv==1.9.1
+pylint==1.9.5; python_version < '3.0'
+pylint==2.7.2; python_version >= '3.0'
 inspektor==0.5.2
 autotest==0.16.2; python_version < '3.0'
 autopep8==1.5.4


### PR DESCRIPTION
The latest pylint version(2.7.3) is mismatch to inspekt-1.5.2, the CI
check will fail with "got an error: 'E1002'".

ID: 1944502
Signed-off-by: Yihuang Yu <yihyu@redhat.com>