### PR TITLE
blockdev_stream_remote_server_down: Remote server down when streaming

### DIFF
--- a/qemu/tests/blockdev_stream_remote_server_down.py
+++ b/qemu/tests/blockdev_stream_remote_server_down.py
@@ -1,0 +1,91 @@
+import socket
+
+from provider.blockdev_stream_nowait import BlockdevStreamNowaitTest
+from provider.job_utils import check_block_jobs_paused
+from provider.job_utils import check_block_jobs_started
+from provider.nbd_image_export import QemuNBDExportImage
+
+
+class BlockdevStreamRemoteServerDownTest(BlockdevStreamNowaitTest):
+    """
+    Suspend/resume remote storage service while doing block stream
+    """
+
+    def __init__(self, test, params, env):
+        localhost = socket.gethostname()
+        params['nbd_server_%s' % params['nbd_image_tag']] = localhost \
+            if localhost else 'localhost'
+        self.nbd_export = QemuNBDExportImage(params,
+                                             params['local_image_tag'])
+        super(BlockdevStreamRemoteServerDownTest, self).__init__(test,
+                                                                 params,
+                                                                 env)
+
+    def pre_test(self):
+        self.nbd_export.create_image()
+        try:
+            self.nbd_export.export_image()
+            super(BlockdevStreamRemoteServerDownTest, self).pre_test()
+        except Exception:
+            self.nbd_export.stop_export()
+            raise
+
+    def post_test(self):
+        super(BlockdevStreamRemoteServerDownTest, self).post_test()
+        self.nbd_export.stop_export()
+        self.params['images'] += ' %s' % self.params['local_image_tag']
+
+    def generate_tempfile(self, root_dir, filename, size='10M', timeout=360):
+        """Create a large file to enlarge stream time"""
+        super(BlockdevStreamRemoteServerDownTest, self).generate_tempfile(
+            root_dir, filename, self.params['tempfile_size'], timeout)
+
+    def do_test(self):
+        self.snapshot_test()
+        self.blockdev_stream()
+        check_block_jobs_started(
+            self.main_vm, [self._job],
+            self.params.get_numeric('job_started_timeout', 60)
+        )
+        self.nbd_export.suspend_export()
+        try:
+            check_block_jobs_paused(
+                self.main_vm, [self._job],
+                self.params.get_numeric('job_paused_interval', 50)
+            )
+        finally:
+            self.nbd_export.resume_export()
+        self.main_vm.monitor.cmd("block-job-set-speed",
+                                 {'device': self._job, 'speed': 0})
+        self.wait_stream_job_completed()
+        self.main_vm.destroy()
+        self.clone_vm.create()
+        self.mount_data_disks()
+        self.verify_data_file()
+
+
+def run(test, params, env):
+    """
+    Suspend/resume remote storage service while doing block stream
+
+    test steps:
+        0. create a local image and export it with qemu-nbd
+        1. boot VM with the nbd image exported above
+        2. format the data disk and mount it
+        3. hotplug a snapshot image for data image
+        4. create a file 'base'
+        5. take snapshot on data image
+        6. create a file 'sn1'
+        7. do blockdev-stream
+        8. suspend nbd server
+        9. stream job should be paused
+       10. resume nbd server
+       11. wait till stream job completed
+       12. restart VM with snapshot disk, check all files and checksums
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    stream_test = BlockdevStreamRemoteServerDownTest(test, params, env)
+    stream_test.run_test()

--- a/qemu/tests/cfg/blockdev_stream_remote_server_down.cfg
+++ b/qemu/tests/cfg/blockdev_stream_remote_server_down.cfg
@@ -1,0 +1,67 @@
+# Storage backends:
+#   filesystem
+# The following testing scenario is covered:
+#   Do block stream, suspend/resume remote storage service
+#     The snapshot image is a local image(filesystem)
+#     The data image is a nbd image
+
+
+- blockdev_stream_remote_server_down:
+    only Linux
+    only filesystem
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_stream_remote_server_down
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    node = drive_data1
+    base_tag = data1
+    snapshot_tag = data1sn
+    tempfile_size = 100M
+    storage_pools = default
+    storage_pool = default
+    speed = 10240
+
+    # Settings for a local fs image 'data',
+    # which will be exported with qemu-nbd
+    local_image_tag = data
+    image_size_data = 2G
+    image_name_data = data
+    image_format_data = qcow2
+    preallocated_data = falloc
+    nbd_port_data = 10810
+    nbd_export_format_data = raw
+    nbd_server_tls_creds_data = ''
+    enable_iscsi_data = no
+    enable_ceph_data = no
+    enable_gluster_data = no
+    enable_nbd_data = no
+    image_raw_device_data = no
+    remove_image_data = yes
+
+    # Settings for nbd image 'data1',
+    # i.e. the exported 'data'
+    nbd_image_tag = data1
+    enable_nbd_data1 = yes
+    storage_type_data1 = nbd
+    nbd_server_data1 = localhost
+    nbd_port_data1 = ${nbd_port_data}
+    remove_image_data1 = no
+    force_create_image_data1 = no
+    image_create_support_data1 = no
+    image_format_data1 = ${image_format_data}
+    image_size_data1 = ${image_size_data}
+    check_image_data1 = no
+
+    # For local snapshot image
+    storage_type_default = directory
+    enable_iscsi_data1sn = no
+    enable_ceph_data1sn = no
+    enable_gluster_data1sn = no
+    enable_nbd_data1sn = no
+    image_raw_device_data1sn = no
+    image_size_data1sn = ${image_size_data}
+    image_format_data1sn = qcow2
+    image_name_data1sn = data1sn


### PR DESCRIPTION
Remote server down when doing block stream, job paused;
Resume remote storage, job should complete.

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1945100