### PR TITLE
qemu-guest-agent: There is not only one user under '/home' dir on rhel9

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -1434,7 +1434,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                                                shell=True, timeout=5)
             login_user = login_user.strip().decode(encoding="utf-8",
                                                    errors="strict")
-            if login_user != params["guest_user"]:
+            if params["guest_user"] not in login_user:
                 test.error("Can not login guest without interaction, "
                            "basic function test is fail.")
 


### PR DESCRIPTION
qemu-guest-agent.py: There is not only one user under '/home' dir

There is an exist user(or a simple file) under dir' home' on RHEL9
so the code logic should be changed as 'if xxx not in /home/*'
instead of original 'if xxx != /home/*'.

ID: 1943792 
Signed-off-by: Dehan Meng <demeng@redhat.com>