### PR TITLE
dirty-bitmaps: Replace to use the 'recording' field to get bitmap status

### DIFF
--- a/provider/block_dirty_bitmap.py
+++ b/provider/block_dirty_bitmap.py
@@ -180,7 +180,7 @@ def block_dirty_bitmap_disable(vm, node, name):
     func(node, name)
     bitmap = get_bitmap_by_name(vm, node, name)
     msg = "block dirty bitmap '%s' is not disabled" % name
-    assert bitmap["status"] == "disabled", msg
+    assert (bitmap["recording"] is False), msg
 
 
 @fail_on
@@ -190,7 +190,7 @@ def block_dirty_bitmap_enable(vm, node, name):
     func(node, name)
     bitmap = get_bitmap_by_name(vm, node, name)
     msg = "block dirty bitmap '%s' is not enabled" % name
-    assert bitmap["status"] == "active", msg
+    assert (bitmap["recording"] is True), msg
 
 
 def get_bitmaps_in_device(vm, device):

--- a/qemu/tests/blockdev_inc_backup_add_disabled_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_add_disabled_bitmap.py
@@ -10,7 +10,7 @@ class BlockdevIncbkAddDisabledBitmapTest(BlockdevLiveBackupBaseTest):
         bitmaps = list(map(
             lambda n, b: get_bitmap_by_name(self.main_vm, n, b),
             self._source_nodes, self._bitmaps))
-        if not all(list(map(lambda b: b and b['status'] == 'disabled'
+        if not all(list(map(lambda b: b and (b['recording'] is False)
                             and b['count'] == 0, bitmaps))):
             self.test.fail('disabled bitmaps changed.')
 

--- a/qemu/tests/blockdev_inc_backup_bitmap_vm_crash_reboot.py
+++ b/qemu/tests/blockdev_inc_backup_bitmap_vm_crash_reboot.py
@@ -17,7 +17,7 @@ class BlockdevIncbkBitmapExistAfterVMCrashReboot(BlockdevLiveBackupBaseTest):
         bitmaps = list(map(
             lambda n, b: get_bitmap_by_name(self.main_vm, n, b),
             self._source_nodes, self._bitmaps))
-        if not all(list(map(lambda b: b and b['status'] == 'active'
+        if not all(list(map(lambda b: b and (b['recording'] is True)
                             and b['count'] >= 0, bitmaps))):
             self.test.fail('bitmap should still exist after vm crash.')
 

--- a/qemu/tests/blockdev_inc_backup_disable_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_disable_bitmap.py
@@ -24,7 +24,7 @@ class BlockdevIncbkDisableBitmapTest(BlockdevLiveBackupBaseTest):
                 lambda b1, b2: (b1 and b2
                                 and b1['count'] == b2['count']    # same count
                                 and b2['count'] > 0               # count > 0
-                                and b2['status'] == 'disabled'),  # disabled
+                                and (b2['recording'] is False)),  # disabled
                 self._disabled_bitmaps_info, bitmaps_info))):
             self.test.fail('bitmaps count or status changed')
 

--- a/qemu/tests/blockdev_inc_backup_disabled_persistent_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_disabled_persistent_bitmap.py
@@ -13,7 +13,7 @@ class BlockdevIncbkDisPersistentBitmapTest(BlockdevLiveBackupBaseTest):
                 lambda b1, b2: (b1 and b2
                                 and b2['count'] > 0
                                 and b1['count'] == b2['count']
-                                and b2['status'] == 'disabled'),
+                                and (b2['recording'] is False)),
                 self._disabled_bitmaps_info, bitmaps_info))):
             self.test.fail("bitmaps' count or status changed")
 

--- a/qemu/tests/blockdev_inc_backup_rm_persistent_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_rm_persistent_bitmap.py
@@ -50,7 +50,7 @@ class BlockdevIncbkRmPersistentBitmapTest(BlockdevLiveBackupBaseTest):
                 lambda b1, b2: (b1 and b2
                                 and b2['count'] > 0
                                 and b1['count'] == b2['count']
-                                and b2['status'] == 'disabled'),
+                                and (b2['recording'] is False)),
                 self._bitmaps_info, bitmaps_info))):
             self.test.fail("bitmaps' count or status changed")
 

--- a/qemu/tests/blockdev_inc_backup_with_migration.py
+++ b/qemu/tests/blockdev_inc_backup_with_migration.py
@@ -102,7 +102,7 @@ class BlockdevIncbkWithMigration(blockdev_base.BlockdevBaseTest):
         for info in self.get_bitmaps_info():
             if info is None:
                 self.test.fail('Failed to get bitmaps after migration')
-            if info['status'] != 'disabled':
+            if info['recording'] is not False:
                 self.test.fail('Bitmap was not disabled after migration')
             if info['count'] != self.bitmap_counts[info['name']]:
                 self.test.fail('Count of bitmap was changed after migration')


### PR DESCRIPTION
On qemu6.0, 'status' field under qmp 'query-block' command output is
deprecated, so use the 'recording' field instead to get the bitmap
status.

Signed-off-by: Nini Gu <ngu@redhat.com>
ID: 1944940