### PR TITLE
chardev: correct short-form usage for some options

### DIFF
--- a/qemu/tests/cfg/chardev_tls_encryption.cfg
+++ b/qemu/tests/cfg/chardev_tls_encryption.cfg
@@ -17,7 +17,7 @@
             gnutls_cmd_client = "cd ${cert_dir} &&"
             gnutls_cmd_client += " gnutls-cli --priority=NORMAL -p %s --x509cafile=ca-cert.pem %s --x509certfile=client-cert.pem --x509keyfile=client-key.pem"
             extra_params = " -object tls-creds-x509,id=tls0,dir=${cert_dir},endpoint=server"
-            extra_params += " -chardev socket,id=tls_chardev,host=%s,port=%s,tls-creds=tls0,server,nowait"
+            extra_params += " -chardev socket,id=tls_chardev,host=%s,port=%s,tls-creds=tls0,server=on,wait=off"
             extra_params += " -device isa-serial,chardev=tls_chardev,id=tls_serial"
         - guest_to_guest:
             only Linux
@@ -26,7 +26,7 @@
             expected_msg = "BOOT_IMAGE"
             guest_cmd = "cat /dev/ttyS0 &"
             extra_params_vm1 = " -object tls-creds-x509,id=tls0,dir=${cert_dir},endpoint=server"
-            extra_params_vm1 += " -chardev socket,id=tls_chardev1,host=%s,port=%s,tls-creds=tls0,server,nowait"
+            extra_params_vm1 += " -chardev socket,id=tls_chardev1,host=%s,port=%s,tls-creds=tls0,server=on,wait=off"
             extra_params_vm1 += " -device isa-serial,chardev=tls_chardev1,id=tls_serial1"
             extra_params_vm2 = " -object tls-creds-x509,id=tls0,dir=${cert_dir},endpoint=client"
             extra_params_vm2 += " -chardev socket,id=tls_chardev2,host=%s,port=%s,tls-creds=tls0"

--- a/qemu/tests/usb_redir.py
+++ b/qemu/tests/usb_redir.py
@@ -118,7 +118,7 @@ def run(test, params, env):
                 chardev_params['host'] = usbredir_params['chardev_host']
                 chardev_params['port'] = free_port
                 chardev_params['server'] = usbredir_params.get('chardev_server')
-                chardev_params['nowait'] = usbredir_params.get('chardev_nowait')
+                chardev_params['wait'] = usbredir_params.get('chardev_wait')
             chardev = qdevices.CharDevice(chardev_params, chardev_id)
             usbredir_dev = qdevices.QDevice('usb-redir',
                                             aobject=usbredirdev_name)


### PR DESCRIPTION
From qemu6.0, short-form boolean options are deprecated, options
such as "server" or "nowait", correct them to "server=on" and
"wait=off"

id: 1945036
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>