### PR TITLE
kdump with stress: fix stress package download failed issue.

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -62,10 +62,8 @@
                         netperf_link = netperf-2.4.5.tar.bz2
                 - io_stress:
                     stress_type = io
-                    download_link = http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz
-                    pkg_md5sum = 7b0859a66fc14eddb349f2fd19cf023e
-                    tmp_dir = "/var/tmp"
-                    install_cmd = "tar -xzvf ${tmp_dir}/stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install"
+                    tmp_dir = "/var/tmp/"
+                    install_cmd = "tar -xzvf ${tmp_dir}stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install"
                     app_check_cmd = "stress --help"
                     start_cmd = "stress --cpu 4 --io 4 --vm 2 --vm-bytes 256M --quiet &"
                     kdump_check_cmd = "pidof -s stress"

--- a/qemu/tests/kdump_with_stress.py
+++ b/qemu/tests/kdump_with_stress.py
@@ -1,11 +1,9 @@
 import logging
-import os
-
-from avocado.utils import download
 
 from virttest import error_context
 from virttest import utils_test
 from virttest import utils_misc
+from virttest import data_dir
 
 from generic.tests import kdump
 
@@ -28,25 +26,12 @@ def run(test, params, env):
         """
         Install stress app in guest.
         """
-        if session.cmd_status(params.get("app_check_cmd", "true")) == 0:
-            logging.info("Stress app already installed in guest.")
-            return
-
-        link = params.get("download_link")
-        md5sum = params.get("pkg_md5sum")
-        tmp_dir = params.get("tmp_dir", "/var/tmp")
-        install_cmd = params.get("install_cmd")
-
-        logging.info("Fetch package: '%s'", link)
-        pkg_name = os.path.basename(link)
-        pkg_path = os.path.join(test.tmpdir, pkg_name)
-        download.get_file(link, pkg_path, hash_expected=md5sum)
-        vm.copy_files_to(pkg_path, tmp_dir)
-
-        logging.info("Install app: '%s' in guest.", install_cmd)
-        s, o = session.cmd_status_output(install_cmd, timeout=300)
-        if s != 0:
-            test.error("Fail to install stress app(%s)" % o)
+        stress_path = data_dir.get_deps_dir("stress")
+        stress_guest_path = params["tmp_dir"]
+        logging.info("Copy stress package to guest.")
+        session.cmd_status_output("mkdir -p %s" % stress_guest_path)
+        vm.copy_files_to(stress_path, stress_guest_path)
+        session.cmd(params["install_cmd"])
 
         logging.info("Install app successed")
 


### PR DESCRIPTION
Since stress's package download link is unavailable, so rewrited
the function of install_stress_app() to install stress app in VM.

Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:1931484