### PR TITLE
block_during_io.cfg: fix iozone error issue for win10

### DIFF
--- a/qemu/tests/cfg/block_during_io.cfg
+++ b/qemu/tests/cfg/block_during_io.cfg
@@ -49,6 +49,8 @@
         - iozone_stress:
             stress_name = iozone
             iozone_cmd_opitons = "-azR -r 64k -n 1G -g 10G -M -i 0 -i 1 -I "
+            Win10:
+                iozone_cmd_opitons = "-azR -r 64k -n 1G -g 5G -M -i 0 -i 1 -I "
             iozone_timeout = 7200
             Windows:
                 iozone_cmd_opitons += "-f %s:\testfile"


### PR DESCRIPTION
No enough system space after installation for win10 to
run iozone on system disk with '-g 10G' option.

ID: 1925926
Signed-off-by: Menghuan Li menli@redhat.com