### PR TITLE
correct the usage of parameter --target-is-zero for luks image

### DIFF
--- a/qemu/tests/cfg/qemu_img_convert_with_target_is_zero.cfg
+++ b/qemu/tests/cfg/qemu_img_convert_with_target_is_zero.cfg
@@ -25,8 +25,3 @@
             convert_target = convert
             image_name_convert = "images/convert_to_qcow2"
             image_format_convert = qcow2
-        - to_luks:
-            convert_target = convert
-            image_name_convert = "images/convert_to_luks"
-            image_format_convert = luks
-            image_secret_convert = convert

--- a/qemu/tests/qemu_img_convert_with_target_is_zero.py
+++ b/qemu/tests/qemu_img_convert_with_target_is_zero.py
@@ -15,7 +15,7 @@ def run(test, params, env):
     2. Create temporary file in the guest
     3. Get md5 value of the temporary file
     4. Destroy the guest
-    5. Convert image to raw/qcow2/luks with parameter --target-is-zero -n
+    5. Convert image to raw/qcow2 with parameter --target-is-zero -n
     6. Boot the target image, check the md5 value of the temporary file
        Make sure the values are the same
     7. remove the target image


### PR DESCRIPTION
the target image can't be luks format, it causes the image corruption

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1949373