### PR TITLE
qemu_guest_agent.py: Improve error messages for freezing a frozen fs.

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -2539,8 +2539,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         try:
             self.gagent.fsfreeze(check_status=False)
         except guest_agent.VAgentCmdError as e:
-            expected = ("The command guest-fsfreeze-freeze has been disabled "
-                        "for this instance")
+            expected = ("Command guest-fsfreeze-freeze has been disabled: "
+                        "the agent is in frozen state")
             if expected not in e.edata["desc"]:
                 test.fail(e)
         else:


### PR DESCRIPTION
Update error message "Command guest-fsfreeze-freeze has been disabled: "
"the agent is in frozen state" instead of original "The command "
"guest-fsfreeze-freeze has been disabled for this instance" to tell user
more clearly.

ID: 1949784
Signed-off-by: Dehan Meng <demeng@redhat.com>