### PR TITLE
Fix virtiofs xfstests

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -147,7 +147,11 @@
                     image_snapshot = yes
                     mem = 32768
                     size_mem1 = 32G
-                    blacklist = generic/551
+                    # Skip tests in both xfs and nfs due to known issue
+                    # generic/003 120: https://gitlab.com/virtio-fs/qemu/-/issues/8
+                    # generic/426 467 477: https://gitlab.com/virtio-fs/qemu/-/issues/10
+                    # generic/551: Costs a lot of time
+                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.
@@ -169,7 +173,7 @@
                     cmd_setenv += 'export SCRATCH_MNT=${fs_dest_fs2} && export FSTYP=virtiofs && export FSX_AVOID="-E" && '
                     cmd_setenv += 'echo -e 'TEST_DEV=${fs_target_fs1}\nTEST_DIR=${fs_dest_fs1}\nSCRATCH_DEV=${fs_target_fs2}\n'
                     cmd_setenv += 'SCRATCH_MNT=${fs_dest_fs2}\nFSTYP=virtiofs\nFSX_AVOID="-E"' > configs/localhost.config'
-                    cmd_setenv += ' && echo "${blacklist}" > blacklist'
+                    cmd_setenv += ' && echo "${generic_blacklist}" > blacklist'
                     cmd_xfstest = './check -virtiofs -E blacklist'
                     cmd_useradd = 'useradd fsgqa && useradd 123456-fsgqa && useradd fsgqa2'
                     cmd_get_tmpfs = 'df -h | grep /dev/shm | gawk '{ print $2 }''
@@ -177,6 +181,9 @@
                     variants:
                         - with_local_source:
                         - with_nfs_source:
+                            # generic/035 nfs specific: https://gitlab.com/virtio-fs/qemu/-/issues/12
+                            nfs_blacklist = 'generic/035'
+                            cmd_setenv_nfs = 'echo  "${nfs_blacklist}" >> blacklist'
                             force_create_fs_source = no
                             export_dir_fs1 = /mnt/virtio_fs1_test_nfs
                             export_dir_fs2 = /mnt/virtio_fs2_test_nfs

--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -143,6 +143,7 @@
                 - with_xfstest:
                     no Windows
                     only run_stress..with_cache.auto
+                    start_vm = no
                     image_snapshot = yes
                     mem = 32768
                     size_mem1 = 32G
@@ -171,10 +172,11 @@
                     cmd_setenv += ' && echo "${blacklist}" > blacklist'
                     cmd_xfstest = './check -virtiofs -E blacklist'
                     cmd_useradd = 'useradd fsgqa && useradd 123456-fsgqa && useradd fsgqa2'
+                    cmd_get_tmpfs = 'df -h | grep /dev/shm | gawk '{ print $2 }''
+                    cmd_set_tmpfs = 'mount -o remount,size=%s /dev/shm'
                     variants:
                         - with_local_source:
                         - with_nfs_source:
-                            start_vm = no
                             force_create_fs_source = no
                             export_dir_fs1 = /mnt/virtio_fs1_test_nfs
                             export_dir_fs2 = /mnt/virtio_fs2_test_nfs

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -97,20 +97,30 @@ def run(test, params, env):
     cmd_setenv = params.get('cmd_setenv')
     cmd_useradd = params.get('cmd_useradd')
     fs_dest_fs1 = params.get('fs_dest_fs1')
+    cmd_get_tmpfs = params.get('cmd_get_tmpfs')
+    cmd_set_tmpfs = params.get('cmd_set_tmpfs')
+    size_mem1 = params.get('size_mem1')
 
     # xfstest-nfs config
     setup_local_nfs = params.get('setup_local_nfs')
 
-    if setup_local_nfs:
-        for fs in params.objects("filesystems"):
-            nfs_params = params.object_params(fs)
-            params["export_dir"] = nfs_params.get("export_dir")
-            params["nfs_mount_src"] = nfs_params.get("nfs_mount_src")
-            params["nfs_mount_dir"] = nfs_params.get("fs_source_dir")
-            nfs_local = nfs.Nfs(params)
-            nfs_local.setup()
+    if cmd_xfstest:
+        # /dev/shm is the default memory-backend-file, the default value is the
+        # half of the host memory. Increase it to guest memory size to avoid crash
+        ori_tmpfs_size = process.run(cmd_get_tmpfs, shell=True).stdout_text.replace("\n", "")
+        logging.debug("original tmpfs size is %s", ori_tmpfs_size)
+        params["post_command"] = cmd_set_tmpfs % ori_tmpfs_size
+        params["pre_command"] = cmd_set_tmpfs % size_mem1
+        if setup_local_nfs:
+            for fs in params.objects("filesystems"):
+                nfs_params = params.object_params(fs)
+                params["export_dir"] = nfs_params.get("export_dir")
+                params["nfs_mount_src"] = nfs_params.get("nfs_mount_src")
+                params["nfs_mount_dir"] = nfs_params.get("fs_source_dir")
+                nfs_local = nfs.Nfs(params)
+                nfs_local.setup()
         params["start_vm"] = "yes"
-        env_process.preprocess_vm(test, params, env, params["main_vm"])
+        env_process.preprocess(test, params, env)
 
     os_type = params.get("os_type")
     vm = env.get_vm(params.get("main_vm"))

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -95,6 +95,7 @@ def run(test, params, env):
     cmd_yum_install = params.get('cmd_yum_install')
     cmd_make_xfs = params.get('cmd_make_xfs')
     cmd_setenv = params.get('cmd_setenv')
+    cmd_setenv_nfs = params.get('cmd_setenv_nfs', '')
     cmd_useradd = params.get('cmd_useradd')
     fs_dest_fs1 = params.get('fs_dest_fs1')
     cmd_get_tmpfs = params.get('cmd_get_tmpfs')
@@ -252,6 +253,7 @@ def run(test, params, env):
                 session.cmd(cmd_yum_install, 180)
                 session.cmd(cmd_make_xfs, 360)
                 session.cmd(cmd_setenv, 180)
+                session.cmd(cmd_setenv_nfs, 180)
                 session.cmd(cmd_useradd, 180)
 
                 try:


### PR DESCRIPTION
Before this commit

guest crash
```
04:23:06 DEBUG| Sending command: ./check -virtiofs -E blacklist
05:00:35 INFO | [qemu output] error: kvm run failed Bad address
05:00:35 INFO | [qemu output]  PC=ffff5eedb65cb5b0 X00=ffffa072a22c0000 X01=0000ffff909a0040
05:00:35 INFO | [qemu output] X02=000000000000ff80 X03=0000ffff909a0000 X04=0000000000000000
05:00:35 INFO | [qemu output] X05=ffffa072a22d0000 X06=ffffa072a22c0000 X07=cdcdcdcdcdcdcdcd
05:00:35 INFO | [qemu output] X08=cdcdcdcdcdcdcdcd X09=cdcdcdcdcdcdcdcd X10=cdcdcdcdcdcdcdcd
05:00:35 INFO | [qemu output] X11=cdcdcdcdcdcdcdcd X12=cdcdcdcdcdcdcdcd X13=cdcdcdcdcdcdcdcd
05:00:35 INFO | [qemu output] X14=cdcdcdcdcdcdcdcd X15=00007889c9852732 X16=ffff5eedb60cae20
05:00:35 INFO | [qemu output] X17=0000ffff91a81c60 X18=0000000000000001 X19=0000000000000000
05:00:35 INFO | [qemu output] X20=0000000000020000 X21=ffff00001cccfd40 X22=ffffa072a22d0000
05:00:35 INFO | [qemu output] X23=0000000000010000 X24=ffff7fe81ca88b00 X25=ffff00001cccfd50
05:00:35 INFO | [qemu output] X26=0000000110320000 X27=0000000000000000 X28=0000000000011032
05:00:35 INFO | [qemu output] X29=ffff00001cccfa70 X30=ffff5eedb60ca7e4  SP=ffff00001cccfa70
05:00:35 INFO | [qemu output] PSTATE=20000005 --C- EL1h
```

After this fix
xfs pass
```
# python3 ConfigTest.py --guestname=RHEL.8.4.0 --platform=aarch64 --driveformat=virtio_scsi --nicmodel=virtio_net --testcase=virtio_fs_share_data.run_stress.with_xfstest.with_local_source.with_cache.auto --clone=no
[snip]
INFO | Start to run test
JOB ID     : 124bd4fe9166871711c95c5cbdb84a70ee2b1d82
JOB LOG    : /root/avocado/job-results/job-2021-04-19T21.20-124bd4f/job.log
 (1/1) Host_RHEL.m8.u4.product_av.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.4.0.aarch64.io-github-autotest-qemu.virtio_fs_share_data.run_stress.with_xfstest.with_local_source.with_cache.auto.arm64-pci: PASS (2846.22 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2021-04-19T21.20-124bd4f/results.html
JOB TIME   : 2847.47 s
```

nfs failed: generic/123 regression
```
# python3 ConfigTest.py --guestname=RHEL.8.4.0 --platform=aarch64 --driveformat=virtio_scsi --nicmodel=virtio_net --testcase=virtio_fs_share_data.run_stress.with_xfstest.with_nfs_source.with_cache.auto --clone=no
[snip]
INFO | Start to run test
JOB ID     : 233e0af6e8207df9e559a9d76230f1c424b51879
JOB LOG    : /root/avocado/job-results/job-2021-04-19T22.29-233e0af/job.log
 (1/1) Host_RHEL.m8.u4.product_av.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.4.0.aarch64.io-github-autotest-qemu.virtio_fs_share_data.run_stress.with_xfstest.with_nfs_source.with_cache.auto.arm64-pci: -^[^[^FAIL: The xfstest failed. (3823.12 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2021-04-19T22.29-233e0af/results.html
JOB TIME   : 3824.37 s

```