### PR TITLE
Add supported for ioeventfd.virtio_serial for s390x

### DIFF
--- a/qemu/tests/cfg/ioeventfd.cfg
+++ b/qemu/tests/cfg/ioeventfd.cfg
@@ -55,3 +55,7 @@
                 clean_cmd = del /f /q
                 tmp_dir = %TEMP%
                 python_bin = python2.7
+            s390x:
+                dev_id = 'virtio_serial_ccw0'
+                orig_ioeventfd = "ioeventfd=on"
+                new_ioeventfd = "ioeventfd=off"

--- a/qemu/tests/ioeventfd.py
+++ b/qemu/tests/ioeventfd.py
@@ -69,7 +69,7 @@ def run(test, params, env):
         dev_type = params.get("dev_type")
         if dev_type == "virtio_serial":
             params['virtio_serial_extra_params_vs1'] = ioeventfd
-            dev_id = 'virtio_serial_pci0'
+            dev_id = params.get('dev_id', 'virtio_serial_pci0')
         elif params['drive_format'] == 'virtio':
             params['blk_extra_params_image1'] = ioeventfd
             dev_id = 'image1'


### PR DESCRIPTION
virtual_block:add virtio_serial_ccw0 to adapt s390x

ID:1951608

Signed-off-by: Boqiao Fu <bfu@redhat.com>