### PR TITLE
fix 'Could not open '/tmp/*' issue on rhel9

### DIFF
--- a/qemu/tests/cfg/block_hotplug_check.cfg
+++ b/qemu/tests/cfg/block_hotplug_check.cfg
@@ -33,7 +33,7 @@
         no RHEL.3.9
         offset = 64k
         match_string = "Virtio block device"
-        guest_check_cmd = cat /proc/partitions |tee /tmp/partitions
+        guest_check_cmd = cat /proc/partitions |tee /var/tmp/partitions
         pci_test_cmd = "echo %s; yes | mke2fs `fdisk -l 2>&1 | awk '/\/dev\/[sv]d[a-z]* doesn/ {print $2}'` | sort | tail -1"
         reference_cmd = lspci
         find_pci_cmd = lspci

--- a/qemu/tests/cfg/block_resize.cfg
+++ b/qemu/tests/cfg/block_resize.cfg
@@ -89,6 +89,6 @@
             md5_test = yes
             Windows:
                 md5_cmd = "%s: && md5sum.exe %s"
-                tmp_md5_file = /tmp/tmp_md5_file
+                tmp_md5_file = /var/tmp/tmp_md5_file
                 pre_command = "dd if=/dev/urandom of=${tmp_md5_file} oflag=direct bs=1M count=10"
                 post_command = "rm -rf ${tmp_md5_file}"

--- a/qemu/tests/cfg/device_option_check.cfg
+++ b/qemu/tests/cfg/device_option_check.cfg
@@ -60,11 +60,11 @@
                     cdrom_cd1 = isos/windows/winutils.iso
                     pseries, s390x:
                         only default_drive_format
-                        cdrom_cd1 = /tmp/new.iso
+                        cdrom_cd1 = /var/tmp/new.iso
                         pre_command_noncritical = no
-                        pre_command = 'dd if=/dev/zero of=/tmp/new bs=10M count=1 &&'
-                        pre_command += ' mkisofs -o /tmp/new.iso /tmp/new'
-                        post_command = 'rm -rf /tmp/new*'
+                        pre_command = 'dd if=/dev/zero of=/var/tmp/new bs=10M count=1 &&'
+                        pre_command += ' mkisofs -o /var/tmp/new.iso /var/tmp/new'
+                        post_command = 'rm -rf /var/tmp/new*'
         - blk_serial_check:
             parameter_value = random
             params_name = drive_serial_image1

--- a/qemu/tests/cfg/eject_media.cfg
+++ b/qemu/tests/cfg/eject_media.cfg
@@ -3,12 +3,12 @@
     type = eject_media
     virt_test_type = qemu
     monitor_type = qmp
-    pre_command += "dd if=/dev/urandom of=/tmp/orig bs=10M count=1 && dd if=/dev/urandom of=/tmp/new bs=10M count=1 && mkisofs -o /tmp/orig.iso /tmp/orig && mkisofs -o /tmp/new.iso /tmp/new;"
+    pre_command += "dd if=/dev/urandom of=/var/tmp/orig bs=10M count=1 && dd if=/dev/urandom of=/var/tmp/new bs=10M count=1 && mkisofs -o /var/tmp/orig.iso /var/tmp/orig && mkisofs -o /var/tmp/new.iso /var/tmp/new;"
     umount_before_eject = yes
     umount_cmd = "for cd in `awk '{if($0 ~ /iso9660/) print $1}' /proc/mounts`;do fuser -k $cd; umount -d $cd;done"
-    post_command += "rm -rf /tmp/orig.iso /tmp/new.iso /tmp/orig /tmp/new;"
-    new_img_name = /tmp/new.iso
-    cdrom_cd1 = /tmp/orig.iso
+    post_command += "rm -rf /var/tmp/orig.iso /var/tmp/new.iso /var/tmp/orig /var/tmp/new;"
+    new_img_name = /var/tmp/new.iso
+    cdrom_cd1 = /var/tmp/orig.iso
     virtio_scsi:
         # disable iothread
         iothread_scheme ?=

--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -182,7 +182,7 @@
             no multi_disk
             # Dont run the actual test, only show the disk setup
             multi_disk_params_only = yes
-            stg_image_name = '/tmp/%s'
+            stg_image_name = '/var/tmp/%s'
             stg_image_size = 1M
             stg_params += "list_params:item1,item2,item3 "
             stg_params += "simplerange:range(55) "

--- a/qemu/tests/cfg/plug_cdrom.cfg
+++ b/qemu/tests/cfg/plug_cdrom.cfg
@@ -8,15 +8,15 @@
     iothreads ?=
     cdroms = 'cd2'
     iso_name_cd2 = new
-    cdrom_cd2 = /tmp/${iso_name_cd2}.iso
+    cdrom_cd2 = /var/tmp/${iso_name_cd2}.iso
     pre_command_noncritical = no
-    pre_command = 'dd if=/dev/urandom of=/tmp/${iso_name_cd2} bs=10M count=1 &&'
-    pre_command += ' mkisofs -o /tmp/${iso_name_cd2}.iso /tmp/${iso_name_cd2}'
-    post_command = "rm -rf /tmp/${iso_name_cd2}.iso /tmp/${iso_name_cd2}"
+    pre_command = 'dd if=/dev/urandom of=/var/tmp/${iso_name_cd2} bs=10M count=1 &&'
+    pre_command += ' mkisofs -o /var/tmp/${iso_name_cd2}.iso /var/tmp/${iso_name_cd2}'
+    post_command = "rm -rf /var/tmp/${iso_name_cd2}.iso /var/tmp/${iso_name_cd2}"
     kill_vm_on_error = yes
     driver_name = vioscsi
     items_checked_cd2 = '{"io-status": "ok", "device": "drive_${cdroms}", "removable": True, '
-    items_checked_cd2 += '"file": "/tmp/${iso_name_cd2}.iso"}'
+    items_checked_cd2 += '"file": "/var/tmp/${iso_name_cd2}.iso"}'
     variants:
         - reboot_vm:
             Windows:


### PR DESCRIPTION
The files in /tmp dir will be removed after reboot on rhel9
but the files still useful after reboot so change the path
to /var/tmp to let the files preserved.

ID: 1925456
Signed-off-by: Menghuan Li menli@redhat.com