### PR TITLE
migration_with_block: Fix KeyError:'drive_orig' issue

### DIFF
--- a/qemu/tests/cfg/migration_with_block.cfg
+++ b/qemu/tests/cfg/migration_with_block.cfg
@@ -53,25 +53,24 @@
                     cdrom_orig_name = orig
                     cdroms = ${cdrom_orig_name}
                     image_boot_orig = yes
-                    cdrom_orig = /tmp/${cdrom_orig_name}.iso
+                    cdrom_orig = /var/tmp/${cdrom_orig_name}.iso
                     cdrom_orig_file = ${cdrom_orig}
                     cdrom_new_name = new
-                    cdrom_new_file = /tmp/${cdrom_new_name}.iso
+                    cdrom_new_file = /var/tmp/${cdrom_new_name}.iso
                     pre_command_noncritical = no
-                    pre_command = 'dd if=/dev/zero of=/tmp/${cdrom_orig_name} bs=1M count=1024 && '
-                    pre_command += 'mkisofs -o /tmp/${cdrom_orig_name}.iso /tmp/${cdrom_orig_name} && '
-                    pre_command += 'dd if=/dev/zero of=/tmp/${cdrom_new_name} bs=1M count=2048 && '
-                    pre_command += 'mkisofs -o /tmp/${cdrom_new_name}.iso /tmp/${cdrom_new_name}'
-                    post_command = "rm -rf /tmp/${cdrom_new_name}.iso /tmp/${cdrom_new_name} "
-                    post_command += "/tmp/${cdrom_orig_name}.iso /tmp/${cdrom_orig_name}"
-                    check_items = '{"io-status": "ok", "device": "drive_${cdrom_orig_name}", "tray_open": False'
-                    check_orig_items =  '${check_items}, "file": "${cdrom_orig_file}"}'
-                    check_new_items =  '${check_items}, "file": "${cdrom_new_file}"}'
+                    pre_command = 'dd if=/dev/zero of=/var/tmp/${cdrom_orig_name} bs=1M count=1024 && '
+                    pre_command += 'mkisofs -o /var/tmp/${cdrom_orig_name}.iso /var/tmp/${cdrom_orig_name} && '
+                    pre_command += 'dd if=/dev/zero of=/var/tmp/${cdrom_new_name} bs=1M count=2048 && '
+                    pre_command += 'mkisofs -o /var/tmp/${cdrom_new_name}.iso /var/tmp/${cdrom_new_name}'
+                    post_command = "rm -rf /var/tmp/${cdrom_new_name}.iso /var/tmp/${cdrom_new_name} "
+                    post_command += "/var/tmp/${cdrom_orig_name}.iso /var/tmp/${cdrom_orig_name}"
+                    check_orig_items = '{"io-status": "ok", "tray_open": False, "file": "${cdrom_orig_file}"}'
+                    check_new_items = '{"io-status": "ok",  "tray_open": False, "file": "${cdrom_new_file}"}'
                     Linux:
                         check_size = cat /sys/block/sr0/size
                     Windows:
                         check_size = wmic LogicalDisk where DriveType=5 get size
-                    set_dst_params = "{'cdrom_cd2': '/tmp/${cdrom_new_name}.iso'}"
+                    set_dst_params = "{'cdrom_cd2': '/var/tmp/${cdrom_new_name}.iso'}"
                 - with_dataplane_on2off:
                     only virtio_blk
                     with_dataplane = yes

--- a/qemu/tests/migration_with_block.py
+++ b/qemu/tests/migration_with_block.py
@@ -197,7 +197,7 @@ def run(test, params, env):
             str(check_items), logging.info)
         blocks = vm.monitor.info_block()
         for key, val in check_items.items():
-            if (key == 'device' and val == dev_id) or blocks[dev_id][key] == val:
+            if blocks[device_name][key] == val:
                 continue
             test.fail(
                 'No such \"%s: %s\" in the output of query-block.' % (key, val))
@@ -216,7 +216,6 @@ def run(test, params, env):
 
     def change_cdrom():
         """ Change cdrom. """
-        new_img_name = params["cdrom_new_file"]
         error_context.context("Insert new image to device.", logging.info)
         with change_check:
             vm.change_media(device_name, new_img_name)
@@ -328,23 +327,23 @@ def run(test, params, env):
     if with_cdrom:
         cdrom_params = params.object_params(params['cdroms'])
         check_orig_items = ast.literal_eval(cdrom_params['check_orig_items'])
-        dev_id = check_orig_items['device']
-        check_cdrom_info_by_qmp(check_orig_items)
-        orig_size = compare_cdrom_size(params['cdrom_orig_file'])
-
         orig_img_name = params["cdrom_orig_file"]
+        new_img_name = params["cdrom_new_file"]
         device_name = vm.get_block({"file": orig_img_name})
         if device_name is None:
             test.fail("Failed to get device using image %s." % orig_img_name)
+        check_cdrom_info_by_qmp(check_orig_items)
+        orig_size = compare_cdrom_size(orig_img_name)
 
         eject_check = QMPEventCheckCDEject(vm, device_name)
         change_check = QMPEventCheckCDChange(vm, device_name)
         eject_cdrom()
         change_cdrom()
 
+        device_name = vm.get_block({"file": new_img_name})
         check_new_items = ast.literal_eval(cdrom_params['check_new_items'])
         check_cdrom_info_by_qmp(check_new_items)
-        new_size = compare_cdrom_size(params['cdrom_new_file'])
+        new_size = compare_cdrom_size(new_img_name)
         if new_size == orig_size:
             test.fail('The new size inside guest is equal to the orig iso size.')
 


### PR DESCRIPTION
Update the device_name of new changed cdrom,
it will change to a random string '#block*' after cdrom changed.
Adjust the code to get the device_name first,
then to check_items one by one in qmp info block.

ID: 1806418
Signed-off-by: Peixiu Hou <phou@redhat.com>