### PR TITLE
blockdev_inc_backup_test: Error msg changed when size is different

### DIFF
--- a/qemu/tests/cfg/blockdev_inc_backup_test.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_test.cfg
@@ -62,15 +62,14 @@
             variants:
                 - @default_complete:
                 - grouped_complete:
+                    no negative_test
                     completion_mode = grouped
             variants:
                 - @postive_test:
                 - negative_test:
-                    # ensure created tmpfile big that incremental backup image
-                    # and tmpfile size less than image size
+                    negative_test = yes
+                    error_msg = Source and target image have different sizes
                     image_size_inc2 = 1G
-                    tempfile_size_data2 = 1280M
-                    create_tempfile_timeout = 900
                     only auto_complete
             variants:
                 - @auto_complete:


### PR DESCRIPTION
'Source and target image have different sizes' will output no
matter completion-mode is individual or grouped

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1954371