### PR TITLE
seabios: use directory /var/tmp instead of /tmp

### DIFF
--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -18,7 +18,7 @@
     variants:
         - cdrom:
             cdroms = "test"
-            cdrom_test = "/tmp/test.iso"
+            cdrom_test = "/var/tmp/test.iso"
             boot_entry_info = "Booting from DVD/CD..."
             start_vm = no
             dev_name = cdrom

--- a/qemu/tests/cfg/seabios_order_once.cfg
+++ b/qemu/tests/cfg/seabios_order_once.cfg
@@ -11,7 +11,7 @@
     force_create_image_stg = yes
     remove_image_stg = yes
     cdroms = "test"
-    cdrom_test = "/tmp/test.iso"
+    cdrom_test = "/var/tmp/test.iso"
     restart_key = "ctrl-alt-delete"
     variants:
         - with_order:


### PR DESCRIPTION
tmpfs filesystem does not support O_DIRECT.

ID: 1953265

Signed-off-by: ybduan <yduan@redhat.com>