### PR TITLE
qemu_guest_agent: Change '/tmp' for checking fsfreeze on rhel9

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -177,7 +177,8 @@
             image_snapshot = yes
         - check_fsfreeze:
             gagent_fs_test_cmd = "echo foo > %s/foo"
-            mountpoint_def = "/tmp"
+            delete_temp_file = "rm -rf ${mountpoint_def}/foo"
+            mountpoint_def = "/home"
             Windows:
                 gagent_fs_test_cmd = "echo 'fsfreeze test' > %s\test_file.txt"
                 mountpoint_def = "C:"
@@ -202,7 +203,8 @@
             type = qemu_guest_agent_snapshot
             gagent_check_type = fsfreeze
             gagent_fs_test_cmd = "echo foo > %s/foo"
-            mountpoint_def = "/tmp"
+            delete_temp_file = "rm -rf ${mountpoint_def}/foo"
+            mountpoint_def = "/home"
             virt_test_type = qemu
             images += " data"
             force_create_image_data = yes

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -2359,7 +2359,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                     mountpoints = check_mountpoints
                 write_cmd_list = []
                 for mpoint in mountpoints:
-                    mpoint = "/tmp" if mpoint == "/" else mpoint
+                    mpoint = "/home" if mpoint == "/" else mpoint
                     write_cmd_m = write_cmd % mpoint
                     write_cmd_list.append(write_cmd_m)
                 write_cmd_guest = ";".join(write_cmd_list)
@@ -2402,7 +2402,12 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param params: Dictionary with the test parameters
         :param env: Dictionary with test environmen.
         """
+        session = self._get_session(params, self.vm)
+        self._open_session_list.append(session)
+
         self._fsfreeze()
+        # clean env at the end of testing
+        session.cmd(self.params["delete_temp_file"])
 
     @error_context.context_aware
     def gagent_check_fsfreeze_list(self, test, params, env):


### PR DESCRIPTION
qemu_guest_agent.cfg: change 'tmp' to '/home' because '/tmp' is
 tmpfs that not support ioctl(FSFREEZE)

ID: 1928609
Signed-off-by: Dehan Meng <demeng@redhat.com>