### PR TITLE
travis-ci: Update pylint version

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,6 +1,6 @@
 virtualenv==1.9.1
 pylint==1.9.5; python_version < '3.0'
-pylint==2.7.2; python_version >= '3.0'
+pylint==2.8.0; python_version >= '3.0'
 inspektor==0.5.2
 autotest==0.16.2; python_version < '3.0'
 autopep8==1.5.4


### PR DESCRIPTION
Update pylint to the fixed version 2.8.0, seems the 2.7.2 has an issue
that could not generate the "checkall" subcommand.

ID: 1953289
Signed-off-by: Yihuang Yu <yihyu@redhat.com>