### PR TITLE
kdump: fix the issue of kdump ssh case

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -2,6 +2,8 @@
     virt_test_type = qemu libvirt
     no Windows
     no RHEL.3, RHEL.4
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
     type = kdump
     # time waited for the completion of crash dump
     crash_timeout = 1200
@@ -30,7 +32,7 @@
     variants:
         - @default:
         - nmi:
-            kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args='crashkernel=128M nmi_watchdog=1'"
+            kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args='crashkernel=auto nmi_watchdog=1'"
             crash_cmd = nmi
 
     variants:
@@ -63,7 +65,7 @@
                 - io_stress:
                     stress_type = io
                     tmp_dir = "/var/tmp/"
-                    install_cmd = "tar -xzvf ${tmp_dir}stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install"
+                    install_cmd = "tar -xzvf ${tmp_dir}stress/stress-1.0.4.tar.gz -C ./ && cd stress-1.0.4 && ./configure --prefix=/usr && make && make install"
                     app_check_cmd = "stress --help"
                     start_cmd = "stress --cpu 4 --io 4 --vm 2 --vm-bytes 256M --quiet &"
                     kdump_check_cmd = "pidof -s stress"
@@ -77,6 +79,9 @@
             vmcore_path = "/var/crash/guest"
             vmcore_chk_cmd = "ls -R %s | grep vmcore"
             vmcore_rm_cmd = "/bin/rm -rf %s"
+            kdump_rsa_path = '/root/.ssh/kdump_id_rsa.pub'
+            auth_key_path = '/root/.ssh/authorized_keys'
+            authorized_key_cmd = "/bin/echo -e "%s" >> ${auth_key_path}"
             host_pwd = redhat
             guest_pwd = redhat
 


### PR DESCRIPTION
This issue root case is missing variable and can not
execute 'kdumpctl propagate' successfully.

Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:1910846