### PR TITLE
Add adaption for driver_load on s390x

### DIFF
--- a/qemu/tests/cfg/driver_load.cfg
+++ b/qemu/tests/cfg/driver_load.cfg
@@ -43,7 +43,7 @@
 
         - with_block:
             drive_format_image1 = ide
-            pseries, aarch64:
+            pseries, aarch64, s390x:
                drive_format_image1 = scsi-hd
             q35:
                 drive_format_image1 = ahci
@@ -60,7 +60,7 @@
         - with_vioscsi:
             cd_format_fixed = ide
             drive_format_image1 = ide
-            pseries, aarch64:
+            pseries, aarch64, s390x:
                cd_format_fixed = scsi-cd
                drive_format_image1 = virtio
             q35:


### PR DESCRIPTION
Virtual_block: add adaption for driver_load.with_block and driver_load
.with_vioscsi on s390x

ID: 1953997

Signed-off-by: Boqiao Fu <bfu@redhat.com>