### PR TITLE
rh_kernel_update: verify virtio only for RHEL.6 and RHEL.7 guest

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -25,6 +25,10 @@
     RHEL.7:
         kernel_deps_pkgs += " kmod hmaccalc"
         upgrade_pkgs += " qemu-guest-agent"
+    RHEL.8:
+        kernel_pkgs += " kernel-core kernel-modules"
+        upgrade_pkgs = ""
+        kernel_deps_pkgs = ""
     x86_64:
         pkg_arch = x86_64
     i386:
@@ -46,22 +50,13 @@
     s390x:
         virtio_drivers_list = ""
         update_kernel_cmd = "zipl"
-    RHEL.8:
-        kernel_pkgs += " kernel-core kernel-modules"
-        upgrade_pkgs = ""
-        kernel_deps_pkgs = ""
-        # From kernel 4.17, some virtio drivers were built into kernel
-        # so not need to install and verify them
-        install_virtio = no
-        verify_virtio = no
     ignore_deps = yes
     install_debuginfo = no
     install_pkg_timeout = 600
-    virtio_net:
-        virtio_drivers_list += " virtio_net"
+    RHEL.6, RHEL.7:
         install_virtio = yes
         verify_virtio = yes
-    virtio_blk:
-        virtio_drivers_list += " virtio_blk"
-        install_virtio = yes
-        verify_virtio = yes
+        virtio_net:
+            virtio_drivers_list += " virtio_net"
+        virtio_blk:
+            virtio_drivers_list += " virtio_blk"


### PR DESCRIPTION
Signed-off-by: Yumei Huang <yuhuang@redhat.com>
ID: 1949402