### PR TITLE
balloon_check: restrict iommu testing only for Intel platform

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -70,6 +70,7 @@
         - iommu_enabled:
             only q35
             only balloon_evict_and_enlarge
+            only HostCpuVendor.intel
             #RHEL guest doesn't support, refer to bug 1791593
             only Windows
             no WinXP WinVista Win7 Win8 Win8.1 Win2000 Win2003


### PR DESCRIPTION
Signed-off-by: Yumei Huang <yuhuang@redhat.com>
ID: 1954954