### PR TITLE
chardev_tls_encryption: fix 'isa' isn't a valid device on aarch64

### DIFF
--- a/qemu/tests/cfg/chardev_tls_encryption.cfg
+++ b/qemu/tests/cfg/chardev_tls_encryption.cfg
@@ -8,6 +8,10 @@
     depends_pkgs = "gnutls-utils"
     ppc64, ppc64le:
         serial_device = "spapr-vty"
+    aarch64:
+        serials += " vs"
+        serial_type_vs = virtserialport
+        serial_device = ${serial_type_vs}
     variants:
         - host_to_guest:
             expected_msg = "Channel binding 'tls-unique'"


### PR DESCRIPTION
fix 'isa-serial' isn't a valid device on aarch64

id:1958727
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>