### PR TITLE
Add support for qemu_disk_img on s390x

### DIFF
--- a/qemu/tests/cfg/qemu_disk_img.cfg
+++ b/qemu/tests/cfg/qemu_disk_img.cfg
@@ -148,7 +148,7 @@
                     drive_format_snA = ide
                     q35:
                         drive_format_snA = ahci
-                    aarch64, pseries:
+                    aarch64, pseries, s390x:
                         virtio_scsi:
                             drive_format_snA = virtio
                         virtio_blk:


### PR DESCRIPTION
disk_format: add qemu_disk_img.info.change_block_interface for s390x

ID: 1959818

Signed-off-by: Boqiao Fu <bfu@redhat.com>