### PR TITLE
virtio_fs_share_data:update the acquisition way of xfstest tool

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -163,7 +163,6 @@
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.
                     # And this case only supports Linux, and don't need to check screendump. So turn off this feature.
-                    xfstest_pkg = xfstests.tar.bz2
                     filesystems = fs1 fs2
                     fs_source_dir_fs1 = /tmp/virtio_fs1_test
                     fs_source_dir_fs2 = /tmp/virtio_fs2_test
@@ -171,7 +170,7 @@
                     fs_target_fs2 = myfs2
                     fs_dest_fs1 = '/mnt/${fs_target_fs1}'
                     fs_dest_fs2 = '/mnt/${fs_target_fs2}'
-                    cmd_unpack_xfstest = 'tar -jxvf ${fs_dest_fs1}/${xfstest_pkg} -C /home'
+                    cmd_download_xfstest = 'cd /home && rm -rf xfstests-dev && git clone https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git'
                     cmd_yum_install = 'yum install -y git acl attr automake bc dump e2fsprogs fio gawk gcc libtool lvm2 '
                     cmd_yum_install += 'make psmisc quota sed xfsdump xfsprogs libacl-devel libattr-devel libaio-devel '
                     cmd_yum_install += 'libuuid-devel xfsprogs-devel python3 sqlite'

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -90,8 +90,7 @@ def run(test, params, env):
     # xfstest config
     cmd_xfstest = params.get('cmd_xfstest')
     fs_dest_fs2 = params.get('fs_dest_fs2')
-    xfstest_pkg = params.get('xfstest_pkg')
-    cmd_unpack_xfstest = params.get('cmd_unpack_xfstest')
+    cmd_download_xfstest = params.get('cmd_download_xfstest')
     cmd_yum_install = params.get('cmd_yum_install')
     cmd_make_xfs = params.get('cmd_make_xfs')
     cmd_setenv = params.get('cmd_setenv')
@@ -262,10 +261,8 @@ def run(test, params, env):
             if cmd_xfstest:
                 error_context.context("Run xfstest on guest.", logging.info)
                 utils_misc.make_dirs(fs_dest_fs2, session)
-                host_path = os.path.join(data_dir.get_deps_dir('xfstest'),
-                                         xfstest_pkg)
-                scp_to_remote(host_addr, port, username, password, host_path, fs_dest_fs1)
-                session.cmd(cmd_unpack_xfstest.format(fs_dest), 180)
+                if session.cmd_status(cmd_download_xfstest, 360):
+                    test.error("Failed to download xfstests-dev")
                 session.cmd(cmd_yum_install, 180)
                 session.cmd(cmd_make_xfs, 360)
                 session.cmd(cmd_setenv, 180)


### PR DESCRIPTION
xfstests-dev is an upstream tool, so it's updated frequently.
After this update, you will use the 'git clone' method to
get the latest code every time.

id: 1960086
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>