### PR TITLE
qemu_guest_agent: Restrict to test OS of check_set_mem_blocks on aarch64

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -122,6 +122,8 @@
             gagent_check_type = set_vcpus
         - check_set_mem_blocks:
             no Windows
+            aarch64:
+                no RHEL.7 RHEL.8
             gagent_check_type = set_mem_blocks
         - check_get_time:
             gagent_check_type = get_time


### PR DESCRIPTION
kernel-4.x on aarch64 does not inculde "/sys/devices/system/memory", so
the test "check_set_mem_blocks" will fail, skip test it on RHEL7 and
RHEL8.

ID: 1962237
Signed-off-by: Yihuang Yu <yihyu@redhat.com>