### PR TITLE
smbios: only test smbios on x86 platforms

### DIFF
--- a/qemu/tests/cfg/smbios.cfg
+++ b/qemu/tests/cfg/smbios.cfg
@@ -1,7 +1,6 @@
 - smbios_table: install setup image_copy unattended_install.cdrom
     only Linux
-    # dmidecode not available (and no plans for it) on s390x
-    no s390x
+    only i386 x86_64
     type = smbios_table
     requires_root = yes
     start_vm = no


### PR DESCRIPTION
smbios should only be tested on x86, because -smbios does not support on
non-x86 platforms IIUC.

ID: 1962242
Signed-off-by: Yihuang Yu <yihyu@redhat.com>