### PR TITLE
boot_with_different_vectors: Support GIC interrupt of aarch64

### DIFF
--- a/qemu/tests/boot_with_different_vectors.py
+++ b/qemu/tests/boot_with_different_vectors.py
@@ -106,7 +106,8 @@ def run(test, params, env):
         irq_check_cmd = params["irq_check_cmd"]
         output = session.cmd_output(irq_check_cmd).strip()
         if vectors == 0 or vectors == 1:
-            if not (re.findall("IO-APIC.*fasteoi|XICS.*Level|XIVE.*Level",
+            if not (re.findall("IO-APIC.*fasteoi|XICS.*Level|XIVE.*Level|"
+                               "GIC.*Level",
                                output)):
                 msg = "Could not find interrupt controller for virito device"
                 msg += " when vectors = %d" % vectors

--- a/qemu/tests/cfg/boot_with_different_vectors.cfg
+++ b/qemu/tests/cfg/boot_with_different_vectors.cfg
@@ -5,6 +5,7 @@
     master_images_clone = image1
     remove_image_image1 = yes
     type = boot_without_vectors
+    disable_pci_msi = no
 
     Linux:
         no RHEL.3 RHEL.4 RHEL.5 RHEL.6


### PR DESCRIPTION
aarch64 uses GICv2/3 interrupt controller, adds support in the
boot_with_different_vectors.py

ID: 1964001
Signed-off-by: Yihuang Yu <yihyu@redhat.com>