### PR TITLE
file_transfer: clone_master should be used to avoid changing kernel CML

### DIFF
--- a/generic/tests/cfg/file_transfer.cfg
+++ b/generic/tests/cfg/file_transfer.cfg
@@ -24,3 +24,6 @@
                             #Force disable guest msi
                             only Linux
                             disable_pci_msi = yes
+                            clone_master = yes
+                            master_images_clone = image1
+                            remove_image_image1 = yes


### PR DESCRIPTION
'disable_pci_msi = yes' will change the kernel command line, so we
should apply a temporary image to avoid dirty change of the kernel
command line.

ID: 1964007
Signed-off-by: Yihuang Yu <yihyu@redhat.com>