### PR TITLE
x86_cpu_flags:test default cpu model

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -93,6 +93,10 @@
                             cpu_model_flags += ",+pcid,+invpcid"
         - others:
             variants:
+                - test_default_model:
+                    auto_cpu_model = no
+                    # will use the default variable 'default_cpu_model' in avocado-vt
+                    flags = ""
                 - flag_disable:
                     only Linux
                     type = x86_cpu_flag_disable


### PR DESCRIPTION
ID: 1965165

Cover the test scenario to test default cpu model,
Now the default cpu model is 'qemu64'

Signed-off-by: nanliu <nanliu@redhat.com>