### PR TITLE
virtio-fs: start virtiofs service at first register for windows vm

### DIFF
--- a/qemu/tests/virtio_fs_multi_vms.py
+++ b/qemu/tests/virtio_fs_multi_vms.py
@@ -109,7 +109,7 @@ def run(test, params, env):
             viofs_sc_start_cmd = params["viofs_sc_start_cmd"]
             viofs_sc_query_cmd = params["viofs_sc_query_cmd"]
 
-            logging.info("Query virtiofs service status.")
+            logging.info("Check if virtiofs service is registered.")
             status, output = session.cmd_status_output(viofs_sc_query_cmd)
             if "not exist as an installed service" in output:
                 logging.info("Register virtiofs service in windows guest.")
@@ -118,7 +118,10 @@ def run(test, params, env):
                 sc_create_s, sc_create_o = session.cmd_status_output(viofs_sc_create_cmd)
                 if sc_create_s != 0:
                     test.fail("Failed to register virtiofs service, output is %s" % sc_create_o)
-            elif "RUNNING" not in output:
+
+            logging.info("Check if virtiofs service is started.")
+            status, output = session.cmd_status_output(viofs_sc_query_cmd)
+            if "RUNNING" not in output:
                 logging.info("Start virtiofs service.")
                 sc_start_s, sc_start_o = session.cmd_status_output(viofs_sc_start_cmd)
                 if sc_start_s != 0:
@@ -153,6 +156,9 @@ def run(test, params, env):
                                                        condition=vol_con)
                 volume_letter = utils_misc.wait_for(lambda: vol_func,
                                                     cmd_timeout)
+                if volume_letter is None:
+                    test.fail("Could not get virtio-fs mounted volume"
+                              " letter for %s." % fs_target)
                 fs_dest = "%s:" % volume_letter
 
             guest_file = os.path.join(fs_dest, 'fs_test')

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -185,7 +185,7 @@ def run(test, params, env):
             viofs_sc_start_cmd = params["viofs_sc_start_cmd"]
             viofs_sc_query_cmd = params["viofs_sc_query_cmd"]
 
-            logging.info("Query virtiofs service status.")
+            logging.info("Check if virtiofs service is registered.")
             status, output = session.cmd_status_output(viofs_sc_query_cmd)
             if "not exist as an installed service" in output:
                 logging.info("Register virtiofs service in windows guest.")
@@ -194,7 +194,10 @@ def run(test, params, env):
                 sc_create_s, sc_create_o = session.cmd_status_output(viofs_sc_create_cmd)
                 if sc_create_s != 0:
                     test.fail("Failed to register virtiofs service, output is %s" % sc_create_o)
-            elif "RUNNING" not in output:
+
+            logging.info("Check if virtiofs service is started.")
+            status, output = session.cmd_status_output(viofs_sc_query_cmd)
+            if "RUNNING" not in output:
                 logging.info("Start virtiofs service.")
                 sc_start_s, sc_start_o = session.cmd_status_output(viofs_sc_start_cmd)
                 if sc_start_s != 0:
@@ -217,6 +220,8 @@ def run(test, params, env):
             vol_con = "VolumeName='%s'" % virtio_fs_disk_label
             vol_func = utils_misc.get_win_disk_vol(session, condition=vol_con)
             volume_letter = utils_misc.wait_for(lambda: vol_func, cmd_timeout)
+            if volume_letter is None:
+                test.fail("Could not get virtio-fs mounted volume letter.")
             fs_dest = "%s:" % volume_letter
 
         guest_file = os.path.join(fs_dest, 'fs_test')


### PR DESCRIPTION
Should start virtiofs service at first register and fail test if not
get virtio-fs mounted volume letter.
ID: 1958446
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>