### PR TITLE
Add a new case, create luks-inside-qcow2 image with non utf8 secret

### DIFF
--- a/qemu/tests/cfg/qemu_img_negative.cfg
+++ b/qemu/tests/cfg/qemu_img_negative.cfg
@@ -27,6 +27,7 @@
                     create_image_new = no
                     rebase_list = "sn > new"
         - luks_with_non_utf8_secret:
+            required_qemu = [4.2.0-23, )
             only luks
             type = image_creation_luks_with_non_utf8_secret
             start_vm = no
@@ -35,6 +36,18 @@
             err_info = "Data from secret\s+\w+\s+is not valid UTF-8"
             echo_non_utf8_secret_cmd = "echo -n -e '\x3a\x3c\x3b\xff' > %s"
             qemu_img_create_cmd = "qemu-img create -f luks --object secret,id=sec0,file=%s -o key-secret=sec0 %s 10M"
+            image_name_stg = "images/stg"
+            remove_image_stg = yes
+        - luks_inside_qcow2_with_non_utf8_secret:
+            required_qemu = [6.0.0-16, )
+            only qcow2
+            type = image_creation_luks_with_non_utf8_secret
+            start_vm = no
+            create_image = no
+            images = stg
+            err_info = "Data from secret\s+\w+\s+is not valid UTF-8"
+            echo_non_utf8_secret_cmd = "echo -n -e '\x3a\x3c\x3b\xff' > %s"
+            qemu_img_create_cmd = "qemu-img create -f qcow2 --object secret,id=sec0,file=%s -o encrypt.format=luks,encrypt.key-secret=sec0 %s 10M"
             image_name_stg = "images/stg"
             remove_image_stg = yes
         - snapshot:


### PR DESCRIPTION
1. It should be failed to create the image.
2. The error information should be corret.
   e.g. Data from secret sec0 is not valid UTF-8

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1966713