### PR TITLE
boot_without_vectors: Failed to clone image

### DIFF
--- a/qemu/tests/boot_without_vectors.py
+++ b/qemu/tests/boot_without_vectors.py
@@ -58,7 +58,7 @@ def run(test, params, env):
         :param vm: guest vm
         """
         login_timeout = int(params.get("login_timeout", 360))
-        env_process.preprocess_vm(test, params, env, params.get("main_vm"))
+        env_process.preprocess(test, params, env)
         vm = env.get_vm(params["main_vm"])
         vm.verify_alive()
         session = vm.wait_for_login(timeout=login_timeout)


### PR DESCRIPTION
1.'disable_pci_msi = yes' will change the kernel command line,
but falied to clone image, so change the code to avoid dirty
change of the kernel command line.

ID:1966855
Signed-off-by: Lei Yang <leiayang@redhat.com>