### PR TITLE
Change the session mode to avoid dirty output

### DIFF
--- a/qemu/tests/bridge_mirror.py
+++ b/qemu/tests/bridge_mirror.py
@@ -116,16 +116,16 @@ def run(test, params, env):
             vm.verify_alive()
             ip = params["ip_%s" % vm_name]
             mac = vm.get_mac_address()
-            session = vm.wait_for_serial_login(timeout=login_timeout)
-            session.cmd(stop_NM_cmd, ignore_all_errors=True)
-            session.cmd(stop_firewall_cmd, ignore_all_errors=True)
-            nic_name = utils_net.get_linux_ifname(session, mac)
+            serial_session = vm.wait_for_serial_login(timeout=login_timeout)
+            serial_session.cmd_output_safe(stop_NM_cmd)
+            serial_session.cmd_output_safe(stop_firewall_cmd)
+            nic_name = utils_net.get_linux_ifname(serial_session, mac)
             ifname = vm.get_ifname()
             ifset_cmd = "ip addr add %s/%s dev %s" % (ip, net_mask, nic_name)
             ifup_cmd = "ip link set dev %s up" % nic_name
-            session.cmd(ifset_cmd)
-            session.cmd(ifup_cmd)
-            vms_info[vm_name] = [vm, ifname, ip, session, nic_name]
+            serial_session.cmd_output_safe(ifset_cmd)
+            serial_session.cmd_output_safe(ifup_cmd)
+            vms_info[vm_name] = [vm, ifname, ip, serial_session, nic_name]
 
         vm_mirror = vm_names[0]
         vm_src = vm_names[1]

--- a/qemu/tests/memory_leak_after_nichotplug.py
+++ b/qemu/tests/memory_leak_after_nichotplug.py
@@ -28,7 +28,7 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     timeout = int(params.get("login_timeout", 360))
-    session = vm.wait_for_serial_login(timeout=timeout)
+    session = vm.wait_for_login(timeout=timeout)
     os_type = params.get("os_type")
 
     free_mem_before_nichotplug = utils_misc.get_free_mem(session,
@@ -55,12 +55,11 @@ def run(test, params, env):
         mac = vm.get_mac_address()
         guest_nic = utils_net.get_linux_ifname(session, mac)
         for i in range(1, 300):
-            session.cmd("ip link add link %s %s.%s type vlan id %s" %
+            session.cmd("ip link add link %s name %s.%s type vlan id %s" %
                         (guest_nic, guest_nic, i, i))
         time.sleep(3)
         for i in range(1, 300):
-            session.cmd("ip link delete %s.%s" %
-                        (guest_nic, i))
+            session.cmd("ip link delete %s.%s" % (guest_nic, i))
 
     free_mem_after_nichotplug = utils_misc.get_free_mem(session,
                                                         os_type)


### PR DESCRIPTION
1.From the session.cmd mode change to serial_session.cmd_out_safe
mode to avoid dirty output due to other serial information.
2.From console session change to ssh session

ID:1966864
Signed-off-by: Lei Yang <leiayang@redhat.com>