### PR TITLE
Re-get session for hotplug on s390x after simple hotplug a disk

### DIFF
--- a/qemu/tests/block_hotplug.py
+++ b/qemu/tests/block_hotplug.py
@@ -83,6 +83,8 @@ def run(test, params, env):
             if ret[1] is False:
                 test.fail("Failed to %s device '%s', %s." % (action, dev, ret[0]))
 
+        if params.get("machine_type").startswith('s390'):
+            session = vm.wait_for_login(timeout=timeout)
         num = 1 if action == 'hotplug' else len(data_imgs)
         plugged_disks = wait_plug_disks(session, action, disks_before_plug, num, windows, test)
         session.close()


### PR DESCRIPTION
Virtual_block: Since s390x could only use serial to connect to guest,
and serial could allow one access at the same time, get session again
after simple hotplug incase could not get return from the session

ID: 1967661

Signed-off-by: Boqiao Fu <bfu@redhat.com>