### PR TITLE
uefi_pkg: update the number of descriptor meta files

### DIFF
--- a/qemu/tests/cfg/uefi_pkg.cfg
+++ b/qemu/tests/cfg/uefi_pkg.cfg
@@ -8,10 +8,10 @@
     Host_RHEL.m7:
         query_package = "rpm -qa | grep OVMF"
         ovmf_package_name = "OVMF.*el7.*"
-    Host_RHEL.m8:
+    Host_RHEL.m8, Host_RHEL.m9:
         query_package = "rpm -qa | grep edk2-ovmf"
-        ovmf_package_name = "edk2-ovmf.*el8.*"
+        ovmf_package_name = "edk2-ovmf.*(el8|el9).*"
     variants:
         - check_descriptor_meta_files:
             file_suffix = ".json"
-            number_of_files = 2
+            number_of_files = 3

--- a/qemu/tests/uefi_pkg.py
+++ b/qemu/tests/uefi_pkg.py
@@ -13,9 +13,11 @@ def run(test, params, env):
     1) Check edk2-ovmf package has been installed already.
     2) Qurey file list on edk2-ovmf package.
     3) Make sure the descriptor meta-files will be in file list.
-       2 files in total.
+       2 or 3 files in total.
        For rhel7: 50-ovmf-sb.json, 60-ovmf.json
-       For rhel8: 40-edk2-ovmf-sb.json, 50-edk2-ovmf.json
+       For rhel8 and rhel9: 40-edk2-ovmf-sb.json, 50-edk2-ovmf.json
+       If it supports SEV-ES on rhel8 and rhel9, there are 3 files in total.
+       40-edk2-ovmf-sb.json, 50-edk2-ovmf.json and 50-edk2-ovmf-cc.json
     4) Check the JSON files internally.
        check that the "filename" elements in both files point to valid files.
 
@@ -55,10 +57,10 @@ def run(test, params, env):
     for line in output.splitlines():
         if line.endswith(file_suffix):
             meta_files.append(line)
-    if len(meta_files) != int(params["number_of_files"]):
-        test.fail("The number of JSON files should be %s. "
-                  "The actual file list is %s"
-                  % (params["number_of_files"], meta_files))
+    if len(meta_files) > int(params["number_of_files"]):
+        test.fail("The number of JSON files should be less than or "
+                  "equal to %s. The actual file list is %s",
+                  params["number_of_files"], meta_files)
     error_context.context("Check the 'filename' elements in both json"
                           " files point to valid files.", logging.info)
     for meta_file in meta_files:


### PR DESCRIPTION
1. if it supports sev-es, the number is 3
2. add support for rhel9

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1960484