### PR TITLE
blockdev_*_no*_exist*: Update error message to adapt qemu6.0 change

### DIFF
--- a/qemu/tests/blockdev_commit_non_existed_node.py
+++ b/qemu/tests/blockdev_commit_non_existed_node.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from virttest.qemu_monitor import QMPCmdError
 
@@ -29,7 +30,8 @@ class BlockdevCommitNonExistedNode(BlockDevCommitTest):
             self.main_vm.monitor.cmd(cmd, args)
         except QMPCmdError as e:
             logging.info("Error message is %s", e.data)
-            if self.params["qmp_error_msg"] not in str(e.data):
+            qmp_error_msg = self.params.get("qmp_error_msg")
+            if not re.search(qmp_error_msg, str(e.data)):
                 self.test.fail("Error message not as expected")
         else:
             self.test.fail("Block commit should fail with "

--- a/qemu/tests/blockdev_inc_backup_target_not_exist.py
+++ b/qemu/tests/blockdev_inc_backup_target_not_exist.py
@@ -1,3 +1,5 @@
+import re
+
 from virttest.qemu_monitor import QMPCmdError
 
 from provider.block_dirty_bitmap import block_dirty_bitmap_add
@@ -27,7 +29,8 @@ class BlockdevIncbkNonExistedTarget(BlockdevLiveBackupBaseTest):
                  'sync': 'incremental'}
             )
         except QMPCmdError as e:
-            if self.params['error_msg'] not in str(e):
+            error_msg = self.params.get('error_msg')
+            if not re.search(error_msg, str(e)):
                 self.test.fail('Unexpected error: %s' % str(e))
         else:
             self.test.fail('blockdev-backup succeeded unexpectedly')

--- a/qemu/tests/blockdev_stream_none_existed_overlay.py
+++ b/qemu/tests/blockdev_stream_none_existed_overlay.py
@@ -1,3 +1,5 @@
+import re
+
 from virttest.qemu_monitor import QMPCmdError
 
 from provider.blockdev_stream_base import BlockDevStreamTest
@@ -21,7 +23,8 @@ class BlockdevStreamNoneExistedOverlay(BlockDevStreamTest):
                 {'device': self.params['none_existed_overlay_node']}
             )
         except QMPCmdError as e:
-            if self.params['error_msg'] not in str(e):
+            error_msg = self.params.get("error_msg")
+            if not re.search(error_msg, str(e)):
                 self.test.fail('Unexpected error: %s' % str(e))
         else:
             self.test.fail('block-stream succeeded unexpectedly')

--- a/qemu/tests/cfg/blockdev_commit_non_existed_node.cfg
+++ b/qemu/tests/cfg/blockdev_commit_non_existed_node.cfg
@@ -21,7 +21,8 @@
     device_tag = "data"
     rebase_mode = unsafe
     qemu_force_use_drive_expression = no
-    qmp_error_msg = "'desc': 'Cannot find device= nor node_name=sn0'"
+    qmp_error_msg = "Cannot find device= nor node_name=sn0"
+    qmp_error_msg += | "Cannot find device='' nor node-name='sn0'"
     variants:
         - none_existed_base:
             none_existed_base = sn0

--- a/qemu/tests/cfg/blockdev_inc_backup_target_not_exist.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_target_not_exist.cfg
@@ -18,4 +18,5 @@
     image_backup_chain_image1= inc
     full_backup_options = {"persistent": "off", "disabled": "off"}
     non_existed_target = target_node
-    error_msg = Cannot find device=${non_existed_target} nor node_name=${non_existed_target}
+    error_msg = "Cannot find device=${non_existed_target} nor node_name=${non_existed_target}"
+    error_msg += | "Cannot find device='${non_existed_target}' nor node-name='${non_existed_target}'"

--- a/qemu/tests/cfg/blockdev_stream_none_existed_overlay.cfg
+++ b/qemu/tests/cfg/blockdev_stream_none_existed_overlay.cfg
@@ -16,4 +16,5 @@
     node = drive_image1
     snapshot_tag = sn
     none_existed_overlay_node = drive_${snapshot_tag}
-    error_msg = 'Cannot find device=${none_existed_overlay_node} nor node_name=${none_existed_overlay_node}'
+    error_msg = "Cannot find device=${none_existed_overlay_node} nor node_name=${none_existed_overlay_node}"
+    error_msg += | "Cannot find device='${none_existed_overlay_node}' nor node-name='${none_existed_overlay_node}'"


### PR DESCRIPTION
Since qemu6.0, the node name related error message changed to
use 'node-name' instead of the original 'node_name' and with ''
surrounded, so update the related cases to make them work on
both qemu6.0 and former qemu versions.

ID: 1967875
Signed-off-by: Nini Gu <ngu@redhat.com>