### PR TITLE
blockdev_inc_backup_migrate_without_bitmap: Change to use 'recording' field to check the bitmap status

### DIFF
--- a/qemu/tests/blockdev_inc_backup_migrate_without_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_migrate_without_bitmap.py
@@ -27,7 +27,7 @@ class BlockdevIncbkMigrateNoBitmap(BlockdevLiveBackupBaseTest):
             if bitmap is None:
                 self.test.fail('No persistent bitmap was found '
                                'after migration')
-            if bitmap.get('status') != 'disabled':
+            if bitmap.get('recording') is not False:
                 self.test.fail('Persistent bitmap was not disabled '
                                'after migration')
             v = debug_block_dirty_bitmap_sha256(self.main_vm,


### PR DESCRIPTION
In order to be compatible with both qemu6.0 and former qemu
versions, change to use 'recording' field in qmp 'query-block'
ouput to get the bitmap status.

ID: 1964824
Signed-off-by: Nini Gu <ngu@redhat.com>