### PR TITLE
Modify pattern for device bit check on s390x

### DIFF
--- a/qemu/tests/cfg/device_bit_check.cfg
+++ b/qemu/tests/cfg/device_bit_check.cfg
@@ -31,6 +31,8 @@
                 bus_extra_params = ""
                 pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio SCSI"
                 dev_type = "virtio-scsi-.*"
+                s390x:
+                    ccw_id_pattern = "\d+\.\d+\."
         - nic_device:
             only virtio_net
             nic_extra_params = ""


### PR DESCRIPTION
Virtual_block: Add id_pattern works on s390x and modify the checking
command to adapt the test on s390x

ID:1969638

Signed-off-by: Boqiao Fu <bfu@redhat.com>