### PR TITLE
virtio-fs: use virtiofs service method for driver test

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -181,8 +181,11 @@
                 install_path = 'C:\Program Files (x86)'
             install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.7.20172.msi /qn'
             check_installed_cmd = 'dir "%s" |findstr /I winfsp'
-            start_vfs_cmd = "start /b %s -d -1 -D C:\\viofs_log.txt"
-            check_virtiofs_cmd = 'wmic process where caption="virtiofs.exe" list brief'
+            viofs_log_file = C:\\viofs_log.txt
+            viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s -d -1 -D ${viofs_log_file}" start=auto'
+            viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
+            viofs_sc_start_cmd = 'sc start VirtioFsSvc'
+            viofs_sc_query_cmd = 'sc query VirtioFsSvc'
             fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
             fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=600 --thread'
             io_timeout = 700

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -249,8 +249,11 @@
                 install_path = 'C:\Program Files (x86)'
             install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.7.20172.msi /qn'
             check_installed_cmd = 'dir "%s" |findstr /I winfsp'
-            start_vfs_cmd = "start /b %s -d -1 -D C:\\viofs_log.txt"
-            check_virtiofs_cmd = 'wmic process where caption="virtiofs.exe" list brief'
+            viofs_log_file = C:\\viofs_log.txt
+            viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s -d -1 -D ${viofs_log_file}" start=auto'
+            viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
+            viofs_sc_start_cmd = 'sc start VirtioFsSvc'
+            viofs_sc_query_cmd = 'sc query VirtioFsSvc'
             fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
             fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800 --thread'
             io_timeout = 2000


### PR DESCRIPTION
Using service method to start virtiofs exd for driver
 load stress test case and driver update test case.
ID: 1958471
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>