### PR TITLE
nmi_bsod_catch.cfg: Win2022 guest min memory has to be 4096

### DIFF
--- a/qemu/tests/cfg/nmi_bsod_catch.cfg
+++ b/qemu/tests/cfg/nmi_bsod_catch.cfg
@@ -2,7 +2,7 @@
     type = nmi_bsod_catch
     only Windows
     mem_fixed = 2048
-    Win2016, Win2019:
+    Win2016, Win2019, Win2022:
         mem_fixed = 4096
     enable_pvpanic = no
     config_cmds = config_cmd1, config_cmd2, config_cmd3, config_cmd4, config_cmd5, config_cmd6


### PR DESCRIPTION
Win2022 guest min memory has to be 4096.

ID: 1968512
Signed-off-by: Menghuan Li menli@redhat.com