### PR TITLE
kdump: fix problems related to kdump cases

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -28,6 +28,8 @@
         kdump_enable_cmd = "chkconfig kdump on && systemctl restart kdump.service"
         kdump_propagate_cmd = "kdumpctl propagate"
         kdump_restart_cmd = "systemctl restart kdump.service"
+    RHEL.9:
+        kdump_enable_cmd = "systemctl restart kdump.service"
 
     variants:
         - @default:


### PR DESCRIPTION
1.Fix the problems of parameter 'auth_key_path' is missing
2.Fix the problem that the "chkconfig" command cannot be found on rhel9
3.Fix the problem of vmocre file not found
Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:1972457,1975606