### PR TITLE
fix 'query-vnc' command

### DIFF
--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -61,10 +61,8 @@
             cmd_result_check = "post_equal"
             cmd_return_value = "['4096']"
         - qmp_query-vnc:
-            pre_cmd = "change device=vnc,target=127.0.0.1:100"
             qmp_cmd = "query-vnc"
             cmd_result_check = contain
-            cmd_return_value = "[{'enabled': True}, {'service': '6000'}, {'host': '127.0.0.1'}]"
         - qmp_query-block:
             qmp_cmd = "query-block"
             cmd_result_check = contain

--- a/qemu/tests/qmp_command.py
+++ b/qemu/tests/qmp_command.py
@@ -258,6 +258,9 @@ def run(test, params, env):
             # Remove avocado machine type
             vm_machines = params["machine_type"].split(':', 1)[-1]
             expect_o = [{'alias': vm_machines}]
+        elif qmp_cmd == "query-vnc":
+            vnc_port =  vm.get_vnc_port()
+            expect_o = [{'service': str(vnc_port)}, {'enabled': True}, {'host': '0.0.0.0'}]
         check_result(qmp_o, expect_o)
     elif result_check.startswith("post_"):
         logging.info("Verify post qmp command '%s' works as designed.", post_cmd)


### PR DESCRIPTION
'change vnc target' command removed in qemu-kvm-6.0,
 so remove it

id: 1973535

Signed-off-by: Yiqian Wei <yiwei@redhat.com>