### PR TITLE
multi_disk.all_drive_format_types: Support s390x

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -72,7 +72,6 @@
         - all_drive_format_types:
             # virtio-scsi driver support from RHEL6.3
             no RHEL.3 RHEL.4 RHEL.5 RHEL.6.0 RHEL.6.1 RHEL.6.2
-            no s390x
             stg_image_num = 4
             stg_image_size = 100M
             stg_params = "drive_format:ide,scsi,virtio,scsi-hd,usb2"
@@ -92,6 +91,9 @@
                 usb_type_extra_usb = ich9-usb-ehci1
                 ppc64le, ppc64:
                     usb_type_extra_usb = nec-usb-xhci
+            s390x:
+                stg_params = "drive_format:virtio,scsi-hd"
+                usbs = ""
         - virtio_scsi_variants:
             only virtio_scsi
             # virtio-scsi driver support from RHEL6.3


### PR DESCRIPTION
Change the cfg file to let it support s390x.

ID: 1973923
Signed-off-by: Nini Gu <ngu@redhat.com>