### PR TITLE
qemu_guest_agent.py: Change operation 'rm' to 'def' on windows

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -192,6 +192,7 @@
             Windows:
                 gagent_fs_test_cmd = "echo 'fsfreeze test' > %s\test_file.txt"
                 mountpoint_def = "C:"
+                delete_temp_file = "del /f /q ${mountpoint_def}\test_file.txt"
                 write_cmd_timeout = 8
             variants:
                 - @default:
@@ -239,6 +240,7 @@
             Windows:
                 gagent_fs_test_cmd = "echo 'fsfreeze test' > %s\test_file.txt"
                 mountpoint_def = "C:"
+                delete_temp_file = "del /f /q ${mountpoint_def}\test_file.txt"
         - check_suspend:
             type = qemu_guest_agent_suspend
             services_up_timeout = 30

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -2409,7 +2409,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
 
         self._fsfreeze()
         # clean env at the end of testing
-        session.cmd(self.params["delete_temp_file"])
+        session.cmd(params["delete_temp_file"])
 
     @error_context.context_aware
     def gagent_check_fsfreeze_list(self, test, params, env):


### PR DESCRIPTION
Command 'rm -rf ${mountpoint_def}/foo' not recognized as internal
 or external command in Windows, so change this operation to
 windows cmd "def".

ID: 1970167
Signed-off-by: Dehan Meng <demeng@redhat.com>