### PR TITLE
timedrift_check_clock_offset: enable w32time before starting it

### DIFF
--- a/qemu/tests/cfg/timedrift_check_clock_offset.cfg
+++ b/qemu/tests/cfg/timedrift_check_clock_offset.cfg
@@ -38,6 +38,7 @@
                 - bsod:
                     only Windows
                     nmi_cmd = "monitor:inject-nmi"
+                    w32time_conf_cmd = "sc config w32time start=auto"
                 - hang:
                     kill_vm = yes
                     # Notes:
@@ -56,6 +57,7 @@
             query_internal = 600
             query_times = 4
             drift_threshold = 3
+            w32time_conf_cmd = "sc config w32time start=auto"
         - non_event:
             only RHEL
             no aarch64

--- a/qemu/tests/timedrift_check_when_crash.py
+++ b/qemu/tests/timedrift_check_when_crash.py
@@ -50,6 +50,8 @@ def run(test, params, env):
 
     error_context.context("sync time in guest", logging.info)
     if os_type == "windows":
+        w32time_conf_cmd = params["w32time_conf_cmd"]
+        session.cmd(w32time_conf_cmd)
         utils_test.start_windows_service(session, "w32time")
     session.cmd(ntp_cmd)
 

--- a/qemu/tests/timedrift_check_when_hotplug_vcpu.py
+++ b/qemu/tests/timedrift_check_when_hotplug_vcpu.py
@@ -44,6 +44,8 @@ def run(test, params, env):
 
     error_context.context("Sync time from guest to ntpserver", logging.info)
     if os_type == "windows":
+        w32time_conf_cmd = params["w32time_conf_cmd"]
+        session.cmd(w32time_conf_cmd)
         utils_test.start_windows_service(session, "w32time")
     session.cmd(ntp_cmd)
 


### PR DESCRIPTION
ID: 1974173
Signed-off-by: yama <yama@redhat.com>