### PR TITLE
hv_check_cpu_utilization: The cpu usage < 10% is reasonable in auto

### DIFF
--- a/qemu/tests/cfg/hv_check_cpu_utilization.cfg
+++ b/qemu/tests/cfg/hv_check_cpu_utilization.cfg
@@ -16,7 +16,7 @@
     host_check_cmd = top -H -p %s -n ${host_check_times} -d ${host_check_interval} -b > fixed-top-pc-result
     vcpn_thread_pattern = r'thread_id.?[:|=]\s*(\d+)'
     thread_process_cmd = "cat fixed-top-pc-result |grep %s|awk -F ' ' '    {print $9;}'|awk '{sum+=$1} END {print sum/NR}'"
-    thread_cpu_level = 5
+    thread_cpu_level = 10
     post_command = rm -f fixed-top-pc-result
     variants:
         - @default:


### PR DESCRIPTION
The cpu usage of thread X should less than 5% in manual and
less than 10% in auto is reasonable when guest is idle. For
there may start some scripts in the background on host to
occupy some cpu.

ID: 1867849
Signed-off-by: Menghuan Li menli@redhat.com