### PR TITLE
virtio-fs: capsh print support on rhel8 later host

### DIFF
--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -63,7 +63,9 @@
             Windows:
                 cmd_dd = 'dd if=/dev/random of=%s bs=1M count=200'
                 cmd_md5 = "%s: && md5sum.exe %s"
-            cmd_capsh_print = 'capsh --print'
+            cmd_capsh_print = 'capsh --print |grep -i Bounding'
+            Host_RHEL.m8:
+                cmd_capsh_print = 'capsh --print |grep -i Current'
             cmd_capsh_drop = 'capsh --drop=%s --'
             variants:
                 - cap_dac_read_search:


### PR DESCRIPTION
Cmd of 'capsh print' result is changed on rhel8 later host.
Change code to support rhel8 and later host.
ID: 1970220
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>