### PR TITLE
virtio-fs: add vcpu_maxcpus parametor

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -133,8 +133,7 @@
                 - with_fio:
                     no with_fio..with_no_writeback
                     smp = 8
-                    aarch64:
-                        vcpu_maxcpus = 8
+                    vcpu_maxcpus = 8
                     io_timeout = 2000
                     fio_options = '--name=stress --filename=%s --ioengine=libaio --rw=write --direct=1 '
                     fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800'


### PR DESCRIPTION
Add vcpu_maxcpus to qemu command line in case test failed with big smp but small vcpu
on host.
ID: 1973577
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>