### PR TITLE
boot_with_disable_ept: update the status of npt parameter

### DIFF
--- a/qemu/tests/cfg/boot_with_disable_ept.cfg
+++ b/qemu/tests/cfg/boot_with_disable_ept.cfg
@@ -2,15 +2,16 @@
     virt_test_type = qemu
     type = boot_with_disable_ept
     start_vm = no
+    expected_status = 'N'
+    default_status = 'Y'
     HostCpuVendor.intel:
         parameter_name = 'ept'
-        expected_status = 'N'
-        default_status = 'Y'
         module_name = 'kvm_intel'
     HostCpuVendor.amd:
         parameter_name = 'npt'
-        expected_status = '0'
-        default_status = '1'
+        Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8.u0, Host_RHEL.m8.u1, Host_RHEL.m8.u2, Host_RHEL.m8.u3, Host_RHEL.m8.u4:
+            expected_status = '0'
+            default_status = '1'
         module_name = 'kvm_amd'
     pre_command = 'modprobe -r ${module_name} && modprobe ${module_name} ${parameter_name}=${expected_status}'
     post_command = 'modprobe -r ${module_name} && modprobe ${module_name} ${parameter_name}=${default_status}'


### PR DESCRIPTION
AMD host also use "Y/N" to enable/disable npt from RHEL-8.5

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1977204