### PR TITLE
nvdimm_mapsync: Fix IndexError

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -73,7 +73,7 @@
             format_command = "mkfs.xfs -f ${dev_path} -m reflink=0"
             mount_command = "mkdir -p ${mount_dir} && mount -o dax ${dev_path} ${mount_dir}"
             truncate_command = "truncate -s ${size_mem} ${mount_dir}/${nv_backend}"
-            check_command = "grep -A21 '${nv_backend}' /proc/%s/smaps"
+            check_pattern = "^[0-9a-fA-F]+-[0-9a-fA-F]+.*${nv_backend}(?:.|\n)*?^VmFlags: (.*)\n"
             clean_command = "rm -rf ${mount_dir}/${nv_backend} && umount ${mount_dir} && rm -rf ${mount_dir}"
             start_vm = no
         - nvdimm_mode:


### PR DESCRIPTION
Due to smaps file structure change, the output of cmd 'grep -A21'
no longer contains the expected 'VmFlags' line. Fix it by adding
more matching lines.

Signed-off-by: Yumei Huang <yuhuang@redhat.com>

ID: 1978092