### PR TITLE
qemu_guest_agent.py: Add new case to check qemu version/build

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -85,6 +85,9 @@
                     device_name = "VirtIO Serial Driver"
         - check_sync:
             gagent_check_type = sync
+        - check_guest_info:
+            gagent_check_type = guest_info
+            cmd_qga_build = wmic product where Name="QEMU guest agent" get Version | findstr /v Version
         - check_powerdown:
             gagent_check_type = powerdown
             journal_file = /var/log/journal


### PR DESCRIPTION
Add new case "guest-info" to check qemu version/build of
 linux/windows guests.

ID: 1967386
Signed-off-by: Dehan Meng <demeng@redhat.com>