### PR TITLE
hv_cpu_hotplug: Set a workaround for win2016 guest

### DIFF
--- a/qemu/tests/cfg/hv_cpu_hotplug.cfg
+++ b/qemu/tests/cfg/hv_cpu_hotplug.cfg
@@ -3,6 +3,13 @@
     only Win2008, Win2012, Win2016, Win2019, Win2022
     Win2008, Win2012:
         check_cpu_topology = no
+    Win2016:
+        # Set a workaround for win2016 guest
+        workaround_need = yes
+        devcon_dir = "win7_amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dir}\devcon.exe"
+        driver_inf_file = "C:\Windows\INF\machine.inf"
+        dev_hwid = '"ACPI\VEN_ACPI&DEV_0010"'
     ovmf:
         required_qemu = [5.2.0, )
     cpu_model_flags += hv_crash


### PR DESCRIPTION
We should set a workaround 'install 'HID Button over Interrupt Driver'
in win2016 guest when test cpu hotplug for a windows issue.

ID: 1975638
Signed-off-by: Menghuan Li menli@redhat.com