### PR TITLE
balloon_check: modify illegal_value to 1 if do evict test

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -598,7 +598,7 @@ def run(test, params, env):
         # set evict illegal value to "0" for both linux and windows
         elif params_tag.get('illegal_value_check', 'no') == 'yes':
             if tag == 'evict':
-                expect_mem = 0
+                expect_mem = 1
             else:
                 expect_mem = int(balloon_test.ori_mem + random.uniform(1, 1000))
         else:


### PR DESCRIPTION
The original value is 0,qmp will reture error with 0.
ID: 1977566
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>