### PR TITLE
Change tmp folder to /var/tmp for case insert_media

### DIFF
--- a/qemu/tests/cfg/insert_media.cfg
+++ b/qemu/tests/cfg/insert_media.cfg
@@ -7,10 +7,10 @@
     start_vm = no
     not_preprocess = yes
     monitor_type = qmp
-    pre_command = "dd if=/dev/zero of=/tmp/new bs=10M count=1 && "
-    pre_command += "mkisofs -o /tmp/new.iso /tmp/new"
-    post_command = "rm -rf /tmp/new.iso /tmp/new"
-    cdrom_cd1 = /tmp/new.iso
+    pre_command = "dd if=/dev/zero of=/var/tmp/new bs=10M count=1 && "
+    pre_command += "mkisofs -o /var/tmp/new.iso /var/tmp/new"
+    post_command = "rm -rf /var/tmp/new.iso /var/tmp/new"
+    cdrom_cd1 = /var/tmp/new.iso
     tray_move_event = DEVICE_TRAY_MOVED
     paused_after_start_vm = yes
     force_drive_format_cd1 = scsi-cd


### PR DESCRIPTION
The /tmp folder is tmpfs in RHEL9 result in vm creation failed.
So change the iso folder from /tmp to /var/tmp.
ID:1968389
Signed-off-by: qingwangrh <qinwang@redhat.com>