### PR TITLE
boot_with_disable_ept: extend timeout value with ept disabled

### DIFF
--- a/qemu/tests/boot_with_disable_ept.py
+++ b/qemu/tests/boot_with_disable_ept.py
@@ -14,11 +14,12 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment
     """
+    timeout = float(params.get("login_timeout", 2400))
     output = process.getoutput(params["check_status_cmd"])
     if output != params["expected_status"]:
         test.fail("Disable %s failed" % params["parameter_name"])
     params["start_vm"] = 'yes'
     env_process.preprocess_vm(test, params, env, params["main_vm"])
     vm = env.get_vm(params['main_vm'])
-    session = vm.wait_for_login()
+    session = vm.wait_for_login(timeout=timeout)
     session.close()

--- a/qemu/tests/cfg/boot_with_disable_ept.cfg
+++ b/qemu/tests/cfg/boot_with_disable_ept.cfg
@@ -2,6 +2,7 @@
     virt_test_type = qemu
     type = boot_with_disable_ept
     start_vm = no
+    login_timeout = 2400
     expected_status = 'N'
     default_status = 'Y'
     HostCpuVendor.intel:


### PR DESCRIPTION
windows guest need more time to login with ept disabled,
so extend timeout value.

ID: 1977181
Signed-off-by: Menghuan Li menli@redhat.com