### PR TITLE
Fix virtio_scsi_cdrom windows installation issue

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_cdrom.cfg
+++ b/qemu/tests/cfg/virtio_scsi_cdrom.cfg
@@ -25,6 +25,11 @@
         iothread_scheme ?=
         iothreads ?=
         image_iothread ?=
+    ovmf:
+        only q35
+        restore_ovmf_vars = yes
+        Windows:
+            send_key_at_install = ret
     variants:
         - with_installation:
             cd_format_cd1 = scsi-cd
@@ -68,12 +73,38 @@
                     image_name_stg22 = images/storage22
                     image_name_stg23 = images/storage23
                     image_name_stg24 = images/storage24
-                    image_name_stg25 = images/storage25
-                    image_size_equal = 1G
+                    image_size_stg = 1G
+                    image_size_stg1 = 1G
+                    image_size_stg2 = 1G
+                    image_size_stg3 = 1G
+                    image_size_stg4 = 1G
+                    image_size_stg5 = 1G
+                    image_size_stg6 = 1G
+                    image_size_stg7 = 1G
+                    image_size_stg8 = 1G
+                    image_size_stg9 = 1G
+                    image_size_stg10 = 1G
+                    image_size_stg11 = 1G
+                    image_size_stg12 = 1G
+                    image_size_stg13 = 1G
+                    image_size_stg14 = 1G
+                    image_size_stg15 = 1G
+                    image_size_stg16 = 1G
+                    image_size_stg17 = 1G
+                    image_size_stg18 = 1G
+                    image_size_stg19 = 1G
+                    image_size_stg20 = 1G
+                    image_size_stg21 = 1G
+                    image_size_stg22 = 1G
+                    image_size_stg23 = 1G
+                    image_size_stg24 = 1G
                     ahci:
                         images = "image1 stg stg2 stg3 stg4 stg5"
-                    default_bios..Windows:
-                        images = "image1 stg stg2 stg3 stg4 stg5"
+                    Windows:
+                        virtio_blk:
+                            images = "image1 stg stg2 stg3 stg4"
+                        default_bios:
+                            images = "image1 stg stg2 stg3 stg4"
             variants:
                 - aio_native:
                     image_aio = native


### PR DESCRIPTION
1. Add auto send key action of ovmf windows installation
2. Reduce disks number of multi disks windows installation

ID:1874693
Signed-off-by: qingwangrh <qinwang@redhat.com>