### PR TITLE
save file under '/var/tmp' instead of '/tmp'

### DIFF
--- a/qemu/tests/cfg/commit_snapshot_to_backing_image.cfg
+++ b/qemu/tests/cfg/commit_snapshot_to_backing_image.cfg
@@ -8,7 +8,7 @@
     image_chain = ${images}
     image_name_sn1 = "images/sn1"
     image_format_sn1 = qcow2
-    guest_tmp_filename = "/tmp/sn1"
+    guest_tmp_filename = "/var/tmp/sn1"
     backup_image_before_testing = yes
     restore_image_after_testing = yes
     dd_blkcnt = 204800

--- a/qemu/tests/cfg/image_commit_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_commit_bypass_host_cache.cfg
@@ -10,7 +10,7 @@
     image_name_sn1 = "images/sn1"
     image_format_sn1 = qcow2
     remove_image_sn1 = yes
-    guest_tmp_filename = "/tmp/sn1"
+    guest_tmp_filename = "/var/tmp/sn1"
     backup_image_before_testing = yes
     restore_image_after_testing = yes
     trace_events = open

--- a/qemu/tests/cfg/image_locking_read_test.cfg
+++ b/qemu/tests/cfg/image_locking_read_test.cfg
@@ -32,6 +32,6 @@
     image_name_sn3_chain2 = images/sn3_chain2
     image_format_sn3_chain2 = qcow2
     image_size_sn3_chain2 = ""
-    tmp_file_name = /tmp/src.tmp
-    guest_tmp_filename = "/tmp/tempfile"
+    tmp_file_name = /var/tmp/src.tmp
+    guest_tmp_filename = "/var/tmp/tempfile"
     file_create_cmd = "dd if=/dev/urandom of=%s bs=1M count=512"

--- a/qemu/tests/cfg/image_rebase_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_rebase_bypass_host_cache.cfg
@@ -14,7 +14,7 @@
     image_format_sn2 = qcow2
     image_size_sn2 = ""
     trace_event = open
-    guest_tmp_filename = "/tmp/%s"
+    guest_tmp_filename = "/var/tmp/%s"
     # only backup system disk
     backup_image_before_testing_image1 = yes
     restore_image_after_testing_image1 = yes

--- a/qemu/tests/cfg/qemu_img_convert_with_backing_file.cfg
+++ b/qemu/tests/cfg/qemu_img_convert_with_backing_file.cfg
@@ -5,7 +5,7 @@
     start_vm = no
     kill_vm = yes
     create_image = no
-    guest_temp_file = "/tmp/convert.tmp"
+    guest_temp_file = "/var/tmp/convert.tmp"
     md5sum_bin = "md5sum"
     Windows:
         guest_temp_file = "C:\testfile"

--- a/qemu/tests/cfg/qemu_img_convert_with_rate_limit.cfg
+++ b/qemu/tests/cfg/qemu_img_convert_with_rate_limit.cfg
@@ -5,7 +5,7 @@
     start_vm = no
     kill_vm = yes
     force_create_image = no
-    guest_temp_file = "/tmp/convert.tmp"
+    guest_temp_file = "/var/tmp/convert.tmp"
     md5sum_bin = "md5sum"
     Windows:
         guest_temp_file = "C:\testfile"

--- a/qemu/tests/cfg/qemu_img_convert_with_target_is_zero.cfg
+++ b/qemu/tests/cfg/qemu_img_convert_with_target_is_zero.cfg
@@ -5,7 +5,7 @@
     start_vm = no
     kill_vm = yes
     force_create_image = no
-    guest_temp_file = "/tmp/convert.tmp"
+    guest_temp_file = "/var/tmp/convert.tmp"
     md5sum_bin = "md5sum"
     Windows:
         guest_temp_file = "C:\testfile"

--- a/qemu/tests/cfg/rebase_onto_no_backing_file.cfg
+++ b/qemu/tests/cfg/rebase_onto_no_backing_file.cfg
@@ -13,7 +13,7 @@
     # the cmdline will not have specified size option
     image_size_sn = ""
     image_format_sn = qcow2
-    guest_tmp_filename = "/tmp/base"
+    guest_tmp_filename = "/var/tmp/base"
     backup_image_before_testing = yes
     restore_image_after_testing = yes
     Windows:

--- a/qemu/tests/cfg/rebase_onto_qcow2.cfg
+++ b/qemu/tests/cfg/rebase_onto_qcow2.cfg
@@ -16,7 +16,7 @@
     image_format_newbase = qcow2
     image_size_newbase = ${image_size}
     remove_image_newbase = yes
-    guest_tmp_filename = "/tmp/%s"
+    guest_tmp_filename = "/var/tmp/%s"
     backup_image_before_testing = yes
     restore_image_after_testing = yes
     Windows:


### PR DESCRIPTION
for some os, '/tmp' is wiped whenever the system reboots where as
'/var/tmp' gets preserved across reboot

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 1982488