### PR TITLE
virtio-fs: correct fixe fs_binary_extra_options's setting

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -31,6 +31,7 @@
     io_timeout = 600
     fs_dest = '/mnt/${fs_target}'
     driver_name = viofs
+    fs_binary_extra_options = ''
     Windows:
         # install winfsp tool
         i386, i686:
@@ -57,36 +58,33 @@
             only default.default.with_cache.auto.default
             viofs_log_file_cmd = 'dir ${viofs_log_file}'
     variants:
+        - @default:
+        - @extra_parameters:
+            variants:
+                - lock_posix_off:
+                    fs_binary_extra_options += ",no_posix_lock"
+                - lock_posix_on:
+                    fs_binary_extra_options += ",posix_lock"
+            variants:
+                - flock_on:
+                    fs_binary_extra_options += ",flock"
+                - flock_off:
+                    fs_binary_extra_options += ",no_flock"
+            variants:
+                - xattr_on:
+                    fs_binary_extra_options += ",xattr"
+                - xattr_off:
+                    fs_binary_extra_options += ",no_xattr"
+                - @default:
+    variants:
         - with_cache:
             variants:
-                - @default:
-                - @extra_parameters:
-                    no run_stress..extra_parameters
-                    variants:
-                        - lock_posix_off:
-                            fs_binary_extra_options += ",no_posix_lock"
-                        - lock_posix_on:
-                            fs_binary_extra_options += ",posix_lock"
-                    variants:
-                        - flock_on:
-                            fs_binary_extra_options += ",flock"
-                        - flock_off:
-                            fs_binary_extra_options += ",no_flock"
-                    variants:
-                        - xattr_on:
-                            fs_binary_extra_options += ",xattr"
-                        - xattr_off:
-                            fs_binary_extra_options += ",no_xattr"
-                        - @default:
-            variants:
                 - auto:
-                    fs_binary_extra_options = " -o cache=auto"
+                    fs_binary_extra_options += ",cache=auto"
                 - always:
-                    fs_binary_extra_options = " -o cache=always"
+                    fs_binary_extra_options += ",cache=always"
                 - none:
-                    fs_binary_extra_options = " -o cache=none"
-        - with_no_writeback:
-            fs_binary_extra_options = " -o no_writeback "
+                    fs_binary_extra_options += ",cache=none"
     variants:
         - @default:
             cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'
@@ -109,7 +107,6 @@
                 - @default:
                 - with_multi_fs_sources:
                     no Windows
-                    no with_multi_fs_sources..with_no_writeback
                     with_multi_fs_sources.with_cache.none:
                         io_timeout = 600
                     filesystems = fs1 fs2 fs3 fs4 fs5
@@ -129,9 +126,9 @@
                     fs_dest_fs4 = '/mnt/${fs_target_fs4}'
                     fs_dest_fs5 = '/mnt/${fs_target_fs5}'
         - run_stress:
+            no run_stress..extra_parameters
             variants:
                 - with_fio:
-                    no with_fio..with_no_writeback
                     smp = 8
                     vcpu_maxcpus = 8
                     io_timeout = 2000
@@ -142,7 +139,6 @@
                         fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800 --thread'
                 - with_pjdfstest:
                     no Windows
-                    no with_pjdfstest..with_no_writeback
                     io_timeout = 1800
                     with_pjdfstest..with_cache.none:
                         io_timeout = 7200


### PR DESCRIPTION
1.distinguish fs_binary_extra_options's and '-o cache'
2.delete with_no_writeback variant as the default is no_writeback in product.

ID: 1983004
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>