### PR TITLE
Remove tpm passthrough test case for rhel 9

### DIFF
--- a/qemu/tests/cfg/tpm_verify_device.cfg
+++ b/qemu/tests/cfg/tpm_verify_device.cfg
@@ -66,6 +66,7 @@
                     remove_image_image1 = yes
         - with_passthrough:
             no aarch64
+            only Host_RHEL.m8
             start_vm = no
             not_preprocess = yes
             cmd_check_tpm_device = ls /dev/tpm0


### PR DESCRIPTION
TPM passthrough is removed on rhel 9.

ID: 1983507

Signed-off-by: Qinghua Cheng <qcheng@redhat.com>