### PR TITLE
blockdev_inc_backup_never: Do incremental live backup with bitmap-mode:never

### DIFF
--- a/qemu/tests/blockdev_inc_backup_never_always.py
+++ b/qemu/tests/blockdev_inc_backup_never_always.py
@@ -1,0 +1,82 @@
+from virttest.qemu_monitor import QMPCmdError
+
+from provider import backup_utils
+from provider import blockdev_base
+
+
+class BlkdevIncNA(blockdev_base.BlockdevBaseTest):
+
+    def __init__(self, test, params, env):
+        super(BlkdevIncNA, self).__init__(
+            test, params, env)
+        self.source_images = []
+        self.full_backups = []
+        self.inc_backups = []
+        self.bitmaps = []
+        self.src_img_tags = params.objects("source_images")
+        self.inc_sync_mode = params["inc_sync_mode"]
+        self.inc_bitmap_mode = params["inc_bitmap_mode"]
+        list(map(self._init_arguments_by_params, self.src_img_tags))
+
+    def _init_arguments_by_params(self, tag):
+        image_params = self.params.object_params(tag)
+        image_chain = image_params.objects("image_backup_chain")
+        self.source_images.append("drive_%s" % tag)
+        self.full_backups.append("drive_%s" % image_chain[0])
+        self.inc_backups.append("drive_%s" % image_chain[1])
+        self.bitmaps.append("bitmap_%s" % tag)
+
+    def do_full_backup(self):
+        extra_options = {"sync": "full", "auto_disable_bitmap": False}
+        backup_utils.blockdev_batch_backup(
+            self.main_vm,
+            self.source_images,
+            self.full_backups,
+            self.bitmaps,
+            **extra_options)
+
+    def generate_inc_files(self):
+        return list(map(self.generate_data_file, self.src_img_tags))
+
+    def do_incremental_backup(self):
+        extra_options = {"sync": self.inc_sync_mode,
+                         "bitmap": self.bitmaps[0],
+                         "bitmap-mode": self.inc_bitmap_mode,
+                         "auto_disable_bitmap": False}
+        inc_backup = backup_utils.blockdev_backup_qmp_cmd
+        cmd, arguments = inc_backup(self.source_images[0], self.inc_backups[0],
+                                    **extra_options)
+        try:
+            self.main_vm.monitor.cmd(cmd, arguments)
+        except QMPCmdError as e:
+            qmp_error_msg = self.params.get("qmp_error_msg")
+            if qmp_error_msg not in str(e.data):
+                self.test.fail(str(e))
+        else:
+            self.test.fail("Inc backup with invalid bitmap mode:%s"
+                           % self.inc_bitmap_mode)
+
+    def do_test(self):
+        self.do_full_backup()
+        self.generate_inc_files()
+        self.do_incremental_backup()
+
+
+def run(test, params, env):
+    """
+    Incremental backup with sync:incremental & bitmap mode:never/always
+
+    test steps:
+        1). boot VM with a 2G data disk
+        2). format data disk and mount it, create a file
+        3). add target disks for backup to VM via qmp commands
+        4). do full backup and add non-persistent bitmap
+        5). create another file
+        6). do inc bakcup(sync: incremental and bitmap-mode:never/always)
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    inc_no_bpmode = BlkdevIncNA(test, params, env)
+    inc_no_bpmode.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_never.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_never.cfg
@@ -1,0 +1,34 @@
+- blockdev_inc_backup_never:
+    only Linux
+    no libcurl, libssh
+    start_vm = no
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_never_always
+    virt_test_type = qemu
+    images += " data"
+    source_images = "data"
+    image_backup_chain_data = "base inc"
+    backing_inc = base
+    remove_image_data = yes
+    force_create_image_data = yes
+    storage_pools = default
+    storage_pool = default
+
+    image_size_data = 2G
+    image_size_base = 2G
+    image_size_inc = 2G
+
+    image_format_data = qcow2
+    image_format_base = qcow2
+    image_format_inc = qcow2
+
+    image_name_data = data
+    image_name_base = base
+    image_name_inc = inc
+
+    inc_sync_mode = incremental
+    rebase_mode = unsafe
+    inc_bitmap_mode = never
+
+    storage_type_default = "directory"
+    qmp_error_msg = "Bitmap sync mode must be 'on-success' when using sync mode 'incremental'"


### PR DESCRIPTION
Do incremental live backup with sync:incremental and
bitmap-mode:never

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:1983902