### PR TITLE
blockdev_inc_backup_always:Do incremental live backup with bitmap-mode:always

### DIFF
--- a/qemu/tests/cfg/blockdev_inc_backup_always.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_always.cfg
@@ -1,0 +1,34 @@
+- blockdev_inc_backup_always:
+    only Linux
+    no libcurl, libssh
+    start_vm = no
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_never_always
+    virt_test_type = qemu
+    images += " data"
+    source_images = "data"
+    image_backup_chain_data = "base inc"
+    backing_inc = base
+    remove_image_data = yes
+    force_create_image_data = yes
+    storage_pools = default
+    storage_pool = default
+
+    image_size_data = 2G
+    image_size_base = 2G
+    image_size_inc = 2G
+
+    image_format_data = qcow2
+    image_format_base = qcow2
+    image_format_inc = qcow2
+
+    image_name_data = data
+    image_name_base = base
+    image_name_inc = inc
+
+    inc_sync_mode = incremental
+    rebase_mode = unsafe
+    inc_bitmap_mode = always
+
+    storage_type_default = "directory"
+    qmp_error_msg = "Bitmap sync mode must be 'on-success' when using sync mode 'incremental'"


### PR DESCRIPTION
Do incremental live backup with bitmap-mode:always

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:1983911