### PR TITLE
blockdev_inc_backup_merge_to_nonexist_bitmap:Merge bitmaps to a non-existed target

### DIFF
--- a/qemu/tests/blockdev_inc_backup_merge_to_nonexist_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_merge_to_nonexist_bitmap.py
@@ -1,0 +1,60 @@
+from virttest.qemu_monitor import QMPCmdError
+
+from provider.block_dirty_bitmap import block_dirty_bitmap_merge
+from provider.blockdev_live_backup_base import BlockdevLiveBackupBaseTest
+
+
+class BlkdevIncMergeToNonexistBitmap(BlockdevLiveBackupBaseTest):
+    """Merge two bitmaps to a non-exist target"""
+
+    def __init__(self, test, params, env):
+        super(BlkdevIncMergeToNonexistBitmap, self).__init__(
+            test, params, env)
+        self._merged_bitmaps = params.objects('bitmap_merge_list')
+        self._merged_target = params['bitmap_merge_target']
+
+    def add_two_bitmaps(self):
+        bitmaps = [{'node': self._source_nodes[0],
+                    'name': bitmap}
+                   for bitmap in self._merged_bitmaps]
+        job_list = [{'type': 'block-dirty-bitmap-add', 'data': data}
+                    for data in bitmaps]
+        self.main_vm.monitor.transaction(job_list)
+
+    def merge_two_bitmaps(self):
+        try:
+            block_dirty_bitmap_merge(self.main_vm, self._source_nodes[0],
+                                     self._merged_bitmaps,
+                                     self._merged_target)
+        except QMPCmdError as e:
+            nonexist_target = self._merged_target
+            qmp_error_msg = self.params.get("qmp_error_msg") % nonexist_target
+            if qmp_error_msg not in str(e.data):
+                self.test.fail(str(e))
+        else:
+            self.test.fail("Merge to a non-exist bitmap:%s"
+                           % self._merged_target)
+
+    def do_test(self):
+        self.add_two_bitmaps()
+        self.generate_inc_files()
+        self.merge_two_bitmaps()
+
+
+def run(test, params, env):
+    """
+    Test for merging bitmaps to a non-exist bitmap target
+
+    test steps:
+        1. boot VM with a 2G data disk
+        2. format data disk and mount it, create a file
+        3. add two bitmaps to data disk
+        4. create a new file
+        5. merge two bitmaps to a non-exist bitmap:bitmap_tmp
+
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    mergeto_nexist_bp = BlkdevIncMergeToNonexistBitmap(test, params, env)
+    mergeto_nexist_bp.run_test()

--- a/qemu/tests/cfg/blockdev_inc_backup_merge_to_nonexist_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_merge_to_nonexist_bitmap.cfg
@@ -1,0 +1,26 @@
+- blockdev_inc_backup_merge_to_nonexist_bitmap:
+    only Linux
+    start_vm = no
+    kill_vm = yes
+    qemu_force_use_drive_expression = no
+    type = blockdev_inc_backup_merge_to_nonexist_bitmap
+    virt_test_type = qemu
+    images += " data1"
+    source_images = data1
+    image_backup_chain_data1 = base
+    remove_image_data1 = yes
+    force_create_image_data1 = yes
+    bitmap_merge_list = 'bitmap0 bitmap1'
+    bitmap_merge_target = 'bitmap_tmp'
+
+    image_size_data1 = 2G
+    image_format_data1 = qcow2
+    image_name_data1 = data1
+    image_size_base = ${image_size_data1}
+    image_format_base = qcow2
+    image_name_base = base
+    storage_pools = default
+    storage_pool = default
+    storage_type_default = directory
+    full_backup_options = '{"sync": "full"}'
+    qmp_error_msg = Dirty bitmap '%s' not found


### PR DESCRIPTION
Merge bitmaps to a non-existed target

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:1984294