### PR TITLE
blockdev_full_backup_with_bitmap: fix ci error

### DIFF
--- a/qemu/tests/blockdev_full_backup_with_bitmap.py
+++ b/qemu/tests/blockdev_full_backup_with_bitmap.py
@@ -1,4 +1,3 @@
-import re
 import json
 
 from virttest.qemu_monitor import QMPCmdError


### PR DESCRIPTION
Remove re which is never used.

Signed-off-by: zhencliu <zhencliu@redhat.com>