### PR TITLE
bridge_qinq: Support s390x and fix some problems

### DIFF
--- a/qemu/tests/cfg/bridge_qinq.cfg
+++ b/qemu/tests/cfg/bridge_qinq.cfg
@@ -7,6 +7,7 @@
     guest_qinq_dir = /home/
     ping_count = 100
     net_mask = "24"
+    set_ip_cmd = "ip addr add %s/${net_mask} dev %s"
     ip_vm = "192.168.1.2"
     vlan_id = 10
     L1tag_iface = "v1v${vlan_id}"


### PR DESCRIPTION
1. Failed to set netmask on s390x using socket, so replace with "ip
link" command.
2. Only stop NetworkManager on RHEL7 since it will conflict with
network.service.
3. Use "ip" command to configure network instead of "ifconfig"
4. Delete the private bridge in the final stage regardless of whether
the test passes or not.

ID: 1985163
Signed-off-by: Yihuang Yu <yihyu@redhat.com>