### PR TITLE
nic_hotplug.used_netdev: Support s390x

### DIFF
--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -101,6 +101,8 @@
         - used_netdev:
             used_sameid = yes
             devadd_match_string = "it's in use"
+            s390, s390x:
+                nic_bus = virtual-css
         - with_iommu:
             only virtio_net
             only nic_virtio

--- a/qemu/tests/nic_hotplug.py
+++ b/qemu/tests/nic_hotplug.py
@@ -114,7 +114,7 @@ def run(test, params, env):
         pci_add_cmd = "device_add id=%s, driver=%s, netdev=%s" % (device_id,
                                                                   pci_model,
                                                                   netdev)
-        bus = vm.devices.get_buses({'aobject': 'pci.0'})[0]
+        bus = vm.devices.get_buses({'aobject': params.get('nic_bus', 'pci.0')})[0]
         if isinstance(bus, qdevices.QPCIEBus):
             root_port_id = bus.get_free_root_port()
             if root_port_id:


### PR DESCRIPTION
s390x does not use pci.0 bus, it uses virtual-css as the parent bus,
update this part to support s390x.

ID: 1986298
Signed-off-by: Yihuang Yu <yihyu@redhat.com>