### PR TITLE
file_transfer: Change the tmp directory to "/var/tmp"

### DIFF
--- a/generic/tests/cfg/file_transfer.cfg
+++ b/generic/tests/cfg/file_transfer.cfg
@@ -3,6 +3,12 @@
     type = file_transfer
     filesize = 4000
     transfer_timeout = 1000
+    Linux:
+        tmp_dir = /var/tmp/
+        clean_cmd = rm -f
+    Windows:
+        tmp_dir = C:\
+        clean_cmd = del /q /f
     variants:
         - @default_setting:
         - vhost_force:


### PR DESCRIPTION
For some dirtos, "/tmp" is a tmpfs file system, its size is half of the
memory, so if the memory is too small, there is no space to copy the
temporary file.

ID: 1987211
Signed-off-by: Yihuang Yu <yihyu@redhat.com>