### PR TITLE
Add support for vlan on s390x

### DIFF
--- a/generic/tests/vlan.py
+++ b/generic/tests/vlan.py
@@ -186,7 +186,7 @@ def run(test, params, env):
     login_timeout = int(params.get("login_timeout", 360))
     prepare_netkvmco_cmd = params.get("prepare_netkvmco_cmd")
     set_vlan_cmd = params.get("set_vlan_cmd")
-    driver_verifier = params["driver_verifier"]
+    driver_verifier = params.get("driver_verifier")
 
     vms.append(env.get_vm(params["main_vm"]))
     vms.append(env.get_vm("vm2"))


### PR DESCRIPTION
Virtual-network: add support for vlan with "driver_verifier" on s390x

ID: 1987282

Signed-off-by: Boqiao Fu <bfu@redhat.com>