### PR TITLE
x86_cpu_flags:add new case to test avx_vnni

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -69,6 +69,12 @@
                             cpu_model = host
                         - default_model:
                             cpu_model_flags = ",+serialize,+avx512-vp2intersect,+avx512-fp16,+tsxldtr"
+                - avx_vnni:
+                    # support since RHEL.8.5 kernel
+                    no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1 RHEL.8.2 RHEL.8.3 RHEL.8.4
+                    required_qemu = [6.0.0-26, )
+                    flags = "avx_vnni"
+                    cpu_model_flags += ",avx_vnni=on"
         - amd:
             only HostCpuVendor.amd
             variants:


### PR DESCRIPTION
ID: 1986694

Steps:
1. boot guest '-cpu $cpu_model,avx_vnni'
on supported host.
2. check cpu flag inside guest.

Signed-off-by: Nana Liu <nanliu@redhat.com>