### PR TITLE
storage_benchmark: Add s390x support when make iozone

### DIFF
--- a/provider/storage_benchmark.py
+++ b/provider/storage_benchmark.py
@@ -285,6 +285,8 @@ class IozoneLinuxCfg(object):
             self.arch = 'linux-powerpc64'
         elif 'aarch64' in machine():
             self.arch = 'linux-arm'
+        elif 's390' in machine():
+            self.arch = 'linux-S390X'
         else:
             self.arch = 'linux-AMD64'
         self.cmd = 'cd %s/src/current && make clean && make %s' % (self.iozone_inst,


### PR DESCRIPTION
Add s390x support in the __init__() function of the
IozoneLinuxCfg class.

ID: 1989333
Signed-off-by: Nini Gu <ngu@redhat.com>