### PR TITLE
pcie_hotplug_opt: update the expected hotplug error message

### DIFF
--- a/qemu/tests/cfg/pcie_hotplug_opt.cfg
+++ b/qemu/tests/cfg/pcie_hotplug_opt.cfg
@@ -29,5 +29,7 @@
     image_name_plug0 = images/plug0
     image_size_plug0 = 1G
     remove_image_plug0 = yes
-    hotplug_error = "Hot-plug failed: unsupported by the port device '%s'"
-    unplug_error = "Hot-unplug failed: unsupported by the port device '%s'"
+    hotplug_error_pattern = "Hot-plug failed: unsupported by the port device '%s'"
+    hotplug_error_pattern += "|Bus '%s' does not support hotplugging"
+    unplug_error_pattern = "Hot-unplug failed: unsupported by the port device '%s'"
+    unplug_error_pattern += "|Bus '%s' does not support hotplugging"


### PR DESCRIPTION
From QEMU6.1, the error message be changed to: "Bus '***' does not
support hotplugging", update the expected error message pattern
to make it work for all version.

id: 1988734
Signed-off-by: Yanan Fu <yfu@redhat.com>