### PR TITLE
block_during_io: Set sub-thread as daemon mode in background

### DIFF
--- a/qemu/tests/block_during_io.py
+++ b/qemu/tests/block_during_io.py
@@ -113,6 +113,7 @@ def run(test, params, env):
         """ Run the test background. """
         error_context.context(target.__doc__, logging.info)
         thread = utils_misc.InterruptedThread(target, args, kwargs)
+        thread.daemon = True
         thread.start()
         return thread
 


### PR DESCRIPTION
Any errors and hangs (or an infinite loop) in a daemon process
will not affect the main process, and it will only be terminated
once the main process exits.The entire Python program exits when
no alive non-daemon threads are left, so we could set all threads
as daemon mode in background.

Signed-off-by: Yongxue Hong <yhong@redhat.com
ID: 1925927