### PR TITLE
storage_volume: Fix hotplug raw image issue

### DIFF
--- a/provider/virt_storage/storage_volume.py
+++ b/provider/virt_storage/storage_volume.py
@@ -191,7 +191,9 @@ class StorageVolume(object):
         cmd, options = protocol_node.hotplug_qmp()
         vm.monitor.cmd(cmd, options)
         format_node = self.format
-        self.format_protocol_by_qmp(vm)
+        # Don't need the format blockdev-create for 'raw'
+        if self.format.TYPE != "raw":
+            self.format_protocol_by_qmp(vm)
         cmd, options = format_node.hotplug_qmp()
         vm.monitor.cmd(cmd, options)
         self.pool.refresh()


### PR DESCRIPTION
For raw format, it does not need the 2nd blockdev-create
command to create the format, so delete it.

ID: 1989785
Signed-off-by: Nini Gu <ngu@redhat.com>