### PR TITLE
virtio_mode: fix driver_verifier missing issue

### DIFF
--- a/qemu/tests/cfg/virtio_mode.cfg
+++ b/qemu/tests/cfg/virtio_mode.cfg
@@ -23,7 +23,8 @@
     variants:
         - with_netkvm:
             only virtio_net
-            driver_verifier = netkvm
+            driver_name = netkvm
+            driver_verifier = ${driver_name}
             Win2016, Win2019, Win8..1, Win2012..r2:
                 driver_verifier += " ndis"
             device_type = "virtio-net-pci"

--- a/qemu/tests/virtio_mode.py
+++ b/qemu/tests/virtio_mode.py
@@ -51,7 +51,8 @@ def run(test, params, env):
         :param virtio_mode: VirtIO mode for the device
         """
         device_name = params["device_name"]
-        driver_verifier = params["driver_verifier"]
+        driver_name = params["driver_name"]
+        driver_verifier = params.get("driver_verifier", driver_name)
         session = utils_test.qemu.windrv_check_running_verifier(session, vm,
                                                                 test, driver_verifier)
         devcon_folder = utils_misc.set_winutils_letter(session,


### PR DESCRIPTION
In virtio_mode test case, other drivers lack driver_verifier parameter except netkvm.
So for other drivers, use driver_name to replace driver_verifier.
ID: 1989893
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>