### PR TITLE
mq_change_qnum: Set ext_host as the guest's gateway instead of host's

### DIFF
--- a/qemu/tests/mq_change_qnum.py
+++ b/qemu/tests/mq_change_qnum.py
@@ -185,7 +185,7 @@ def run(test, params, env):
 
         if params.get("ping_after_changing_queues", "yes") == "yes":
             default_host = "www.redhat.com"
-            ext_host = utils_net.get_default_gateway()
+            ext_host = utils_net.get_default_gateway(session)
             if not ext_host:
                 # Fallback to a hardcode host, eg:
                 logging.warn("Can't get specified host,"


### PR DESCRIPTION
Sometimes guest will be launched with a private bridge, the bridge is a
NAT network so it cannot connect to the host's gateway. The gateway of
the guest should be the correct one as the ext_host because we are
testing the network connection of the guest.

ID: 1990518
Signed-off-by: Yihuang Yu <yihyu@redhat.com>