### PR TITLE
tcpreplay: Fix the tcpreplay execution command using a fixed bridge name

### DIFF
--- a/qemu/tests/cfg/tcpreplay.cfg
+++ b/qemu/tests/cfg/tcpreplay.cfg
@@ -5,4 +5,4 @@
     tcpreplay_file_name = "${uncompress_dir}.tar.gz"
     pcap_file_name = "2603.pcap"
     tcpreplay_compile_cmd = 'cd %s && ./configure && make && make install'
-    run_tcpreplay_cmd = "cd /tmp && tcpreplay -i switch ${pcap_file_name}"
+    run_tcpreplay_cmd = "cd /tmp && tcpreplay -i ${netdst} ${pcap_file_name}"


### PR DESCRIPTION
ID: 1991794
Signed-off-by: Yihuang Yu <yihyu@redhat.com>