### PR TITLE
Added guest start to DHCP block of code

### DIFF
--- a/qemu/tests/sr_iov_sanity.py
+++ b/qemu/tests/sr_iov_sanity.py
@@ -11,7 +11,7 @@ from virttest import test_setup
 from virttest import utils_net
 from virttest import error_context
 from virttest import utils_misc
-
+from virttest import env_process
 
 def check_network_interface_ip(interface, ipv6="no"):
     check_cmd = "ifconfig %s" % interface
@@ -219,5 +219,7 @@ def run(test, params, env):
                           "drivers in guest image")
         else:
             # User has opted for DHCP IP inside guest
+            params["start_vm"] = "yes"
+            env_process.preprocess_vm(test, params, env, vm_name)
             vm.verify_alive()
             vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))


### PR DESCRIPTION
User can opt for dhcp IP or a static IP configuration for probed interfaces inside guest. In case of dhcp IP, we have to start the guest before probing interfaces.

Without the fix:

# avocado run --vt-type qemu --vt-machine-type i440fx --vt-guest-os Guest.Linux.OL.7.9.x86_64 type_specific.io-github-autotest-qemu.sr_iov_sanity.vfio-pci
JOB ID     : c8511df51611330cbec026a1ecde9adba6dbb831
JOB LOG    : /root/avocado/job-results/job-2021-08-10T05.12-c8511df/job.log
 (1/1) type_specific.io-github-autotest-qemu.sr_iov_sanity.vfio-pci: ERROR: 'NoneType' object has no attribute 'get_output' (136.64 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 141.26 s
#


With the fix:

# avocado run --vt-type qemu --vt-machine-type i440fx --vt-guest-os Guest.Linux.OL.7.9.x86_64 user-qemu.sr_iov_sanity.vfio-pci
JOB ID     : 505baf68d9e70ae243460b2332579bf50fd38aa6
JOB LOG    : /root/avocado/job-results/job-2021-08-10T06.33-505baf6/job.log
 (1/1) type_specific.user-qemu.sr_iov_sanity.vfio-pci: PASS (198.84 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 229.27 s
#



