### PR TITLE
virtio_serial: Set sub-thread as daemon mode in background

### DIFF
--- a/qemu/tests/vioser_in_use.py
+++ b/qemu/tests/vioser_in_use.py
@@ -97,6 +97,7 @@ def run_bg_test(test, params, vm, sender="both"):
     stress_thread = utils_misc.InterruptedThread(
         virtio_serial_file_transfer.transfer_data, (params, vm),
         {"sender": sender})
+    stress_thread.daemon = True
     stress_thread.start()
 
     check_bg_timeout = float(params.get('check_bg_timeout', 120))

--- a/qemu/tests/virtio_serial_file_transfer.py
+++ b/qemu/tests/virtio_serial_file_transfer.py
@@ -130,6 +130,7 @@ def _transfer_data(session, host_cmd, guest_cmd, timeout, sender):
                               % host_cmd, logging.info)
         host_thread = utils_misc.InterruptedThread(process.getoutput,
                                                    kwargs=kwargs)
+        host_thread.daemon = True
         host_thread.start()
         time.sleep(3)
         g_output = session.cmd_output(guest_cmd, timeout=timeout)

--- a/qemu/tests/win_virtio_serial_data_transfer_reboot.py
+++ b/qemu/tests/win_virtio_serial_data_transfer_reboot.py
@@ -55,6 +55,7 @@ def run(test, params, env):
                 args = (test, session, receive_cmd, data_file)
                 guest_receive = utils_misc.InterruptedThread(receive_data,
                                                              args)
+                guest_receive.daemon = True
                 guest_receive.start()
                 process.system(send_cmd, timeout=30, shell=True)
             finally:


### PR DESCRIPTION
Change the following files for this update:
1. vioser_in_use.py
2. virtio_serial_file_transfer.py
3. win_virtio_serial_data_transfer_reboot.py

ID: 1926582
Signed-off-by: Dehan Meng <demeng@redhat.com>