### PR TITLE
qemu-guest-agent: Getting 'qga_v' for rhel9 and fix a minor issue

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent_hotplug.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent_hotplug.cfg
@@ -11,6 +11,7 @@
     gagent_restart_cmd = "systemctl restart qemu-guest-agent"
     gagent_status_cmd = "service qemu-guest-agent status"
     gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
+    cmd_check_qgaservice = journalctl -e | grep -Ei "syslog is obsolete|ERROR|FAILED|WARNING|FAIL"
     gagent_check_type = sync
     # /qga_setup_fail.log is saved during guest preinstall phase, if you don't have this file, please skip this parameter.
     cmd_check_qga_installlog = "ls /qga_setup_fail.log"

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -146,8 +146,8 @@ class QemuGuestAgentTest(BaseVirtTest):
                                 "of qga rpm in advance" % self.qga_pkg_path)
             elif version_list[1] != version_list[0]:
                 return False
-        elif self.params.get("os_variant", "") == 'rhel7':
-            pattern = r"guest-agent-(\d+.\d+.\d+-\d+).el7"
+        else:
+            pattern = r"guest-agent-(\d+.\d+.\d+-\d+).el"
             qga_v = re.findall(pattern, o, re.I)
             self.qga_v = qga_v
         return s == 0


### PR DESCRIPTION
1. Change the code logic that get attribute 'qga_v' for RHEL9
2. Add parameter 'cmd_check_qgaservice' to qemu_guest_agent_hotplug.cfg

ID: 1990794
Signed-off-by: Dehan Meng <demeng@redhat.com>