### PR TITLE
blockdev_mirror_*: replace job-cancel by block-job-cancel for mirror job

### DIFF
--- a/qemu/tests/blockdev_mirror_cancel_ready_job_with_io.py
+++ b/qemu/tests/blockdev_mirror_cancel_ready_job_with_io.py
@@ -23,7 +23,7 @@ class BlockdevMirrorCancelReadyIOJobTest(BlockdevMirrorNowaitTest):
             session.close()
 
     def cancel_job(self):
-        self.main_vm.monitor.cmd("job-cancel", {'id': self._jobs[0]})
+        self.main_vm.monitor.cmd("block-job-cancel", {'device': self._jobs[0], 'force': True})
         event = get_event_by_condition(
             self.main_vm, 'BLOCK_JOB_CANCELLED',
             self.params.get_numeric('job_cancelled_timeout', 60),

--- a/qemu/tests/blockdev_mirror_cancel_running_job.py
+++ b/qemu/tests/blockdev_mirror_cancel_running_job.py
@@ -8,7 +8,7 @@ class BlockdevMirrorCancelRunningJob(BlockdevMirrorNowaitTest):
     """
 
     def cancel_job(self):
-        self.main_vm.monitor.cmd("job-cancel", {'id': self._jobs[0]})
+        self.main_vm.monitor.cmd("block-job-cancel", {'device': self._jobs[0]})
         event = get_event_by_condition(
             self.main_vm, 'BLOCK_JOB_CANCELLED',
             self.params.get_numeric('job_cancelled_timeout', 60),


### PR DESCRIPTION
Replace job-cancel by block-job-cancel for mirror job
according to the usage change of upper layer

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:1992514