### PR TITLE
ansible: check ansible exists or not before test start

### DIFF
--- a/qemu/tests/ansible_test.py
+++ b/qemu/tests/ansible_test.py
@@ -4,6 +4,7 @@ import logging
 
 from avocado.utils import process
 
+from virttest import env_process
 from virttest import error_context
 
 from provider import ansible
@@ -13,8 +14,8 @@ from provider import ansible
 def run(test, params, env):
     """
     Ansible playbook basic test:
-    1) Check ansible package exists
-    2) Launch the guest
+    1) Check ansible-playbook exists and try to install it if not exists
+    2) Launch the guest if ansible-playbook program exists
     3) Clone an ansible playbook repo
     4) Generate the ansible-playbook command
     5) Execute the playbook and verify the return status
@@ -23,6 +24,10 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters.
     :param env: Dictionary with test environment.
     """
+
+    # check ansible-playbook program
+    if not ansible.check_ansible_playbook(params):
+        test.cancel("No available ansible-playbook program")
 
     guest_user = params["username"]
     guest_passwd = params["password"]
@@ -39,6 +44,8 @@ def run(test, params, env):
     # Use this directory to copy some logs back from the guest
     test_harness_log_dir = test.logdir
 
+    params['start_vm'] = 'yes'
+    env_process.preprocess(test, params, env)
     vms = env.get_all_vms()
     guest_ip_list = []
     for vm in vms:

--- a/qemu/tests/cfg/ansible_test.cfg
+++ b/qemu/tests/cfg/ansible_test.cfg
@@ -9,6 +9,8 @@
     ansible_ssh_extra_args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     # Here we can define an extra set of variables for the playbook with json format
     #ansible_extra_vars = '{"debug_msg": "Hello Ansible!", "force_handlers": true}'
+    start_vm = no
+    ansible_install_policy = 'distro_install'
     variants:
         - @default:
         - responsive_migration:


### PR DESCRIPTION
1. Check ansible exists or not before test start
2. Install ansible use the method that defined by ansible_install_policy
3. If install ansible with pip, install sshpass separately as it can't be
    installed automatically. Install specified sshpass if failed to install
    it from distro and there is a specified sshpass pkg.

id: 1993730

Signed-off-by: Yanan Fu <yfu@redhat.com>