### PR TITLE
Remove numa test cases require more than one node on s390x

### DIFF
--- a/qemu/tests/cfg/numa_opts.cfg
+++ b/qemu/tests/cfg/numa_opts.cfg
@@ -9,6 +9,8 @@
     vcpu_maxcpus = ${smp}
     backend_mem = memory-backend-ram
     use_mem = no
+    s390x:
+        only nodes.0
     variants:
         - nodes.0:
             # no extra parameters => one node in guest os


### PR DESCRIPTION
Memory: Since s390x only have one numa node, remove test case requires
more

ID: 1995036

Signed-off-by: Boqiao Fu <bfu@redhat.com>