### PR TITLE
blockdev_commit_forbidden_actions:Forbide block job ops during commit

### DIFF
--- a/qemu/tests/blockdev_commit_forbidden_actions.py
+++ b/qemu/tests/blockdev_commit_forbidden_actions.py
@@ -1,0 +1,82 @@
+from virttest.qemu_monitor import QMPCmdError
+
+from provider import job_utils
+from provider import backup_utils
+from provider.blockdev_commit_base import BlockDevCommitTest
+
+
+class BlockdevCommitForbiddenActions(BlockDevCommitTest):
+
+    def commit_snapshots(self):
+        device = self.params.get("device_tag")
+        device_params = self.params.object_params(device)
+        snapshot_tags = device_params["snapshot_tags"].split()
+        self.device_node = self.get_node_name(device)
+        options = ["speed"]
+        arguments = self.params.copy_from_keys(options)
+        arguments["speed"] = self.params["commit_speed"]
+        self.active_node = self.get_node_name(snapshot_tags[-1])
+        self.forbidden_node = self.get_node_name(self.params["fnode"])
+        commit_cmd = backup_utils.block_commit_qmp_cmd
+        cmd, args = commit_cmd(self.active_node, **arguments)
+        self.main_vm.monitor.cmd(cmd, args)
+        job_id = args.get("job-id", self.active_node)
+        self.do_forbidden_actions()
+        self.main_vm.monitor.cmd("block-job-set-speed",
+                                 {'device': job_id, 'speed': 0})
+        job_utils.wait_until_block_job_completed(self.main_vm, job_id)
+
+    def commit(self):
+        self.main_vm.monitor.cmd(
+            "block-commit", {'device': self.active_node}
+        )
+
+    def resize(self):
+        self.main_vm.monitor.cmd(
+            "block_resize",
+            {'node-name': self.active_node, 'size': 1024*1024*1024}
+        )
+
+    def mirror(self):
+        self.main_vm.monitor.cmd(
+            "blockdev-mirror",
+            {'device': self.active_node,
+             'target': self.forbidden_node, 'sync': 'full'}
+        )
+
+    def snapshot(self):
+        self.main_vm.monitor.cmd(
+            "blockdev-snapshot",
+            {'node': self.active_node, 'overlay': self.forbidden_node}
+        )
+
+    def stream(self):
+        self.main_vm.monitor.cmd("block-stream", {'device': self.active_node})
+
+    def do_forbidden_actions(self):
+        """Run the qmp commands one by one, all should fail"""
+        self.prepare_snapshot_file(self.params["fnode"].split())
+        for action in self.params.objects('forbidden_actions'):
+            error_msg = self.params['error_msg_%s' % action]
+            f = getattr(self, action)
+            try:
+                f()
+            except QMPCmdError as e:
+                if error_msg not in str(e):
+                    self.test.fail('Unexpected error: %s' % str(e))
+            else:
+                self.test.fail('Unexpected qmp command success')
+
+
+def run(test, params, env):
+    """
+    Snapshot related action should be forbidden after live commit starts
+
+    1. boot guest with data disk
+    2. do live commit
+    3. during commit, do snapshot related actions, as live snapshot, resize
+       and so on,
+    """
+
+    block_test = BlockdevCommitForbiddenActions(test, params, env)
+    block_test.run_test()

--- a/qemu/tests/cfg/blockdev_commit_forbidden_actions.cfg
+++ b/qemu/tests/cfg/blockdev_commit_forbidden_actions.cfg
@@ -1,0 +1,36 @@
+- blockdev_commit_forbidden_actions:
+    type = blockdev_commit_forbidden_actions
+    virt_test_type = qemu
+    only Linux
+    device_tag = 'data'
+    images += " ${device_tag}"
+    force_create_image_data = yes
+    remove_image_data = yes
+    start_vm = yes
+    kill_vm = yes
+    storage_pools = default
+    storage_type_default = "directory"
+    storage_pool = default
+    image_size_data = 500M
+    image_name_data = data
+    snapshot_tags_data = sn1
+    top_device_node = drive_sn1
+
+    image_size_sn1 = 500M
+    image_name_sn1 = sn1
+    image_format_sn1 = qcow2
+    image_size_sn2 = 500M
+    image_name_sn2 = sn2
+    image_format_sn2 = qcow2
+
+    rebase_mode = unsafe
+    qemu_force_use_drive_expression = no
+    commit_speed = 1000
+    fnode = sn2
+
+    forbidden_actions = snapshot stream mirror commit resize
+    error_msg_snapshot = "Node '${top_device_node}' is busy: block device is in use by block job: commit"
+    error_msg_stream = "Node '${top_device_node}' is busy: block device is in use by block job: commit"
+    error_msg_mirror = "Need a root block node"
+    error_msg_commit = "Need a root block node"
+    error_msg_resize = "Device '(null)' is in use"


### PR DESCRIPTION
Snapshot related action should be forbidden after live commit starts

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:1995912