### PR TITLE
blockdev_stream_on_error_ignore:update job event check after extend lvm

### DIFF
--- a/qemu/tests/cfg/blockdev_stream_on_error_ignore.cfg
+++ b/qemu/tests/cfg/blockdev_stream_on_error_ignore.cfg
@@ -35,6 +35,8 @@
     image_name_data1 = data1
     image_name_data1sn = data1sn
 
+    error_msg = "No space left on device"
+
     nbd:
         nbd_port_data1 = 10822
         force_create_image_data1 = no


### PR DESCRIPTION
Check stream complete with no space left after lvm extend

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:1965216