### PR TITLE
virtio_fs:fix memory-backend-file option cfg is invalid on S390

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -5,8 +5,6 @@
     type = virtio_fs_share_data
     virt_test_type = qemu
     required_qemu = [4.2.0,)
-    s390, s390x:
-        required_qemu = [5.2.0,)
     kill_vm = yes
     start_vm = yes
     filesystems = fs
@@ -24,6 +22,14 @@
     size_mem1 = 4G
     use_mem_mem1 = no
     share_mem = yes
+    s390, s390x:
+        required_qemu = [5.2.0,)
+        share_machine_mem = yes
+        pre_command_noncritical = yes
+        pre_command = "echo 3 > /proc/sys/vm/drop_caches"
+        setup_hugepages = yes
+        kvm_module_parameters = 'hpage=1'
+        expected_hugepage_size = 1024
     !s390, s390x:
         guest_numa_nodes = shm0
         numa_memdev_shm0 = mem-mem1


### PR DESCRIPTION
fix memory-backend-file option configuration is invalid on S390

id:1996927
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>