### PR TITLE
bypass_host_cache: switch to 'openat' for rhel9 hosts

### DIFF
--- a/qemu/tests/cfg/image_commit_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_commit_bypass_host_cache.cfg
@@ -14,7 +14,7 @@
     backup_image_before_testing = yes
     restore_image_after_testing = yes
     trace_events = open
-    Host_RHEL.m8:
+    Host_RHEL.m8, Host_RHEL.m9:
         trace_events = openat
     Windows:
         guest_tmp_filename = "C:\\sn1"

--- a/qemu/tests/cfg/image_compare_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_compare_bypass_host_cache.cfg
@@ -9,5 +9,5 @@
     image_name_target = "images/target"
     convert_target = "target"
     strace_event = open
-    Host_RHEL.m8:
+    Host_RHEL.m8, Host_RHEL.m9:
         strace_event = openat

--- a/qemu/tests/cfg/image_convert_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_convert_bypass_host_cache.cfg
@@ -11,7 +11,7 @@
     image_name_target1 = "images/target1"
     convert_target = " target0 target1"
     strace_event = open
-    Host_RHEL.m8:
+    Host_RHEL.m8, Host_RHEL.m9:
         strace_event = openat
     variants:
         - luks_to_luks:

--- a/qemu/tests/cfg/image_rebase_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_rebase_bypass_host_cache.cfg
@@ -18,7 +18,7 @@
     # only backup system disk
     backup_image_before_testing_image1 = yes
     restore_image_after_testing_image1 = yes
-    Host_RHEL.m8:
+    Host_RHEL.m8, Host_RHEL.m9:
         trace_event = openat
     Windows:
         guest_tmp_filename = "C:\\%s"


### PR DESCRIPTION
Switch to 'openat' in rhel9 host for commit, compare, rebase and
convert cases

Signed-off-by: Tingting Mao <timao@redhat.com>