### PR TITLE
blockdev_commit_backing_file: Update the mount_point to be /var/tmp

### DIFF
--- a/qemu/tests/cfg/blockdev_commit_backing_file.cfg
+++ b/qemu/tests/cfg/blockdev_commit_backing_file.cfg
@@ -23,5 +23,5 @@
 
     device_tag = "image1"
     rebase_mode = unsafe
-    mount_point = "/tmp"
+    mount_point = "/var/tmp"
     qemu_force_use_drive_expression = no


### PR DESCRIPTION
Since the /tmp filesystem does not support O_DIRECT, replace the
mount_point(of=... in dd command) /tmp to be /var/tmp.

ID: 1967375
Signed-off-by: Nini Gu <ngu@redhat.com>