### PR TITLE
qemu_guest_agent: Add download and update CA for container test

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -483,6 +483,9 @@
             get_container_ver_cmd = "podman inspect qemu-guest-agent | grep %s"
             # Please define create_container_cmd before this test:
             # create_container_cmd = podman create --name qemu-guest-agent --network xxx --privileged --volume xxx:xxx --pull missing qemu-guest-agent:xxx
+            ca_url = https://password.corp.redhat.com/RH-IT-Root-CA.crt
+            ca_dir = /etc/pki/ca-trust/source/anchors
+            ca_name = Red_Hat_IT_Root_CA.crt
         - gagent_ssh_public_key_injection:
             only Linux
             guest_user = "fedora"

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -484,8 +484,8 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         Start qga container behavior only for linux guest
         and release version above rhel8.2.0 now:
         steps:
-        1) Prepare for container that stop qga.service and
-         install podman.
+        1) Prepare for container that stop qga.service,
+         install podman and download/update ca trust.
         2) Create qga container.
         3) start qga container.
         4) Check target qga pkg we aim to test.
@@ -502,6 +502,11 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                               logging.info)
         self.gagent_stop(session, self.vm)
         utils_package.package_install('podman', session)
+        ca_dir = params["ca_dir"]
+        ca_name = params["ca_name"]
+        ca_url = params["ca_url"]
+        session.cmd("curl -kL -o %s/%s %s" % (ca_dir, ca_name, ca_url))
+        session.cmd("update-ca-trust")
 
         error_context.context("Create a qemu-ga container.", logging.info)
         cmd_create_container = params["create_container_cmd"]


### PR DESCRIPTION
For gagent_container test, add the download and update CA
certificates and associated trust steps in the guest to make
following steps go smoothly.

ID: 1943795
Signed-off-by: Nini Gu <ngu@redhat.com>