### PR TITLE
discard_for_raw_block_target: update according to the behavior changes of 'fallocate'

### DIFF
--- a/qemu/tests/discard_for_raw_block_target.py
+++ b/qemu/tests/discard_for_raw_block_target.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 from provider.qemu_img_utils import strace
 
@@ -7,6 +8,7 @@ from avocado import fail_on
 from avocado.utils import process
 
 from virttest import data_dir
+from virttest import utils_numeric
 from virttest.qemu_storage import QemuImg
 
 
@@ -18,21 +20,31 @@ def run(test, params, env):
     2. Modprobe a 1G scsi_debug disk with writesame_16 mode.
     3. Trace the system calls while converting the zero image to the
        scsi_debug block device, then check whether 'fallocate' system call
-       works in the log.
+       results work in the log.
     :param test: Qemu test object.
     :param params: Dictionary with the test parameters.
     :param env: Dictionary with test environment.
     """
-    def check_output(strace_event, strace_output, match_str):
+
+    def _check_output(strace_event, strace_output, match_str):
         """Check whether the value is good in the output file."""
         logging.debug("Check the output file '%s'.", strace_output)
         with open(strace_output) as fd:
-            if match_str not in fd.read():
-                test.fail("The system call of '%s' is not right, "
+            m = re.findall(match_str + r', \d+, \d+', fd.read())
+            if not m:
+                test.fail("The result of system call '%s' is not right, "
                           "check '%s' for more details."
                           % (strace_event, strace_output))
+            last_lst = m[-1].split(',')
+            sum_size = int(last_lst[-1]) + int(last_lst[-2])
+            # get the source image size in byte unit
+            byte_image_size = int(utils_numeric.normalize_data_size(image_size, "B"))
+            if sum_size != byte_image_size:
+                test.fail("The target allocated size '%s' is different from the source image size, "
+                          "check '%s' for more details." % (str(sum_size), strace_output))
 
     src_image = params["images"]
+    image_size = params["image_size_test"]
     root_dir = data_dir.get_data_dir()
     source = QemuImg(params.object_params(src_image), root_dir, src_image)
     strace_event = params["strace_event"]
@@ -52,5 +64,4 @@ def run(test, params, env):
         fail_on((process.CmdError,))(source.convert)(
             params.object_params(src_image), root_dir, cache_mode="none")
 
-    check_output(strace_event, strace_output_file,
-                 "FALLOC_FL_PUNCH_HOLE, 0, 1073741824")
+    _check_output(strace_event, strace_output_file, "FALLOC_FL_PUNCH_HOLE")


### PR DESCRIPTION
Update the output check function to match the read size with the imag size.

Signed-off-by: Tingting Mao <timao@redhat.com>

ID: 1998022