### PR TITLE
Add new case for fwcfg64 basic testing

### DIFF
--- a/provider/win_dump_utils.py
+++ b/provider/win_dump_utils.py
@@ -1,0 +1,130 @@
+"""
+Windows dump related utilities.
+"""
+import os
+import logging
+
+from avocado.utils import process
+from virttest import env_process
+from virttest import utils_misc
+
+
+def set_vm_for_dump(test, params):
+    """
+    Update vm mem and image size params to match dump generate and analysed.
+
+    :param test: kvm test object
+    :param params: Params object
+    """
+    host_free_mem = utils_misc.get_mem_info(attr='MemFree')
+    host_avail_disk = int(process.getoutput(params["get_avail_disk"]))
+    sys_image_size = int(float(
+            utils_misc.normalize_data_size(params["image_size"], "G")))
+    if host_avail_disk < (host_free_mem // 1024**2) * 1.2 + sys_image_size:
+        params["mem"] = (host_avail_disk - sys_image_size) * 0.8 // 2.4 * 1024
+    image_size_stg = int(float(
+            utils_misc.normalize_data_size(params["mem"] + "M", "G")) * 1.4)
+    params["image_size_stg"] = str(image_size_stg) + "G"
+
+    params["force_create_image_stg"] = "yes"
+    image_params = params.object_params("stg")
+    env_process.preprocess_image(test, image_params, "stg")
+
+
+def generate_mem_dump(test, params, vm):
+    """
+    Generate the Memory.dmp file through qemu side.
+
+    :param test: kvm test object
+    :param params: the dict used for parameters.
+    :param vm: VM object.
+    """
+    tmp_dir = params["tmp_dir"]
+    if not os.path.isdir(tmp_dir):
+        process.system("mkdir %s" % tmp_dir)
+    dump_name = utils_misc.generate_random_string(4) + "Memory.dmp"
+    dump_file = tmp_dir + "/" + dump_name
+
+    output = vm.monitor.human_monitor_cmd('dump-guest-memory -w %s'
+                                          % dump_file)
+    if output:
+        test.fail("Save dump file failed as: %s" % output)
+    else:
+        cmd = "ls -l %s | awk '{print $5}'" % dump_file
+        dump_size = int(process.getoutput(cmd))
+        if dump_size == 0:
+            test.fail("The size of dump file is %d" % dump_size)
+
+    dump_name_zip = "%s.zip" % dump_name
+    process.system("cd %s && zip %s %s" % (tmp_dir, dump_name_zip,
+                                           dump_name), shell=True)
+    dump_file_zip = tmp_dir + "/" + dump_name_zip
+    return dump_file, dump_file_zip
+
+
+def install_windbg(test, params, session, timeout=600):
+    """
+    Install Windows Debug Tools.
+
+    :param test: kvm test object
+    :param params: the dict used for parameters.
+    :param session: The guest session object.
+    :param timeout: waiting debug tool install finish.
+    """
+    logging.info("Install Windows Debug Tools in guest.")
+    windbg_install_cmd = params["windbg_install_cmd"]
+    windbg_install_cmd = utils_misc.set_winutils_letter(session,
+                                                        windbg_install_cmd
+                                                        % params["feature"])
+    session.cmd(windbg_install_cmd)
+    if not utils_misc.wait_for(lambda: check_windbg_installed(params, session),
+                               timeout=timeout):
+        test.fail("windbg tool has not been installed")
+
+
+def check_windbg_installed(params, session):
+    """
+    Check Windows Debug Tools is installed
+
+    :param params: the dict used for parameters.
+    :param session: The guest session object.
+    """
+    check_cmd = params["chk_windbg_cmd"] % params["windbg_path"]
+    status, _ = session.cmd_status_output(check_cmd)
+    return False if status else True
+
+
+def dump_windbg_check(test, params, session):
+    """
+    Check the dump file can be open through windbg tool.
+
+    :param test: kvm test object
+    :param params: the dict used for parameters.
+    :param session: The guest session object.
+    """
+    logging.info("Check the dump file can be opened by windbg tool")
+    chk_dump_cmd = params["chk_dump_cmd"]
+    log_file = params["dump_analyze_file"]
+    chk_dump_cmd = utils_misc.set_winutils_letter(session,
+                                                  chk_dump_cmd)
+    session.cmd(chk_dump_cmd)
+    if not utils_misc.wait_for(lambda: check_log_exist(session, log_file),
+                               timeout=120):
+        test.error("Cannot generate dump analyze log.")
+    chk_id_cmd = params["chk_id_cmd"] % log_file
+    status, output = session.cmd_status_output(chk_id_cmd)
+    if status:
+        output = session.cmd_output("type %s" % log_file)
+        test.fail("Check dump file failed, output as %s" % output)
+
+
+def check_log_exist(session, log_file):
+    """
+    Check if the analyzed log of dump file is exist.
+
+    :param session: The guest session object.
+    :param log_file: The log file of dump analyze.
+    """
+    chk_log_exist = "dir %s" % log_file
+    status, _ = session.cmd_status_output(chk_log_exist)
+    return False if status else True

--- a/qemu/tests/cfg/fwcfg.cfg
+++ b/qemu/tests/cfg/fwcfg.cfg
@@ -1,0 +1,29 @@
+- fwcfg:
+    only Windows
+    type = fwcfg
+    driver_name = "fwcfg"
+    required_qemu = [6.0.0, )
+    vmcoreinfo = yes
+    start_vm = no
+    tmp_dir = "/var/tmp"
+    get_avail_disk = df -h /home | grep home | awk -F "G" '{print $3}'
+    unzip_cmd = 'powershell -command "Expand-Archive %s:\Memory.dmp.zip %s:"'
+    unzip_speed = 60
+    move_cmd = "move {0}:\*Memory.dmp {0}:\Memory.dmp"
+    chk_id_cmd = 'type %s | find /i "LIVE_SYSTEM_DUMP (161)"'
+    images += " stg"
+    image_name_stg = "images/storage"
+    remove_image_stg = yes
+    no ppc64 ppc64le aarch64
+    i386:
+        windbg_path = "x86\windbg.exe"
+    x86_64:
+        windbg_path = "x64\windbg.exe"
+    Win8..1:
+        unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
+        chk_id_cmd = 'type %s | find /i "Bugcheck code 00000161"'
+    chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
+    feature = "OptionId.WindowsDesktopDebuggers"
+    windbg_install_cmd = "WIN_UTILS:\winsdksetup.exe /features %s /q"
+    chk_dump_cmd = "WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"
+    dump_analyze_file = "C:\dump_analyze.log"

--- a/qemu/tests/fwcfg.py
+++ b/qemu/tests/fwcfg.py
@@ -1,0 +1,65 @@
+import logging
+
+from avocado.utils import process
+from virttest import env_process
+from virttest import error_context
+from virttest import utils_disk
+from virttest import utils_test
+from provider import win_dump_utils
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Fwcfg64 basic function test:
+
+    1) Boot guest with -device vmcoreinfo.
+    2) Check the fwcfgg64 driver has been installed.
+    3) Run "dump-guest-memory -w memory.dmp" in qemu monitor.
+    4) Check the memory.dmp can be saved and the size is larger then 0Kb.
+    5) Check the dump file can be open with windb tools.
+    """
+    win_dump_utils.set_vm_for_dump(test, params)
+    vm_name = params['main_vm']
+    params['start_vm'] = 'yes'
+    env_process.preprocess_vm(test, params, env, vm_name)
+    vm = env.get_vm(vm_name)
+
+    session = vm.wait_for_login()
+    driver = params["driver_name"]
+    wdbg_timeout = params.get("wdbg_timeout", 600)
+    error_context.context("Check fwcfg driver is running", logging.info)
+    utils_test.qemu.windrv_verify_running(session, test, driver)
+    error_context.context("Enable fwcfg driver verified", logging.info)
+    session = utils_test.qemu.setup_win_driver_verifier(session, driver, vm)
+
+    disk = sorted(session.cmd('wmic diskdrive get index').split()[1:])[-1]
+    utils_disk.update_windows_disk_attributes(session, disk)
+    disk_letter = utils_disk.configure_empty_disk(session,
+                                                  disk,
+                                                  params['image_size_stg'],
+                                                  params["os_type"])[0]
+
+    error_context.context("Generate the Memory.dmp file", logging.info)
+    dump_file, dump_zip_file = win_dump_utils.generate_mem_dump(test,
+                                                                params,
+                                                                vm)
+
+    try:
+        error_context.context("Copy the Memory.dmp.zip file "
+                              "from host to guest", logging.info)
+        unzip_speed = int(params.get("unzip_speed", 80))
+        vm.copy_files_to(dump_zip_file, "%s:\\Memory.dmp.zip" % disk_letter)
+        unzip_cmd = params["unzip_cmd"] % (disk_letter, disk_letter)
+        unzip_timeout = int(params["mem"]) // unzip_speed
+        status, output = session.cmd_status_output(unzip_cmd,
+                                                   timeout=unzip_timeout)
+        if status:
+            test.error("unzip dump file failed as:\n%s" % output)
+        session.cmd(params["move_cmd"].format(disk_letter))
+        win_dump_utils.install_windbg(test, params, session,
+                                      timeout=wdbg_timeout)
+        win_dump_utils.dump_windbg_check(test, params, session)
+    finally:
+        process.system("rm %s %s" % (dump_file, dump_zip_file), shell=True)
+        session.close()


### PR DESCRIPTION
Fwcfg64 basic function test:
1) Boot guest with -device vmcoreinfo.
2) Check the fwcfgg64 driver has been installed.
3) Run "dump-guest-memory -w memory.dmp" in qemu monitor.
4) Check the memory.dmp can be saved and the size is larger then 0Kb.
5) Check the dump file can be open with windb tools.

id: 1992917
Signed-off-by: Peixiu Hou <phou@redhat.com>