### PR TITLE
fio_perf: remove the setup steps of fio for Linux guests

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -15,30 +15,23 @@
         no ide
         order_list = "Block_size Iodepth Threads BW(MB/S) IOPS Latency(ms) Host_CPU BW/CPU KVM_Exits Util%"
         guest_ver_cmd = "uname -r"
-        check_install_fio = "which fio"
-        tarball = "performance/fio-3.27.tar.gz"
-        fio_path = "/tmp/fio-3.27"
-        compile_cmd = "make && make install"
         pre_cmd = "i=`/bin/ls /dev/[vs]db` && mkfs.xfs $i > /dev/null; partprobe; umount /mnt; mount $i /mnt"
         ppc64, ppc64le:
             virtio_blk:
                 pre_cmd = "i=`/bin/ls /dev/vda` && mkfs.xfs $i > /dev/null; partprobe; umount /mnt; mount $i /mnt"
         drop_cache = "sync && echo 3 > /proc/sys/vm/drop_caches"
-        guest_result_file = /tmp/fio_result
-        fio_cmd = "fio --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/mnt/%s --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=/tmp/fio_result &> /dev/null"
+        guest_result_file = /var/tmp/fio_result
+        fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/mnt/%s --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=${guest_result_file} &> /dev/null"
     Windows:
         virtio_blk:
             guest_ver_cmd = wmic datafile where name="c:\\windows\\system32\\drivers\\viostor.sys"
         virtio_scsi:
             guest_ver_cmd = wmic datafile where name="c:\\windows\\system32\\drivers\\vioscsi.sys"
         order_list = "Block_size Iodepth Threads BW(MB/S) IOPS Latency(ms) Host_CPU BW/CPU KVM_Exits"
-        check_install_fio = "dir C:\fio-3.9-x64\ | findstr /I fio"
-        tarball = "performance/fio-3.9-x64/*"
-        fio_path = "C:\fio-3.9-x64"
         pre_cmd = "echo select disk 1 > imDiskpart.script && echo create partition primary >> imDiskpart.script && echo assign letter=I >> imDiskpart.script&& echo exit >> imDiskpart.script && diskpart /s imDiskpart.script && format I: /FS:NTFS /V:local /Q /y"
         online_disk_cmd = "echo select disk %s > imDiskpart.script && echo online disk >> imDiskpart.script && echo attr disk clear readonly >> imDiskpart.script && echo exit >> imDiskpart.script && diskpart /s imDiskpart.script"
         guest_result_file = "C:\fio_result"
-        fio_cmd = 'cmd /c C:\fio-3.9-x64\fio.exe --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=I\:%s --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output="C:\\fio_result"'
+        fio_options = '--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=I\:%s --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=${guest_result_file}'
     variants:
         - file_system_block:
             image_size_disk1 = 40G


### PR DESCRIPTION
fio package is setup in Linux guests installation processs by default,
so remove the setup steps of fio in the case.

Signed-off-by: Tingting Mao <timao@redhat.com>

ID: 2000378