### PR TITLE
blockdev_commit_auto_readonly:Support auto-read-only=on for filesystem backend

### DIFF
--- a/qemu/tests/blockdev_commit_auto_readonly.py
+++ b/qemu/tests/blockdev_commit_auto_readonly.py
@@ -1,0 +1,31 @@
+from provider import backup_utils
+from provider import job_utils
+from provider.blockdev_commit_base import BlockDevCommitTest
+
+
+class BlockdevCommitAutoReadonly(BlockDevCommitTest):
+
+    def commit_snapshots(self):
+        device = self.params.get("device_tag")
+        device_params = self.params.object_params(device)
+        snapshot_tags = device_params["snapshot_tags"].split()
+        device = self.get_node_name(snapshot_tags[-1])
+        commit_cmd = backup_utils.block_commit_qmp_cmd
+        cmd, args = commit_cmd(device)
+        self.main_vm.monitor.cmd(cmd, args)
+        job_id = args.get("job-id", device)
+        job_utils.wait_until_block_job_completed(self.main_vm, job_id)
+
+
+def run(test, params, env):
+    """
+    Block commit base Test
+
+    1). boot guest with system disk
+    2). create 2 snapshots and save file in each snapshot
+    3). commit from sn2 to base
+    4). verify files's md5
+    """
+
+    block_test = BlockdevCommitAutoReadonly(test, params, env)
+    block_test.run_test()

--- a/qemu/tests/cfg/blockdev_commit_auto_readonly.cfg
+++ b/qemu/tests/cfg/blockdev_commit_auto_readonly.cfg
@@ -1,0 +1,28 @@
+- blockdev_commit_auto_readonly:
+    type = blockdev_commit_auto_readonly
+    virt_test_type = qemu
+    only Linux
+    start_vm = yes
+    kill_vm = yes
+    image_auto_readonly_image1 = on
+    storage_pools = default
+    storage_type_default = "directory"
+    storage_pool = default
+    snapshot_tags = sn1 sn2
+
+    image_size_sn1 = 20G
+    image_name_sn1 = sn1
+    image_format_sn1 = qcow2
+
+    image_name_sn2 = sn2
+    image_size_sn2 = 20G
+    image_format_sn2 = qcow2
+    image_auto_readonly_sn2 = off
+
+    device_tag = "image1"
+    format = qcow2
+    rebase_mode = unsafe
+    mount_point = "/var/tmp"
+    !Host_RHEL.m7:
+        node = ${device}
+        qemu_force_use_drive_expression = no


### PR DESCRIPTION
Support auto-read-only=on for various backends:filesystem at present

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2000429