### PR TITLE
virtio-fs: create a new multi_backend config file

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -1,17 +1,17 @@
-- virtio_fs_share_data:
+- virtio_fs_share_data_multi_backend:
     no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
     no Win2008 Win7
     no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
     type = virtio_fs_share_data
     virt_test_type = qemu
     required_qemu = [4.2.0,)
+    start_vm = no
     kill_vm = yes
-    start_vm = yes
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_type = mount
-    fs_source_dir = virtio_fs_test/
-    force_create_fs_source = yes
+    fs_source_dir = /tmp/virtio_fs_test
+    force_create_fs_source = no
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
@@ -54,17 +54,30 @@
         virtio_win_media_type = iso
         cdroms += " virtio"
     variants:
-        - @default:
-        - with_reboot:
-            only default.default.with_cache.auto.default
-            reboot_guest = 'yes'
-            cmd_ps_virtiofsd = 'ps -eo pid,args |grep "socket-path=%s" |grep -v grep'
-        - with_log_check:
-            only Windows
-            only default.default.with_cache.auto.default
-            viofs_log_file_cmd = 'dir ${viofs_log_file}'
+        - with_nfs_source:
+            setup_local_nfs = yes
+            nfs_mount_options = rw
+            export_options = 'rw,insecure,no_root_squash,async'
+            variants:
+                - @default:
+                    export_dir = /mnt/virtio_fs_test_nfs
+                    nfs_mount_src = 127.0.0.1:/mnt/virtio_fs_test_nfs
+                - multi_fs:
+                    only run_stress.with_xfstest
+                    export_dir_fs1 = /mnt/virtio_fs1_test_nfs
+                    export_dir_fs2 = /mnt/virtio_fs2_test_nfs
+                    nfs_mount_src_fs1 = 127.0.0.1:/mnt/virtio_fs1_test_nfs
+                    nfs_mount_src_fs2 = 127.0.0.1:/mnt/virtio_fs2_test_nfs
     variants:
         - @default:
+        - with_stdev_check:
+            no Windows
+            only default.with_cache.auto.default_extra_parameters
+            fs_binary_extra_options += ",announce_submounts"
+            cmd_get_stdev = stat %%d %s
+            nfs_mount_dst_name = nfs_dir
+    variants:
+        - @default_extra_parameters:
         - @extra_parameters:
             variants:
                 - lock_posix_off:
@@ -108,57 +121,11 @@
                 cmd_del_folder = "rd /q /s ${test_folder}"
             default..with_cache.none:
                 io_timeout = 600
-            variants:
-                - @default:
-                - with_multi_fs_sources:
-                    no Windows
-                    with_multi_fs_sources.with_cache.none:
-                        io_timeout = 600
-                    filesystems = fs1 fs2 fs3 fs4 fs5
-                    fs_source_dir_fs1 = '/tmp/virtio_fs1_test'
-                    fs_source_dir_fs2 = '/tmp/virtio_fs2_test'
-                    fs_source_dir_fs3 = '/tmp/virtio_fs3_test'
-                    fs_source_dir_fs4 = '/tmp/virtio_fs4_test'
-                    fs_source_dir_fs5 = '/tmp/virtio_fs5_test'
-                    fs_target_fs1 = 'myfs1'
-                    fs_target_fs2 = 'myfs2'
-                    fs_target_fs3 = 'myfs3'
-                    fs_target_fs4 = 'myfs4'
-                    fs_target_fs5 = 'myfs5'
-                    fs_dest_fs1 = '/mnt/${fs_target_fs1}'
-                    fs_dest_fs2 = '/mnt/${fs_target_fs2}'
-                    fs_dest_fs3 = '/mnt/${fs_target_fs3}'
-                    fs_dest_fs4 = '/mnt/${fs_target_fs4}'
-                    fs_dest_fs5 = '/mnt/${fs_target_fs5}'
         - run_stress:
-            no run_stress..extra_parameters
             variants:
-                - with_fio:
-                    smp = 8
-                    vcpu_maxcpus = 8
-                    io_timeout = 2000
-                    fio_options = '--name=stress --filename=%s --ioengine=libaio --rw=write --direct=1 '
-                    fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800'
-                    Windows:
-                        fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
-                        fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800 --thread'
-                - with_pjdfstest:
-                    no Windows
-                    io_timeout = 1800
-                    with_pjdfstest..with_cache.none:
-                        io_timeout = 7200
-                    pjdfstest_pkg = pjdfstest-0.1.tar.bz2
-                    cmd_unpack = 'tar -zxvf {0}/${pjdfstest_pkg} -C {0}'
-                    cmd_yum_deps = 'yum install -y perl-Test-Harness'
-                    cmd_autoreconf = 'autoreconf -ifs %s/pjdfstest/'
-                    cmd_configure = '{0}/pjdfstest/configure && '
-                    cmd_configure += 'mv config.* {0}/pjdfstest/ && mv Makefile {0}/pjdfstest/ && mv stamp-h1 {0}/pjdfstest/'
-                    cmd_make = 'make %s/pjdfstest/pjdfstest'
-                    cmd_pjdfstest = 'prove -rv %s/pjdfstest/tests'
                 - with_xfstest:
+                    only with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs
                     no Windows
-                    only run_stress..with_cache.auto
-                    start_vm = no
                     image_snapshot = yes
                     mem = 32768
                     size_mem1 = 32G
@@ -166,11 +133,13 @@
                     # generic/003 120: https://gitlab.com/virtio-fs/qemu/-/issues/8
                     # generic/426 467 477: https://gitlab.com/virtio-fs/qemu/-/issues/10
                     # generic/551: Costs a lot of time
-                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551'
+                    # generic/035 nfs specific: https://gitlab.com/virtio-fs/qemu/-/issues/12
+                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551 generic/035'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.
                     # And this case only supports Linux, and don't need to check screendump. So turn off this feature.
+                    force_create_fs_source = no
                     filesystems = fs1 fs2
                     fs_source_dir_fs1 = /tmp/virtio_fs1_test
                     fs_source_dir_fs2 = /tmp/virtio_fs2_test


### PR DESCRIPTION
Avoid the whole virtio_fs_share_data.cfg being too long,the multi backend
part is seperated to be one new cfg file.
ID: 1997512
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>