### PR TITLE
hv_check_cpu_utilization: extend time to let guest chill

### DIFF
--- a/qemu/tests/hv_check_cpu_utilization.py
+++ b/qemu/tests/hv_check_cpu_utilization.py
@@ -123,7 +123,7 @@ def run(test, params, env):
         session = vm.wait_for_serial_login(timeout=timeout)
 
     # wait for the guest to chill
-    time.sleep(900)
+    time.sleep(1800)
 
     # start background checking guest cpu usage
     thread = threading.Thread(target=_check_cpu_thread_func,


### PR DESCRIPTION
Guest not get idle status with current sleep time,
so the test result will be wrong.

ID: 1998977
Signed-off-by: Menghuan Li menli@redhat.com