### PR TITLE
driver_in_use: update driver running verify for vioinput

### DIFF
--- a/qemu/tests/cfg/vioinput_enable.cfg
+++ b/qemu/tests/cfg/vioinput_enable.cfg
@@ -5,6 +5,7 @@
     type = driver_in_use
     inputs = input1
     input_dev_bus_type_input1 = virtio
+    driver_running = "vioinput"
     driver_name = "vioinput viohidkmdf hidclass hidparse"
     run_bg_flag = "before_bg_test"
     del usb_devices

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -112,6 +112,7 @@ def run(test, params, env):
 
     driver = params["driver_name"]
     driver_verifier = params.get("driver_verifier", driver)
+    driver_running = params.get('driver_running', driver_verifier)
     timeout = int(params.get("login_timeout", 360))
 
     vm = env.get_vm(params["main_vm"])
@@ -121,7 +122,7 @@ def run(test, params, env):
     if params["os_type"] == "windows":
         session = vm.wait_for_login(timeout=timeout)
         utils_test.qemu.windrv_verify_running(session, test,
-                                              driver_verifier)
+                                              driver_running)
         session = utils_test.qemu.setup_win_driver_verifier(session,
                                                             driver_verifier,
                                                             vm)


### PR DESCRIPTION
Some codes changed impact the vioinput_enable case.
Change the driver running check codes to match vioinput device.

id: 2000844
Signed-off-by: Peixiu Hou <phou@redhat.com>