### PR TITLE
ansible_test: Add nested kvm module load steps to support s390x

### DIFF
--- a/qemu/tests/ansible_test.py
+++ b/qemu/tests/ansible_test.py
@@ -44,6 +44,11 @@ def run(test, params, env):
     # Use this directory to copy some logs back from the guest
     test_harness_log_dir = test.logdir
 
+    # Configure host kernel modules when necessary
+    module_cmd = params["module_cmd"]
+    if module_cmd:
+        process.run(module_cmd, shell=True)
+
     params['start_vm'] = 'yes'
     env_process.preprocess(test, params, env)
     vms = env.get_all_vms()

--- a/qemu/tests/cfg/ansible_test.cfg
+++ b/qemu/tests/cfg/ansible_test.cfg
@@ -11,6 +11,8 @@
     #ansible_extra_vars = '{"debug_msg": "Hello Ansible!", "force_handlers": true}'
     start_vm = no
     ansible_install_policy = 'distro_install'
+    s390x:
+        module_cmd = "modprobe kvm && rmmod kvm && modprobe kvm nested=1 hpage=0"
     variants:
         - @default:
         - responsive_migration:


### PR DESCRIPTION
To enable s390x nested, it's necessary to load the nested
kvm module first, so add the steps before other test steps

ID: 2005175
Signed-off-by: Nini Gu <ngu@redhat.com>