### PR TITLE
blockdev_commit_standby: limit support version

### DIFF
--- a/qemu/tests/cfg/blockdev_commit_standby.cfg
+++ b/qemu/tests/cfg/blockdev_commit_standby.cfg
@@ -2,6 +2,8 @@
     type = blockdev_commit_standby
     virt_test_type = qemu
     only Linux
+    #support this feature since RHEL8.4
+    no Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8.u0, Host_RHEL.m8.u1, Host_RHEL.m8.u2, Host_RHEL.m8.u3
     start_vm = yes
     kill_vm = yes
     storage_pools = default


### PR DESCRIPTION
Limit case support version to "larger than RHEL8.3"

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2004365