### PR TITLE
blockdev_inc_backup_inconsistent_bitmap:remove repair_bitmap_with_qemu_img

### DIFF
--- a/qemu/tests/cfg/blockdev_inc_backup_inconsistent_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_inconsistent_bitmap.cfg
@@ -29,8 +29,8 @@
     variants:
         - remove_bitmap_with_qmp_cmd:
             test_scenario = remove_bitmap_with_qmp_cmd
-        - repair_bitmap_with_qemu_img:
-            test_scenario = repair_bitmap_with_qemu_img
+        #- repair_bitmap_with_qemu_img:
+        #    test_scenario = repair_bitmap_with_qemu_img
         - handle_bitmap_with_qmp_cmd:
             test_scenario = handle_bitmap_with_qmp_cmd
             error_msg = Bitmap '%s' is inconsistent and cannot be used


### PR DESCRIPTION
…u_img

Remove repair_bitmap_with_qemu_img from
blockdev_inc_backup_inconsistent_bitmap.cfg

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2007525