### PR TITLE
seabios: disable sga device in rhel9

### DIFF
--- a/qemu/tests/boot_from_device.py
+++ b/qemu/tests/boot_from_device.py
@@ -43,7 +43,17 @@ def run(test, params, env):
         """
         boot info check
         """
-        return re.search(info, vm.serial_console.get_stripped_output(), re.S)
+        return re.search(info, get_serial_console_output(), re.S)
+
+    def get_serial_console_output():
+        """
+        get the output of serail console
+        """
+        if params["enable_sga"] == "yes":
+            output = vm.serial_console.get_stripped_output()
+        else:
+            output = vm.serial_console.get_output()
+        return output
 
     timeout = int(params.get("login_timeout", 360))
     boot_menu_key = params.get("boot_menu_key", 'esc')
@@ -70,7 +80,7 @@ def run(test, params, env):
             # Send boot menu key in monitor.
             vm.send_key(boot_menu_key)
 
-            output = vm.serial_console.get_stripped_output()
+            output = get_serial_console_output()
             boot_list = re.findall(r"^\d+\. (.*)\s", output, re.M)
             if not boot_list:
                 test.fail("Could not get boot entries list")

--- a/qemu/tests/boot_order_check.py
+++ b/qemu/tests/boot_order_check.py
@@ -103,7 +103,10 @@ def run(test, params, env):
     error_context.context("Check the guest boot result", logging.info)
     start = time.time()
     while True:
-        output = vm.serial_console.get_stripped_output()
+        if params["enable_sga"] == "yes":
+            output = vm.serial_console.get_stripped_output()
+        else:
+            output = vm.serial_console.get_output()
         result = re.findall(boot_fail_infos, output, re.S | re.I)
         if result or time.time() > start + timeout:
             break

--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -5,6 +5,9 @@
     image_boot = no
     boot_menu = on
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     boot_menu_key = "esc"
     Host_RHEL.m6:
         boot_menu_key = "f12"

--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -6,6 +6,9 @@
     kill_vm = yes
     boot_menu = on
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     devices_load_timeout = 10
     # we have QEMU machine with three NICs (virtio, e1000, rtl8139)
     # and two disks (default, IDE). firmware should try to boot from the bootindex=1

--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -9,6 +9,9 @@
             kill_vm = yes
             boot_menu = on
             enable_sga = yes
+            Host_RHEL.m9:
+                enable_sga = no
+                machine_type_extra_params = "graphics=off"
             image_verify_bootable = no
             boot_menu_key = "esc"
             Host_RHEL.m6:
@@ -21,7 +24,7 @@
             # SGA Bios info message, using sep as ";"
             # Please update this message to suit for your own system.
             restart_key = "ctrl-alt-delete"
-            Host_RHEL:
+            Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8:
                 sgabios_info = "Google, Inc.\s"
                 sgabios_info += "Serial Graphics Adapter .*\s"
                 sgabios_info += "SGABIOS \$Id.*\s"

--- a/qemu/tests/cfg/seabios_hotplug_unplug.cfg
+++ b/qemu/tests/cfg/seabios_hotplug_unplug.cfg
@@ -3,6 +3,9 @@
     type = seabios_hotplug_unplug
     boot_menu = on
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     boot_menu_key = "esc"
     Host_RHEL.m6:
         boot_menu_key = "f12"
@@ -17,7 +20,7 @@
     flexible_nic_index = yes
     q35:
         pcie_extra_root_port = 2
-    Host_RHEL:
+    Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8:
         sgabios_info = "Google, Inc.\s"
         sgabios_info += "Serial Graphics Adapter .*\s"
         sgabios_info += "SGABIOS \$Id.*\s"

--- a/qemu/tests/cfg/seabios_order_once.cfg
+++ b/qemu/tests/cfg/seabios_order_once.cfg
@@ -4,6 +4,9 @@
     boot_menu = on
     start_vm =no
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     image_boot = no
     images = "stg"
     image_name_stg = "images/stg"

--- a/qemu/tests/cfg/seabios_strict.cfg
+++ b/qemu/tests/cfg/seabios_strict.cfg
@@ -5,6 +5,9 @@
     image_boot = no
     boot_menu = on
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     images = 'stg'
     bootindex_stg = 1
     image_name_stg = 'images/stg'

--- a/qemu/tests/seabios.py
+++ b/qemu/tests/seabios.py
@@ -24,7 +24,11 @@ def run(test, params, env):
         """
         Use the function to short the lines in the scripts
         """
-        return session_obj.get_stripped_output()
+        if params["enable_sga"] == "yes":
+            output = session_obj.get_stripped_output()
+        else:
+            output = session_obj.get_output()
+        return output
 
     def boot_menu():
         return re.search(boot_menu_hint, get_output(seabios_session))

--- a/qemu/tests/seabios_hotplug_unplug.py
+++ b/qemu/tests/seabios_hotplug_unplug.py
@@ -29,7 +29,11 @@ def run(test, params, env):
         """
         Use the function to short the lines in the scripts
         """
-        return session_obj.get_stripped_output()
+        if params["enable_sga"] == "yes":
+            output = session_obj.get_stripped_output()
+        else:
+            output = session_obj.get_output()
+        return output
 
     def sga_info_check():
         return re.search(sgabios_info, get_output(vm.serial_console))

--- a/qemu/tests/seabios_order_once.py
+++ b/qemu/tests/seabios_order_once.py
@@ -44,7 +44,11 @@ def run(test, params, env):
         """
         boot info check
         """
-        return re.search(info, vm.serial_console.get_stripped_output(), re.S)
+        if params["enable_sga"] == "yes":
+            output = vm.serial_console.get_stripped_output()
+        else:
+            output = vm.serial_console.get_output()
+        return re.search(info, output, re.S)
 
     cdrom_test = params["cdrom_test"]
     create_cdroms(cdrom_test)

--- a/qemu/tests/seabios_strict.py
+++ b/qemu/tests/seabios_strict.py
@@ -48,7 +48,11 @@ def run(test, params, env):
         """
         boot info check
         """
-        return re.search(info, vm.serial_console.get_stripped_output(), re.S)
+        if params["enable_sga"] == "yes":
+            output = vm.serial_console.get_stripped_output()
+        else:
+            output = vm.serial_console.get_output()
+        return re.search(info, output, re.S)
 
     error_context.context("Start guest with sga bios", logging.info)
     create_cdrom()


### PR DESCRIPTION
1. since sga device has been removed in rhel9, disable it
2. using "-machine graphics=off" instead of "-device sga"

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2008574