### PR TITLE
virtio-fs: getcap output support in different rhel os

### DIFF
--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -91,7 +91,9 @@
                     cmd_get_trusted = 'getfattr -m '' ${fs_dest}'
                     get_trusted_on_host = 'getfattr $s'
                     host_attributes = user.virtiofsd.trusted.test
-                    file_capability = 'cap_net_raw+eip'
+                    file_capability = 'cap_net_raw=eip'
+                    RHEL.8:
+                        file_capability = 'cap_net_raw+eip'
                     cmd_create_file = 'touch ${fs_dest}/test_file && chmod a+w ${fs_dest}/test_file'
                     cmd_set_capability = 'setcap cap_net_raw+eip ${fs_dest}/test_file'
                     cmd_get_capability = 'getcap ${fs_dest}/test_file'


### PR DESCRIPTION
Add getcap result check on different guest.
ID: 1974231
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>