### PR TITLE
usb_spice: add host restriction for spice-related usb cases

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -355,7 +355,6 @@
         - usb_redir:
             no ppc64 ppc64le
             type = usb_redir
-            only Linux
             usbredirdev_name = usbredir1
             chardev_backend_usbredir1 = spicevmc
             chardev_name_usbredir1 = usbredir
@@ -365,8 +364,10 @@
             #usbredir_productid = xxxx
             variants option:
                 - @basic:
+                    only Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8
                     display = spice
                 - with_bootindex:
+                    only Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8
                     display = spice
                     boot_menu = on
                     enable_sga = yes
@@ -377,6 +378,7 @@
                     boot_entry_info = "Booting from Hard Disk..."
                     usbdev_option_bootindex_usbredir1 = 0
                 - with_filter:
+                    only Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8
                     display = spice
                     variants policy:
                         - allow:
@@ -384,9 +386,11 @@
                         - deny:
                             usbdev_option_filter_usbredir1 = "'-1:0x${usbredir_vendorid}:0x${usbredir_productid}:-1:0|-1:-1:-1:-1:1'"
                 - with_negative_config:
+                    only Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8
                     display = spice
                     usbredir_unconfigured_value = -1
                 - via_tcp:
+                    only Linux
                     chardev_backend_usbredir1 = tcp_socket
                     chardev_host_usbredir1 = localhost
                     # Please configure temp repository url for package usbredir-server
@@ -394,11 +398,11 @@
         - usb_smartcard_sharing:
             no ppc64 ppc64le
             type = usb_smartcard_sharing
-            only Linux
             usbscdev_name = sc1
             smartcard = 'yes'
             smartcard_chardev = 'spicevmc'
             smartcard_id = 'chardev_${usbscdev_name}'
+            only Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8
             display = spice
             del spice_password
             del spice_addr


### PR DESCRIPTION
SPICE is deprecated in latest RHEL.

ID: 1974045

Signed-off-by: ybduan <yduan@redhat.com>