### PR TITLE
netperf: stop driver verifier for performance testing

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -122,6 +122,9 @@
                         # server_private_ip = <netperf server's private ip>
                     Windows:
                         #client = <external host/guest ip>
+                        config_cmds = driver_verifier_query
+                        driver_verifier_query = "verifier /querysettings"
+                        reboot_after_config = yes
                 - best_registry_setting:
                     only Windows
                     reboot_after_config = yes


### PR DESCRIPTION
If driver verifier is enabled, the %errorlevel% is 2 when
"verifier /reset"

id: 2014962

Signed-off-by: Wenli Quan <wquan@redhat.com>