### PR TITLE
Make ansible_extra_vars can be customized separately

### DIFF
--- a/qemu/tests/ansible_test.py
+++ b/qemu/tests/ansible_test.py
@@ -36,6 +36,7 @@ def run(test, params, env):
     ansible_addl_opts = params.get("ansible_addl_opts", "")
     ansible_ssh_extra_args = params["ansible_ssh_extra_args"]
     ansible_extra_vars = params.get("ansible_extra_vars", "{}")
+    custom_extra_vars = params.objects("custom_extra_vars")
     playbook_repo = params["playbook_repo"]
     playbook_timeout = params.get_numeric("playbook_timeout")
     playbook_dir = params.get("playbook_dir",
@@ -63,6 +64,9 @@ def run(test, params, env):
                   "ansible_ssh_pass": guest_passwd,
                   "test_harness_log_dir": test_harness_log_dir}
     extra_vars.update(json.loads(ansible_extra_vars))
+    custom_params = params.object_params("extra_vars")
+    for cev in custom_extra_vars:
+        extra_vars[cev] = custom_params[cev]
 
     error_context.context("Execute the ansible playbook.", logging.info)
     playbook_executor = ansible.PlaybookExecutor(

--- a/qemu/tests/ansible_with_responsive_migration.py
+++ b/qemu/tests/ansible_with_responsive_migration.py
@@ -39,6 +39,7 @@ def run(test, params, env):
     ansible_addl_opts = params.get("ansible_addl_opts", "")
     ansible_ssh_extra_args = params["ansible_ssh_extra_args"]
     ansible_extra_vars = params.get("ansible_extra_vars", "{}")
+    custom_extra_vars = params.objects("custom_extra_vars")
     playbook_repo = params["playbook_repo"]
     playbook_timeout = params.get_numeric("playbook_timeout")
     playbook_dir = params.get("playbook_dir",
@@ -71,6 +72,9 @@ def run(test, params, env):
                   "mq_port": mq_listen_port,
                   "test_harness_log_dir": test_harness_log_dir}
     extra_vars.update(json.loads(ansible_extra_vars))
+    custom_params = params.object_params("extra_vars")
+    for cev in custom_extra_vars:
+        extra_vars[cev] = custom_params[cev]
 
     error_context.context("Execute the ansible playbook.", logging.info)
     playbook_executor = ansible.PlaybookExecutor(

--- a/qemu/tests/cfg/ansible_test.cfg
+++ b/qemu/tests/cfg/ansible_test.cfg
@@ -9,6 +9,10 @@
     ansible_ssh_extra_args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     # Here we can define an extra set of variables for the playbook with json format
     #ansible_extra_vars = '{"debug_msg": "Hello Ansible!", "force_handlers": true}'
+    # Sometimes we have a fixed ansible_extra_vars, but also one or more flexibly configurable vars
+    #custom_extra_vars = foo echo_word
+    #foo_extra_vars = bar
+    #echo_word_extra_vars = Hello ansible
     start_vm = no
     ansible_install_policy = 'distro_install'
     variants:


### PR DESCRIPTION
Sometimes we have a fixed ansible_extra_vars, but also one or more
configurable vars, make them left of ansible_extra_vars and can be
customized separately are more flexible.

ID: 2016303
Signed-off-by: Yihuang Yu <yihyu@redhat.com>