### PR TITLE
blockdev_stream_to_invalid_node:support new error msg in qemu6.1

### DIFF
--- a/qemu/tests/cfg/blockdev_stream_to_invalid_node.cfg
+++ b/qemu/tests/cfg/blockdev_stream_to_invalid_node.cfg
@@ -25,8 +25,11 @@
     rebase_mode = unsafe
     mount_point = "/var/tmp"
     qemu_force_use_drive_expression = no
+    required_qemu_version = [6.1.0, )
 
     virtio_scsi:
-        qmp_error_msg = "Conflicts with use by ${device_tag} as 'root', which uses 'write' on %s"
+        qmp_error_before_6_1 = "Conflicts with use by ${device_tag} as 'root', which uses 'write' on %s"
+        qmp_error_since_6_1 = "permissions 'write' are both required by block device '${device_tag}' (uses node '%s' as 'root' child)"
     virtio_blk:
-        qmp_error_msg = "Conflicts with use by /machine/peripheral/${device_tag}/virtio-backend as 'root', which uses 'write' on %s"
+        qmp_error_before_6_1 = "Conflicts with use by /machine/peripheral/${device_tag}/virtio-backend as 'root', which uses 'write' on %s"
+        qmp_error_since_6_1 = "permissions 'write' are both required by block device '/machine/peripheral/${device_tag}/virtio-backend' (uses node '%s' as 'root' child)"


### PR DESCRIPTION
Error msg is changed after qemu6.1, add support for it

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2004327