### PR TITLE
driver_load_stress: join() argument must be str, bytes not 'NoneType'

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -159,6 +159,7 @@
             fs_driver = virtio-fs
             fs_source_type = mount
             fs_source_dir = virtio_fs_test/
+            test_file = 'test_file'
             force_create_fs_source = yes
             remove_fs_source = yes
             fs_target = 'myfs'

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -225,6 +225,7 @@
             fs_driver = virtio-fs
             fs_source_type = mount
             fs_source_dir = virtio_fs_test/
+            test_file = 'test_file'
             force_create_fs_source = yes
             remove_fs_source = yes
             fs_target = 'myfs'


### PR DESCRIPTION
join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
ID: 2020157
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>