### PR TITLE
Change fio parameter for viofs driver test

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -191,5 +191,5 @@
             viofs_sc_start_cmd = 'sc start VirtioFsSvc'
             viofs_sc_query_cmd = 'sc query VirtioFsSvc'
             fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
-            fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=600 --thread'
+            fio_options += '--bs=4K --size=1G --iodepth=16 --numjobs=8 --runtime=600 --thread'
             io_timeout = 700

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -259,7 +259,7 @@
             viofs_sc_start_cmd = 'sc start VirtioFsSvc'
             viofs_sc_query_cmd = 'sc query VirtioFsSvc'
             fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
-            fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800 --thread'
+            fio_options += '--bs=4K --size=1G --iodepth=16 --numjobs=8 --runtime=1800 --thread'
             io_timeout = 2000
         - with_fwcfg:
             driver_name = "fwcfg"


### PR DESCRIPTION
No need to use stress testing for the background test during do
driver update/downgrade/install/uninstall/load/unload test
ID: 2020996
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>