### PR TITLE
timedrift_with_multi_vms: Change clocksource on aarch64

### DIFF
--- a/qemu/tests/cfg/timedrift_with_multi_vms.cfg
+++ b/qemu/tests/cfg/timedrift_with_multi_vms.cfg
@@ -20,6 +20,8 @@
     clocksource = kvm-clock
     pseries:
         clocksource = timebase
+    aarch64:
+        clocksource = arch_sys_counter
     expected_time_drift = 5
     variants:
         - same_cpu:


### PR DESCRIPTION
aarch64 architecture only supports 'arch_sys_counter' clocksource, so
change it accordingly.

ID: 2021712
Signed-off-by: Yihuang Yu <yihyu@redhat.com>