### PR TITLE
add ballon device support on s390x

### DIFF
--- a/qemu/tests/balloon_hotplug.py
+++ b/qemu/tests/balloon_hotplug.py
@@ -67,14 +67,15 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
 
-    balloon_device = params.get("ballon_device", "virtio-balloon-pci")
+    balloon_device = params.get("balloon_device", "virtio-balloon-pci")
     error_context.context("Hotplug and unplug balloon device in a loop",
                           logging.info)
     for i in range(int(params.get("balloon_repeats", 3))):
         vm.devices.set_dirty()
         new_dev = qdevices.QDevice(balloon_device,
                                    {'id': 'balloon%d' % idx},
-                                   parent_bus={'aobject': 'pci.0'})
+                                   parent_bus={'aobject': params.get(
+                                       "balloon_bus", 'pci.0')})
 
         error_context.context("Hotplug balloon device for %d times" % (i+1),
                               logging.info)

--- a/qemu/tests/cfg/balloon_hotplug.cfg
+++ b/qemu/tests/cfg/balloon_hotplug.cfg
@@ -24,6 +24,7 @@
         unplug_timeout = 90
     s390x:
         balloon_device = virtio-balloon-ccw
+        balloon_bus = virtual-css
     variants:
         - @default:
             balloon_repeats = 100


### PR DESCRIPTION
Memory: add parent_bus to support ballon device on s390x

ID: 2022207

Signed-off-by: Boqiao Fu <bfu@redhat.com>