### PR TITLE
balloon_memhp: wait a while before check guest memeory for windows vm

### DIFF
--- a/qemu/tests/balloon_memhp.py
+++ b/qemu/tests/balloon_memhp.py
@@ -1,5 +1,6 @@
 import random
 import logging
+import time
 
 from virttest import utils_test
 from virttest import error_context
@@ -30,6 +31,7 @@ def run(test, params, env):
         Check guest memory
         """
         if params['os_type'] == 'windows':
+            time.sleep(2)
             memhp_test.check_memory(vm)
         else:
             expected_mem = new_mem + mem_dev_sz


### PR DESCRIPTION
After hotplug memdev, need to wait a while before check memory in windows guest.
ID: 1874694
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>