### PR TITLE
qemu_guest_agent: Hotfix for adding 'gagent_download_cmd'

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -42,6 +42,7 @@
         devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
         cmd_serial_driver_install = '${devcon_path} updateni %s %s'
         gagent_host_path = "/var/tmp/"
+        gagent_download_cmd = "wget https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-qemu-ga/${qemu_ga_pkg} -O ${gagent_host_path}"
         gagent_download_url = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-qemu-ga/${qemu_ga_pkg} -O ${gagent_host_path}"
         gagent_guest_dir = "C:\qemu-ga"
         src_qgarpm_path= "qemu-ga-win*.rpm"

--- a/qemu/tests/qemu_guest_agent_update.py
+++ b/qemu/tests/qemu_guest_agent_update.py
@@ -127,6 +127,8 @@ class QemuGuestAgentUpdateTest(QemuGuestAgentBasicCheckWin):
 
         error_context.context("Install the previous qemu-ga in guest.",
                               logging.info)
+        gagent_download_url = params["gagent_download_url"]
+        rpm_install = "rpm_install" in gagent_download_url
         if self._check_ga_pkg(session, params["gagent_pkg_check_cmd"]):
             logging.info("Uninstall the one which is installed.")
             self.gagent_uninstall(session, vm)
@@ -134,7 +136,10 @@ class QemuGuestAgentUpdateTest(QemuGuestAgentBasicCheckWin):
         if self.gagent_src_type == "virtio-win":
             _change_agent_media(params["cdrom_virtio_downgrade"])
         elif self.gagent_src_type == "url":
-            _get_pkg_download_cmd()
+            if rpm_install:
+                _change_agent_media(params["cdrom_virtio_downgrade"])
+            else:
+                _get_pkg_download_cmd()
         else:
             self.test.error("Only support 'url' and 'virtio-win' method.")
 
@@ -143,6 +148,8 @@ class QemuGuestAgentUpdateTest(QemuGuestAgentBasicCheckWin):
         error_context.context("Update qemu-ga to the latest one.",
                               logging.info)
         if self.gagent_src_type == "virtio-win":
+            _change_agent_media(params["cdrom_virtio"])
+        elif rpm_install:
             _change_agent_media(params["cdrom_virtio"])
         else:
             params["gagent_download_cmd"] = latest_qga_download_cmd


### PR DESCRIPTION
1. qemu_guest_agent.cfg: add 'gagent_download_cmd' to avoid case
get skip in test loop.
2. qemu_guest_agent_update.py: "add 'rpm_install' situation and
process code in another way that use the same logic with
self.gagent_src_type == 'virtio-win'."

ID: 2024030
Signed-off-by: demeng <demeng@redhat.com>