### PR TITLE
balloon_check: Check vm.monitor before get balloon info

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -52,10 +52,15 @@ class BallooningTest(MemoryBaseTest):
         :rtype: int
         """
         try:
-            output = self.vm.monitor.info("balloon")
-            ballooned_mem = int(re.findall(r"\d+", str(output))[0])
-            if self.vm.monitor.protocol == "qmp":
-                ballooned_mem = ballooned_mem / (1024 ** 2)
+            if self.vm.monitor:
+                output = self.vm.monitor.info("balloon")
+                ballooned_mem = int(re.findall(r"\d+", str(output))[0])
+                if self.vm.monitor.protocol == "qmp":
+                    ballooned_mem = ballooned_mem / (1024 ** 2)
+            else:
+                logging.info('could not get balloon_memory, cause vm.monitor '
+                             'is None')
+                return 0
         except qemu_monitor.MonitorError as emsg:
             logging.error(emsg)
             return 0


### PR DESCRIPTION
Memory_balloon: check if vm.monitor is None before get balloon info
since vm.monitor would be none sometimes

ID: 2024564

Signed-off-by: Boqiao Fu <bfu@redhat.com>