### PR TITLE
valgrind_memalign: Pause VM and continue it to verify status on s390

### DIFF
--- a/qemu/tests/cfg/valgrind_memalign.cfg
+++ b/qemu/tests/cfg/valgrind_memalign.cfg
@@ -16,7 +16,8 @@
         cpu_model = ""
         # s390 firmware quits when no-bootable devices (unlike x86)
         extra_params += " -no-shutdown"
-        expected_status = "paused (shutdown)"
+        expected_status = "guest-panicked"
+        paused_after_start_vm = yes
     images = ""
     nics = ""
     serials = ""

--- a/qemu/tests/valgrind_memalign.py
+++ b/qemu/tests/valgrind_memalign.py
@@ -48,6 +48,8 @@ def run(test, params, env):
     time.sleep(interval)
     error_context.context("Verify guest status is running after cont",
                           logging.info)
+    if params.get('machine_type').startswith("s390"):
+        vm.monitor.cmd("cont")
     vm.verify_status(params.get("expected_status", "running"))
 
     error_context.context("Quit guest and check the process quit normally",


### PR DESCRIPTION
In this case, s390x guest will enter the "guest-panicked" status
instead of "running", so vm.resume() cannot verify the correct status.

ID: 2024601
Signed-off-by: Yihuang Yu <yihyu@redhat.com>