### PR TITLE
qemu_guest_agent: Extend wait time for command guest-fstrim

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -4163,6 +4163,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
         error_context.context("Execute the guest-fstrim cmd via qga.",
                               logging.info)
         self.gagent.fstrim()
+        time.sleep(360)
 
         error_context.context("Check blocks of data disk after fstrim.",
                               logging.info)


### PR DESCRIPTION
qemu_guest_agent.py: Command guest-fstrim need more, so extend
360s to wait for command guest-fstrim to end.

ID: 2024508 
Signed-off-by: demeng <demeng@redhat.com>