### PR TITLE
kdump: Disable nmi test cases on s390 platform

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -34,7 +34,7 @@
     variants:
         - @default:
         - nmi:
-            no aarch64
+            no aarch64 s390 s390x
             kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args='crashkernel=auto nmi_watchdog=1'"
             crash_cmd = nmi
 


### PR DESCRIPTION
s390 could not find any nmi file under /proc/sys/kernel, so should 
skip testing nmi scenarios.

ID: 2026191
Signed-off-by: Yihuang Yu <yihyu@redhat.com>