### PR TITLE
blockdev_mirror_cancel_running_job: add option speed

### DIFF
--- a/qemu/tests/cfg/blockdev_mirror_cancel_running_job.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_cancel_running_job.cfg
@@ -9,8 +9,9 @@
     target_images = mirror1
     remove_image_data1 = yes
     force_create_image_data1 = yes
-    backup_options_data1 = sync
+    backup_options_data1 = sync speed
     sync = full
+    speed = 100000
     storage_pools = default
     storage_pool = default
 


### PR DESCRIPTION
Add param "speed" for mirror job to make it can be
cancelled before reach ready status

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2004360