### PR TITLE
blockdev_mirror_after_block_error: add event timeout

### DIFF
--- a/qemu/tests/cfg/blockdev_mirror_after_block_error.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_after_block_error.cfg
@@ -39,3 +39,4 @@
     pre_command_timeout = 30
     post_command_timeout = 30
     write_file_cmd = "dd if=/dev/urandom of=%s/file bs=1M count=200"
+    event_timeout = 120


### PR DESCRIPTION
Set BLOCK_IO_ERROR event timeout

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:1966879