### PR TITLE
virtio_fs: clear memory backend file after vm is shutdown

### DIFF
--- a/qemu/tests/cfg/virtio_fs_multi_vms.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_vms.cfg
@@ -24,9 +24,10 @@
     fs_driver_props = {"queue-size": 1024}
     force_create_fs_source = yes
     remove_fs_source = yes
-    mem-path_mem1_vm1 = /dev/shm
-    mem-path_mem1_vm2 = /dev/shn
-    mem-path_mem1_vm3 = /dev/sho
+    mem-path_mem1_vm1 = /var/ram_vm1
+    mem-path_mem1_vm2 = /var/ram_vm2
+    mem-path_mem1_vm3 = /var/ram_vm3
+    post_command += "rm -rf /var/ram_vm1 && rm -rf /var/ram_vm2 && rm -rf /var/ram_vm3"
     s390, s390x:
         required_qemu = [5.2.0,)
         vm_mem_share = yes


### PR DESCRIPTION
If using a normal file as the memory backend, should delete it
at the end,otherwise, next time the vm system will fail to boot up.
Also libvirt will delete the file after shutdown vm.
ID: 1978177
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>