### PR TITLE
Update settings for fwcfg related cases

### DIFF
--- a/qemu/tests/cfg/fwcfg.cfg
+++ b/qemu/tests/cfg/fwcfg.cfg
@@ -8,8 +8,11 @@
     tmp_dir = "/var/tmp"
     get_avail_disk = df -h /home | grep home | awk -F "G" '{print $3}'
     unzip_cmd = 'powershell -command "Expand-Archive %s:\Memory.dmp.zip %s:"'
-    unzip_speed = 60
-    move_cmd = "move {0}:\*Memory.dmp {0}:\Memory.dmp"
+    unzip_timeout = 1800
+    dump_file = Memory.dmp
+    move_cmd = "move {0}:\*${dump_file} {0}:\${dump_file}"
+    save_path_cmd = "echo {0}:\${dump_file} > C:\dump_path.txt"
+    del_path_file = "del C:\dump_path.txt"
     chk_id_cmd = 'type %s | find /i "LIVE_SYSTEM_DUMP (161)"'
     images += " stg"
     image_name_stg = "images/storage"
@@ -19,11 +22,21 @@
         windbg_path = "x86\windbg.exe"
     x86_64:
         windbg_path = "x64\windbg.exe"
-    Win8..1:
-        unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
-        chk_id_cmd = 'type %s | find /i "Bugcheck code 00000161"'
     chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
     feature = "OptionId.WindowsDesktopDebuggers"
-    windbg_install_cmd = "WIN_UTILS:\winsdksetup.exe /features %s /q"
-    chk_dump_cmd = "WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"
+    sdk_setup = winsdksetup.exe
+    Win8..1, Win2012..r1, Win2012..r2:
+        sdk_setup = sdksetup_81.exe
+        unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
+        chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\8.1\Debuggers\%s"'
+    Win2016:
+        sdk_setup = sdksetup_1607.exe
+    Win2019:
+        sdk_setup = winsdksetup_1809.exe
+    Win11, Win2022:
+        sdk_setup = winsdksetup_11.exe
+    windbg_install_cmd = "WIN_UTILS:\winsdksetup\${sdk_setup} /features %s /q"
+    sdk_name = 'Windows Software Development Kit'
+    chk_sdk_ins = 'wmic product get name,version | find /i "${sdk_name}"'
+    chk_dump_cmd = "WIN_UTILS:\AutoIt3\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"
     dump_analyze_file = "C:\dump_analyze.log"

--- a/qemu/tests/cfg/fwcfg_enable.cfg
+++ b/qemu/tests/cfg/fwcfg_enable.cfg
@@ -11,8 +11,11 @@
     tmp_dir = "/home/tmp"
     get_avail_disk = df -h /home | grep home | awk -F "G" '{print $3}'
     unzip_cmd = 'powershell -command "Expand-Archive %s:\Memory.dmp.zip %s:"'
-    unzip_speed = 60
-    move_cmd = "move {0}:\*Memory.dmp {0}:\Memory.dmp"
+    unzip_timeout = 1800
+    dump_file = Memory.dmp
+    move_cmd = "move {0}:\*${dump_file} {0}:\${dump_file}"
+    save_path_cmd = "echo {0}:\${dump_file} > C:\dump_path.txt"
+    del_path_file = "del C:\dump_path.txt"
     chk_id_cmd = 'type %s | find /i "LIVE_SYSTEM_DUMP (161)"'
     images += " stg"
     image_name_stg = "images/storage"
@@ -22,13 +25,23 @@
         windbg_path = "x86\windbg.exe"
     x86_64:
         windbg_path = "x64\windbg.exe"
-    Win8..1:
-        unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
-        chk_id_cmd = 'type %s | find /i "Bugcheck code 00000161"'
     chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
     feature = "OptionId.WindowsDesktopDebuggers"
-    windbg_install_cmd = "WIN_UTILS:\winsdksetup.exe /features %s /q"
-    chk_dump_cmd = "WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"
+    sdk_setup = winsdksetup.exe
+    Win8..1, Win2012..r1, Win2012..r2:
+        sdk_setup = sdksetup_81.exe
+        unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
+        chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\8.1\Debuggers\%s"'
+    Win2016:
+        sdk_setup = sdksetup_1607.exe
+    Win2019:
+        sdk_setup = winsdksetup_1809.exe
+    Win11, Win2022:
+        sdk_setup = winsdksetup_11.exe
+    windbg_install_cmd = "WIN_UTILS:\winsdksetup\${sdk_setup} /features %s /q"
+    sdk_name = 'Windows Software Development Kit'
+    chk_sdk_ins = 'wmic product get name,version | find /i "${sdk_name}"'
+    chk_dump_cmd = "WIN_UTILS:\AutoIt3\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"
     dump_analyze_file = "C:\dump_analyze.log"
     variants:
         - with_shutdown:

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -273,8 +273,11 @@
             tmp_dir = "/home/tmp"
             get_avail_disk = df -h /home | grep home | awk -F "G" '{print $3}'
             unzip_cmd = 'powershell -command "Expand-Archive %s:\Memory.dmp.zip %s:"'
-            unzip_speed = 60
-            move_cmd = "move {0}:\*Memory.dmp {0}:\Memory.dmp"
+            unzip_timeout = 1800
+            dump_file = Memory.dmp
+            move_cmd = "move {0}:\*${dump_file} {0}:\${dump_file}"
+            save_path_cmd = "echo {0}:\${dump_file} > C:\dump_path.txt"
+            del_path_file = "del C:\dump_path.txt"
             chk_id_cmd = 'type %s | find /i "LIVE_SYSTEM_DUMP (161)"'
             images += " stg"
             image_name_stg = "images/storage"
@@ -284,11 +287,21 @@
                 windbg_path = "x86\windbg.exe"
             x86_64:
                 windbg_path = "x64\windbg.exe"
-            Win8..1:
-                unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
-                chk_id_cmd = 'type %s | find /i "Bugcheck code 00000161"'
             chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
             feature = "OptionId.WindowsDesktopDebuggers"
-            windbg_install_cmd = "WIN_UTILS:\winsdksetup.exe /features %s /q"
-            chk_dump_cmd = "WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"
+            sdk_setup = winsdksetup.exe
+            Win8..1, Win2012..r1, Win2012..r2:
+                sdk_setup = sdksetup_81.exe
+                unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
+                chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\8.1\Debuggers\%s"'
+            Win2016:
+                sdk_setup = sdksetup_1607.exe
+            Win2019:
+                sdk_setup = winsdksetup_1809.exe
+            Win11, Win2022:
+                sdk_setup = winsdksetup_11.exe
+            windbg_install_cmd = "WIN_UTILS:\winsdksetup\${sdk_setup} /features %s /q"
+            sdk_name = 'Windows Software Development Kit'
+            chk_sdk_ins = 'wmic product get name,version | find /i "${sdk_name}"'
+            chk_dump_cmd = "WIN_UTILS:\AutoIt3\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"
             dump_analyze_file = "C:\dump_analyze.log"


### PR DESCRIPTION
1. Add disable security alert step
2. Change the way for finding memory dump file path
3. Adjust win2012-64/r2 extracted and dump id check cmds
4. optimize the dump extracted timeout issues

id: 2019273, 2024074
Signed-off-by: Peixiu Hou <phou@redhat.com>