### PR TITLE
qemu_guest_agent: Inactive case 'gagent_container'

### DIFF
--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -15,7 +15,6 @@ from avocado.utils import process
 from avocado.core import exceptions
 from aexpect.exceptions import ShellTimeoutError
 
-from virttest import utils_package
 from virttest import error_context
 from virttest import guest_agent
 from virttest import utils_misc


### PR DESCRIPTION
1. qemu_guest_agent.cfg: erase container related code.
2. qemu_guest_agent.py: erase container related code.

ID: 2024789
Signed-off-by: demeng <demeng@redhat.com>