### PR TITLE
multi_nics_stress:Set guest memory based on host resource

### DIFF
--- a/qemu/tests/cfg/multi_nics_stress.cfg
+++ b/qemu/tests/cfg/multi_nics_stress.cfg
@@ -1,6 +1,7 @@
 - multi_nics_stress: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu
     type = multi_nics_stress
+    start_vm = no
     kill_vm = yes
     flexible_nic_index = yes
     image_snapshot = yes
@@ -8,6 +9,9 @@
     netperf_client = vm1
     netperf_server = "vm2 vm3 vm4 vm5"
     nics_vm1 = "nic1 nic2 nic3 nic4"
+    min_mem = 2048
+    Win11:
+        min_mem = 4096
     test_protocols = "TCP_STREAM TCP_MAERTS TCP_SENDFILE UDP_STREAM TCP_RR TCP_CRR UDP_RR"
     netperf_sessions = 1
     package_sizes = 1500


### PR DESCRIPTION
Currently, memory overcommit has not yet been officially supported.
But avocado will give each guest half of the host's memory, which will cause oom.

Signed-off-by: Leidong Wang <leidwang@redhat.com>
ID:2025824