### PR TITLE
cpu_device_hotplug_during_boot: Update boot pattern

### DIFF
--- a/qemu/tests/cpu_device_hotplug_during_boot.py
+++ b/qemu/tests/cpu_device_hotplug_during_boot.py
@@ -23,7 +23,8 @@ def run(test, params, env):
     """
     vcpu_devices = params.objects("vcpu_devices")
     unplug_during_boot = params.get_boolean("unplug_during_boot")
-    boot_patterns = [r".*Started udev Wait for Complete Device Initialization.*"]
+    boot_patterns = [r".*Started udev Wait for Complete Device Initialization.*",
+                     r".*Finished .*Wait for udev To Complete Device Initialization.*"]
     reboot_patterns = [r".*[Rr]ebooting.*", r".*[Rr]estarting system.*",
                        r".*[Mm]achine restart.*"]
 


### PR DESCRIPTION
In the newer version of kernel, the output of udev device
initialization has a little change, so the current pattern could not
capture the output, so update the "boot_patterns" accordingly.

ID: 2001530
Signed-off-by: Yihuang Yu <yihyu@redhat.com>