### PR TITLE
fio_perf: fix TypeError of the raw disk

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -52,9 +52,12 @@
             vhost_nic1 =
             remove_image = no
             Linux:
-                fio_cmd = "i=`/bin/ls /dev/[vs]db` && fio --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=$i --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=/tmp/fio_result &> /dev/null"
+                virtio_blk:
+                    fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/dev/vdb --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=/var/tmp/fio_result &> /dev/null"
+                virtio_scsi:
+                    fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/dev/sdb --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=/var/tmp/fio_result &> /dev/null"
             Windows:
-                fio_cmd = 'cmd /c C:\fio-3.9-x64\fio.exe --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=\\.\PHYSICALDRIVE1 --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output="C:\\fio_result"'
+                fio_options = '--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=\\.\PHYSICALDRIVE1 --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output="C:\\fio_result"'
             variants:
                 - fusion-io:
                     #Pls specify your own fusion-io ssd in the host.
@@ -86,7 +89,7 @@
             numa_memdev_shm0 = mem-mem1
             numa_nodeid_shm0 = 0
             fs_dest = '/mnt/${fs_target}'
-            fio_cmd = "fio --rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=${fs_dest}/%s --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=/tmp/fio_result &> /dev/null"
+            fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=${fs_dest}/%s --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=/tmp/fio_result &> /dev/null"
             order_list = "Block_size Iodepth Threads BW(MB/S) IOPS Latency(ms) Host_CPU BW/CPU KVM_Exits"
             variants:
                 - auto:


### PR DESCRIPTION
change the fio cmd to fio options to match the current framework

Signed-off-by: Tingting Mao <timao@redhat.com>

ID: 2029259