### PR TITLE
balloon_memhp: wait a while before check guest memory for windows vm

### DIFF
--- a/qemu/tests/balloon_memhp.py
+++ b/qemu/tests/balloon_memhp.py
@@ -30,7 +30,7 @@ def run(test, params, env):
         Check guest memory
         """
         if params['os_type'] == 'windows':
-            memhp_test.check_memory(vm)
+            memhp_test.check_memory(vm, wait_time=3)
         else:
             expected_mem = new_mem + mem_dev_sz
             guest_mem_size = memhp_test.get_guest_total_mem(vm)


### PR DESCRIPTION
After hotplug memdev, need to wait a while before check memory in windows guest.
ID: 1874694
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>