### PR TITLE
fio_perf: fix scp failed issue on virtiofs perf test

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -53,11 +53,11 @@
             remove_image = no
             Linux:
                 virtio_blk:
-                    fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/dev/vdb --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=/var/tmp/fio_result &> /dev/null"
+                    fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/dev/vdb --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=${guest_result_file} &> /dev/null"
                 virtio_scsi:
-                    fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/dev/sdb --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=/var/tmp/fio_result &> /dev/null"
+                    fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=/dev/sdb --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --time_based --output=${guest_result_file} &> /dev/null"
             Windows:
-                fio_options = '--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=\\.\PHYSICALDRIVE1 --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output="C:\\fio_result"'
+                fio_options = '--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=\\.\PHYSICALDRIVE1 --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=${guest_result_file}'
             variants:
                 - fusion-io:
                     #Pls specify your own fusion-io ssd in the host.
@@ -89,7 +89,7 @@
             numa_memdev_shm0 = mem-mem1
             numa_nodeid_shm0 = 0
             fs_dest = '/mnt/${fs_target}'
-            fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=${fs_dest}/%s --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=/tmp/fio_result &> /dev/null"
+            fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=${fs_dest}/%s --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=${guest_result_file} &> /dev/null"
             order_list = "Block_size Iodepth Threads BW(MB/S) IOPS Latency(ms) Host_CPU BW/CPU KVM_Exits"
             variants:
                 - auto:


### PR DESCRIPTION
The output file of fio cmd isn't the same with it in scp cmd,
fix this issue.
ID: 2031500
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>