### PR TITLE
trans_hugepage: fix several TypeError

### DIFF
--- a/generic/tests/cfg/trans_hugepage.cfg
+++ b/generic/tests/cfg/trans_hugepage.cfg
@@ -8,8 +8,11 @@
     setup_thp = yes
     variants:
         - base:
+            no aarch64 s390x
             type = trans_hugepage
             dd_timeout = 900
+            #The file is different for different product, different arch, check in py
+            largepages_files = 'pages_2m pages_1g num_2M_pages num_1G_pages lpages largepages'
         - defrag:
             type = trans_hugepage_defrag
         - swapping:


### PR DESCRIPTION
1. the output of 'process.system_output' is a bytes-list object
for python3, and 're' cannot use a str pattern on a bytes-like object
2. '<' not supported between instances of 'float' and 'str'
3. Replace 'logging' with 'test.log'
4. Disable 'trans_hugepage.base' with aarch64 and s390x platform
5. For different products, the filename to show the largepages are
    different, add optional filename list

depends on: https://github.com/avocado-framework/avocado-vt/pull/3335

id: 2032252
Signed-off-by: Yanan Fu <yfu@redhat.com>