### PR TITLE
trans_hugepage_swapping: fix several Error

### DIFF
--- a/generic/tests/trans_hugepage_swapping.py
+++ b/generic/tests/trans_hugepage_swapping.py
@@ -1,9 +1,11 @@
 import os
-import re
+import math
 
 from avocado.utils import process
 from virttest import env_process
 from virttest import error_context
+from virttest.staging import utils_memory
+from virttest.utils_misc import normalize_data_size
 
 
 @error_context.context_aware
@@ -16,48 +18,44 @@ def run(test, params, env):
     :param params: Dictionary with test parameters.
     :param env: Dictionary with the test environment.
     """
-    def get_args(args_list):
+
+    def get_mem_info(mem_check_list):
         """
-        Get the memory arguments from system
+        Get mem info from /proc/meminfo, with magnitude "M"
         """
-        args_list_tmp = args_list.copy()
-        with open('/proc/meminfo', 'r') as f:
-            for line in f.readlines():
-                for key in args_list_tmp.keys():
-                    if line.startswith("%s" % args_list_tmp[key]):
-                        args_list_tmp[key] = int(re.split(r'\s+', line)[1])
-        return args_list_tmp
+        mem_info = {}
+        for key in mem_check_list:
+            value = utils_memory.read_from_meminfo(key)
+            mem_info[key] = int(float(normalize_data_size("%s kB" % value)))
+        return mem_info
 
     try:
         # Swapping test
         test.log.info("Swapping test start")
         # Parameters of memory information
-        # @total: Memory size
-        # @free: Free memory size
-        # @swap_size: Swap size
-        # @swap_free: Free swap size
-        # @hugepage_size: Page size of one hugepage
-        # @page_size: The biggest page size that app can ask for
-        args_dict_check = {"free": "MemFree", "swap_size": "SwapTotal",
-                           "swap_free": "SwapFree", "total": "MemTotal",
-                           "hugepage_size": "Hugepagesize", }
-        args_dict = get_args(args_dict_check)
-        swap_free = []
-        total = int(args_dict['total']) / 1024
-        free = int(args_dict['free']) / 1024
-        swap_size = int(args_dict['swap_size']) / 1024
-        swap_free.append(int(args_dict['swap_free']) / 1024)
-        hugepage_size = int(args_dict['hugepage_size']) / 1024
-        login_timeout = float(params.get("login_timeout", 360))
-        check_cmd_timeout = float(params.get("check_cmd_timeout", 900))
+        # @total: Memory size - MemTotal
+        # @free: Free memory size - MemFree
+        # @swap_size: Swap size - SwapTotal
+        # @swap_free: Free swap size - SwapFree
+        # @hugepage_size: Page size of one hugepage - Hugepagesize
+        mem_check_list = ["MemTotal", "MemFree", "SwapTotal",
+                          "SwapFree", "Hugepagesize"]
+        mem_info = get_mem_info(mem_check_list)
+        total = mem_info["MemTotal"]
+        free = mem_info["MemFree"]
+        swap_size = mem_info["SwapTotal"]
+        swap_free_initial = mem_info["SwapFree"]
+        hugepage_size = mem_info["Hugepagesize"]
+        login_timeout = params.get_numeric("login_timeout", 360)
+        check_cmd_timeout = params.get_numeric("check_cmd_timeout", 900)
         mem_path = os.path.join(test.tmpdir, 'thp_space')
 
         # If swap is enough fill all memory with dd
-        if swap_free > (total - free):
-            count = total / hugepage_size
+        if swap_free_initial > (total - free):
+            count = int(total / hugepage_size)
             tmpfs_size = total
         else:
-            count = free / hugepage_size
+            count = int(free / hugepage_size)
             tmpfs_size = free
 
         if swap_size <= 0:
@@ -73,13 +71,14 @@ def run(test, params, env):
             # To ignore the oom killer set it to the free swap size
             vm = env.get_vm(params.get("main_vm"))
             vm.verify_alive()
-            if int(params['mem']) > swap_free[0]:
+            if params.get_numeric('mem') > swap_free_initial:
                 vm.destroy()
                 vm_name = 'vmsw'
                 vm0 = params.get("main_vm")
                 vm0_key = env.get_vm(vm0)
                 params['vms'] = params['vms'] + " " + vm_name
-                params['mem'] = str(swap_free[0])
+                # For ppc, vm mem must align to 256MB, apply it for all arch
+                params['mem'] = math.floor(swap_free_initial / 256) * 256
                 vm_key = vm0_key.clone(vm0, params)
                 env.register_vm(vm_name, vm_key)
                 env_process.preprocess_vm(test, params, env, vm_name)
@@ -88,19 +87,24 @@ def run(test, params, env):
             else:
                 session = vm.wait_for_login(timeout=login_timeout)
 
+            error_context.context("Disable swap in the guest", test.log.info)
+            s, o = session.cmd_status_output('swapoff -a')
+            if s != 0:
+                test.error("Disable swap in guest failed as %s" % o)
+
             error_context.context("making guest to swap memory")
-            cmd = ("dd if=/dev/zero of=%s/zero bs=%s000000 count=%s" %
+            cmd = ("dd if=/dev/zero of=%s/zero bs=%sM count=%s" %
                    (mem_path, hugepage_size, count))
             process.run(cmd, shell=True)
 
-            args_dict = get_args(args_dict_check)
-            swap_free.append(int(args_dict['swap_free']) / 1024)
+            mem_info = get_mem_info(mem_check_list)
+            swap_free_after = mem_info["SwapFree"]
 
-            if swap_free[1] - swap_free[0] >= 0:
+            if swap_free_after - swap_free_initial >= 0:
                 test.fail("No data was swapped to memory")
 
             # Try harder to make guest memory to be swapped
-            session.cmd("find / -name \"*\"", timeout=check_cmd_timeout)
+            session.cmd("find / -name \"*\"", timeout=check_cmd_timeout, ignore_all_errors=True)
         finally:
             if session is not None:
                 process.run("umount %s" % mem_path, shell=True)


### PR DESCRIPTION
1. fix several TypeError
2. Use utils_memory to handle meminfo, and normalize the data size
3. Correct the incorrect unit conversion in dd cmd
4. For ppc, vm mem must align to 256M
5. Disable the swap in the guest before allocate the memory of guest

depends on: https://github.com/avocado-framework/avocado-vt/pull/3335

id: 2032449
Signed-off-by: Yanan Fu <yfu@redhat.com>