### PR TITLE
trans_hugepage_defrag: fix AttributeError,refactor it to adopt SysFS

### DIFF
--- a/generic/tests/cfg/trans_hugepage.cfg
+++ b/generic/tests/cfg/trans_hugepage.cfg
@@ -14,6 +14,7 @@
             #The file is different for different product, different arch, check in py
             largepages_files = 'pages_2m pages_1g num_2M_pages num_1G_pages lpages largepages'
         - defrag:
+            no s390x
             type = trans_hugepage_defrag
         - swapping:
             type = trans_hugepage_swapping


### PR DESCRIPTION
1. Fix AttributeError:'TransparentHugePageConfig' object has no
attribute 'value_listed'.
2. Refactor it to adopt SysFs() API to get and set sys value.

depends on: https://github.com/avocado-framework/avocado-vt/pull/3335

id: 2032402

Signed-off-by: Yanan Fu <yfu@redhat.com>