### PR TITLE
CI: disable the check on Python 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.9]
+        python-version: [3.6, 3.9]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Disable the CI check on Python 2.7 as we no longer support such the
use case.

Signed-off-by: Xu Han <xuhan@redhat.com>