### PR TITLE
block_resize: update block_size calculation algorithm

### DIFF
--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -117,6 +117,9 @@ def run(test, params, env):
 
     for ratio in params.objects("disk_change_ratio"):
         block_size = int(int(block_virtual_size) * float(ratio))
+        # The new size must be a multiple of 512 for windows
+        if params.get("os_type") == "windows" and block_size % 512 != 0:
+            block_size = int(block_size / 512) * 512
 
         # Record md5
         if params.get('md5_test') == 'yes':


### PR DESCRIPTION
Since we recently updated the windows image size, some windows versions
have an image size of 32G, which will cause the block size to be not a
multiple of 512.

Signed-off-by: Leidong Wang <leidwang@redhat.com>

ID:2031569