### PR TITLE
Workaround avocado.utils.process' allow_output_check parameter drop

### DIFF
--- a/generic/tests/syzkaller.py
+++ b/generic/tests/syzkaller.py
@@ -92,9 +92,7 @@ def run(test, params, env):
     # test timeout excluding current elapsed time + buffer
     testtimeout = int(params.get("test_timeout")) - (int(end_time - start_time) + 10)
     cmd = "%s/bin/syz-manager -config %s %s" % (syzkaller_path, syz_config_path, params.get("syz_cmd_params"))
-    process.run(cmd, timeout=testtimeout,
-                allow_output_check="combined",
-                ignore_status=True, shell=True)
+    process.run(cmd, timeout=testtimeout, ignore_status=True, shell=True)
     # Let's delete linux kernel folder from test-results as it would
     # consume lot of space and test log have all the information about
     # it incase to retrieve it back.

--- a/qemu/tests/usb_redir.py
+++ b/qemu/tests/usb_redir.py
@@ -77,24 +77,28 @@ def run(test, params, env):
 
         if backend == 'spicevmc':
             gui_group = "Server with GUI"
-            out = process.getoutput('yum group list --installed',
-                                    allow_output_check='stdout', shell=True)
+            list_res = process.run('yum group list --installed',
+                                   shell=True, ignore_status=True)
             obj = re.search(r"(Installed Environment Groups:.*?)^\S",
-                            out, re.S | re.M)
+                            list_res.stdout_text, re.S | re.M)
             if not obj or gui_group not in obj.group(1):
                 gui_groupinstall_cmd = "yum groupinstall -y '%s'" % gui_group
-                s, o = process.getstatusoutput(gui_groupinstall_cmd, shell=True)
-                if s:
+                install_res = process.run(gui_groupinstall_cmd,
+                                          shell=True, ignore_status=True)
+                if install_res.exit_status:
                     status = False
                     err_msg = "Fail to install '%s' on host, " % gui_group
-                    err_msg += "output: %s" % o
+                    err_msg += 'output: "%s" ' % install_res.stdout_text
+                    err_msg += 'error: "%s"' % install_res.stderr_text
                     return (status, err_msg)
             virt_viewer_cmd = "rpm -q virt-viewer || yum install -y virt-viewer"
-            s, o = process.getstatusoutput(virt_viewer_cmd, shell=True)
-            if s:
+            viewer_install_res = process.run(virt_viewer_cmd,
+                                             shell=True, ignore_status=True)
+            if viewer_install_res.exit_status:
                 status = False
                 err_msg = "Fail to install 'virt-viewer' on host, "
-                err_msg += "output: %s" % o
+                err_msg += 'output: "%s" ' % install_res.stdout_text
+                err_msg += 'error: "%s"' % install_res.stderr_text
                 return (status, err_msg)
         elif backend == 'tcp_socket':
             create_repo()

--- a/qemu/tests/usb_smartcard_sharing.py
+++ b/qemu/tests/usb_smartcard_sharing.py
@@ -29,17 +29,18 @@ def run(test, params, env):
         status = True
         err_msg = ''
         gui_group = "Server with GUI"
-        out = process.getoutput('yum group list --installed',
-                                allow_output_check='stdout', shell=True)
+        list_res = process.getoutput('yum group list --installed', shell=True)
         obj = re.search(r"(Installed Environment Groups:.*?)^\S",
-                        out, re.S | re.M)
+                        list_res.stdout_text, re.S | re.M)
         if not obj or gui_group not in obj.group(1):
             gui_groupinstall_cmd = "yum groupinstall -y '%s'" % gui_group
-            s, o = process.getstatusoutput(gui_groupinstall_cmd, shell=True)
-            if s:
+            install_res = process.run(gui_groupinstall_cmd,
+                                      shell=True, ignore_status=True)
+            if install_res.exit_status:
                 status = False
                 err_msg = "Fail to install '%s' on client, " % gui_group
-                err_msg += "output: %s" % o
+                err_msg += 'output: "%s" ' % install_res.stdout_text
+                err_msg += 'error: "%s"' % install_res.stderr_text
                 return (status, err_msg)
 
         virt_viewer_cmd = "rpm -q virt-viewer || yum install -y virt-viewer"


### PR DESCRIPTION
The "allow_output_check" is no longer available in the many different
functions in avocado.utils.process.

Based on its usage here, it should bring no change in behavior.

Reference: https://github.com/avocado-framework/avocado-vt/issues/3299
Signed-off-by: Cleber Rosa <crosa@redhat.com>