### PR TITLE
sve_basic: Update error_msg for unsupported vector length

### DIFF
--- a/qemu/tests/cfg/sve_basic.cfg
+++ b/qemu/tests/cfg/sve_basic.cfg
@@ -7,7 +7,7 @@
             type = sve_invalid
             variants:
                 - @default:
-                    error_msg = This KVM host does not support the vector length {}-bits
+                    error_msg = does not support the vector length {}-bits
                 - invalid_length:
                     start_vm = no
                     invalid_length = sve127


### PR DESCRIPTION
The new qemu version update the error message when launch a guest with
unsupported sve length, the error messages are similar but not the
same, so update the pattern accordingly.

ID: 2034464
Signed-off-by: Yihuang Yu <yihyu@redhat.com>