### PR TITLE
Replace nc-vsock with ncat for vsock test

### DIFF
--- a/qemu/tests/cfg/vsock.cfg
+++ b/qemu/tests/cfg/vsock.cfg
@@ -2,6 +2,10 @@
     no Windows
     type = vsock_test
     vsocks = vhost_vsock0
+    RHEL.7, RHEL.8:
+      vsock_test_tool = nc_vsock
+    RHEL.9:
+      vsock_test_tool = ncat
     # TODO: Work out a python version nc-vsock and use the APIs directly
     variants:
         - @basic_test:
@@ -12,7 +16,7 @@
             vsocks = ''
             addr_pattern = '\d\d:\d\d\.\d'
             device_pattern = 'Communication controller: Red Hat.* Device'
-            q35: 
+            q35:
               device_pattern = 'Communication controller: Red Hat.* Virtio socket'
               RHEL.7, RHEL.8.1, RHEL.8.2:
                 device_pattern = 'Communication controller: Red Hat.* Device'

--- a/qemu/tests/migration_with_vsock.py
+++ b/qemu/tests/migration_with_vsock.py
@@ -2,15 +2,16 @@ import random
 import logging
 import ast
 
+from avocado.utils import path
 from avocado.utils import process
 from virttest import error_context
 from virttest import utils_misc
 from qemu.tests.vsock_test import (
     compile_nc_vsock,
-    nc_vsock_listen,
+    vsock_listen,
     send_data_from_guest_to_host,
     check_received_data,
-    nc_vsock_connect
+    vsock_connect
 )
 
 
@@ -20,18 +21,17 @@ def run(test, params, env):
     Vsock migration test
 
     1. Boot guest with vhost-vsock-pci device
-    2. Download and compile nc-vsock on both guest and host
-    S1):
-    3. Start listening inside guest, nc-vsock -l $port
-    4. Connect guest CID from host, nc-vsock $guest_cid $port
+    2. Download and compile nc-vsock on both guest and host if needed
+    3. Start listening inside guest
+    4. Connect guest CID from host
     5. Input character, e.g. 'Hello world'
     6. Check if guest receive the content correctly
     7. Reboot guest with differnt guest CID
     8. Migration
     9. Check guest session exited and close host session
     10. repeat step 3 to 6
-    11. Send data from guest, nc-vsock -l $port < tmp_file
-    12. Receive data from host, nc-vsock $guest_cid $port
+    11. Send data from guest
+    12. Receive data from host
     13. Do ping-pong migration 3 times
 
     :param test: QEMU test object
@@ -45,7 +45,8 @@ def run(test, params, env):
         mig_protocol = params.get("migration_protocol", "tcp")
         mig_cancel_delay = int(params.get("mig_cancel") == "yes") * 2
         inner_funcs = ast.literal_eval(params.get("migrate_inner_funcs", "[]"))
-        capabilities = ast.literal_eval(params.get("migrate_capabilities", "{}"))
+        capabilities = ast.literal_eval(
+            params.get("migrate_capabilities", "{}"))
         for i in range(repeat_times):
             if i % 2 == 0:
                 logging.info("Round %s ping...", str(i / 2))
@@ -61,19 +62,27 @@ def run(test, params, env):
             )
 
     def input_character_vsock():
-        connected_str = r"Connection from cid*"
-        nc_vsock_listen(nc_vsock_bin, port, session)
-        host_vsock_session = nc_vsock_connect(nc_vsock_bin, guest_cid, port)
+        if vsock_test_tool == "ncat":
+            vsock_listen(tool_bin, port, session)
+            host_vsock_session = vsock_connect(tool_bin, guest_cid, port)
         send_data = "Hello world"
-        check_received_data(test, session, connected_str)
+        if vsock_test_tool == "nc_vsock":
+            vsock_listen(tool_bin, port, session)
+            host_vsock_session = vsock_connect(tool_bin, guest_cid, port)
+            connected_str = r"Connection from cid*"
+            check_received_data(test, session, connected_str)
         error_context.context('Input "Hello world" to vsock.', logging.info)
         host_vsock_session.sendline(send_data)
         check_received_data(test, session, send_data)
         return host_vsock_session
 
+    vsock_test_tool = params["vsock_test_tool"]
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login()
-    nc_vsock_bin = compile_nc_vsock(test, vm, session)
+    if vsock_test_tool == "nc_vsock":
+        tool_bin = compile_nc_vsock(test, vm, session)
+    if vsock_test_tool == "ncat":
+        tool_bin = path.find_command("ncat")
     vsock_dev = params["vsocks"].split()[0]
     guest_cid = vm.devices.get(vsock_dev).get_param("guest-cid")
     port = random.randrange(1, 6000)
@@ -87,25 +96,25 @@ def run(test, params, env):
     ping_pong_migration(1)
     session = vm.wait_for_login()
     if session.cmd_output("ss --vsock | grep %s" % port):
-        test.fail("nc-vsock listening process inside guest does not exit after migrate")
+        test.fail(
+            "vsock listening process inside guest does not exit after migrate")
     host_vsock_session.close()
     # send data from guest to host
     tmp_file = "/tmp/vsock_file_%s" % utils_misc.generate_random_string(6)
     rec_session = send_data_from_guest_to_host(
-        session, nc_vsock_bin, guest_cid, tmp_file
+        session, tool_bin, guest_cid, tmp_file
     )
     utils_misc.wait_for(lambda: not rec_session.is_alive(), timeout=20)
     cmd_chksum = "md5sum %s" % tmp_file
     md5_origin = session.cmd_output(cmd_chksum).split()[0]
     md5_received = process.system_output(cmd_chksum).split()[0].decode()
-
     host_vsock_session = input_character_vsock()
     ping_pong_migration(3)
-    cmd_rm = "rm -rf %s*" % nc_vsock_bin
-    if tmp_file:
-        cmd_rm += "; rm -rf %s" % tmp_file
+    cmd_rm = "rm -rf %s" % tmp_file
+    if vsock_test_tool == "nc_vsock":
+        cmd_rm += "; rm -rf %s*" % tool_bin
     session.cmd_output_safe(cmd_rm)
-    process.system(cmd_rm, ignore_status=True)
+    process.system(cmd_rm, shell=True, ignore_status=True)
     if md5_received != md5_origin:
         test.fail(
             "Data transfer not integrated, the original md5 value"

--- a/qemu/tests/vsock_negative_test.py
+++ b/qemu/tests/vsock_negative_test.py
@@ -3,6 +3,7 @@ import signal
 import os
 import logging
 
+from avocado.utils import path
 from avocado.utils import process
 
 from virttest import utils_misc
@@ -16,7 +17,7 @@ def check_data_received(test, rec_session, file):
     Check if data is received successfully
 
     :param test: QEMU test object
-    :param rec_session: nc-vsock receive session
+    :param rec_session: vsock receive session
     :param file: file to receive data
     """
     if not utils_misc.wait_for(lambda: rec_session.is_alive(),
@@ -26,7 +27,7 @@ def check_data_received(test, rec_session, file):
                                timeout=3, step=0.1):
         test.fail("Host does not create receive file successfully.")
     elif not utils_misc.wait_for(lambda: os.path.getsize(file) > 0,
-                                 timeout=3, step=0.1):
+                                 timeout=10, step=0.1):
         test.fail('Host does not receive data successfully.')
 
 
@@ -36,14 +37,14 @@ def kill_host_receive_process(test, rec_session):
     Kill the receive process on host
 
     :param test: QEMU test object
-    :param rec_session: nc-vsock receive session
+    :param rec_session: vsock receive session
     """
-    error_context.context("Kill the nc-vsock process on host...",
+    error_context.context("Kill the vsock process on host...",
                           logging.info)
     rec_session.kill(sig=signal.SIGINT)
     if not utils_misc.wait_for(lambda: not rec_session.is_alive(),
                                timeout=1, step=0.1):
-        test.fail("Host nc-vsock process does not quit as expected.")
+        test.fail("Host vsock process does not quit as expected.")
 
 
 @error_context.context_aware
@@ -52,13 +53,11 @@ def run(test, params, env):
     Vsock negative test
 
     1. Boot guest with vhost-vsock-pci device
-    2. Download and compile nc-vsock on both guest and host
-    S1):
+    2. Download and compile vsock on both guest and host
     3. Connect guest CID(on host) without listening port inside guest
-    S2):
-    3. Send data from guest, nc-vsock -l $port < tmp_file
-    4. Receive data from host, nc-vsock $guest_cid $port
-    5. Interrupt nc-vsock process during transfering data on host
+    3. Send data from guest
+    4. Receive data from host
+    5. Interrupt vsock process during transfering data on host
 
     :param test: QEMU test object
     :param params: Dictionary with the test parameters
@@ -67,16 +66,23 @@ def run(test, params, env):
 
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login()
-    nc_vsock_bin = vsock_test.compile_nc_vsock(test, vm, session)
+    vsock_test_tool = params["vsock_test_tool"]
+    if vsock_test_tool == "nc_vsock":
+        tool_bin = vsock_test.compile_nc_vsock(test, vm, session)
+    if vsock_test_tool == "ncat":
+        tool_bin = path.find_command("ncat")
     port = random.randrange(1, 6000)
     vsock_dev = params["vsocks"].split()[0]
     guest_cid = vm.devices.get(vsock_dev).get_param("guest-cid")
-    nc_vsock_cmd = "%s %s %s" % (nc_vsock_bin, guest_cid, port)
+    if vsock_test_tool == "nc_vsock":
+        conn_cmd = "%s %s %s" % (tool_bin, guest_cid, port)
+    if vsock_test_tool == "ncat":
+        conn_cmd = "%s --vsock %s %s" % (tool_bin, guest_cid, port)
     connected_str = "Connection reset by peer"
     error_context.context("Connect vsock from host without"
                           " listening on guest.", logging.info)
     try:
-        process.system_output(nc_vsock_cmd)
+        process.system_output(conn_cmd)
     except process.CmdError as e:
         if connected_str not in str(e.result):
             test.fail("The connection does not fail as expected.")
@@ -88,11 +94,11 @@ def run(test, params, env):
     session = vm.wait_for_login()
     tmp_file = "/tmp/vsock_file_%s" % utils_misc.generate_random_string(6)
     rec_session = vsock_test.send_data_from_guest_to_host(
-        session, nc_vsock_bin, guest_cid, tmp_file, file_size=10000)
+        session, tool_bin, guest_cid, tmp_file, file_size=10000)
     try:
         check_data_received(test, rec_session, tmp_file)
         kill_host_receive_process(test, rec_session)
-        vsock_test.check_guest_nc_vsock_exit(test, session)
+        vsock_test.check_guest_vsock_conn_exit(test, session)
     finally:
         session.cmd_output("rm -f %s" % tmp_file)
         session.close()


### PR DESCRIPTION
Replace nc-vsock with ncat for vsock test on rhel9

ID: 2034163

Signed-off-by: qcheng <qcheng@redhat.com>