### PR TITLE
Remove ib700 test cases for q35

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -15,6 +15,7 @@
         -ib700:
             no RHEL.5
             only i386 x86_64
+            only i440fx
             watchdog_device_type = ib700
             dmesg_info = "ib700wdt.*init"
         -diag288:


### PR DESCRIPTION
Device 'ib700' can't go on PCIE bus, so remove it

ID: 2035734

Signed-off-by: Yiqian Wei <yiwei@redhat.com>