### PR TITLE
qmp_rtc_change: Add aarch64 support

### DIFF
--- a/qemu/tests/cfg/qmp_event_notification.cfg
+++ b/qemu/tests/cfg/qmp_event_notification.cfg
@@ -49,7 +49,9 @@
             event_cmd = c
             event_check = "RESUME"
         - qmp_rtc_change:
-            no Windows, aarch64
+            no Windows
+            aarch64:
+                required_qemu = [6.2.0, )
             event_cmd = hwclock --systohc
             event_check = "RTC_CHANGE"
         - qmp_watchdog:


### PR DESCRIPTION
The commit https://github.com/qemu/qemu/commit/1adf528ec3bdf62ea3b580b7ad562534a3676ff5
enables the current PL031 to report the guest's RTC changes to the QMP
monitor, so after this(qemu-6.2) on the aarch64 platform can also
enable qmp_rtc_change.

ID: 2037580
Signed-off-by: Yihuang Yu <yihyu@redhat.com>