### PR TITLE
block_during_io: update the iozone -g parameter to 4G

### DIFF
--- a/qemu/tests/cfg/block_during_io.cfg
+++ b/qemu/tests/cfg/block_during_io.cfg
@@ -48,9 +48,7 @@
     variants:
         - iozone_stress:
             stress_name = iozone
-            iozone_cmd_opitons = "-azR -r 64k -n 1G -g 10G -M -i 0 -i 1 -I "
-            Win10:
-                iozone_cmd_opitons = "-azR -r 64k -n 1G -g 5G -M -i 0 -i 1 -I "
+            iozone_cmd_opitons = "-azR -r 64k -n 1G -g 4G -M -i 0 -i 1 -I "
             iozone_timeout = 7200
             Windows:
                 iozone_cmd_opitons += "-f %s:\testfile"


### PR DESCRIPTION
Sometimes, iozone test with -g 10G will write full the system disk, cause the system not bootable normally, will block all other jobs behind this job.

id: 1774814

Signed-off-by: Peixiu Hou <phou@redhat.com>