### PR TITLE
transfer_file_over_ipv6: Configurable IPv6 address type

### DIFF
--- a/qemu/tests/cfg/transfer_file_over_ipv6.cfg
+++ b/qemu/tests/cfg/transfer_file_over_ipv6.cfg
@@ -7,6 +7,7 @@
     file_trans_timeout = 2400
     file_md5_check_timeout = 600
     dd_cmd = "dd if=/dev/zero of=%s bs=1M count=%d"
+    link_local_ipv6_addr = false
     Linux:
         tmp_dir = "/var/tmp/"
     Windows:

--- a/qemu/tests/transfer_file_over_ipv6.py
+++ b/qemu/tests/transfer_file_over_ipv6.py
@@ -33,6 +33,7 @@ def run(test, params, env):
     dd_cmd = params["dd_cmd"]
     file_trans_timeout = int(params.get("file_trans_timeout", '1200'))
     file_md5_check_timeout = int(params.get("file_md5_check_timeout", '600'))
+    link_local_ipv6_addr = params.getboolean("link_local_ipv6_addr")
 
     def get_file_md5sum(file_name, session, timeout):
         """
@@ -56,7 +57,7 @@ def run(test, params, env):
     # config ipv6 address host and guest.
     host_ifname = params.get("netdst")
     host_address = utils_net.get_host_ip_address(
-        params, ip_ver="ipv6", linklocal=True)
+        params, ip_ver="ipv6", linklocal=link_local_ipv6_addr)
 
     error_context.context("Get ipv6 address of host: %s" % host_address,
                           test.log.info)
@@ -71,7 +72,7 @@ def run(test, params, env):
             vm.get_mac_address(),
             params.get("os_type"),
             ip_version="ipv6",
-            linklocal=True)
+            linklocal=link_local_ipv6_addr)
 
         error_context.context("Get ipv6 address of %s: %s" % (vm.name, addresses[vm]),
                               test.log.info)


### PR DESCRIPTION
Link-local IPv6 address is a local unicast address with prefix fe80,
for general IPv6 testing, we should use the public/remote IPv6 address
instead of link-local address, this should be a more general scenario.
But we should also test local IPv6, to make it as configurable.

ID: 2039110
Signed-off-by: Yihuang Yu <yihyu@redhat.com>