### PR TITLE
memory_leak_after_nichotplug: Use serial session for Linux

### DIFF
--- a/qemu/tests/memory_leak_after_nichotplug.py
+++ b/qemu/tests/memory_leak_after_nichotplug.py
@@ -28,8 +28,11 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     timeout = int(params.get("login_timeout", 360))
-    session = vm.wait_for_login(timeout=timeout)
     os_type = params.get("os_type")
+    if os_type == "windows":
+        session = vm.wait_for_login(timeout=timeout)
+    else:
+        session = vm.wait_for_serial_login(timeout=timeout)
 
     free_mem_before_nichotplug = utils_misc.get_free_mem(session,
                                                          os_type)


### PR DESCRIPTION
The ssh session will take a few memory for use when we connect using
ssh and execute a lot of commands, there has confusion that the memory
is used by ssh or "ip link add", so use the serial session to avoid it.

ID: 2039155
Signed-off-by: Yihuang Yu <yihyu@redhat.com>