### PR TITLE
virtio_serial_hotplug_port_pci: Fix guest crash caused by hotplug

### DIFF
--- a/qemu/tests/block_resize.py
+++ b/qemu/tests/block_resize.py
@@ -117,6 +117,9 @@ def run(test, params, env):
 
     for ratio in params.objects("disk_change_ratio"):
         block_size = int(int(block_virtual_size) * float(ratio))
+        # The new size must be a multiple of 512 for windows
+        if params.get("os_type") == "windows" and block_size % 512 != 0:
+            block_size = int(block_size / 512) * 512
 
         # Record md5
         if params.get('md5_test') == 'yes':

--- a/qemu/tests/boot_from_device.py
+++ b/qemu/tests/boot_from_device.py
@@ -43,7 +43,17 @@ def run(test, params, env):
         """
         boot info check
         """
-        return re.search(info, vm.serial_console.get_stripped_output(), re.S)
+        return re.search(info, get_serial_console_output(), re.S)
+
+    def get_serial_console_output():
+        """
+        get the output of serail console
+        """
+        if params["enable_sga"] == "yes":
+            output = vm.serial_console.get_stripped_output()
+        else:
+            output = vm.serial_console.get_output()
+        return output
 
     timeout = int(params.get("login_timeout", 360))
     boot_menu_key = params.get("boot_menu_key", 'esc')
@@ -70,7 +80,7 @@ def run(test, params, env):
             # Send boot menu key in monitor.
             vm.send_key(boot_menu_key)
 
-            output = vm.serial_console.get_stripped_output()
+            output = get_serial_console_output()
             boot_list = re.findall(r"^\d+\. (.*)\s", output, re.M)
             if not boot_list:
                 test.fail("Could not get boot entries list")

--- a/qemu/tests/boot_order_check.py
+++ b/qemu/tests/boot_order_check.py
@@ -103,7 +103,10 @@ def run(test, params, env):
     error_context.context("Check the guest boot result", logging.info)
     start = time.time()
     while True:
-        output = vm.serial_console.get_stripped_output()
+        if params["enable_sga"] == "yes":
+            output = vm.serial_console.get_stripped_output()
+        else:
+            output = vm.serial_console.get_output()
         result = re.findall(boot_fail_infos, output, re.S | re.I)
         if result or time.time() > start + timeout:
             break

--- a/qemu/tests/cfg/blockdev_commit_standby.cfg
+++ b/qemu/tests/cfg/blockdev_commit_standby.cfg
@@ -2,6 +2,8 @@
     type = blockdev_commit_standby
     virt_test_type = qemu
     only Linux
+    #support this feature since RHEL8.4
+    no Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8.u0, Host_RHEL.m8.u1, Host_RHEL.m8.u2, Host_RHEL.m8.u3
     start_vm = yes
     kill_vm = yes
     storage_pools = default

--- a/qemu/tests/cfg/boot_from_device.cfg
+++ b/qemu/tests/cfg/boot_from_device.cfg
@@ -5,6 +5,9 @@
     image_boot = no
     boot_menu = on
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     boot_menu_key = "esc"
     Host_RHEL.m6:
         boot_menu_key = "f12"

--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -6,6 +6,9 @@
     kill_vm = yes
     boot_menu = on
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     devices_load_timeout = 10
     # we have QEMU machine with three NICs (virtio, e1000, rtl8139)
     # and two disks (default, IDE). firmware should try to boot from the bootindex=1

--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -9,6 +9,9 @@
             kill_vm = yes
             boot_menu = on
             enable_sga = yes
+            Host_RHEL.m9:
+                enable_sga = no
+                machine_type_extra_params = "graphics=off"
             image_verify_bootable = no
             boot_menu_key = "esc"
             Host_RHEL.m6:
@@ -21,7 +24,7 @@
             # SGA Bios info message, using sep as ";"
             # Please update this message to suit for your own system.
             restart_key = "ctrl-alt-delete"
-            Host_RHEL:
+            Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8:
                 sgabios_info = "Google, Inc.\s"
                 sgabios_info += "Serial Graphics Adapter .*\s"
                 sgabios_info += "SGABIOS \$Id.*\s"

--- a/qemu/tests/cfg/seabios_hotplug_unplug.cfg
+++ b/qemu/tests/cfg/seabios_hotplug_unplug.cfg
@@ -3,6 +3,9 @@
     type = seabios_hotplug_unplug
     boot_menu = on
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     boot_menu_key = "esc"
     Host_RHEL.m6:
         boot_menu_key = "f12"
@@ -17,7 +20,7 @@
     flexible_nic_index = yes
     q35:
         pcie_extra_root_port = 2
-    Host_RHEL:
+    Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8:
         sgabios_info = "Google, Inc.\s"
         sgabios_info += "Serial Graphics Adapter .*\s"
         sgabios_info += "SGABIOS \$Id.*\s"

--- a/qemu/tests/cfg/seabios_order_once.cfg
+++ b/qemu/tests/cfg/seabios_order_once.cfg
@@ -4,6 +4,9 @@
     boot_menu = on
     start_vm =no
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     image_boot = no
     images = "stg"
     image_name_stg = "images/stg"

--- a/qemu/tests/cfg/seabios_strict.cfg
+++ b/qemu/tests/cfg/seabios_strict.cfg
@@ -5,6 +5,9 @@
     image_boot = no
     boot_menu = on
     enable_sga = yes
+    Host_RHEL.m9:
+        enable_sga = no
+        machine_type_extra_params = "graphics=off"
     images = 'stg'
     bootindex_stg = 1
     image_name_stg = 'images/stg'

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -1,19 +1,17 @@
-- virtio_fs_share_data:
+- virtio_fs_share_data_multi_backend:
     no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
     no Win2008 Win7
     no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
     type = virtio_fs_share_data
     virt_test_type = qemu
     required_qemu = [4.2.0,)
-    s390, s390x:
-        required_qemu = [5.2.0,)
+    start_vm = no
     kill_vm = yes
-    start_vm = yes
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_type = mount
-    fs_source_dir = virtio_fs_test/
-    force_create_fs_source = yes
+    fs_source_dir = /tmp/virtio_fs_test
+    force_create_fs_source = no
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
@@ -24,6 +22,14 @@
     size_mem1 = 4G
     use_mem_mem1 = no
     share_mem = yes
+    s390, s390x:
+        required_qemu = [5.2.0,)
+        share_machine_mem = yes
+        pre_command_noncritical = yes
+        pre_command = "echo 3 > /proc/sys/vm/drop_caches"
+        setup_hugepages = yes
+        kvm_module_parameters = 'hpage=1'
+        expected_hugepage_size = 1024
     !s390, s390x:
         guest_numa_nodes = shm0
         numa_memdev_shm0 = mem-mem1
@@ -48,17 +54,30 @@
         virtio_win_media_type = iso
         cdroms += " virtio"
     variants:
-        - @default:
-        - with_reboot:
-            only default.default.with_cache.auto.default
-            reboot_guest = 'yes'
-            cmd_ps_virtiofsd = 'ps -eo pid,args |grep "socket-path=%s" |grep -v grep'
-        - with_log_check:
-            only Windows
-            only default.default.with_cache.auto.default
-            viofs_log_file_cmd = 'dir ${viofs_log_file}'
+        - with_nfs_source:
+            setup_local_nfs = yes
+            nfs_mount_options = rw
+            export_options = 'rw,insecure,no_root_squash,async'
+            variants:
+                - @default:
+                    export_dir = /mnt/virtio_fs_test_nfs
+                    nfs_mount_src = 127.0.0.1:/mnt/virtio_fs_test_nfs
+                - multi_fs:
+                    only run_stress.with_xfstest
+                    export_dir_fs1 = /mnt/virtio_fs1_test_nfs
+                    export_dir_fs2 = /mnt/virtio_fs2_test_nfs
+                    nfs_mount_src_fs1 = 127.0.0.1:/mnt/virtio_fs1_test_nfs
+                    nfs_mount_src_fs2 = 127.0.0.1:/mnt/virtio_fs2_test_nfs
     variants:
         - @default:
+        - with_stdev_check:
+            no Windows
+            only default.with_cache.auto.default_extra_parameters
+            fs_binary_extra_options += ",announce_submounts"
+            cmd_get_stdev = stat %%d %s
+            nfs_mount_dst_name = nfs_dir
+    variants:
+        - @default_extra_parameters:
         - @extra_parameters:
             variants:
                 - lock_posix_off:
@@ -102,57 +121,11 @@
                 cmd_del_folder = "rd /q /s ${test_folder}"
             default..with_cache.none:
                 io_timeout = 600
-            variants:
-                - @default:
-                - with_multi_fs_sources:
-                    no Windows
-                    with_multi_fs_sources.with_cache.none:
-                        io_timeout = 600
-                    filesystems = fs1 fs2 fs3 fs4 fs5
-                    fs_source_dir_fs1 = '/tmp/virtio_fs1_test'
-                    fs_source_dir_fs2 = '/tmp/virtio_fs2_test'
-                    fs_source_dir_fs3 = '/tmp/virtio_fs3_test'
-                    fs_source_dir_fs4 = '/tmp/virtio_fs4_test'
-                    fs_source_dir_fs5 = '/tmp/virtio_fs5_test'
-                    fs_target_fs1 = 'myfs1'
-                    fs_target_fs2 = 'myfs2'
-                    fs_target_fs3 = 'myfs3'
-                    fs_target_fs4 = 'myfs4'
-                    fs_target_fs5 = 'myfs5'
-                    fs_dest_fs1 = '/mnt/${fs_target_fs1}'
-                    fs_dest_fs2 = '/mnt/${fs_target_fs2}'
-                    fs_dest_fs3 = '/mnt/${fs_target_fs3}'
-                    fs_dest_fs4 = '/mnt/${fs_target_fs4}'
-                    fs_dest_fs5 = '/mnt/${fs_target_fs5}'
         - run_stress:
-            no run_stress..extra_parameters
             variants:
-                - with_fio:
-                    smp = 8
-                    vcpu_maxcpus = 8
-                    io_timeout = 2000
-                    fio_options = '--name=stress --filename=%s --ioengine=libaio --rw=write --direct=1 '
-                    fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800'
-                    Windows:
-                        fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
-                        fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800 --thread'
-                - with_pjdfstest:
-                    no Windows
-                    io_timeout = 1800
-                    with_pjdfstest..with_cache.none:
-                        io_timeout = 7200
-                    pjdfstest_pkg = pjdfstest-0.1.tar.bz2
-                    cmd_unpack = 'tar -zxvf {0}/${pjdfstest_pkg} -C {0}'
-                    cmd_yum_deps = 'yum install -y perl-Test-Harness'
-                    cmd_autoreconf = 'autoreconf -ifs %s/pjdfstest/'
-                    cmd_configure = '{0}/pjdfstest/configure && '
-                    cmd_configure += 'mv config.* {0}/pjdfstest/ && mv Makefile {0}/pjdfstest/ && mv stamp-h1 {0}/pjdfstest/'
-                    cmd_make = 'make %s/pjdfstest/pjdfstest'
-                    cmd_pjdfstest = 'prove -rv %s/pjdfstest/tests'
                 - with_xfstest:
+                    only with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs
                     no Windows
-                    only run_stress..with_cache.auto
-                    start_vm = no
                     image_snapshot = yes
                     mem = 32768
                     size_mem1 = 32G
@@ -160,11 +133,13 @@
                     # generic/003 120: https://gitlab.com/virtio-fs/qemu/-/issues/8
                     # generic/426 467 477: https://gitlab.com/virtio-fs/qemu/-/issues/10
                     # generic/551: Costs a lot of time
-                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551'
+                    # generic/035 nfs specific: https://gitlab.com/virtio-fs/qemu/-/issues/12
+                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551 generic/035'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.
                     # And this case only supports Linux, and don't need to check screendump. So turn off this feature.
+                    force_create_fs_source = no
                     filesystems = fs1 fs2
                     fs_source_dir_fs1 = /tmp/virtio_fs1_test
                     fs_source_dir_fs2 = /tmp/virtio_fs2_test

--- a/qemu/tests/seabios.py
+++ b/qemu/tests/seabios.py
@@ -24,7 +24,11 @@ def run(test, params, env):
         """
         Use the function to short the lines in the scripts
         """
-        return session_obj.get_stripped_output()
+        if params["enable_sga"] == "yes":
+            output = session_obj.get_stripped_output()
+        else:
+            output = session_obj.get_output()
+        return output
 
     def boot_menu():
         return re.search(boot_menu_hint, get_output(seabios_session))

--- a/qemu/tests/seabios_hotplug_unplug.py
+++ b/qemu/tests/seabios_hotplug_unplug.py
@@ -29,7 +29,11 @@ def run(test, params, env):
         """
         Use the function to short the lines in the scripts
         """
-        return session_obj.get_stripped_output()
+        if params["enable_sga"] == "yes":
+            output = session_obj.get_stripped_output()
+        else:
+            output = session_obj.get_output()
+        return output
 
     def sga_info_check():
         return re.search(sgabios_info, get_output(vm.serial_console))

--- a/qemu/tests/seabios_order_once.py
+++ b/qemu/tests/seabios_order_once.py
@@ -44,7 +44,11 @@ def run(test, params, env):
         """
         boot info check
         """
-        return re.search(info, vm.serial_console.get_stripped_output(), re.S)
+        if params["enable_sga"] == "yes":
+            output = vm.serial_console.get_stripped_output()
+        else:
+            output = vm.serial_console.get_output()
+        return re.search(info, output, re.S)
 
     cdrom_test = params["cdrom_test"]
     create_cdroms(cdrom_test)

--- a/qemu/tests/seabios_strict.py
+++ b/qemu/tests/seabios_strict.py
@@ -48,7 +48,11 @@ def run(test, params, env):
         """
         boot info check
         """
-        return re.search(info, vm.serial_console.get_stripped_output(), re.S)
+        if params["enable_sga"] == "yes":
+            output = vm.serial_console.get_stripped_output()
+        else:
+            output = vm.serial_console.get_output()
+        return re.search(info, output, re.S)
 
     error_context.context("Start guest with sga bios", logging.info)
     create_cdrom()

--- a/qemu/tests/virtio_serial_hotplug_port_pci.py
+++ b/qemu/tests/virtio_serial_hotplug_port_pci.py
@@ -93,6 +93,8 @@ def run(test, params, env):
     params['start_vm'] = "yes"
     env_process.preprocess(test, params, env)
     vm = env.get_vm(params['main_vm'])
+    # Make sure the guest boot successfully before hotplug
+    vm.wait_for_login()
     vm.devices.insert(char_devices)
     serials = params.objects('extra_serials')
     buses, serial_devices = get_buses_and_serial_devices(


### PR DESCRIPTION
Make sure the guest boot successfully before hotplug otherwise the guest may crash.

Before
```
# python3 ConfigTest.py --guestname=RHEL.8.6.0 --mem=8192 --vcpu=4 --clone=no --testcase=virtio_port_hotplug.hotplug_port_pci.default
[snip]
(1/1) Host_RHEL.m8.u6.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.6.0.aarch64.io-github-autotest-qemu.virtio_port_hotplug.hotplug_port_pci.arm64-pci: ERROR: VM is dead due to a kernel crash, see debug/serial log for details (295.34 s)
```
After
```
# python3 ConfigTest.py --guestname=RHEL.8.6.0 --mem=8192 --vcpu=4 --clone=no --testcase=virtio_port_hotplug.hotplug_port_pci.default
[snip]
(1/1) Host_RHEL.m8.u6.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.6.0.aarch64.io-github-autotest-qemu.virtio_port_hotplug.hotplug_port_pci.arm64-pci: PASS (85.32 s)
```
