### PR TITLE
virtio_serial_hotplug_port_pci: Fix guest crash caused by hotplug

### DIFF
--- a/qemu/tests/virtio_serial_hotplug_port_pci.py
+++ b/qemu/tests/virtio_serial_hotplug_port_pci.py
@@ -93,6 +93,8 @@ def run(test, params, env):
     params['start_vm'] = "yes"
     env_process.preprocess(test, params, env)
     vm = env.get_vm(params['main_vm'])
+    # Make sure the guest boot successfully before hotplug
+    vm.wait_for_login()
     vm.devices.insert(char_devices)
     serials = params.objects('extra_serials')
     buses, serial_devices = get_buses_and_serial_devices(


### PR DESCRIPTION
Make sure the guest boot successfully before hotplug otherwise the guest
may crash.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# python3 ConfigTest.py --guestname=RHEL.8.6.0 --mem=8192 --vcpu=4 --clone=no --testcase=virtio_port_hotplug.hotplug_port_pci.default
[snip]
(1/1) Host_RHEL.m8.u6.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.6.0.aarch64.io-github-autotest-qemu.virtio_port_hotplug.hotplug_port_pci.arm64-pci: ERROR: VM is dead due to a kernel crash, see debug/serial log for details (295.34 s)
```
After
```
# python3 ConfigTest.py --guestname=RHEL.8.6.0 --mem=8192 --vcpu=4 --clone=no --testcase=virtio_port_hotplug.hotplug_port_pci.default
[snip]
(1/1) Host_RHEL.m8.u6.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.6.0.aarch64.io-github-autotest-qemu.virtio_port_hotplug.hotplug_port_pci.arm64-pci: PASS (85.32 s)
```