### PR TITLE
Netperf: remove "ifconfig down"

### DIFF
--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -346,7 +346,7 @@ def run(test, params, env):
             mtu_set(mtu_default)
         if params.get("client_physical_nic") and params.get(
                                                     "os_type_client") == "linux":
-            cmd = 'ifconfig %s 0.0.0.0 down' % params.get("client_physical_nic")
+            cmd = 'ifconfig %s 0.0.0.0' % params.get("client_physical_nic")
             netperf_base.ssh_cmd(client, cmd)
 
 


### PR DESCRIPTION
When test failover case in loop, it's failed since the external device
was set down in last test. in such case, the deivce on host is
NO-CARRIER, then the guest could not get ip through dhclient.

Signed-off-by: Wenli Quan <wquan@redhat.com>

id: 2041356