### PR TITLE
seabios_bin: skip bios.bin checking for rhel9

### DIFF
--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -32,3 +32,5 @@
         - bin_file:
             type = seabios_bin
             machine_type_remove = "Supported none pc q35"
+            Host_RHEL.m9:
+                bin_file_skip = "bios.bin"

--- a/qemu/tests/seabios_bin.py
+++ b/qemu/tests/seabios_bin.py
@@ -30,8 +30,9 @@ def run(test, params, env):
 
     error_context.context("Get available bin files", logging.info)
     output = process.system_output('ls /usr/share/seabios', shell=True).decode()
+    bin_file_skip = params.get("bin_file_skip", "")
     for value in bin_dict.values():
-        if value not in output:
+        if value not in output and value != bin_file_skip:
             test.fail("%s is not available" % value)
 
     error_context.context("Get supported machine types", logging.info)


### PR DESCRIPTION
bios.bin is used for rhel6 machine type, it has been remove
from the seabios build in rhel9. So skip checking it.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2040348