### PR TITLE
seabios_bin: only check bios.bin in rhel6, rhel7 and rhel8

### DIFF
--- a/qemu/tests/cfg/seabios.cfg
+++ b/qemu/tests/cfg/seabios.cfg
@@ -32,5 +32,6 @@
         - bin_file:
             type = seabios_bin
             machine_type_remove = "Supported none pc q35"
-            Host_RHEL.m9:
-                bin_file_skip = "bios.bin"
+            bin_file_skip = bios.bin
+            Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8:
+                bin_file_skip = ""


### PR DESCRIPTION
bios.bin has been remove from the seabios build in rhel9.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2040348