### PR TITLE
memhp_threads: fix attribute error

### DIFF
--- a/qemu/tests/memhp_threads.py
+++ b/qemu/tests/memhp_threads.py
@@ -47,8 +47,6 @@ def run(test, params, env):
     pre_threads = get_qemu_threads(get_threads_cmd)
     mem = params.get("target_mems")
     new_params = params.object_params(mem).object_params("mem")
-    attrs = Memory.__attributes__[new_params["backend"]][:]
-    new_params = new_params.copy_from_keys(attrs)
     dev = Memory(new_params["backend"], new_params)
     dev.set_param("id", "%s-%s" % ("mem", mem))
     args = [vm.monitor, vm.devices.qemu_version]


### PR DESCRIPTION
memhp_threads: fix \_\_atributes\_\_ error

\_\_atributes\_\_ was deleted from Memory class in
virttest/qemu_devices/qdevices.py on avocado-vt,
but since three lines block was added in \_\_init\_\_
that assings the value to params, no call to the
Memory.\_\_atributes\_\_  is longer needed nor the
following line, just the call to the constructor.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2035697