### PR TITLE
blockdev_snapshot: support backend ceph support for live snapshot

### DIFF
--- a/qemu/tests/blockdev_snapshot_chains.py
+++ b/qemu/tests/blockdev_snapshot_chains.py
@@ -32,6 +32,11 @@ class BlockdevSnapshotChainsTest(BlockDevSnapshotTest):
             snapshot_format = params.get("snapshot_format", "qcow2")
             params["image_format_%s" % snapshot_tag] = snapshot_format
             self.params["image_format_%s" % snapshot_tag] = snapshot_format
+            if self.params["image_backend"] == "iscsi_direct":
+                self.params.update({"enable_iscsi_%s" % snapshot_tag: "no"})
+                self.params.update({"image_raw_device_%s" % snapshot_tag: "no"})
+            elif self.params["image_backend"] == "ceph":
+                self.params.update({"enable_ceph_%s" % snapshot_tag: "no"})
             image = sp_admin.volume_define_by_params(snapshot_tag, params)
             image.hotplug(self.main_vm)
 

--- a/qemu/tests/blockdev_snapshot_merge.py
+++ b/qemu/tests/blockdev_snapshot_merge.py
@@ -24,6 +24,8 @@ class BlockdevSnapshotMergeTest(BlockDevSnapshotTest):
         if self.params["image_backend"] == "iscsi_direct":
             self.params.update({"enable_iscsi_%s" % self.snapshot_tag: "no"})
             self.params.update({"image_raw_device_%s" % self.snapshot_tag: "no"})
+        elif self.params["image_backend"] == "ceph":
+            self.params.update({"enable_ceph_%s" % self.snapshot_tag: "no"})
         params = self.params.copy()
         params.setdefault("target_path", data_dir.get_data_dir())
         image = sp_admin.volume_define_by_params(self.snapshot_tag, params)

--- a/qemu/tests/cfg/blockdev_snapshot.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot.cfg
@@ -37,3 +37,7 @@
         enable_iscsi_sn1 = no
         enable_iscsi_data = yes
         image_raw_device_sn1 = no
+    ceph:
+        enable_ceph_sn1 = no
+        enable_ceph_data = yes
+        image_format_data = raw

--- a/qemu/tests/cfg/blockdev_snapshot_chains.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_chains.cfg
@@ -21,3 +21,6 @@
     iscsi_direct:
         lun_data1 = 1
         enable_iscsi_data1 = yes
+    ceph:
+        enable_ceph_data1 = yes
+        image_format_data1 = raw

--- a/qemu/tests/cfg/blockdev_snapshot_data_file.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_data_file.cfg
@@ -36,3 +36,8 @@
         enable_iscsi_data = yes
         image_raw_device_sn1 = no
         image_raw_device_sn2 = no
+    ceph:
+        enable_ceph_data = yes
+        image_format_data = raw
+        enable_ceph_sn1 = no
+        enable_ceph_sn2 = no

--- a/qemu/tests/cfg/blockdev_snapshot_guest_agent.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_guest_agent.cfg
@@ -25,3 +25,6 @@
         enable_iscsi_sn1 = no
         enable_iscsi_image1 = yes
         image_raw_device_sn1 = no
+    ceph:
+        enable_ceph_sn1 = no
+        enable_ceph_image1 = yes

--- a/qemu/tests/cfg/blockdev_snapshot_install.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_install.cfg
@@ -46,3 +46,8 @@
         enable_iscsi_unattended = no
         enable_iscsi_image1 = yes
         image_raw_device_sn1 = no
+    ceph:
+       enable_ceph_cd1 = no
+       enable_ceph_unattended = no
+       enable_ceph_sn1 = no
+       enable_ceph_image1 = yes

--- a/qemu/tests/cfg/blockdev_snapshot_merge.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_merge.cfg
@@ -27,3 +27,6 @@
         lun_data1 = 1
         enable_iscsi_data1 = yes
         image_size_data1 = 1G
+    ceph:
+        enable_ceph_data1 = yes
+        image_format_data1 = raw

--- a/qemu/tests/cfg/blockdev_snapshot_multi_disks.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_multi_disks.cfg
@@ -37,3 +37,10 @@
         enable_iscsi_sn2 = no
         image_raw_device_sn1 = no
         image_raw_device_sn2 = no
+    ceph:
+        enable_ceph_sn1 = no
+        enable_ceph_sn2 = no
+        enable_ceph_data1 = yes
+        enable_ceph_data2 =yes
+        image_format_data1 = raw
+        image_format_data2 = raw

--- a/qemu/tests/cfg/blockdev_snapshot_readonly.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_readonly.cfg
@@ -34,3 +34,7 @@
         enable_iscsi_data1 = yes
         image_raw_device_sn1 = no
         image_size_data1 = 1G
+    ceph:
+        enable_ceph_sn1 = no
+        enable_ceph_data1 = yes
+        image_format_data1 = raw

--- a/qemu/tests/cfg/blockdev_snapshot_reboot.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_reboot.cfg
@@ -19,3 +19,6 @@
         enable_iscsi_sn1 = no
         enable_iscsi_image1 = yes
         image_raw_device_sn1 = no
+    ceph:
+        enable_ceph_sn1 = no
+        enable_ceph_image1 = yes

--- a/qemu/tests/cfg/blockdev_snapshot_stop_cont.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_stop_cont.cfg
@@ -19,3 +19,6 @@
         enable_iscsi_sn1 = no
         enable_iscsi_image1 = yes
         image_raw_device_sn1 = no
+    ceph:
+        enable_ceph_sn1 = no
+        enable_ceph_image1 = yes

--- a/qemu/tests/cfg/blockdev_snapshot_stress.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_stress.cfg
@@ -19,3 +19,6 @@
         enable_iscsi_sn1 = no
         enable_iscsi_image1 = yes
         image_raw_device_sn1 = no
+    ceph:
+        enable_ceph_sn1 = no
+        enable_ceph_image1 = yes


### PR DESCRIPTION
Add ceph support for live snapshot

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2045982