### PR TITLE
virtio_fs: support writeback option on virtiofsd

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -82,6 +82,9 @@
                     fs_binary_extra_options += ",xattr"
                 - xattr_off:
                     fs_binary_extra_options += ",no_xattr"
+        - with_writeback:
+            only with_cache
+            fs_binary_extra_options += ",writeback"
     variants:
         - with_cache:
             variants:


### PR DESCRIPTION
Default is no_writeback, so add test scenario with writeback.
ID: 2035203
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>