### PR TITLE
block_hotplug_in_pause: stg0_encrypted not deleted

### DIFF
--- a/qemu/tests/block_hotplug_in_pause.py
+++ b/qemu/tests/block_hotplug_in_pause.py
@@ -87,6 +87,10 @@ def run(test, params, env):
             return False
 
         for dev in device_list:
+            # QObjects don't receive a DELETED EVENT back from QMP
+            # Filter them out
+            if isinstance(dev, qdevices.QObject):
+                continue
             dev_qid = dev.get_qid()
             if not utils_misc.wait_for(
                     lambda: get_deleted_event(dev_qid), timeout, 0, 0):


### PR DESCRIPTION
Applying small changes over the block_hotplug_in_pause testcase.

A bug was reported since the script was waiting for QMP to generate a `<type>_DELETED` event after deleting a stg0_encrypted object by QMP, using the `object-del` command.
Since the scope of the test is just limited to hotplugging and unpluging block devices, checking if the just-unplugged thing is a QObject or a QDevice and awaiting for the event in case of the latter should do the work.

ID: 1990759