### PR TITLE
virtio-fs: capsh print result check change

### DIFF
--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -74,8 +74,6 @@
                 cmd_dd = 'dd if=/dev/random of=%s bs=1M count=200'
                 cmd_md5 = "%s: && md5sum.exe %s"
             cmd_capsh_print = 'capsh --print |grep -i Bounding'
-            Host_RHEL.m8:
-                cmd_capsh_print = 'capsh --print |grep -i Current'
             cmd_capsh_drop = 'capsh --drop=%s --'
             variants:
                 - cap_dac_read_search:


### PR DESCRIPTION
Output of 'capsh print'  is changed on rhel9 and rhel860,
so to make the output check works on the old one and the latest one, redesign it.
Now just check 'Bounding set' line works on both.
ID: 2052775
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>