### PR TITLE
multi_disk_random_hotplug: cant insert ehci device

### DIFF
--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -55,6 +55,7 @@
                 stg_params = "fmt:virtio,virtio_scsi,usb2"
             usbs += " ehci"
             usb_type_ehci = usb-ehci
+            bus_tablet1 = usb1.0
             Host_RHEL.m6:
                 usbs= "ehci"
                 usb_type_ehci = ich9-usb-ehci1


### PR DESCRIPTION
The change in the configuration fixes the issue when trying to plug a 6th device during the test mentioned in the PR title.

I think that the issue should be fixed in the base.cfg. However that
could be risky since it wouldn't be affecting only to tests from this
provider. I opened another issue in the avocado-vt repo to discuss
about the usb_bus config. https://github.com/avocado-framework/avocado-vt/issues/3351

Meanwhile, I provide this patch, which fixes the issue for this test, while the more general fix is discussed.

Signed-off-by: Beñat Gartzia <bgartzia@redhat.com>
ID: 2034503