### PR TITLE
openflow_acl_test: Disable telnet test on rhel9

### DIFF
--- a/qemu/tests/cfg/openflow_acl_test.cfg
+++ b/qemu/tests/cfg/openflow_acl_test.cfg
@@ -54,6 +54,7 @@
             del setup_cmd
             del stop_cmd
         - telnet:
+            only Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8
             service_linux = xinetd
             service_windows = telnet
             prepare_cmd_linux = sed -i 's/^auth       required/#auth       required/g' /etc/pam.d/remote


### PR DESCRIPTION
1.The main connection tools on rhel9 are ssh and nc

ID:2052853

Signed-off-by: Lei Yang <leiayang@redhat.com>