### PR TITLE
ansible_test: switch to `python_install` policy

### DIFF
--- a/qemu/tests/cfg/ansible_test.cfg
+++ b/qemu/tests/cfg/ansible_test.cfg
@@ -14,7 +14,7 @@
     #foo_extra_vars = bar
     #echo_word_extra_vars = Hello ansible
     start_vm = no
-    ansible_install_policy = 'distro_install'
+    ansible_install_policy = 'python_install'
     variants:
         - @default:
         - responsive_migration:


### PR DESCRIPTION
There is `ansible-core` installed via `dnf in ansible`, which is not sufficient for the purpose `ansible_test`. 
We need to ensure full version of `ansible` is installed.

ID: 2043071

Signed-off by: Lukas Kotek <lkotek@redhat.com>