### PR TITLE
virtio_fs: virtiofsd config update for some options

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -71,9 +71,11 @@
                 - lock_posix_off:
                     fs_binary_extra_options += ",no_posix_lock"
                 - lock_posix_on:
+                    only Host_RHEL.m8
                     fs_binary_extra_options += ",posix_lock"
             variants:
                 - flock_on:
+                    only Host_RHEL.m8
                     fs_binary_extra_options += ",flock"
                 - flock_off:
                     fs_binary_extra_options += ",no_flock"

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -85,9 +85,11 @@
                 - lock_posix_off:
                     fs_binary_extra_options += ",no_posix_lock"
                 - lock_posix_on:
+                    only Host_RHEL.m8
                     fs_binary_extra_options += ",posix_lock"
             variants:
                 - flock_on:
+                    only Host_RHEL.m8
                     fs_binary_extra_options += ",flock"
                 - flock_off:
                     fs_binary_extra_options += ",no_flock"
@@ -96,6 +98,8 @@
                     fs_binary_extra_options += ",xattr"
                 - xattr_off:
                     fs_binary_extra_options += ",no_xattr"
+        - with_writeback:
+            fs_binary_extra_options += ",writeback"
     variants:
         - with_cache:
             variants:


### PR DESCRIPTION
1. on rhel900,we use virtiofsd-rust version which it doesn't support -o posix_lock and -o flock
2. Also add writeback test for multi backend test.
ID:  2052843
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>