### PR TITLE
nested_interactive_agent: Add a timeout value for vm.reboot()

### DIFF
--- a/qemu/tests/cfg/nested_interactive_agent.cfg
+++ b/qemu/tests/cfg/nested_interactive_agent.cfg
@@ -3,6 +3,7 @@
     virt_test_type = qemu
     type = nested_interactive_agent
     wait_response_timeout = 1800
+    vm_login_timout = 240
     # remote host information
     #mq_publisher =
     #mq_port =

--- a/qemu/tests/nested_interactive_agent.py
+++ b/qemu/tests/nested_interactive_agent.py
@@ -55,7 +55,8 @@ def run(test, params, env):
         test.log.info('Already captured the "APPROVE" message.')
 
         if not stress_tool:
-            vm.reboot()
+            wait_login_timeout = params.get_numeric('wait_login_timeout', 240)
+            vm.reboot(timeout=wait_login_timeout)
     finally:
         if stress_tool:
             stress_tool.clean()


### PR DESCRIPTION
After the L2 guest reboot, the default login timeout value is too
small, i.e. 10s, so extend it to 240s(the same as the initial
guest boot up login value).

ID: 2056455
Signed-off-by: Nini Gu <ngu@redhat.com>