### PR TITLE
usb: Disable usb-ccid and re-enable usb-storage on ARM

### DIFF
--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -9,7 +9,9 @@
     aarch64:
         Host_RHEL:
             only qemu-xhci
-            no usb_storage
+            no usb_ccid
+        usb_storage:
+            required_qemu = [6.0.0, )
 
     # usb controllers
     variants:


### PR DESCRIPTION
1. Disable usb-ccid device tests since ARM does not support it
2. Re-enable usb-storage tests starting with qemu-6.0

ID: 2057305
Signed-off-by: Yihuang Yu <yihyu@redhat.com>