### PR TITLE
qemu_guest_agent: Add new case that run qga as a program

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -531,6 +531,12 @@
             cmd_get_hostkey = "cat ~/.ssh/id_rsa.pub"
             cmd_del_key_file = "rm -rf ${guest_homepath}/.ssh/authorized_keys"
             test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls /home
+        - gagent_run_qga_as_program:
+            only Windows
+            gagent_check_type = run_qga_as_program
+            run_gagent_program_cmd = 'cd "C:\Program Files\Qemu-ga\"&'
+            run_gagent_program_cmd += 'start /b qemu-ga.exe'
+            kill_qga_program_cmd = taskkill /im qemu-ga.exe /t /f
     variants:
         - virtio_serial:
             gagent_serial_type = virtio


### PR DESCRIPTION
qga has two methods to run in windows:
1. The default method is to run as a service after installing
qemu-ga,msi. most users/customers are using that way.
2. Stop the default qemu-ga.service and run qemu-ga.exe as a
program.
Both of them are avaliable to work.

ID: 2054028
Signed-off-by: 6-dehan <demeng@redhat.com>