### PR TITLE
usb: port and bus param parsing

### DIFF
--- a/qemu/tests/cfg/block_with_share_rw.cfg
+++ b/qemu/tests/cfg/block_with_share_rw.cfg
@@ -22,7 +22,7 @@
                     aarch64:
                         no Host_RHEL
                     usbs = " usbtest"
-                    usb_bus = "usbtest.0"
+                    usbdev_bus = "usbtest.0"
                     variants:
                         - with_uhci:
                             no ppc64 ppc64le

--- a/qemu/tests/cfg/interrupt_check.cfg
+++ b/qemu/tests/cfg/interrupt_check.cfg
@@ -19,7 +19,7 @@
                 - usb_device:
                     irq_pattern = "xhci_hcd"
                     usbs = usb_xhci
-                    usb_bus = "usb_xhci.0"
+                    usbdev_bus = "usb_xhci.0"
                     usb_type_usb_xhci = qemu-xhci
                     usb_controller = xhci
                     drive_format_stg = usb3

--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -55,7 +55,6 @@
                 stg_params = "fmt:virtio,virtio_scsi,usb2"
             usbs += " ehci"
             usb_type_ehci = usb-ehci
-            bus_tablet1 = usb1.0
             Host_RHEL.m6:
                 usbs= "ehci"
                 usb_type_ehci = ich9-usb-ehci1

--- a/qemu/tests/cfg/pvpanic_basic.cfg
+++ b/qemu/tests/cfg/pvpanic_basic.cfg
@@ -47,7 +47,7 @@
             only Windows
             crash_method = usb_keyboard
             usb_devices += " kb1"
-            usb_type_kb1 = "usb-kbd"
+            usbdev_type_kb1 = "usb-kbd"
             set_panic_cmd = 'wmic class stdregprov call SetDwordValue hDefKey="&h80000002" sSubKeyName="SYSTEM\CurrentControlSet\Services\kbdhid\Parameters" sValueName="CrashOnCtrlScroll" uValue=1'
             # There is no inbox usb3.0 driver on Win2008, Win2008R2 and Win7, so run with usb2.0 instead.
             Win7, Win2008:

--- a/qemu/tests/cfg/slof_memory.cfg
+++ b/qemu/tests/cfg/slof_memory.cfg
@@ -7,7 +7,7 @@
     start_vm = yes
     not_preprocess = yes
     usb_devices += ' kbd1'
-    usb_type_kbd1 = 'usb-kbd'
+    usbdev_type_kbd1 = 'usb-kbd'
     slots_mem = 4
     only ppc64le ppc64
     only Linux

--- a/qemu/tests/cfg/slof_open_bios.cfg
+++ b/qemu/tests/cfg/slof_open_bios.cfg
@@ -6,7 +6,7 @@
     login_timeout = 240
     start_vm = yes
     usb_devices += ' kbd1'
-    usb_type_kbd1 = 'usb-kbd'
+    usbdev_type_kbd1 = 'usb-kbd'
     only ppc64le ppc64
     only Linux
     # Select one drive format since just test slof open bios.

--- a/qemu/tests/cfg/slof_order.cfg
+++ b/qemu/tests/cfg/slof_order.cfg
@@ -16,7 +16,7 @@
     boot_order = cdn
     boot_strict = off
     usb_devices += ' kbd1'
-    usb_type_kbd1 = 'usb-kbd'
+    usbdev_type_kbd1 = 'usb-kbd'
     nics = 'nic1'
     # force to set the dirve format of system image to virtio-blk
     drive_format_empty_image1 = virtio

--- a/qemu/tests/cfg/slof_user_interface.cfg
+++ b/qemu/tests/cfg/slof_user_interface.cfg
@@ -11,7 +11,7 @@
     boot_order = cdn
     boot_strict = off
     usb_devices += ' kbd1'
-    usb_type_kbd1 = 'usb-kbd'
+    usbdev_type_kbd1 = 'usb-kbd'
     ack_timeout = 30
     start_s = 'SLOF'
     end_s = '0 >'

--- a/qemu/tests/cfg/systemtap_tracing.cfg
+++ b/qemu/tests/cfg/systemtap_tracing.cfg
@@ -101,8 +101,8 @@
             usb_type_usb2 = usb-ehci
             usb_controller_tablet1 = uhci
             usb_controller_hub = uhci
-            usb_type_tablet1 =  usb-tablet
-            usb_type_hub = usb-hub
+            usbdev_type_tablet1 =  usb-tablet
+            usbdev_type_hub = usb-hub
             usb_max_port_usb2 = 6
             images += " stg"
             image_name_stg = "images/usbdevice"

--- a/qemu/tests/cfg/usb.cfg
+++ b/qemu/tests/cfg/usb.cfg
@@ -5,7 +5,7 @@
     restart_vm = yes
     kill_vm_on_error = yes
     usbs = " usbtest"
-    usb_bus = "usbtest.0"
+    usbdev_bus = "usbtest.0"
     aarch64:
         Host_RHEL:
             only qemu-xhci
@@ -98,29 +98,29 @@
             no usb_host, usb_redir, usb_multi_disk
             no usb-ehci
             usb_devices += " hub1"
-            usb_type_hub1 = usb-hub
-            usb_port_hub1 = "2"
-            usb_port_testdev = "2.1"
+            usbdev_type_hub1 = usb-hub
+            usbdev_port_hub1 = "2"
+            usbdev_port_testdev = "2.1"
             variants:
                 - one_usb_dev:
                 - max_usb_dev:
                     only usb_boot, usb_reboot
                     no usb_hub
                     usb_devices += " d1 d2 d3 d4 d5 d6 d7"
-                    usb_port_d1 = "2.2"
-                    usb_port_d2 = "2.3"
-                    usb_port_d3 = "2.4"
-                    usb_port_d4 = "2.5"
-                    usb_port_d5 = "2.6"
-                    usb_port_d6 = "2.7"
-                    usb_port_d7 = "2.8"
+                    usbdev_port_d1 = "2.2"
+                    usbdev_port_d2 = "2.3"
+                    usbdev_port_d3 = "2.4"
+                    usbdev_port_d4 = "2.5"
+                    usbdev_port_d5 = "2.6"
+                    usbdev_port_d6 = "2.7"
+                    usbdev_port_d7 = "2.8"
                 - max_usb_hub_dev:
                     only usb_boot, usb_reboot
                     only usb_hub
                     usb_devices += " hub2 hub3 hub4"
-                    usb_port_hub2 = "2.2"
-                    usb_port_hub3 = "2.3"
-                    usb_port_hub4 = "2.4"
+                    usbdev_port_hub2 = "2.2"
+                    usbdev_port_hub3 = "2.3"
+                    usbdev_port_hub4 = "2.4"
 
     # usb devices
     variants:
@@ -130,7 +130,7 @@
             Host_RHEL.m6:
                 no usb-ehci
             only usb_reboot, usb_hotplug
-            usb_type = "usb-kbd"
+            usbdev_type = "usb-kbd"
             info_usb_name = "QEMU USB Keyboard"
             vendor_id = "0627"
             product_id = "0001"
@@ -140,7 +140,7 @@
             Host_RHEL.m6:
                 no usb-ehci
             only usb_reboot, usb_hotplug
-            usb_type = "usb-mouse"
+            usbdev_type = "usb-mouse"
             info_usb_name = "QEMU USB Mouse"
             vendor_id = "0627"
             product_id = "0001"
@@ -150,7 +150,7 @@
             Host_RHEL.m6:
                 no usb-ehci
             only usb_reboot, usb_hotplug
-            usb_type = "usb-tablet"
+            usbdev_type = "usb-tablet"
             info_usb_name = "QEMU USB Tablet"
             vendor_id = "0627"
             product_id = "0001"
@@ -159,7 +159,7 @@
         - usb_ccid:
             no usb-ehci
             only usb_boot, usb_reboot, usb_hotplug
-            usb_type = "usb-ccid"
+            usbdev_type = "usb-ccid"
             info_usb_name = "QEMU USB CCID"
             vendor_id = "08E6"
             product_id = "4433"
@@ -170,7 +170,7 @@
         - usb_audio:
             no Host_RHEL
             only usb_boot, usb_reboot, usb_hotplug
-            usb_type = usb-audio
+            usbdev_type = usb-audio
             info_usb_name = "QEMU USB Audio"
             vendor_id = "46F4"
             product_id = "0002"
@@ -179,7 +179,7 @@
         - usb_hub:
             no usb-ehci
             only usb_boot, usb_reboot, usb_hotplug
-            usb_type = usb-hub
+            usbdev_type = usb-hub
             info_usb_name = "QEMU USB Hub"
             vendor_id = "(0000|0409)"
             product_id = "(0000|55aa)"
@@ -315,7 +315,7 @@
             type = usb_host
             only Linux
             usb_devices += " usbhostdev"
-            usb_type_usbhostdev = usb-host
+            usbdev_type_usbhostdev = usb-host
             variants options:
                 # must configure which device should be used
                 - @with_no_hostdev:

--- a/qemu/tests/cfg/usb_device_check.cfg
+++ b/qemu/tests/cfg/usb_device_check.cfg
@@ -4,7 +4,7 @@
     not_preprocess = yes
     kill_vm_on_error = yes
     usbs = "usbtest"
-    usb_bus = "usbtest.0"
+    usbdev_bus = "usbtest.0"
     cmd_timeout = 240
     login_timeout = 180
     type = usb_device_check
@@ -99,15 +99,15 @@
         - multi_hubs_in_parallel:
             no usb-ehci
             usb_topology = '{"usb-hub":9}'
-            port_d0 = 1
-            port_d1 = 1.1
-            port_d2 = 1.2
-            port_d3 = 1.3
-            port_d4 = 1.4
-            port_d5 = 1.5
-            port_d6 = 1.6
-            port_d7 = 1.7
-            port_d8 = 1.8
+            usbdev_port_d0 = 1
+            usbdev_port_d1 = 1.1
+            usbdev_port_d2 = 1.2
+            usbdev_port_d3 = 1.3
+            usbdev_port_d4 = 1.4
+            usbdev_port_d5 = 1.5
+            usbdev_port_d6 = 1.6
+            usbdev_port_d7 = 1.7
+            usbdev_port_d8 = 1.8
         - input_devices_under_one_hub:
             no usb-ehci
             usb_topology = '{"usb-hub":1,"usb-mouse":1,"usb-kbd":1,"usb-tablet":1}'

--- a/qemu/tests/usb_common.py
+++ b/qemu/tests/usb_common.py
@@ -16,7 +16,7 @@ def parse_usb_topology(params):
     Parse the usb devices topology to the params.
 
     :param params: Dictionary with the test parameters.
-    :return: A list of dictionary ({usb_type_d0: usb_type}) of specified
+    :return: A list of dictionary ({usbdev_type_d0: usbdev_type}) of specified
              usb topology.
     """
     params["usb_devices"] = ""
@@ -27,7 +27,7 @@ def parse_usb_topology(params):
     for key, value in usb_topology.items():
         for i in range(value):
             params["usb_devices"] += " d%s" % len(parsed_devs)
-            usb_type = '{"usb_type_d%s": "%s"}' % (len(parsed_devs), key)
+            usb_type = '{"usbdev_type_d%s": "%s"}' % (len(parsed_devs), key)
             params.update(json.loads(usb_type))
             parsed_devs.append(json.loads(usb_type))
     return parsed_devs
@@ -53,7 +53,7 @@ def collect_usb_dev(params, vm, parsed_devs, suffix):
     devs = []
     for parsed_dev in parsed_devs:
         key = list(parsed_dev.keys())[0]
-        usb_dev_id = "usb-%s" % key[9:]
+        usb_dev_id = "usb-%s" % key[12:]
         usb_dev_info = params[_change_dev_info_key(parsed_dev[key], suffix)]
         usb_dev_port = str(vm.devices.get(usb_dev_id).get_param("port"))
         devs.append([usb_dev_id, usb_dev_info, usb_dev_port])

--- a/qemu/tests/usb_hotplug.py
+++ b/qemu/tests/usb_hotplug.py
@@ -52,7 +52,7 @@ def run(test, params, env):
         if messages_del.find(match_del) == -1:
             test.fail("Guest didn't detect unplug")
 
-    device = params.object_params("testdev")["usb_type"]
+    device = params.object_params("testdev")["usbdev_type"]
     vendor_id = params["vendor_id"]
     product_id = params["product_id"]
 

--- a/qemu/tests/usb_redir.py
+++ b/qemu/tests/usb_redir.py
@@ -122,7 +122,7 @@ def run(test, params, env):
                                             aobject=usbredirdev_name)
             usbredir_filter = usbredir_params.get("usbdev_option_filter")
             usbredir_bootindex = usbredir_params.get("usbdev_option_bootindex")
-            usbredir_bus = usbredir_params.get("usb_bus")
+            usbredir_bus = usbredir_params.get("usbdev_bus")
             usbredir_dev.set_param('id', 'usb-%s' % usbredirdev_name)
             usbredir_dev.set_param('chardev', chardev_id)
             usbredir_dev.set_param('filter', usbredir_filter)


### PR DESCRIPTION
Several usb device configuration parameters were not being read during device generation in virttest. That implied introducing changes that also affected the name of the keys used to configure those device parameters (please refer to https://github.com/avocado-framework/avocado-vt/pull/3361)

This changes updates the cfg files so the parameters will be taken into account once the mentioned PR gets merged.
It also reverts 75f26e28ae21e4e49b6dfbd1858994cf28362ff1 since the added configuration in that commit will be implied in the base configuration if the already mentioned pr gets merged.

ID: 2059254