### PR TITLE
vt_ulimit_nofile: workarounds deletion

### DIFF
--- a/qemu/tests/cfg/hotplug_unplug_during_io_repeat.cfg
+++ b/qemu/tests/cfg/hotplug_unplug_during_io_repeat.cfg
@@ -14,7 +14,6 @@
     iozone_timeout = 7200
     sleep_time = 30
     repeat_time = 100
-    vt_ulimit_nofile = 10240
     q35:
         pcie_extra_root_port = 1
     Linux:

--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -64,7 +64,6 @@
         - single_type:
             no ide, ahci, scsi
             virtio_scsi:
-                vt_ulimit_nofile = 8192
                 stg_params = "fmt:virtio_scsi"
                 set_drive_bus = no
                 Linux:


### PR DESCRIPTION
After some research about the vt_ulimit_nofile key usage in configurations, I catched a test case using the parameter as a workaround. I also catched (in multi_disk_random_hotplug) a redundant value assignment.
It looks like the rest of test cases using the vt_ulimit_nofile are doing it with other goals in mind rather than avoiding getting an error for the fd-leak when opening/closing sessions.

ID: 2051875
