### PR TITLE
tpm_bind_luks: New case to bind luks disk with TPM2 policy via clevis

### DIFF
--- a/qemu/tests/cfg/tpm_bind_luks.cfg
+++ b/qemu/tests/cfg/tpm_bind_luks.cfg
@@ -1,0 +1,43 @@
+- tpm_bind_luks:
+    virt_test_type = qemu
+    type = tpm_bind_luks
+    only Linux
+    start_vm = yes
+    kill_vm = yes
+    images += " stg"
+    image_name_stg = "images/stg"
+    image_size_stg = 1G
+    force_create_image_stg = yes
+    force_remove_image_stg = yes
+    clone_master = yes
+    master_images_clone = image1
+    remove_image_image1 = yes
+    tpms = tpm0
+    tpm_version_tpm0 = 2.0
+    tpm_type_tpm0 = emulator
+    x86_64:
+        only q35
+        only ovmf
+        required_qemu= [4.2.0,)
+        tpm_model_tpm0 = tpm-crb
+    ppc64le, ppc64:
+        required_qemu= [5.0.0,)
+        tpm_model_tpm0 = tpm-spapr
+    aarch64:
+        required_qemu = [5.1.0,)
+        tpm_model_tpm0 = tpm-tis-device
+    required_pkgs = clevis-luks clevis-systemd clevis-dracut cryptsetup
+    luks_passphrase = tpm2decrypt
+    mapper_name = luks_fs
+    mapper_dev = '/dev/mapper/${mapper_name}'
+    mount_path = '/mnt/luks_fs'
+    dd_file = '${mount_path}/dd_file'
+    dd_cmd = "dd if=/dev/urandom of=${dd_file} bs=1M count=512"
+    pcr_policy = '"pcr_ids":"7"'
+    cryptsetup_format_cmd = 'cryptsetup --force-password -q luksFormat %s <<< "${luks_passphrase}"'
+    cryptsetup_check_cmd = 'cryptsetup isLuks '
+    cryptsetup_close_cmd = 'cryptsetup close ${mapper_name}'
+    cryptsetup_open_cmd = 'cryptsetup open %s ${mapper_name} <<< "${luks_passphrase}"'
+    clevis_bind_cmd = clevis luks bind -y -k - -d %s tpm2 '{"pcr_bank":"sha256",${pcr_policy}}' <<< "${luks_passphrase}"
+    clevis_list_cmd = 'clevis luks list -d '
+    clevis_unlock_cmd = 'clevis luks unlock -d %s -n ${mapper_name}'

--- a/qemu/tests/tpm_bind_luks.py
+++ b/qemu/tests/tpm_bind_luks.py
@@ -1,0 +1,161 @@
+import re
+
+from virttest import error_context
+from virttest import utils_disk
+from virttest import utils_package
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Verify the TPM device can automatically unlock the LUKs device.
+    Steps:
+        1. Format the extra disk to LUKs via cryptsetup
+        2. Open the LUKs disk, mount it and create a file system
+        3. Bind the extra disk using the TPM2 policy
+        4. Open the LUKs device via clevis and check the file's md5
+        5. Modify crypttab and fstab to enable automatic boot unlocking
+        6. Reboot guest and check if OS can unlock the LUKs FS automatically
+
+    :param test: QEMU test object.
+    :type  test: avocado.core.test.Test
+    :param params: Dictionary with the test parameters.
+    :type  params: virttest.utils_params.Params
+    :param env: Dictionary with test environment.
+    :type  env: virttest.utils_env.Env
+    """
+
+    def mount_disk(file_func):
+        """
+        Mount and umount the disk before and after operate a file.
+
+        :param file_func: function to handle the random file in the LUKs volume
+        :type file_func: file_func
+        """
+
+        def wrapper(*args, **kwargs):
+            if not utils_disk.is_mount(
+                    mapper_dev, mount_path, session=session):
+                test.log.info("Mount the LUKs FS...")
+                if not utils_disk.mount(mapper_dev, mount_path,
+                                        session=session):
+                    test.error("Cannot mount %s to %s" % (mapper_dev,
+                                                          mount_path))
+            out = file_func(*args, **kwargs)
+            test.log.info("Umount the LUKs FS...")
+            if not utils_disk.umount(mapper_dev, mount_path, session=session):
+                test.error("Cannot umount " + mount_path)
+            return out
+
+        return wrapper
+
+    def get_md5sum():
+        """
+        Return the file's MD5
+        """
+        return session.cmd_output("md5sum " + dd_file).split()[0]
+
+    @mount_disk
+    def create_random_file():
+        """
+        Create a file with random data and return it's MD5
+        """
+        test.log.info("Create a random file...")
+        session.cmd(dd_cmd)
+        return get_md5sum()
+
+    @mount_disk
+    def compare_md5sum():
+        """
+        Compare the current MD5 value with the original one
+        """
+        md5_current = get_md5sum()
+        if md5_current != md5_original:
+            test.fail(
+                "File %s changed, the current md5(%s) is mismatch of the"
+                " original md5(%s)" %
+                (dd_file, md5_current, md5_original))
+        test.log.info("File's md5 matched, md5: %s", md5_current)
+
+    @mount_disk
+    def auto_boot_unlocking():
+        """
+        Steps to configure automatic unlocking at late boot stage
+        """
+        session.cmd('echo "%s %s - _netdev" >> /etc/crypttab' % (mapper_name,
+                                                                 extra_disk))
+        session.cmd(
+            'echo "%s %s xfs _netdev 0 0" >> /etc/fstab' %
+            (mapper_dev, mount_path))
+        s, o = session.cmd_status_output("mount -av")
+        if s != 0:
+            test.fail("Mount format is incorrect:\n%s" % o)
+        test.log.debug("The full mount list is:\n%s", o)
+        session.cmd("systemctl enable clevis-luks-askpass.path")
+
+    clevis_bind_cmd = params["clevis_bind_cmd"]
+    clevis_list_cmd = params["clevis_list_cmd"]
+    clevis_unlock_cmd = params["clevis_unlock_cmd"]
+    cryptsetup_check_cmd = params["cryptsetup_check_cmd"]
+    cryptsetup_close_cmd = params["cryptsetup_close_cmd"]
+    cryptsetup_format_cmd = params["cryptsetup_format_cmd"]
+    cryptsetup_open_cmd = params["cryptsetup_open_cmd"]
+    dd_cmd = params["dd_cmd"]
+    dd_file = params["dd_file"]
+    mapper_dev = params["mapper_dev"]
+    mapper_name = params["mapper_name"]
+    mount_path = params.get("mount_path", "/mnt")
+    pcr_policy = params["pcr_policy"]
+    required_packages = params.objects("required_pkgs")
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login()
+    extra_disk = "/dev/" + list(utils_disk.get_linux_disks(session).keys())[0]
+
+    test.log.info("Install required packages in VM")
+    if not utils_package.package_install(required_packages, session):
+        test.cancel("Cannot install required packages in VM")
+
+    error_context.base_context("Format the extra disk to LUKs", test.log.info)
+    session.cmd(cryptsetup_format_cmd % extra_disk)
+    test.log.info("Check if the extra disk is LUKs format")
+    if session.cmd_status(cryptsetup_check_cmd + extra_disk) != 0:
+        test.fail("The extra disk cannot be formatted to LUKs")
+    test.log.debug("The extra disk is formatted to LUKs:\n%s",
+                   session.cmd_output("cryptsetup luksDump " + extra_disk))
+
+    error_context.context("Open the LUKs disk", test.log.info)
+    session.cmd(cryptsetup_open_cmd % extra_disk)
+    session.cmd("mkfs.xfs -f " + mapper_dev)
+    test.log.info("A new xfs file system is created for %s", mapper_dev)
+
+    error_context.context("Mount the FS and create a random file",
+                          test.log.info)
+    if session.cmd_status("test -d " + mount_path) != 0:
+        session.cmd("mkdir -p " + mount_path)
+    md5_original = create_random_file()
+    session.cmd(cryptsetup_close_cmd)
+
+    error_context.base_context("Bind %s using the TPM2 policy" % extra_disk,
+                               test.log.info)
+    session.cmd(clevis_bind_cmd % extra_disk)
+    clevis_list = session.cmd_output(clevis_list_cmd + extra_disk)
+    if not re.search(r'tpm2 \S+%s' % pcr_policy, clevis_list, re.M):
+        test.fail("Failed to bind the disk with TPM2 policy via clevis")
+    test.log.info("The LUKs device is bound to TPM:\n%s", clevis_list)
+
+    error_context.context("Open the LUKs device using clevis and check the md5"
+                          " of the file", test.log.info)
+    session.cmd(clevis_unlock_cmd % extra_disk)
+    compare_md5sum()
+
+    error_context.context("Modify crypttab and fstab to enable automatic boot "
+                          "unlocking", test.log.info)
+    auto_boot_unlocking()
+    session.cmd(cryptsetup_close_cmd)
+
+    error_context.context("Reboot the guest to check if the operating system "
+                          "can unlock the LUKs FS automatically")
+    session = vm.reboot(session)
+    compare_md5sum()


### PR DESCRIPTION
Add the new case to format the extra disk to LUKs format, bind it with
TPM2 policy via clevis, and reboot the guest to check if the operating
system can unlock it automatically.

ID: 2060234
Signed-off-by: Yihuang Yu <yihyu@redhat.com>