### PR TITLE
tpm_with_tss: Add a new case to test tpm2-tss unit test inside guest

### DIFF
--- a/qemu/tests/cfg/tpm_with_tss.cfg
+++ b/qemu/tests/cfg/tpm_with_tss.cfg
@@ -1,0 +1,25 @@
+- tpm_with_tss:
+    virt_test_type = qemu
+    type = tpm_with_tss
+    only Linux
+    tpms = tpm0
+    tpm_version_tpm0 = 2.0
+    tpm_type_tpm0 = emulator
+    x86_64:
+        only q35
+        only ovmf
+        required_qemu= [4.2.0,)
+        tpm_model_tpm0 = tpm-crb
+    ppc64le, ppc64:
+        required_qemu= [5.0.0,)
+        tpm_model_tpm0 = tpm-spapr
+    aarch64:
+        required_qemu = [5.1.0,)
+        tpm_model_tpm0 = tpm-tis-device
+    tpm_device = /dev/tpmrm0
+    required_pkgs = autoconf autoconf-archive automake gcc json-c-devel libcmocka libcmocka-devel libcurl-devel pkg-config openssl-devel
+    tpm2_tss_repo = https://github.com/tpm2-software/tpm2-tss.git
+    tpm2_tss_path = /var/tmp/tpm2_tss
+    check_log_cmd = 'grep "^#" ${tpm2_tss_path}/test-suite.log'
+    configure_cmd = cd ${tpm2_tss_path} && ./bootstrap && ./configure --enable-unit --with-device=${tpm_device}
+    make_check_cmd = make check-device

--- a/qemu/tests/tpm_with_tss.py
+++ b/qemu/tests/tpm_with_tss.py
@@ -1,0 +1,64 @@
+import re
+
+from virttest import error_context
+from virttest import utils_package
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Verify the TPM device info inside guest and host.
+    Steps:
+        1. Launch a guest with vTPM device
+        2. Clone the tpm2-tss repository and compile it
+        3. Execute the tpm2-tss unit test and analyze the test result
+
+    :param test: QEMU test object.
+    :type  test: avocado.core.test.Test
+    :param params: Dictionary with the test parameters.
+    :type  params: virttest.utils_params.Params
+    :param env: Dictionary with test environment.
+    :type  env: virttest.utils_env.Env
+    """
+
+    configure_cmd = params["configure_cmd"]
+    check_log_cmd = params["check_log_cmd"]
+    make_check_cmd = params["make_check_cmd"]
+    required_packages = params.objects("required_pkgs")
+    tpm_device = params["tpm_device"]
+    tpm2_tss_path = params["tpm2_tss_path"]
+    tpm2_tss_repo = params["tpm2_tss_repo"]
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login()
+
+    error_context.context("Check if TPM2 device exists", test.log.info)
+    if session.cmd_status("test -c %s" % tpm_device) != 0:
+        test.error("Cannot find the TPM2 device inside guest")
+
+    test.log.info("Install required packages in VM")
+    if not utils_package.package_install(required_packages, session):
+        test.cancel("Cannot install required packages in VM")
+
+    try:
+        error_context.context("Compile the tpm2-tss test suite", test.log.info)
+        test.log.info("Clone the tpm2-tss repo...")
+        session.cmd("git clone --depth=1 %s %s" % (tpm2_tss_repo,
+                                                   tpm2_tss_path))
+        test.log.info("Configure tpm2-tss...")
+        session.cmd(configure_cmd, timeout=180)
+
+        error_context.context("Check test result of tpm2-tss", test.log.info)
+        status, output = session.cmd_status_output(make_check_cmd, timeout=600)
+        if status != 0:
+            test.fail("tpm2-tss test suite execution failed, output is:\n%s"
+                      % output)
+        result = session.cmd_output(check_log_cmd)
+        t_total, t_pass = re.findall(r"^# (?:TOTAL|PASS): +(\d+)$", result,
+                                     re.M)
+        if t_total != t_pass:
+            test.fail("The count of TOTAL and PASS do not match")
+    finally:
+        session.cmd("rm -rf %s" % tpm2_tss_path, ignore_all_errors=True)
+        session.close()


### PR DESCRIPTION
Clone the tpm2-tss repo and configure with tpm device, execute the unit
test and check the test result.

ID: 2060235
Signed-off-by: Yihuang Yu <yihyu@redhat.com>