### PR TITLE
ksm_base: adds ksmtuned in cmds_installed_host cfg option

### DIFF
--- a/generic/tests/cfg/ksm_services.cfg
+++ b/generic/tests/cfg/ksm_services.cfg
@@ -4,6 +4,7 @@
     vms = ""
     main_vm = ""
     setup_ksm = "yes"
+    cmds_installed_host = "ksmtuned"
     variants:
         - set_params:
             ksm_ref = "set_params"

--- a/qemu/tests/cfg/ksm_base.cfg
+++ b/qemu/tests/cfg/ksm_base.cfg
@@ -8,6 +8,7 @@
     query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
     split = "yes"
     guest_script_overhead = 20
+    cmds_installed_host = "ksmtuned"
     variants:
         - disable:
             test_type = "disable"

--- a/qemu/tests/cfg/ksm_ksmtuned.cfg
+++ b/qemu/tests/cfg/ksm_ksmtuned.cfg
@@ -4,6 +4,7 @@
     ksm_config_file = '/etc/ksmtuned.conf'
     ksm_thres_conf = 'KSM_THRES_COEF'
     ksm_threshold = 60
+    cmds_installed_host = "ksmtuned"
     ppc64, ppc64le:
         ksm_threshold = 80
     cmd_get_thres = 'cat ${ksm_config_file} | grep ${ksm_thres_conf}'

--- a/qemu/tests/cfg/ksm_overcommit.cfg
+++ b/qemu/tests/cfg/ksm_overcommit.cfg
@@ -17,6 +17,7 @@
     # ksm_host_reserve = 512
     # ksm_guest_reserve = 1024
     setup_ksm = yes
+    cmds_installed_host = "ksmtuned"
     variants:
         - ksm_serial:
             ksm_mode = "serial"


### PR DESCRIPTION
ksm: adds ksmtuned in cmds_installed_host cfg option
for ksm_base, ksm_services, ksm_overcommit and ksm_ksmtuned
cfg files

depends on: https://github.com/avocado-framework/avocado-vt/pull/3353

ID: 2034135
Signed-off-by: mcasquer <mcasquer@redhat.com>