### PR TITLE
tpm_with_check_aavmf: Add new case to check TPM contents in edk2 on ARM

### DIFF
--- a/qemu/tests/cfg/tpm_verify_device.cfg
+++ b/qemu/tests/cfg/tpm_verify_device.cfg
@@ -55,6 +55,9 @@
                             pattern_check_log += \[TPM2PP\] PPRequest=\w+ \(PPRequestParameter=\w+\);
                             Windows:
                                 pattern_check_log += TPM2 Tcg2Dxe Measure Data when ReadyToBoot;
+                        - with_check_aavmf:
+                            only aarch64
+                            type = tpm_with_check_aavmf
                         - with_reboot:
                             reboot_method = system_reset
                             repeat_times = 20

--- a/qemu/tests/tpm_with_check_aavmf.py
+++ b/qemu/tests/tpm_with_check_aavmf.py
@@ -1,0 +1,45 @@
+from aexpect.exceptions import ExpectProcessTerminatedError
+from aexpect.exceptions import ExpectTimeoutError
+
+from virttest import error_context
+from virttest import utils_package
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Verify the TPM device in the guest and check it in UEFI
+    Steps:
+        1. Boot guest with an emulator TPM device.
+        2. Check and verify TPM/vTPM device info in the UEFI log
+        3. Use tpm2_selftest for a basic check.
+
+    :param test: QEMU test object.
+    :type  test: avocado.core.test.Test
+    :param params: Dictionary with the test parameters.
+    :type  params: virttest.utils_params.Params
+    :param env: Dictionary with test environment.
+    :type  env: virttest.utils_env.Env
+    """
+    tpm_pattern = [r".*efi: SMBIOS .* TPMFinalLog=.* TPMEventLog=.*"]
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    error_context.context("Check TPM pattern in the serial output",
+                          test.log.info)
+    try:
+        vm.serial_console.read_until_output_matches(tpm_pattern)
+    except (ExpectProcessTerminatedError, ExpectTimeoutError) as err:
+        test.log.error(err)
+        test.fail("Failed to get the expected tpm pattern.")
+
+    error_context.context("Execute tpm2_selftest command for a basic check",
+                          test.log.info)
+    session = vm.wait_for_login()
+    if not utils_package.package_install("tpm2-tools", session):
+        test.error("Cannot install tpm2-tools to execute tpm2_selftest")
+    s, o = session.cmd_status_output("tpm2_selftest")
+    if s != 0:
+        test.log.error("tpm2_selftest output:\n%s", o)
+        test.fail("tpm2_selftest failed")


### PR DESCRIPTION
Check if the TPM message is correct in the edk2 output.

ID: 2062956
Signed-off-by: Yihuang Yu <yihyu@redhat.com>