### PR TITLE
qmp_command: changed cmd_return_value for aarch64

### DIFF
--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -189,11 +189,17 @@
             qmp_cmd = "qom-list-types implements=conventional-pci-device"
             cmd_result_check = "contain"
             cmd_return_value = "[{'name': 'vfio-pci'}, {'name': 'qemu-xhci'}, {'name': 'virtio-net-pci'}, {'name': 'rtl8139'}]"
+            aarch64:
+                cmd_return_value = "[{'name': 'vfio-pci'}, {'name': 'qemu-xhci'}, {'name': 'virtio-net-pci'}]"    
         - qmp_qom-list-types_pcie:
             qmp_cmd = "qom-list-types implements=pci-express-device"
             cmd_result_check = "contain"
             cmd_return_value = "[{'name': 'vfio-pci'}, {'name': 'qemu-xhci'}, {'name': 'virtio-blk-pci'}, {'name': 'e1000e'}]"
+            aarch64:
+                cmd_return_value = "[{'name': 'vfio-pci'}, {'name': 'qemu-xhci'}, {'name': 'virtio-blk-pci'}]"
         - qmp_qom-list-types_pci:
             qmp_cmd = "qom-list-types implements=pci-device"
             cmd_result_check = "contain"
             cmd_return_value = "[{'name': 'rtl8139'}, {'name': 'e1000e'}, {'name': 'vfio-pci'}, {'name': 'qemu-xhci'}, {'name': 'virtio-blk-pci'}]"
+            aarch64:
+                cmd_return_value = "[{'name': 'vfio-pci'}, {'name': 'qemu-xhci'}, {'name': 'virtio-blk-pci'}]"


### PR DESCRIPTION
From cmd_return_value for aarch64 was deleted
{'name':'e1000e'} and {'name':'rtl8139'}.

ID: 2062912
Signed-off-by: Bogdan Marcynkov <bmarcynk@redhat.com>