### PR TITLE
blockdev_commit_fio: to verify commit can finish after fio done

### DIFF
--- a/qemu/tests/blockdev_commit_fio.py
+++ b/qemu/tests/blockdev_commit_fio.py
@@ -56,12 +56,13 @@ class BlockdevCommitFio(BlockDevCommitTest):
 
 def run(test, params, env):
     """
-    Block commit base Test
+    To verify the commit job can be completed after heavy IO finishes
 
     1. boot guest with system disk
     2. create snapshot
     3. run fio test in guest
-    4. commit snapshot to base during fio running
+    4. commit snapshot to base during fio running,
+       wait commit done after fio done
     5. verify file's md5 after commit
     """
 

--- a/qemu/tests/cfg/blockdev_commit_fio.cfg
+++ b/qemu/tests/cfg/blockdev_commit_fio.cfg
@@ -16,14 +16,12 @@
     rebase_mode = unsafe
     qemu_force_use_drive_expression = no
     mount_point = "/var/tmp"
-    sleep_min = 300
-    sleep_max = 480
-    fio_timeout = 2400
-    commit_job_timeout = 1800
-    ppc64le, s390x:
-        commit_job_timeout = 2400
+    sleep_min = 50
+    sleep_max = 100
+    fio_timeout = 300
+    commit_job_timeout = 420
     fio_options = '--name=stress --filename=/home/atest --ioengine=libaio --rw=write --direct=1 '
-    fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=256 --runtime=${fio_timeout} --time_based'
+    fio_options += '--bs=4K --size=2G --iodepth=256 --numjobs=256 --runtime=${fio_timeout} --time_based'
     iscsi_direct:
         enable_iscsi_sn1 = no
         image_raw_device_sn1 = no


### PR DESCRIPTION
To verify the commit job can be completed after heavy IO finishes

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2066993