### PR TITLE
chardev_tls_encryption: Add s390x support

### DIFF
--- a/qemu/tests/cfg/chardev_tls_encryption.cfg
+++ b/qemu/tests/cfg/chardev_tls_encryption.cfg
@@ -12,6 +12,8 @@
         serials += " vs"
         serial_type_vs = virtserialport
         serial_device = ${serial_type_vs}
+    s390x:
+        serial_device = "sclpconsole"
     variants:
         - host_to_guest:
             expected_msg = "Channel binding 'tls-unique'"
@@ -37,6 +39,9 @@
             ppc64, ppc64le:
                 expected_msg = "SLOF"
                 guest_cmd = "cat /dev/hvc0 &"
+            s390x:
+                expected_msg = "LOADPARM"
+                guest_cmd = "cat /dev/ttysclp0 &"
             extra_params_vm1 = " -object tls-creds-x509,id=tls0,dir=${cert_dir},endpoint=server"
             extra_params_vm1 += " -chardev socket,id=tls_chardev1,host=%s,port=%s,tls-creds=tls0,server=on,wait=off"
             extra_params_vm1 += " -device ${serial_device},chardev=tls_chardev1,id=tls_serial1"


### PR DESCRIPTION
Add code to support s390x test for the chardev tls encryption
scnearios.

ID: 2070005
Signed-off-by: Nini Gu <ngu@redhat.com>