### PR TITLE
hotplug_mem_reserve: correct 'required_qemu_version' to 'required_qemu'

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_reserve.cfg
+++ b/qemu/tests/cfg/hotplug_mem_reserve.cfg
@@ -3,7 +3,7 @@
     mem_fixed = 4096
     slots_mem = 4
     maxmem_mem = 32G
-    required_qemu_version = [6.1.0, )
+    required_qemu = [6.1.0, )
     no Windows..i386
     no WinXP Win2000 Win2003 WinVista Win7 Win8 Win10 Win11
     guest_numa_nodes = node0


### PR DESCRIPTION
In avocado-vt framework, the correct param name be used in env_process to
check required qemu is 'required_qemu'.

id:2070384

Signed-off-by: Yanan Fu <yfu@redhat.com>