### PR TITLE
Add cases for cpu-model-expansion and boot with different CPU-models

### DIFF
--- a/qemu/tests/cfg/s390x_cpu_model.cfg
+++ b/qemu/tests/cfg/s390x_cpu_model.cfg
@@ -1,0 +1,40 @@
+- s390x_cpu_model:
+    auto_cpu_model = yes
+    start_vm = yes
+    kill_vm_on_error = yes
+    take_regular_screendumps = no
+    virt_test_type = qemu
+    only s390x
+    variants:
+        - expansion:
+            type = s390x_cpu_model_expansion
+            variants:
+               - model_type_z196_z196_2_z114:
+                    cpu_models = "z196 z196.2 z114"
+                    props = 'aefsi=True msa4=True msa3=True msa2=True msa1=True sthyi=True edat=True ipter=True bpb=True ppa15=True cmm=True'
+               - model_type_zEC12_zEC12_2_zBC12:
+                    cpu_models = "zEC12 zEC12.2 zBC12"
+                    props = 'aen=True aefsi=True msa4=True msa3=True msa2=True msa1=True sthyi=True edat=True ri=True edat2=True ipter=True esop=True cte=True bpb=True ppa15=True zpci=True sea_esop2=True te=True cmm=True'
+               - model_type_z13_z13_2_z13s:
+                    cpu_models = "z13 z13.2 z13s"
+                    props = 'aen=True aefsi=True msa5=True msa4=True msa3=True msa2=True msa1=True sthyi=True edat=True ri=True edat2=True vx=True ipter=True esop=True cte=True bpb=True ppa15=True zpci=True sea_esop2=True te=True cmm=True'
+               - model_type_z14_z14_2_z14ZR1:
+                    cpu_models = "z14 z14.2 z14ZR1"
+                    props = 'aen=True aefsi=True mepoch=True msa8=True msa7=True msa6=True msa5=True msa4=True msa3=True msa2=True msa1=True sthyi=True edat=True ri=True edat2=True vx=True ipter=True mepochptff=True vxeh=True vxpd=True esop=True iep=True cte=True bpb=True gs=True ppa15=True zpci=True sea_esop2=True te=True cmm=True'
+               - model_type_gen15a_gen15b:
+                    cpu_models = "gen15a gen15b"
+                    props = 'aen=True vxpdeh=True aefsi=True mepoch=True msa9=True msa8=True msa7=True msa6=True msa5=True msa4=True msa3=True msa2=True msa1=True sthyi=True edat=True ri=True deflate=True edat2=True etoken=True vx=True ipter=True mepochptff=True vxeh=True vxpd=True esop=True msa9_pckmo=True vxeh2=True iep=True cte=True gs=True ppa15=True zpci=True sea_esop2=True te=True cmm=True'
+               - model_type_gen16a_gen16b:
+                    cpu_models = "gen16a gen16b"
+                    props = 'nnpa=True aen=True vxpdeh=True aefsi=True mepoch=True msa9=True msa8=True msa7=True msa6=True msa5=True msa4=True msa3=True msa2=True msa1=True sthyi=True edat=True ri=True deflate=True edat2=True etoken=True vx=True ipter=True pai=True mepochptff=True vxeh=True vxpd=True esop=True msa9_pckmo=True vxeh2=True iep=True cte=True gs=True ppa15=True zpci=True rdp=True sea_esop2=True beareh=True te=True cmm=True vxpdeh2=True'
+        - boot_cpu_models:
+            type = s390x_cpu_model_boot
+            auto_cpu_model = yes
+            cpu_model_check_cmd = "query-cpu-model-expansion"
+            cpu_model_check_args = '{"type": "static", "model": {"name": "host"}}'
+            RHEL.7:
+                boot_cpu_models = 'z196,z196.2,z114;zEC12,zEC12.2,zBC12;z13,z13.2,z13s;z14,z14.2,z14ZR1;gen15a,gen15b;gen16a,gen16b'
+            RHEL.8:
+                boot_cpu_models = 'z13,z13.2,z13s;z14,z14.2,z14ZR1;gen15a,gen15b;gen16a,gen16b'
+            RHEL.9:
+                boot_cpu_models = 'z14,z14.2,z14ZR1;gen15a,gen15b;gen16a,gen16b'

--- a/qemu/tests/s390x_cpu_model_boot.py
+++ b/qemu/tests/s390x_cpu_model_boot.py
@@ -1,0 +1,48 @@
+import json
+
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Boot guest with supported cpu-models
+    :param test: QEMU test object.
+    :param params: Dictionary with test parameters.
+    :param env: Dictionary with the test environment.
+    :param boot_cpu_models: list of the all expected CPU models
+    :param boot_models: list of all expected CPU models suitable with the
+    current testing machine
+    :param boot_model: the CPU model of booting the guest
+    :param cpu_model_check_cmd: cmd of checking cpu models
+    :param cpu_model_check_args: arguments of checking cpu models
+    """
+    boot_cpu_models = params.get_list("boot_cpu_models", delimiter=";")
+    cpu_model_check_cmd = params.get('cpu_model_check_cmd')
+    cpu_model_check_args = json.loads(params.get('cpu_model_check_args'))
+    vm_name = params['main_vm']
+    vm = env.get_vm(vm_name)
+    host_model = vm.monitor.cmd(cpu_model_check_cmd,
+                                cpu_model_check_args).get('model')
+    host_model_name = host_model.get('name')[:-5]
+    for boot_models in boot_cpu_models:
+        if host_model_name in boot_models:
+            boot_cpu_models = boot_cpu_models[:boot_cpu_models.index(
+                boot_models) + 1]
+            break
+    vm.destroy()
+    for boot_models in boot_cpu_models:
+        params["boot_models"] = boot_models
+        boot_models = params.get_list("boot_models", delimiter=",")
+        for boot_model in boot_models:
+            params["cpu_model"] = boot_model
+            try:
+                test.log.info("Start boot guest with cpu model: %s.",
+                              boot_model)
+                vm.create(params=params)
+                vm.verify_alive()
+                vm.wait_for_serial_login()
+                vm.destroy()
+            except Exception as info:
+                test.log.error("Guest failed to boot up with: %s" % boot_model)
+                test.fail(info)

--- a/qemu/tests/s390x_cpu_model_expansion.py
+++ b/qemu/tests/s390x_cpu_model_expansion.py
@@ -1,0 +1,48 @@
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Boot guest and query-cpu-model-expansion
+
+    :param test: QEMU test object.
+    :param params: Dictionary with test parameters.
+    :param env: Dictionary with the test environment.
+    :params cpu_models: expected cpu model list
+    :params props: expected cpu model properties
+    """
+    vm = env.get_vm(params["main_vm"])
+    test.log.info('Start query cpu model supported by qmp')
+    # get cpu models for test
+    cpu_models = params.objects('cpu_models')
+    for cpu_model in cpu_models:
+        args = {'type': 'static', 'model': {'name': cpu_model}}
+        output = vm.monitor.cmd('query-cpu-model-expansion', args)
+        try:
+            model = output.get('model')
+            model_name = model.get('name')
+            model_props = model.get('props')
+            if model_name != cpu_model+'-base':
+                test.fail('Command query-cpu-model-expansion return'
+                          ' wrong model: %s with %s' % (cpu_model+'-base',
+                                                        model_name))
+            if model_name[:-5] in cpu_models:
+                props = params.get_dict('props')
+                keys = props.keys()
+                for key in keys:
+                    if props[key] == 'True':
+                        props[key] = True
+                    elif props[key] == 'False':
+                        props[key] = False
+                    else:
+                        test.fail('unexpected values in configuration,'
+                                  'key: %s, value：%s' % (key, props[key]))
+                if model_props != props:
+                    test.fail('Properties %s was not same as expected,%s' %
+                              (model_props, props))
+            else:
+                test.fail('There is no suitable cpu model searched by expansion'
+                          'guest: %s, expected: %s' % (model_name, cpu_models))
+        except Exception as info:
+            test.fail(info)


### PR DESCRIPTION
CPU model: add cases to check if the QMP command "query-cpu-model-expansion" works
expected and adaption test with different CPU models on s390x

ID: 2070199

Signed-off-by: Boqiao Fu <bfu@redhat.com>