### PR TITLE
balloon_memhp: increases threshold value to avoid memory size mismatch

### DIFF
--- a/qemu/tests/cfg/balloon_memhp.cfg
+++ b/qemu/tests/cfg/balloon_memhp.cfg
@@ -22,7 +22,7 @@
     balloon = balloon0
     balloon_dev_devid = balloon0
     balloon_dev_add_bus = yes
-    threshold = 0.12
+    threshold = 0.19
     aarch64,ppc64,ppc64le:
         threshold = 0.15
     # Due to known issue


### PR DESCRIPTION
balloon_memhp: increases threshold value to avoid memory size mismatch

ID: 2063976
Signed-off-by: mcasquer <mcasquer@redhat.com>