### PR TITLE
tpm_verify_device: Update some TPM parameters

### DIFF
--- a/qemu/tests/cfg/tpm_verify_device.cfg
+++ b/qemu/tests/cfg/tpm_verify_device.cfg
@@ -4,7 +4,7 @@
     start_vm = yes
     kill_vm = yes
     tpms = tpm0
-    tpm_version_tpm0 = 2.0
+    tpm_version = 2.0
     x86_64:
         only q35
         only ovmf
@@ -31,13 +31,12 @@
         pattern_output_get_tpm = TpmPresent\s+:\s+True;TpmReady\s+:\s+True
     variants:
         - with_emulator:
-            tpm_type_tpm0 = emulator
-            tpm_model_tpm0 = tpm-crb
+            tpm_type = emulator
+            tpm_model = tpm-crb
             ppc64le, ppc64:
-                tpm_model_tpm0 = tpm-spapr
+                tpm_model = tpm-spapr
             aarch64:
-                tpm_model_tpm0 = tpm-tis-device
-            tpm_version_tpm0 = 2.0
+                tpm_model = tpm-tis-device
             variants:
                 - @default:
                     variants:
@@ -63,6 +62,9 @@
                             repeat_times = 20
                 - with_multi_vms:
                     vms = vm1 vm2 vm3
+                    tpms_vm1 = tpm1
+                    tpms_vm2 = tpm2
+                    tpms_vm3 = tpm3
                     mem = 4096
                     clone_master = yes
                     master_images_clone = image1


### PR DESCRIPTION
Deps on avocado-framework/avocado-vt/pull/3364, Update
global TPM parameters and set different TPM names in
different VMs.

ID: 2072812
Signed-off-by: Yihuang Yu <yihyu@redhat.com>