### PR TITLE
win_irq_check: Add multi queues test scenario

### DIFF
--- a/qemu/tests/cfg/win_irq_check.cfg
+++ b/qemu/tests/cfg/win_irq_check.cfg
@@ -90,6 +90,11 @@
                 - by_registry:
                     no with_balloon, with_viorng
                     msi_cmd = "reg add "HKLM\System\CurrentControlSet\Enum\%s\Device Parameters\Interrupt Management\MessageSignaledInterruptProperties" /v MSISupported /d %d /t REG_DWORD /f"
+                    variants:
+                        - default_queues:
+                        - multi_queues:
+                            only with_netkvm
+                            queues = 4
                 - by_vectors:
                     only with_viostor, with_netkvm
                     vectors = 0


### PR DESCRIPTION
1.Boot the guest with multiple queues nic with guest msi disabled
inside guest, should support windows guest

ID:1485223

Signed-off-by: Lei Yang <leiayang@redhat.com>