### PR TITLE
slof: add checking slof version step for slof_boot test cases

### DIFF
--- a/qemu/tests/cfg/slof_boot.cfg
+++ b/qemu/tests/cfg/slof_boot.cfg
@@ -7,6 +7,7 @@
     start_vm = yes
     only ppc64le ppc64
     only Linux
+    check_slof_version = "rpm -qa | grep SLOF"
     variants:
         - from_virtio_blk:
             only virtio_blk

--- a/qemu/tests/slof_boot.py
+++ b/qemu/tests/slof_boot.py
@@ -16,6 +16,7 @@ slof_boot.py include following case:
 """
 import re
 
+from avocado.utils import process
 from virttest import error_context
 from provider import slof
 from virttest import utils_net
@@ -80,6 +81,9 @@ def run(test, params, env):
                                        child_addr, sub_child_addr):
             test.fail(fail_info)
         test.log.info(ret_info)
+
+    o = process.getoutput(params.get("check_slof_version")).strip()
+    test.log.info("Check the version of SLOF: '%s'", o)
 
     vm = env.get_vm(params['main_vm'])
     vm.verify_alive()


### PR DESCRIPTION
While running slof test cases we'd better record the slof version.
ID:2073261
Signed-off-by: MiriamDeng <mdeng@redhat.com>