### PR TITLE
smbios_default_check: the RHEL-AV / RHEL split is gone in rhel9

### DIFF
--- a/qemu/tests/cfg/smbios_default_check.cfg
+++ b/qemu/tests/cfg/smbios_default_check.cfg
@@ -12,7 +12,7 @@
         System_Manufacturer = "^Red Hat$"
         System_SKU_Number = "^8.[23456789].0|9.\d.0$"
         Baseboard_Manufacturer = "^Red Hat$"
-        Baseboard_Product_Name = "^RHEL-AV$"
+        Baseboard_Product_Name = "^RHEL(-AV|)$"
     # Command to get BIOS info
     RHEL:
         get_sys_manufacturer = dmidecode -s system-manufacturer


### PR DESCRIPTION
For baseboard-product-name, either RHEL-AV or RHEL is right.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2038054