### PR TITLE
seabios: disable sga device from rhel8.6 and the later version

### DIFF
--- a/qemu/tests/cfg/boot_order_check.cfg
+++ b/qemu/tests/cfg/boot_order_check.cfg
@@ -5,10 +5,11 @@
     type = boot_order_check
     kill_vm = yes
     boot_menu = on
-    enable_sga = yes
-    Host_RHEL.m9:
-        enable_sga = no
-        machine_type_extra_params = "graphics=off"
+    enable_sga = no
+    machine_type_extra_params = "graphics=off"
+    Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8.u0, Host_RHEL.m8.u1, Host_RHEL.m8.u2, Host_RHEL.m8.u3, Host_RHEL.m8.u4, Host_RHEL.m8.u5:
+        enable_sga = yes
+        machine_type_extra_params = ""
     devices_load_timeout = 10
     # we have QEMU machine with three NICs (virtio, e1000, rtl8139)
     # and two disks (default, IDE). firmware should try to boot from the bootindex=1


### PR DESCRIPTION
1. since sga device has been removed in rhel9, disable it
2. using "-machine graphics=off" instead of "-device sga"
3. rhel8 will continue to support sgabios, but starting with 8.6
   libvirt uses "-machine graphics=off" so rhel-8 testing
   should be switched over too.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2036174