### PR TITLE
blockdev_commit_fio: fix background thread can't exit preperly

### DIFF
--- a/provider/storage_benchmark.py
+++ b/provider/storage_benchmark.py
@@ -44,7 +44,7 @@ class StorageBenchmark(object):
     """
     cmds = {'linux': {'_symlinks': 'ln -s -f %s %s',
                       '_list_pid': 'pgrep -xl %s',
-                      '_kill_pid': 'killall %s',
+                      '_kill_pid': 'killall -s SIGKILL %s',
                       '_rm_file': 'rm -rf {}'},
             'windows': {'_symlinks': 'mklink %s %s',
                         '_list_pid': 'TASKLIST /FI "IMAGENAME eq %s',

--- a/qemu/tests/blockdev_commit_fio.py
+++ b/qemu/tests/blockdev_commit_fio.py
@@ -16,11 +16,7 @@ class BlockdevCommitFio(BlockDevCommitTest):
             self.test.log.info("Start to run fio")
             self.fio = generate_instance(self.params, self.main_vm, 'fio')
             fio_run_timeout = self.params.get_numeric("fio_timeout", 2400)
-            try:
-                self.fio.run(fio_options, fio_run_timeout)
-            finally:
-                self.fio.clean()
-            self.main_vm.verify_dmesg()
+            self.fio.run(fio_options, fio_run_timeout)
 
     def commit_snapshots(self):
         for device in self.params["device_tag"].split():
@@ -49,8 +45,9 @@ class BlockdevCommitFio(BlockDevCommitTest):
             self.commit_snapshots()
             self.verify_data_file()
         finally:
-            if bg_test.is_alive():
-                self.fio.clean(force=True)
+            # clean fio cause fio.run exit, then fio thread exit soon
+            self.fio.clean(force=True)
+            self.main_vm.verify_dmesg()
             self.post_test()
 
 

--- a/qemu/tests/blockdev_snapshot_reboot.py
+++ b/qemu/tests/blockdev_snapshot_reboot.py
@@ -21,6 +21,8 @@ class BlockdevSnapshotRebootTest(BlockDevSnapshotTest):
         LOG_JOB.info("sleep random time to perform before snapshot")
         time.sleep(random.randint(0, 10))
         super(BlockdevSnapshotRebootTest, self).create_snapshot()
+        if bg_test.is_alive():
+            bg_test.join()
 
     def vm_reset(self):
         self.main_vm.reboot(method="system_reset")


### PR DESCRIPTION
Need ensure all backgroupd threads exit before the main thread exits,
otherwise, will hit error "Test reported status but did not finish"

id: 2072801
Signed-off-by: Yanan Fu <yfu@redhat.com>