### PR TITLE
block_with_share_rw:add environment checks

### DIFF
--- a/qemu/tests/block_with_share_rw.py
+++ b/qemu/tests/block_with_share_rw.py
@@ -1,3 +1,7 @@
+import re
+
+from avocado.utils import process
+
 from virttest import error_context
 from virttest import env_process
 from virttest import virt_vm
@@ -22,6 +26,29 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
     msgs = ['"write" lock', 'Is another process using the image']
+    modprobe_cmd = params.get('modprobe_cmd')
+    disk_check_cmd = params.get('disk_check_cmd')
+    indirect_image_blacklist = params.get('indirect_image_blacklist').split()
+
+    # In some environments, The image in indirect_image_blacklist
+    # does not exist in host. So we need to check the host env
+    # first and update the blacklist.
+    if disk_check_cmd:
+        image_stg_blacklist = params.get('image_stg_blacklist').split()
+        matching_images = process.run(disk_check_cmd, ignore_status=True,
+                                      shell=True).stdout_text
+        for disk in image_stg_blacklist:
+            if not re.search(disk, matching_images):
+                indirect_image_blacklist.remove(disk)
+        params["indirect_image_blacklist"] = " ".join(indirect_image_blacklist)
+
+        process.run(modprobe_cmd, ignore_status=True, shell=True)
+        params["image_raw_device_stg"] = "yes"
+        params["indirect_image_select_stg"] = "-1"
+        params["start_vm"] = "yes"
+        env_process.preprocess_vm(test, params, env,
+                                  params["main_vm"])
+
     vm1 = env.get_vm(params["main_vm"])
     vm1.verify_alive()
     vm1.wait_for_login(timeout=360)

--- a/qemu/tests/cfg/block_with_share_rw.cfg
+++ b/qemu/tests/cfg/block_with_share_rw.cfg
@@ -39,11 +39,12 @@
                             drive_format_stg = "usb3"
         -@passthrough:
             only virtio_scsi
-            pre_command = "modprobe -r scsi_debug; modprobe sg; "
-            pre_command += "modprobe scsi_debug add_host=1 dev_size_mb=50"
+            start_vm = no
+            disk_check_cmd = "ls -1d ${image_name_stg}"
+            image_stg_blacklist = "/dev/sda[\d]* /dev/sg0"
+            modprobe_cmd = "modprobe -r scsi_debug; modprobe sg; "
+            modprobe_cmd += "modprobe scsi_debug add_host=1 dev_size_mb=50"
             post_command = "rmmod scsi_debug"
-            image_raw_device_stg = yes
-            indirect_image_select_stg = -1
             variants:
                 - with_scsi_block:
                     image_name_stg = /dev/sd*


### PR DESCRIPTION
Some arm servers only have nvme controller,
so add an environment check for arm.

ID:2073269
Signed-off-by: zhenyzha <zhenyzha@redhat.com>