### PR TITLE
virtio_console..restart.stressed: Only test virtio serial devices

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -96,6 +96,8 @@
                             virtio_console_method = shell
                             variants:
                                 - stressed:
+                                    s390x:
+                                        serials = "serial0 vs1 vs2 vs3 vs4"
                                     virtio_console_test = stressed_restart
                                 - unplugged_ports:
                                     virtio_console_test = unplugged_restart


### PR DESCRIPTION
Since there is a product bug on s390x virtio console, will only
test virtio serial devices for this case.

ID: 2074794
Signed-off-by: Nini Gu <ngu@redhat.com>