### PR TITLE
transfer_file_over_ipv6: Add IPv6 address type

### DIFF
--- a/qemu/tests/cfg/transfer_file_over_ipv6.cfg
+++ b/qemu/tests/cfg/transfer_file_over_ipv6.cfg
@@ -7,8 +7,12 @@
     file_trans_timeout = 2400
     file_md5_check_timeout = 600
     dd_cmd = "dd if=/dev/zero of=%s bs=1M count=%d"
-    link_local_ipv6_addr = false
     Linux:
         tmp_dir = "/var/tmp/"
     Windows:
         tmp_dir = "C:\\"
+    variants:
+        - remote_addr:
+             link_local_ipv6_addr = false
+        - link_local_addr:
+             link_local_ipv6_addr = true

--- a/qemu/tests/transfer_file_over_ipv6.py
+++ b/qemu/tests/transfer_file_over_ipv6.py
@@ -55,7 +55,7 @@ def run(test, params, env):
         vms.append(env.get_vm(vm_name))
 
     # config ipv6 address host and guest.
-    host_ifname = params.get("netdst")
+    host_ifname = params.get("netdst") if link_local_ipv6_addr else None
     host_address = utils_net.get_host_ip_address(
         params, ip_ver="ipv6", linklocal=link_local_ipv6_addr)
 


### PR DESCRIPTION
1.Add linklocal and remote IPv6 addr for windows and linux

ID:2074848

Signed-off-by: Lei Yang <leiayang@redhat.com>