### PR TITLE
blockdev_mirror:remove image_create_support_*

### DIFF
--- a/provider/blockdev_base.py
+++ b/provider/blockdev_base.py
@@ -59,13 +59,6 @@ class BlockdevBaseTest(object):
     def preprocess_data_disks(self):
         for tag in self.params.objects("source_images"):
             params = self.params.object_params(tag)
-            if params.get("force_create_image") == "yes":
-                # vt takes care of the image creation
-                continue
-            elif params.get("image_create_support") == "no":
-                # image creation is not supported, e.g. nbd storage
-                continue
-
             if params.get("random_cluster_size") == "yes":
                 blacklist = list(
                     map(int, params.objects("cluster_size_blacklist")))
@@ -173,7 +166,6 @@ class BlockdevBaseTest(object):
                 self.trash.append(disk)
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self.prepare_data_disks()
         self.add_target_data_disks()

--- a/qemu/tests/blockdev_mirror_readonly.py
+++ b/qemu/tests/blockdev_mirror_readonly.py
@@ -11,7 +11,6 @@ class BlockdevMirrorReadonlyDeviceTest(BlockdevMirrorWaitTest):
     """
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self.add_target_data_disks()
 

--- a/qemu/tests/blockdev_mirror_sync_top.py
+++ b/qemu/tests/blockdev_mirror_sync_top.py
@@ -114,7 +114,6 @@ class BlockdevMirrorSyncTopTest(BlockdevMirrorNowaitTest):
             img_obj.convert(convert_params, img_obj.root_dir)
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self.prepare_data_disks()
         self.create_snapshot_images()

--- a/qemu/tests/cfg/blockdev_mirror_cancel_ready_job_with_io.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_cancel_ready_job_with_io.cfg
@@ -33,7 +33,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_complete_running_job.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_complete_running_job.cfg
@@ -36,7 +36,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_error.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_error.cfg
@@ -38,7 +38,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_filternode.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_filternode.cfg
@@ -35,7 +35,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_firewall.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_firewall.cfg
@@ -39,7 +39,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1
@@ -70,7 +69,6 @@
     storage_type_mirror1 = nbd
     nbd_port_mirror1 = ${nbd_port_data}
     force_create_image_mirror1 = no
-    image_create_support_mirror1 = no
     image_format_mirror1 = ${image_format_data}
 
     # commands used for break connection to nbd image

--- a/qemu/tests/cfg/blockdev_mirror_forbidden_actions.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_forbidden_actions.cfg
@@ -41,7 +41,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_hotunplug.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_hotunplug.cfg
@@ -38,7 +38,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_multiple_blocks.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_multiple_blocks.cfg
@@ -49,8 +49,6 @@
         nbd_port_data2 = 10832
         image_format_data1 = raw
         image_format_data2 = raw
-        image_create_support_data1 = no
-        image_create_support_data2 = no
     iscsi_direct:
         lun_data1 = 1
         lun_data2 = 2

--- a/qemu/tests/cfg/blockdev_mirror_no_space.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_no_space.cfg
@@ -15,7 +15,6 @@
     kill_vm = yes
     source_images = image1
     target_images = mirror1
-    image_create_support_image1 = no
     backup_options_image1 = sync
     sync = full
     storage_pools = default

--- a/qemu/tests/cfg/blockdev_mirror_readonly.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_readonly.cfg
@@ -37,7 +37,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_ready_vm_down.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_ready_vm_down.cfg
@@ -34,7 +34,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_remote_server_down.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_remote_server_down.cfg
@@ -30,7 +30,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1
@@ -60,5 +59,4 @@
     storage_type_mirror1 = nbd
     nbd_port_mirror1 = ${nbd_port_data}
     force_create_image_mirror1 = no
-    image_create_support_mirror1 = no
     image_format_mirror1 = ${image_format_data}

--- a/qemu/tests/cfg/blockdev_mirror_simple.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_simple.cfg
@@ -46,7 +46,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_speed.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_speed.cfg
@@ -40,7 +40,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_stress.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_stress.cfg
@@ -13,7 +13,6 @@
     virt_test_type = qemu
     source_images = image1
     target_images = mirror1
-    image_create_support_image1 = no
     backup_options_image1 = sync
     parallel_tests = stress_test
     stress_args = --cpu 2 --vm 2 --io 2 --vm-bytes 1024

--- a/qemu/tests/cfg/blockdev_mirror_sync_none.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_sync_none.cfg
@@ -36,7 +36,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_mirror_sync_top.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_sync_top.cfg
@@ -52,7 +52,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         enable_nbd_data1 = yes
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_mirror_vm_reboot.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_vm_reboot.cfg
@@ -13,7 +13,6 @@
     virt_test_type = qemu
     source_images = image1
     target_images = mirror1
-    image_create_support_image1 = no
     backup_options_image1 = sync
     parallel_tests = reboot_vm
     sync = full

--- a/qemu/tests/cfg/blockdev_mirror_vm_stop_cont.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_vm_stop_cont.cfg
@@ -13,7 +13,6 @@
     virt_test_type = qemu
     source_images = image1
     target_images = mirror1
-    image_create_support_image1 = no
     backup_options_image1 = sync speed
     parallel_tests = stop_cont_vm
     sync = full


### PR DESCRIPTION
    Remove "image_create_support_*" from *.cfg 
    Signed-off-by: Aihua Liang <aliang@redhat.com>
    id:2074479