### PR TITLE
kdump:remove crashkernel=auto setting

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -36,6 +36,8 @@
         - nmi:
             no aarch64 s390 s390x
             kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args='crashkernel=auto nmi_watchdog=1'"
+            RHEL.9:
+                kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args='nmi_watchdog=1'"
             crash_cmd = nmi
             send_nmi_cmd = "echo 1 > /proc/sys/kernel/unknown_nmi_panic" 
             ppc64, ppc64le:


### PR DESCRIPTION
Since crashkernel=auto is not supported on latest rhel9,
so remove the setting from our scripts.

Signed-off-by: Leidong Wang <leidwang@redhat.com>
ID:2075732