### PR TITLE
virtio_fs: add --no-killpriv-v2 for nfs backend

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -59,6 +59,8 @@
             setup_local_nfs = yes
             nfs_mount_options = rw
             export_options = 'rw,insecure,no_root_squash,async'
+            Host_RHEL.m9:
+                fs_binary_extra_options += " --no-killpriv-v2"
             variants:
                 - @default:
                     export_dir = /mnt/virtio_fs_test_nfs
@@ -75,7 +77,7 @@
             no Windows
             required_qemu = [6.0.0,)
             only default.with_cache.auto.default_extra_parameters
-            fs_binary_extra_options += ",announce_submounts"
+            fs_binary_extra_options += " -o announce_submounts"
             cmd_get_stdev = stat %%d %s
             nfs_mount_dst_name = nfs_dir
     variants:
@@ -83,32 +85,32 @@
         - @extra_parameters:
             variants:
                 - lock_posix_off:
-                    fs_binary_extra_options += ",no_posix_lock"
+                    fs_binary_extra_options += " -o no_posix_lock"
                 - lock_posix_on:
                     only Host_RHEL.m8
-                    fs_binary_extra_options += ",posix_lock"
+                    fs_binary_extra_options += " -o posix_lock"
             variants:
                 - flock_on:
                     only Host_RHEL.m8
-                    fs_binary_extra_options += ",flock"
+                    fs_binary_extra_options += " -o flock"
                 - flock_off:
-                    fs_binary_extra_options += ",no_flock"
+                    fs_binary_extra_options += " -o no_flock"
             variants:
                 - xattr_on:
-                    fs_binary_extra_options += ",xattr"
+                    fs_binary_extra_options += " -o xattr"
                 - xattr_off:
-                    fs_binary_extra_options += ",no_xattr"
+                    fs_binary_extra_options += " -o no_xattr"
         - with_writeback:
-            fs_binary_extra_options += ",writeback"
+            fs_binary_extra_options += " -o writeback"
     variants:
         - with_cache:
             variants:
                 - auto:
-                    fs_binary_extra_options += ",cache=auto"
+                    fs_binary_extra_options += " -o cache=auto"
                 - always:
-                    fs_binary_extra_options += ",cache=always"
+                    fs_binary_extra_options += " -o cache=always"
                 - none:
-                    fs_binary_extra_options += ",cache=none"
+                    fs_binary_extra_options += " -o cache=none"
     variants:
         - @default:
             cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'


### PR DESCRIPTION
For nfs backend --no-killpriv-v2 option should be set to virtiofsd.
ID: 2069900
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>