### PR TITLE
fio_perf: Enable virtio_fs_perf for aarch64

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -1,5 +1,5 @@
 - fio_perf:
-    only x86_64,ppc64,ppc64le
+    no s390x
     type = fio_perf
     numa_node = -1
     image_aio = native


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

```
(1/1) Host_RHEL.m8.u6.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.6.0.aarch64.io-github-autotest-qemu.fio_perf.shared_fs.virtio_fs_perf.always.arm64-pci
```