### PR TITLE
blockdev_backup:remove image_create_support_*

### DIFF
--- a/provider/blockdev_backup_base.py
+++ b/provider/blockdev_backup_base.py
@@ -151,7 +151,6 @@ class BlockdevBackupBaseTest(object):
             disk.hotplug(self.main_vm)
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self.prepare_data_disks()
         self.add_target_data_disks()

--- a/qemu/tests/blockdev_full_backup_nonexist_target.py
+++ b/qemu/tests/blockdev_full_backup_nonexist_target.py
@@ -9,7 +9,6 @@ from provider.blockdev_full_backup_base import BlockdevFullBackupBaseTest
 class BlockdevFullBackupNonexistTargetTest(BlockdevFullBackupBaseTest):
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self.prepare_data_disks()
 

--- a/qemu/tests/blockdev_inc_backup_add_bitmap_to_raw.py
+++ b/qemu/tests/blockdev_inc_backup_add_bitmap_to_raw.py
@@ -7,7 +7,6 @@ class BlockdevIncbkAddBitmapToRawImgNeg(BlockdevLiveBackupBaseTest):
     """Negative test: Add bitmaps to a raw image"""
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
 
     def add_bitmap_to_raw_image(self):

--- a/qemu/tests/blockdev_inc_backup_add_persistent_bitmap_when_paused.py
+++ b/qemu/tests/blockdev_inc_backup_add_persistent_bitmap_when_paused.py
@@ -14,7 +14,6 @@ class BlockdevIncbkAddPersistentBitmapVMPaused(BlockdevLiveBackupBaseTest):
             self.params, self._source_images[0])
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
 
     def add_persistent_bitmap(self):

--- a/qemu/tests/blockdev_inc_backup_bitmap_max_len_name.py
+++ b/qemu/tests/blockdev_inc_backup_bitmap_max_len_name.py
@@ -26,7 +26,6 @@ class BlockdevIncbkAddBitmapMaxLenName(BlockdevLiveBackupBaseTest):
         ).stdout.decode().strip()
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
 
     def add_persistent_bitmap(self):

--- a/qemu/tests/blockdev_inc_backup_bitmap_with_hotplug.py
+++ b/qemu/tests/blockdev_inc_backup_bitmap_with_hotplug.py
@@ -45,6 +45,11 @@ class BlockdevIncbkAddBitmapToHotplugImg(BlockdevLiveBackupBaseTest):
         if not all([len(l) == 0 for l in bitmaps.values()]):
             self.test.fail("bitmap found unexpectedly after unplug")
 
+    def prepare_test(self):
+        if self.params.get("not_preprocess") == "yes":
+            self.preprocess_data_disks()
+        super(BlockdevIncbkAddBitmapToHotplugImg, self).prepare_test()
+
     def do_test(self):
         self.do_full_backup()
         self.generate_inc_files()

--- a/qemu/tests/blockdev_inc_backup_convert_with_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_convert_with_bitmap.py
@@ -19,7 +19,6 @@ class BlockdevIncbkConvertWithBitmapsTest(BlockdevLiveBackupBaseTest):
             self.params, self.params['convert_target'])
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
 
     def add_persistent_bitmaps(self):

--- a/qemu/tests/blockdev_inc_backup_expose_active_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_expose_active_bitmap.py
@@ -50,7 +50,6 @@ class BlockdevIncbkExposeActiveBitmap(BlockdevLiveBackupBaseTest):
                 self.test.fail("Failed to hotplug '%s'" % dev)
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self.add_bitmap()
         self.prepare_data_disks()

--- a/qemu/tests/blockdev_inc_backup_inconsistent_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_inconsistent_bitmap.py
@@ -21,7 +21,6 @@ class BlockdevIncbkInconsistentBitmap(BlockdevLiveBackupBaseTest):
         self.test_scenario = getattr(self, self.params['test_scenario'])
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self.prepare_data_disks()
 

--- a/qemu/tests/blockdev_inc_backup_mod_readonly_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_mod_readonly_bitmap.py
@@ -12,7 +12,6 @@ class BlockdevIncbkModRdonlyBitmapTest(BlockdevLiveBackupBaseTest):
     """Clear/Remove readonly bitmaps"""
 
     def prepare_test(self):
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self._error_msg = '(core dumped)|{pid} Aborted'.format(
             pid=self.main_vm.get_pid())

--- a/qemu/tests/blockdev_inc_backup_with_ignore.py
+++ b/qemu/tests/blockdev_inc_backup_with_ignore.py
@@ -77,7 +77,6 @@ class BlkdevIncWithIgnore(BlockdevLiveBackupBaseTest):
 
     def prepare_test(self):
         self._create_inc_dir()
-        self.preprocess_data_disks()
         self.prepare_main_vm()
         self.prepare_data_disks()
         self.add_target_data_disks()

--- a/qemu/tests/cfg/blockdev_full_backup.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup.cfg
@@ -8,7 +8,6 @@
     #target_path_default = "/var/lib/avocado/data/avocado-vt"
     images += " src1"
     start_vm = no
-    not_preprocess = yes
     storage_pool = default
     image_size_src1 = 200M
     image_name_src1 = "sr1"
@@ -56,10 +55,14 @@
                     only auto_compress
                     only auto_completed
                 - src_cluster_size_512:
+                    no nbd
+                    only qcow2
                     image_cluster_size_src1 = 512
                     only not_compress
                     only auto_completed
                 - src_cluster_size_2M:
+                    no nbd
+                    only qcow2
                     image_cluster_size_src1 = 2097152
                     only auto_compress
                     only manual_completed

--- a/qemu/tests/cfg/blockdev_full_backup_invalid_max_workers.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_invalid_max_workers.cfg
@@ -32,7 +32,6 @@
         image_size_data1 = 2G
         nbd_port_data1 = 10831
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
         enable_nbd_full = no
     image_size_full = ${image_size_data1}

--- a/qemu/tests/cfg/blockdev_full_backup_invalid_sync_mode.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_invalid_sync_mode.cfg
@@ -34,6 +34,5 @@
         image_format_data1 = raw
         nbd_port_data1 = 10831
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
         enable_nbd_full = no

--- a/qemu/tests/cfg/blockdev_full_backup_multi_disks.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_multi_disks.cfg
@@ -8,7 +8,6 @@
     #target_path_default = "/var/lib/avocado/data/avocado-vt"
     images += " src1 src2"
     start_vm = no
-    not_preprocess = yes
     storage_pool = default
     image_size_src1 = 200M
     image_name_src1 = "sr1"

--- a/qemu/tests/cfg/blockdev_full_backup_nonexist_target.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_nonexist_target.cfg
@@ -7,7 +7,6 @@
     storage_type_default = "directory"
     images += " src1"
     start_vm = no
-    not_preprocess = yes
     storage_pool = default
     image_size_src1 = 200M
     image_name_src1 = "src1"

--- a/qemu/tests/cfg/blockdev_full_backup_with_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_with_bitmap.cfg
@@ -31,6 +31,5 @@
         image_format_data1 = raw
         nbd_port_data1 = 10831
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
         enable_nbd_full = no

--- a/qemu/tests/cfg/blockdev_full_backup_x_perf.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_x_perf.cfg
@@ -32,7 +32,6 @@
         image_size_data1 = 2G
         nbd_port_data1 = 10831
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
         enable_nbd_full = no
     image_size_full = ${image_size_data1}

--- a/qemu/tests/cfg/blockdev_full_mirror.cfg
+++ b/qemu/tests/cfg/blockdev_full_mirror.cfg
@@ -7,7 +7,6 @@
     storage_type_default = "directory"
     images += " src1"
     start_vm = no
-    not_preprocess = yes
     storage_pool = default
     image_size_src1 = 100M
     image_name_src1 = "sr1"

--- a/qemu/tests/cfg/blockdev_inc_backup_add_bitmap_to_raw.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_add_bitmap_to_raw.cfg
@@ -33,5 +33,4 @@
         enable_nbd_base = no
         remove_image_data1 = no
         force_create_image_data1 = no
-        image_create_support_data1 = no
         nbd_port_data1 = 10831

--- a/qemu/tests/cfg/blockdev_inc_backup_add_disabled_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_add_disabled_bitmap.cfg
@@ -39,4 +39,3 @@
         nbd_port_data1 = 10831
         remove_image_data1 = no
         force_create_image_data1 = no
-        image_create_support_data1 = no

--- a/qemu/tests/cfg/blockdev_inc_backup_after_commit.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_after_commit.cfg
@@ -46,7 +46,6 @@
         nbd_port_data = 10831
         image_format_data = raw
         force_create_image_data = no
-        image_create_support_data = no
         enable_nbd_data = yes
     iscsi_direct:
         lun_data = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_inuse.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_inuse.cfg
@@ -31,7 +31,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_vm_crash_reboot.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_vm_crash_reboot.cfg
@@ -37,7 +37,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_granularity.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_granularity.cfg
@@ -33,7 +33,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_hotplug.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_hotplug.cfg
@@ -8,6 +8,7 @@
     only Linux
     only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
+    not_preprocess = yes
     kill_vm = yes
     qemu_force_use_drive_expression = no
     type = blockdev_inc_backup_bitmap_with_hotplug
@@ -15,7 +16,6 @@
     source_images = data1
     image_backup_chain_data1 = base
     remove_image_data1 = yes
-    force_create_image_data1 = no
     storage_pools = default
     storage_pool = default
     storage_type_default = directory
@@ -31,8 +31,8 @@
     nbd:
         nbd_port_data1 = 10831
         image_format_data1 = raw
-        image_create_support_data1 = no
         remove_image_data1 = no
+        not_preprocess = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_inc_backup_clear_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_clear_bitmap.cfg
@@ -33,7 +33,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_disable_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_disable_bitmap.cfg
@@ -33,7 +33,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_enable_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_enable_bitmap.cfg
@@ -33,7 +33,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_expose_active_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_expose_active_bitmap.cfg
@@ -56,7 +56,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         enable_nbd_data1 = yes
         nbd_export_name_data1 = ''
     iscsi_direct:

--- a/qemu/tests/cfg/blockdev_inc_backup_filternode.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_filternode.cfg
@@ -34,7 +34,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_inc_success.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_inc_success.cfg
@@ -47,7 +47,6 @@
         force_create_image_data = no
         nbd_port_data = 10831
         image_format_data = raw
-        image_create_support_data = no
     iscsi_direct:
         lun_data = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_inc_backup_merge_bitmaps_with_diff_granularity.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_merge_bitmaps_with_diff_granularity.cfg
@@ -35,7 +35,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_merge_external_bitmaps.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_merge_external_bitmaps.cfg
@@ -48,7 +48,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
     iscsi_direct:
         lun_data1 = 1

--- a/qemu/tests/cfg/blockdev_inc_backup_merge_to_nonexist_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_merge_to_nonexist_bitmap.cfg
@@ -36,5 +36,4 @@
         nbd_port_data1 = 10831
         remove_image_data1 = no
         force_create_image_data1 = no
-        image_create_support_data1 = no
         enable_nbd_base= no

--- a/qemu/tests/cfg/blockdev_inc_backup_merge_with_nonexist_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_merge_with_nonexist_bitmap.cfg
@@ -37,4 +37,3 @@
         nbd_port_data1 = 10831
         remove_image_data1 = no
         force_create_image_data1 = no
-        image_create_support_data1 = no

--- a/qemu/tests/cfg/blockdev_inc_backup_migrate_without_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_migrate_without_bitmap.cfg
@@ -32,7 +32,6 @@
         nbd_port_data1 = 10831
         remove_image_data1 = no
         force_create_image_data1 = no
-        image_create_support_data1 = no
 
     # For local backup images
     image_size_base = ${image_size_data1}

--- a/qemu/tests/cfg/blockdev_inc_backup_no_space.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_no_space.cfg
@@ -32,7 +32,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
     iscsi_direct:
         lun_data1 = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_inc_backup_nospace_with_bitmap_mode.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_nospace_with_bitmap_mode.cfg
@@ -51,7 +51,6 @@
         force_create_image_data1 = no
         nbd_port_data1 = 10831
         image_format_data1 = raw
-        image_create_support_data1 = no
         enable_nbd_full = no
         enable_nbd_inc = no
     iscsi_direct:

--- a/qemu/tests/cfg/blockdev_inc_backup_remove_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_remove_bitmap.cfg
@@ -33,7 +33,6 @@
         nbd_port_data1 = 10831
         image_format_data1 = raw
         force_create_image_data1 = no
-        image_create_support_data1 = no
         remove_image_data1 = no
         enable_nbd_base = no
     iscsi_direct:

--- a/qemu/tests/cfg/blockdev_inc_backup_with_complete_mode.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_with_complete_mode.cfg
@@ -69,8 +69,6 @@
         image_format_data1 = raw
         nbd_port_data2 = 10832
         image_format_data2 = raw
-        image_create_support_data1 = no
-        image_create_support_data2 = no
     iscsi_direct:
         lun_data1 = 1
         lun_data2 = 2

--- a/qemu/tests/cfg/blockdev_inc_backup_with_guest_agent.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_with_guest_agent.cfg
@@ -58,7 +58,6 @@
         force_create_image_data = no
         nbd_port_data = 10831
         image_format_data = raw
-        image_create_support_data = no
     iscsi_direct:
         lun_data = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_inc_backup_with_ignore.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_with_ignore.cfg
@@ -61,4 +61,3 @@
         nbd_port_data1 = 10831
         remove_image_data1 = no
         force_create_image_data1 = no
-        image_create_support_data1 = no

--- a/qemu/tests/cfg/blockdev_inc_backup_with_migration.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_with_migration.cfg
@@ -56,7 +56,6 @@
         force_create_image_data = no
         nbd_port_data = 10831
         image_format_data = raw
-        image_create_support_data = no
     iscsi_direct:
         lun_data = 1
     ceph:

--- a/qemu/tests/cfg/blockdev_inc_backup_with_throttling.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_with_throttling.cfg
@@ -36,7 +36,6 @@
         nbd_port_data = 10831
         image_format_data = raw
         force_create_image_data = no
-        image_create_support_data = no
     iscsi_direct:
         lun_data = 1
     ceph:


### PR DESCRIPTION
Remove image_create_suuport_* and not_preprocess=yes
to make image creation by avocado-vt in default.
    
Signed-off-by: Aihua Liang <aliang@redhat.com>
id: 2074422