### PR TITLE
bridge_qinq: Fix unexpected errors and reduce log size 

### DIFF
--- a/qemu/tests/bridge_qinq.py
+++ b/qemu/tests/bridge_qinq.py
@@ -144,6 +144,11 @@ def run(test, params, env):
     process.system(set_ip_cmd % ("192.168.1.1", brname))
     host_bridge_iface.up()
 
+    file_size = int(params.get("file_size", "4096"))
+    host_path = os.path.join(test.tmpdir, "transferred_file")
+    guest_path = params.get("guest_path", "/var/tmp/transferred_file")
+    transfer_timeout = int(params.get("transfer_timeout", 1000))
+
     try:
         login_timeout = int(params.get("login_timeout", "600"))
         params['netdst'] = brname
@@ -285,10 +290,6 @@ def run(test, params, env):
                              vlan_tag2="vlan 20,")
 
         # scp file to guest with L2 vlan tag
-        file_size = int(params.get("file_size", "4096"))
-        host_path = os.path.join(test.tmpdir, "transferred_file")
-        guest_path = params.get("guest_path", "/var/tmp/transferred_file")
-        transfer_timeout = int(params.get("transfer_timeout", 1000))
         cmd = "dd if=/dev/zero of=%s bs=1M count=%d" % (host_path, file_size)
         error_context.context(
             "Creating %dMB file on host" % file_size, test.log.info)
@@ -305,6 +306,6 @@ def run(test, params, env):
     finally:
         session.cmd("rm -rf %s" % guest_path)
         session.close()
-        vm.destroy(gracefully=True)
+        vm.destroy(gracefully=False)
         host_bridge_iface.down()
         host_bridges.del_bridge(brname)

--- a/qemu/tests/cfg/bridge_qinq.cfg
+++ b/qemu/tests/cfg/bridge_qinq.cfg
@@ -5,14 +5,14 @@
     private_bridge = tmpbr
     copy_qinq_script = linux_qinq/qinq.sh
     guest_qinq_dir = /home/
-    ping_count = 100
+    ping_count = 10
     net_mask = "24"
     set_ip_cmd = "ip addr add %s/${net_mask} dev %s"
     ip_vm = "192.168.1.2"
     vlan_id = 10
     L1tag_iface = "v1v${vlan_id}"
     L1tag_iface_ip = "192.168.10.10"
-    tcpdump_cmd = "tcpdump -xxvvleni %s > %s &"
+    tcpdump_cmd = "setsid tcpdump -xxvvleni %s > %s"
     tcpdump_log = "/tmp/tcpdump-%s.log"
     get_tcpdump_log_cmd = "cat ${tcpdump_log}"
     advlan_name = "${private_bridge}-vl${vlan_id}"


### PR DESCRIPTION
1. Move some static parameters to the top to avoid UnboundLocalError
2. The guest contains many vlan interfaces, when destroying the VM,
"ifconfig -a" will time out, so set gracefully to "False" to avoid the
issue.
3. This is only a basic test to check extertypes, however tcpdump will 
capture all packages and this makes the log size too huge. So reduce the 
ping count to reduce the log size, also use "setsid" command to run 
tcpdump in the background, to avoid dirty output when issuing "pkill 
tcpdump".

ID: 2078050
Signed-off-by: Yihuang Yu <yihyu@redhat.com>