### PR TITLE
replace netaddr with ipaddress

### DIFF
--- a/qemu/tests/remote_server_disconnected.py
+++ b/qemu/tests/remote_server_disconnected.py
@@ -1,5 +1,5 @@
 import os
-import netaddr
+import ipaddress
 import json
 
 from avocado.utils import process
@@ -14,11 +14,18 @@ def run(test, params, env):
        make sure the vm can be accessed.
     """
 
+    def _is_ipv6_addr(addr):
+        try:
+            ipaddress.IPv6Address(addr)
+        except ipaddress.AddressValueError:
+            return False
+        return True
+
     def _check_hosts(hosts):
         if len(hosts) < 2:
             test.cancel("2 remote servers at least are required.")
         for h in hosts:
-            if os.path.exists(h) or netaddr.valid_ipv6(h):
+            if os.path.exists(h) or _is_ipv6_addr(h):
                 test.cancel("Neither ipv6 nor unix domain"
                             " socket is supported by now.")
 

--- a/qemu/tests/sr_iov_sanity.py
+++ b/qemu/tests/sr_iov_sanity.py
@@ -1,7 +1,7 @@
 import re
 import time
 import random
-import netaddr
+from ipaddress import ip_address
 
 from avocado.utils import process
 
@@ -189,7 +189,7 @@ def run(test, params, env):
         # below
         if static_ip:
             if 'IP_addr_VF' not in locals():
-                IP_addr_VF = netaddr.IPAddress(params.get("start_addr_VF"))
+                IP_addr_VF = ip_address(params.get("start_addr_VF"))
                 net_mask = params.get("net_mask")
             if not IP_addr_VF:
                 test.fail("No IP address found, please"


### PR DESCRIPTION
Since Python 3.3+ provides `ipaddress` as the standard library for
IPv4/IPv6 manipulation, let's replace the third-party one (`netaddr`)
with it for a better maintainability.

Signed-off-by: Xu Han <xuhan@redhat.com>