### PR TITLE
Viorng_in_use: Changed ‘winutils.iso’ since it only for Windows

### DIFF
--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -7,9 +7,9 @@
     suppress_exception = no
     run_bgstress = rng_bat
     session_cmd_timeout = 360
-    cdrom_cd1 = isos/windows/winutils.iso
     no no_virtio_rng
     Windows:
+        cdrom_cd1 = isos/windows/winutils.iso
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
         target_process = random\w*.exe
         rng_data_rex = "0x\w"


### PR DESCRIPTION
Relocate ‘winutils.iso’ part since it only for Windows.

ID: 2079223
Signed-off-by: Bogdan Marcynkov <bmarcynk@redhat.com>