### PR TITLE
blockdev_stream_general:correct job paused check

### DIFF
--- a/qemu/tests/blockdev_commit_standby.py
+++ b/qemu/tests/blockdev_commit_standby.py
@@ -17,8 +17,7 @@ class BlockdevCommitStandby(BlockDevCommitTest):
         job_id = args.get("job-id", device)
         job_utils.wait_until_job_status_match(self.main_vm, "ready", job_id, timeout=120)
         self.main_vm.monitor.cmd("job-pause", {"id": job_id})
-        if not job_utils.is_block_job_paused(self.main_vm, job_id):
-            self.test.fail("Block job is not paused")
+        job_utils.wait_until_job_status_match(self.main_vm, "standby", job_id, timeout=120)
         self.main_vm.monitor.cmd("job-complete", {"id": job_id})
         self.main_vm.monitor.cmd("job-resume", {"id": job_id})
         if not job_utils.get_event_by_condition(self.main_vm, "BLOCK_JOB_COMPLETED"):

--- a/qemu/tests/blockdev_stream_general.py
+++ b/qemu/tests/blockdev_stream_general.py
@@ -14,8 +14,8 @@ class BlockdevStreamGeneralTest(BlockdevStreamNowaitTest):
             self.params.get_numeric('job_started_timeout', 30)
         )
         self.main_vm.monitor.cmd("job-pause", {'id': self._job})
-        job_utils.check_block_jobs_paused(
-            self.main_vm, [self._job],
+        job_utils.wait_until_job_status_match(
+            self.main_vm, 'paused', self._job,
             self.params.get_numeric('job_paused_interval', 30)
         )
         self.main_vm.monitor.cmd(
@@ -24,8 +24,8 @@ class BlockdevStreamGeneralTest(BlockdevStreamNowaitTest):
              'speed': self.params.get_numeric('resume_speed')}
         )
         self.main_vm.monitor.cmd("job-resume", {'id': self._job})
-        job_utils.check_block_jobs_running(
-            self.main_vm, [self._job],
+        job_utils.wait_until_job_status_match(
+            self.main_vm, 'running', self._job,
             self.params.get_numeric('job_running_timeout', 300)
         )
         self.main_vm.monitor.cmd("job-cancel", {'id': self._job})


### PR DESCRIPTION
In case blockdev_stream_general and blockdev_commit_standby
we check job in paused/standby status by "job's offset not
changed", that is not precise. So now we check it's status
directly.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2078394