### PR TITLE
blockdev_inc_backup_with_ignore: Fail case when prepare test env failed

### DIFF
--- a/qemu/tests/blockdev_inc_backup_with_ignore.py
+++ b/qemu/tests/blockdev_inc_backup_with_ignore.py
@@ -26,6 +26,7 @@ class BlkdevIncWithIgnore(BlockdevLiveBackupBaseTest):
                            ignore_status=False, shell=True)
         except:
             self._clean_inc_dir()
+            raise
 
     def _clean_inc_dir(self):
         process.system(self.params["storage_clean_cmd"],


### PR DESCRIPTION
In original design, when failed to prepare test env, like lvm setup,
case's step continue to run, which will cause "target dir not exist"
error.
Now, add test.fail in _create_inc_dir.except to make the case fail
if prepare test env failed

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2073931