### PR TITLE
blockdev_inc_backup_nospace_with_bitmap_mode: add "yes" when mkfs disk

### DIFF
--- a/qemu/tests/cfg/blockdev_inc_backup_nospace_with_bitmap_mode.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_nospace_with_bitmap_mode.cfg
@@ -41,7 +41,8 @@
     storage_pool_inc = pool2
 
     tmp_image_file = /tmp/tmp_image_file
-    pre_command = "mkdir -p ${inc_path} && dd if=/dev/urandom of=${tmp_image_file} bs=1M count=100 &&"
+    pre_command = "mountpoint -q ${inc_path} && umount -f ${inc_path} && rm -rf ${tmp_image_file} ${inc_path};"
+    pre_command += " mkdir -p ${inc_path} && dd if=/dev/urandom of=${tmp_image_file} bs=1M count=100 &&"
     pre_command += " mkfs.ext4 ${tmp_image_file} && mount -o loop ${tmp_image_file} ${inc_path}"
     post_command = "umount -f ${inc_path} && rm -rf ${tmp_image_file} ${inc_path}"
     pre_command_timeout = 30


### PR DESCRIPTION
Add "yes" to mkfs when format a disk

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2061234