### PR TITLE
numa_consistency: include only numa nodes with memory and cpus

### DIFF
--- a/qemu/tests/numa_consistency.py
+++ b/qemu/tests/numa_consistency.py
@@ -37,7 +37,7 @@ def run(test, params, env):
     error_context.context("Get host numa topological structure", test.log.info)
     timeout = float(params.get("login_timeout", 240))
     host_numa_node = utils_misc.NumaInfo()
-    node_list = host_numa_node.online_nodes
+    node_list = host_numa_node.online_nodes_withcpumem
     if len(node_list) < 2:
         test.cancel("This host only has one NUMA node, skipping test...")
     node_list.sort()


### PR DESCRIPTION
numa_consistency: include only numa nodes with memory and cpus

Changes the numa nodes list to include only the nodes with
memory and cpus assigned

ID: 2070405
Signed-off-by: mcasquer <mcasquer@redhat.com>