### PR TITLE
Add restriction to tpm test cases for some old rhel 8 releases

### DIFF
--- a/qemu/tests/cfg/tpm_unattended_install.cfg
+++ b/qemu/tests/cfg/tpm_unattended_install.cfg
@@ -37,6 +37,7 @@
     tpms = tpm0
     tpm_model_tpm0 = tpm-crb
     x86_64:
+        no Host_RHEL.m8.u0, Host_RHEL.m8.u1, Host_RHEL.m8.u2
         only q35
         only ovmf
         required_qemu= [4.2.0,)

--- a/qemu/tests/cfg/tpm_verify_device.cfg
+++ b/qemu/tests/cfg/tpm_verify_device.cfg
@@ -6,6 +6,7 @@
     tpms = tpm0
     tpm_version = 2.0
     x86_64:
+        no Host_RHEL.m8.u0, Host_RHEL.m8.u1, Host_RHEL.m8.u2
         only q35
         only ovmf
         required_qemu= [4.2.0,)


### PR DESCRIPTION
Fix an issue on old rhel 8 releases caused by a product bz. 

ID: 2084051
Signed-off-by: qcheng <qcheng@redhat.com>