### PR TITLE
multi_nics_verify: Increase login time and modify cli parameters

### DIFF
--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -3,7 +3,7 @@
     type = multi_nics_verify
     no RHEL.3.9
     start_vm = no
-    login_timeout = 1800
+    login_timeout = 3600
     variants:
         - nic_virtio:
             only virtio_net
@@ -22,8 +22,6 @@
             vt_ulimit_nofile = 10240
             Windows:
                 # Windows product limit, it will fail when queues is too large
-                del vcpu_maxcpus
-                smp = 4
-                queues = ${smp}
+                queues = 4
                 i386:
                     nics_num = 8


### PR DESCRIPTION
1.Windows guests will occupy more machine resources, so the login
time needs to be inceased
2.From the perspective of QE, in the case of multiple queues and
multiple network cards, more machine resources are required, and
it is not a good choice to limit the number of smps to be equal
to queues, so delete this line of configuration.

ID:2087640

Signed-off-by: Lei Yang <leiayang@redhat.com>