### PR TITLE
qemu_guest_agent: Add reboot/halt support for RHEL 8

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -106,6 +106,8 @@
                 gagent_guest_reboot_pattern = ""
             s390x:
                 gagent_guest_reboot_pattern = "System Reboot"
+                RHEL.8:
+                    gagent_guest_reboot_pattern = "Started Reboot"
         - check_halt:
             gagent_check_type = halt
             # This config would be overriden in guest-os.cfg.
@@ -114,6 +116,8 @@
                 gagent_guest_shutdown_pattern = ""
             s390x:
                 gagent_guest_shutdown_pattern = "System Halt"
+                RHEL.8:
+                    gagent_guest_shutdown_pattern = "Starting Halt"
         - check_sync_delimited:
             gagent_check_type = sync_delimited
         - check_set_user_password:


### PR DESCRIPTION
qemu_guest_agent: add reboot/halt support for RHEL 8
ID:2088394

Signed-off-by: Bogdan Marcynkov <bmarcynk@redhat.com>