### PR TITLE
x86_cpu_protection_key: support protection keys

### DIFF
--- a/qemu/tests/cfg/x86_cpu_protection_key.cfg
+++ b/qemu/tests/cfg/x86_cpu_protection_key.cfg
@@ -1,0 +1,17 @@
+- x86_cpu_protection_key:
+    type = x86_cpu_protection_key
+    only RHEL
+    only i386 x86_64
+    only HostCpuVendor.amd
+    no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1 RHEL.8.2 RHEL.8.3 RHEL.8.4 RHEL.8.5 RHEL.8.6
+    required_qemu = [6.2, )
+    start_vm = no
+    timeout = 120
+    unsupported_models = [EPYC-Rome, EPYC, Opteron_G5, Opteron_G4, Opteron_G3, Opteron_G2, Opteron_G1]
+    guest_dir = '/home/tpm-test/'
+    test_dir = '/tools/testing/selftests/vm/'
+    download_rpm_cmd = brew download-build --rpm %s
+    uncompress_cmd_src = rpm2cpio *.src.rpm |cpio -iv
+    uncompress_cmd = tar -xvJf *.tar.xz
+    compile_cmd = gcc -o protection_keys -O2 -g -std=gnu99 -pthread -Wall protection_keys.c -lrt -ldl -lm -march=x86-64-v3
+    run_cmd =  ./protection_keys

--- a/qemu/tests/x86_cpu_protection_key.py
+++ b/qemu/tests/x86_cpu_protection_key.py
@@ -1,0 +1,60 @@
+from virttest import cpu
+from virttest import env_process
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Get kernel src code from src rpm and run protection key tests.
+
+    1) Download src rpm from brew
+    2) Unpack src code and compile protection_keys.c
+    3) Run executable file 'protection_keys'
+    4) Check results
+
+    :param test:   QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env:    Dictionary with test environment.
+    """
+    unsupported_models = params.get("unsupported_models", "")
+    cpu_model = params.get("cpu_model", cpu.get_qemu_best_cpu_model(params))
+    if cpu_model in unsupported_models.split():
+        test.cancel("'%s' doesn't support this test case" % cpu_model)
+
+    params["start_vm"] = "yes"
+    vm_name = params['main_vm']
+    env_process.preprocess_vm(test, params, env, vm_name)
+
+    vm = env.get_vm(vm_name)
+    error_context.context("Try to log into guest", test.log.info)
+    session = vm.wait_for_login()
+
+    guest_dir = params["guest_dir"]
+    timeout = params.get_numeric("timeout")
+    kernel_v = session.cmd_output("uname -r").strip()
+    mkdir_cmd = session.cmd('mkdir -p %s' % guest_dir)
+    src_rpm = "kernel-" + kernel_v.rsplit(".", 1)[0] + ".src.rpm"
+    linux_name = "linux-" + kernel_v.rsplit(".", 1)[0]
+    download_rpm_cmd = 'cd %s && ' % guest_dir + params["download_rpm_cmd"] % src_rpm
+    uncompress_cmd_src = 'cd %s && ' % guest_dir + params["uncompress_cmd_src"]
+    uncompress_cmd = 'cd %s && ' % guest_dir + params["uncompress_cmd"]
+    test_dir = guest_dir + linux_name + params["test_dir"]
+    compile_cmd = 'cd %s && ' % test_dir + params["compile_cmd"]
+    run_cmd = 'cd %s && ' % test_dir + params["run_cmd"]
+
+    try:
+        session.cmd(mkdir_cmd)
+        error_context.context("Get kernel source code", test.log.info)
+        session.cmd(download_rpm_cmd, timeout=600)
+        session.cmd(uncompress_cmd_src, timeout)
+        session.cmd(uncompress_cmd, timeout)
+        session.cmd(compile_cmd, timeout)
+        s, output = session.cmd_status_output(run_cmd, safe=True)
+        if 'done (all tests OK)' not in output:
+            test.fail("Protection key test runs failed.")
+
+        vm.verify_kernel_crash()
+    finally:
+        session.cmd("rm -rf %s" % guest_dir)
+        session.close()


### PR DESCRIPTION
ID: 2094628

New case which support protection keys in an
AMD EPYC-Milan or newer models VM.

Signed-off-by: nanliu <nanliu@redhat.com>