### PR TITLE
hotplug_mem_share_discard_data: new auto case for memory hotplug with share and discard-data options

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_share_discard_data.cfg
+++ b/qemu/tests/cfg/hotplug_mem_share_discard_data.cfg
@@ -1,0 +1,35 @@
+- hotplug_mem_share_discard_data:
+    only Linux
+    type = hotplug_mem_share_discard_data
+    virt_test_type = qemu
+    login_timeout = 240
+    prealloc_mem = yes
+    not_preprocess = yes
+    slots_mem = 4
+    maxmem_mem = 32G
+    mem_fixed = 4096
+    use_mem_mem0 = no
+    mem_devs = 'mem0'
+    guest_numa_nodes = 'node0'
+    size_mem_mem0 = ${mem_fixed}M
+    numa_memdev_node0 = mem-mem0
+    backend_mem = memory-backend-file
+    target_mems = "plug1"
+    share_mem_plug1 = yes
+    size_mem_plug1 = 1G
+    pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches && echo 1 > /proc/sys/vm/compact_memory"
+    mem-path = /mnt/kvm_hugepage
+    threshold = 0.15
+    variants:
+        - backend_ram:
+            required_qemu = [6.1.0, )
+            backend_mem_plug1 = memory-backend-ram
+        - backend_file:
+            backend_mem_plug1 = memory-backend-file
+            mem-path_plug1 = /mnt/kvm_hugepage/test_file
+            pre_command += " && rm -rf ${mem-path_plug1}"
+            variants:
+                - discard_data_on:
+                    discard-data_plug1 = yes
+                - discard_data_off:
+                    discard-data_plug1 = no

--- a/qemu/tests/hotplug_mem_share_discard_data.py
+++ b/qemu/tests/hotplug_mem_share_discard_data.py
@@ -1,0 +1,88 @@
+from avocado.utils import process
+
+from virttest import error_context
+from virttest import env_process
+
+from virttest.utils_numeric import normalize_data_size
+from virttest.utils_test.qemu import MemoryHotplugTest
+from virttest.staging import utils_memory
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Memory share and discard-data hotplug test
+    1) Setup hugepages
+    2) Mount /mnt/kvm_hugepage
+    3) Boot guest with one numa node
+    4) Hotplug 1G memory
+    5) Check memory
+    6) Unplug memory
+    7) Check memory
+    8) Check results for discard-data value
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    timeout = int(params.get("login_timeout", 240))
+
+    mem_dev = params.get('mem_devs')
+    size_mem = int(normalize_data_size(params['size_mem_%s' % mem_dev], 'K'))
+    total_hg_size = size_mem
+
+    target_mem = params.get("target_mems")
+    if params.get('backend_mem_%s' % target_mem) == 'memory-backend-file':
+        size_target_mem = int(normalize_data_size(params['size_mem_%s' % target_mem], 'K'))
+        total_hg_size += size_target_mem
+
+    hp_size = utils_memory.read_from_meminfo("Hugepagesize")
+    params['target_hugepages'] = int(total_hg_size // hp_size)
+    params['setup_hugepages'] = "yes"
+    params['not_preprocess'] = "no"
+
+    env_process.preprocess(test, params, env)
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=timeout)
+
+    hotplug_test = MemoryHotplugTest(test, params, env)
+    hotplug_test.hotplug_memory(vm, target_mem)
+    hotplug_test.check_memory(vm)
+    hotplug_test.unplug_memory(vm, target_mem)
+    hotplug_test.check_memory(vm)
+
+    session.close()
+    error_context.context("Shutdown guest...", test.log.debug)
+    vm.destroy()
+
+    hp_total = int(utils_memory.read_from_meminfo("HugePages_Total"))
+    hp_free = int(utils_memory.read_from_meminfo('HugePages_Free'))
+
+    error_context.context("hp_total: %s" % str(hp_total), test.log.debug)
+    error_context.context("hp_free: %s" % str(hp_free), test.log.debug)
+
+    if params.get("backend_mem_plug1") == "memory-backend-file":
+        if not params.get_boolean("discard-data_plug1", True):
+            try:
+                process.system("ls %s" % params["mem-path_plug1"])
+            except process.CmdError:
+                test.fail("Error, %s not found." % params["mem-path_plug1"])
+
+            op = (hp_total - hp_free) * (hp_size / 1024)
+            hp_used = int(normalize_data_size("%sM" % str(op), "K"))
+
+            error_context.context("hp_used: %s" % str(hp_used), test.log.debug)
+
+            if hp_used != size_target_mem:
+                test.fail("Error, total hugepages doesn't match with used memory")
+        elif hp_total != hp_free:
+            test.fail("Error, free hugepages doesn't match with total hugepages")
+        # Deletes the mem-path file to avoid test error
+        process.system("rm -rf %s" % params["mem-path_plug1"])
+        # Compares free and total memory values after deleting mem-path file
+        hp_free_after_delete = int(utils_memory.read_from_meminfo('HugePages_Free'))
+        if hp_total != hp_free_after_delete:
+            test.fail("Error, free hugepages doesn't match with total hugepages after deleting mem-path file")


### PR DESCRIPTION
hotplug_mem_share_discard_data: new memory auto case
hotplug with share and discard-data options

Creates a new auto case that setup hugeapages, boots a guest with a 
memory-backend-file object and one numa node, hotplugs backend-ram
or backend-file memory object with share: True option and the first one 
could be with discard-data on/off, then checks the plugged memory device,
unplugs it and check results for discard-data value

ID: 2095232
Signed-off-by: mcasquer <mcasquer@redhat.com>