### PR TITLE
block_hotplug_in_pause:add sleep time to wait guest finish booting

### DIFF
--- a/qemu/tests/block_hotplug_in_pause.py
+++ b/qemu/tests/block_hotplug_in_pause.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 from virttest import error_context
 from virttest import utils_misc
@@ -237,6 +238,7 @@ def run(test, params, env):
     vm.verify_alive()
     is_vm_paused = False
     session = vm.wait_for_login()
+    time.sleep(20)
 
     for iteration in range(repeat_times):
         device_list = []


### PR DESCRIPTION
Not all services are available even if automation login guest already.
It may result in unexpected result if send request to guest to do something.

It may consider to add some sleep time to ensure guest finish booting.

ID:2095166