### PR TITLE
blockdev_mirror:remove backend limitation

### DIFF
--- a/qemu/tests/cfg/blockdev_mirror_cancel_ready_job_with_io.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_cancel_ready_job_with_io.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   blockdev-mirror speed test
 #     The mirror image is a local image(filesystem)
 
 - blockdev_mirror_cancel_ready_job_with_io:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_cancel_ready_job_with_io

--- a/qemu/tests/cfg/blockdev_mirror_complete_running_job.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_complete_running_job.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Completing a running job should fail
 #     The mirror image is a local image(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_complete_running_job:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_complete_running_job

--- a/qemu/tests/cfg/blockdev_mirror_error.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_error.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror with '"on-source-error": "stop", "on-target-error": "stop"'
 #     The mirror image is a local image(filesystem)
 
 - blockdev_mirror_error:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_error

--- a/qemu/tests/cfg/blockdev_mirror_filternode.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_filternode.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror with filter-node-name test
 #     The mirror image is a local image(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_filternode:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_filternode

--- a/qemu/tests/cfg/blockdev_mirror_firewall.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_firewall.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror with firewall test
 #     The mirror image is a nbd image
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_firewall:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_mirror_forbidden_actions.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_forbidden_actions.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   mirror/commit/resize/live snapshot/stream action should be forbidden during mirror
 #     The mirror image is a local image(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_forbidden_actions:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_forbidden_actions

--- a/qemu/tests/cfg/blockdev_mirror_hotunplug.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_hotunplug.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror with hotunplug test
 #     The mirror image is a local fs image
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_hotunplug:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_mirror_install.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_install.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror with vm installation test
 #     The mirror image is a local filesystem image
@@ -7,7 +5,6 @@
 - blockdev_mirror_install:
     only Linux
     no RHEL.5 RHEL.6 RHEL.7 RHEL.8.1
-    only filesystem iscsi_direct ceph nbd gluster_direct
     type = blockdev_mirror_install
     qemu_force_use_drive_expression = no
     need_install = yes

--- a/qemu/tests/cfg/blockdev_mirror_multiple_blocks.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_multiple_blocks.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Multiple block mirror simultaneously
 #     The mirror images are local images(filesystem)
 
 - blockdev_mirror_multiple_blocks:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_multiple_blocks

--- a/qemu/tests/cfg/blockdev_mirror_no_space.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_no_space.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   block mirror to an image without enough space
 #     The mirror image is a local image(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_no_space:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     qemu_force_use_drive_expression = no
     virt_test_type = qemu
     type = blockdev_mirror_no_space

--- a/qemu/tests/cfg/blockdev_mirror_readonly.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_readonly.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror on readonly device test
 #     The mirror image is a local image(filesystem)
 
 - blockdev_mirror_readonly:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_readonly

--- a/qemu/tests/cfg/blockdev_mirror_ready_vm_down.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_ready_vm_down.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   vm poweroff when mirror job is ready
 #     The mirror image is a local image(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_ready_vm_down:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_ready_vm_down

--- a/qemu/tests/cfg/blockdev_mirror_remote_server_down.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_remote_server_down.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do blockdev-mirror, suspend/resume remote storage service
 #     The mirror image is a on nfs
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_remote_server_down:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_mirror_same_src_tgt.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_same_src_tgt.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do block mirror from source node to source node
 
 
 - blockdev_mirror_same_src_tgt:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_same_src_tgt
     virt_test_type = qemu

--- a/qemu/tests/cfg/blockdev_mirror_simple.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_simple.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror granularity test
 #     The mirror image is a local image(filesystem)
@@ -17,7 +15,6 @@
 
 - blockdev_mirror_simple:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_simple

--- a/qemu/tests/cfg/blockdev_mirror_speed.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_speed.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   blockdev-mirror speed test
 #     The mirror image is a local image(filesystem)
 
 - blockdev_mirror_speed:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_speed

--- a/qemu/tests/cfg/blockdev_mirror_stress.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_stress.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Basic block mirror test with stress -- only system disk
 #     The mirror image is a local image(filesystem)
 
 - blockdev_mirror_stress:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_stress

--- a/qemu/tests/cfg/blockdev_mirror_sync_none.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_sync_none.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror with sync mode:none
 #     The mirror image is a local image(filesystem)
 
 - blockdev_mirror_sync_none:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_sync_none

--- a/qemu/tests/cfg/blockdev_mirror_sync_top.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_sync_top.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Block mirror with sync mode top test
 #     The mirror image is a local image(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_mirror_sync_top:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_mirror_vm_reboot.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_vm_reboot.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Basic block mirror during vm reboot -- only system disk
 #     The mirror image is a local image(filesystem)
 
 - blockdev_mirror_vm_reboot:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_vm_reboot

--- a/qemu/tests/cfg/blockdev_mirror_vm_stop_cont.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_vm_stop_cont.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Basic block mirror during vm stop_cont -- only system disk
 #     The mirror image is a local image(filesystem)
 
 - blockdev_mirror_vm_stop_cont:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_mirror_vm_stop_cont


### PR DESCRIPTION
Remove backend limitation for mirror cases, excluse
those defined under specific backend

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2097610