### PR TITLE
Change some cdrom relevant cases to set no limit on iothread

### DIFF
--- a/qemu/tests/cfg/cdrom_block_size_check.cfg
+++ b/qemu/tests/cfg/cdrom_block_size_check.cfg
@@ -5,11 +5,6 @@
     cdrom_without_file = yes
     excepted_qmp_err = "Device '${test_cdroms}' is locked and force was not specified, "
     excepted_qmp_err += "wait for tray to open and try again"
-    virtio_scsi:
-        # disable iothread
-        iothread_scheme ?=
-        iothreads ?=
-        image_iothread ?=
     Linux:
         check_cdrom_size_cmd = cat /sys/block/sr0/size
         mount_cdrom_cmd = "mount %s %s"
@@ -20,3 +15,13 @@
         #umount_cdrom_cmd = "mountvol %s /d"
         #show_mount_cmd = "wmic volume list brief"
         check_cdrom_size_cmd = wmic LogicalDisk where drivetype=5 get size
+    variants:
+        - unlimited_iothread:
+            required_qemu = [7.0.0-4,)
+        - no_iothread:
+            required_qemu = (,7.0.0-3]
+            virtio_scsi:
+                # disable iothread
+                iothread_scheme ?=
+                image_iothread ?=
+                iothreads ?=

--- a/qemu/tests/cfg/change_media.cfg
+++ b/qemu/tests/cfg/change_media.cfg
@@ -8,11 +8,16 @@
     orig_img_name = /var/tmp/orig.iso
     new_img_name = /var/tmp/new.iso
     cdrom_cd1 = /var/tmp/orig.iso
-    virtio_scsi:
-        # disable iothread
-        iothread_scheme ?=
-        image_iothread ?=
-        iothreads ?=
     Linux:
         cd_mount_cmd = mount %s /mnt
         cd_umount_cmd = umount /mnt
+    variants:
+        - unlimited_iothread:
+            required_qemu = [7.0.0-4,)
+        - no_iothread:
+            required_qemu = (,7.0.0-3]
+            virtio_scsi:
+                # disable iothread
+                iothread_scheme ?=
+                image_iothread ?=
+                iothreads ?=

--- a/qemu/tests/cfg/plug_cdrom.cfg
+++ b/qemu/tests/cfg/plug_cdrom.cfg
@@ -2,10 +2,6 @@
     only virtio_scsi
     virt_test_type = qemu
     type = plug_cdrom
-    # explicitly disable iothread
-    iothread_scheme ?=
-    image_iothread ?=
-    iothreads ?=
     cdroms = 'cd2'
     iso_name_cd2 = new
     cdrom_cd2 = /var/tmp/${iso_name_cd2}.iso
@@ -31,3 +27,12 @@
             boot_drive_cd2 = no
         - with_unplug:
             boot_drive_cd2 = yes
+    variants:
+        - unlimited_iothread:
+            required_qemu = [7.0.0-4,)
+        - no_iothread:
+            required_qemu = (,7.0.0-3]
+            # disable iothread
+            iothread_scheme ?=
+            image_iothread ?=
+            iothreads ?=


### PR DESCRIPTION
The provious product do not support iothread on scsi-cd.
The feature is supported from qemu version 7.0.0-4
Some typical cases are choosen to remove disable iothread limit.

ID:2097576