### PR TITLE
incremenatal_live_backup: remove backend limitation

### DIFF
--- a/qemu/tests/cfg/blockdev_inc_backup_add_bitmap_to_raw.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_add_bitmap_to_raw.cfg
@@ -1,11 +1,8 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Add a persistent bitmap to a raw image
 
 - blockdev_inc_backup_add_bitmap_to_raw:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_add_disabled_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_add_disabled_bitmap.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Add disabled bitmaps test
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_add_disabled_bitmap:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_add_persistent_bitmap_when_paused.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_add_persistent_bitmap_when_paused.cfg
@@ -1,12 +1,10 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, gluster_direct
 # The following testing scenario is covered:
 #   Add a persistent bitmap when vm paused
 
 - blockdev_inc_backup_add_persistent_bitmap_when_paused:
     only Linux
     #FIXME: add ceph support back after qcow2 works normally on it
-    only filesystem iscsi_direct gluster_direct
+    no ceph nbd
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_after_commit.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_after_commit.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do incremental backup after block commit
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_after_commit:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_inc_backup_after_commit

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_inuse.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_inuse.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Bitmap in-use cannot be cleared/removed/used
 
 
 - blockdev_inc_backup_bitmap_inuse:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     virt_test_type = qemu
     type = blockdev_inc_backup_bitmap_inuse
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_max_len_name.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_max_len_name.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, gluster_direct
 # The following testing scenario is covered:
 #   Add a persistent bitmap with 1023-char(max) as its name
 
@@ -7,7 +5,7 @@
 - blockdev_inc_backup_bitmap_max_len_name:
     only Linux
     #FIXME:add ceph back if qcow2 works normally on it
-    only filesystem iscsi_direct gluster_direct
+    no ceph nbd
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_not_exist.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_not_exist.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do incremental backup with a non-existed bitmap
 # Note:
@@ -9,7 +7,7 @@
 - blockdev_inc_backup_bitmap_not_exist:
     only Linux
     #FIXME:will add ceph back if qcow2 supported on it
-    only filesystem iscsi_direct gluster_direct
+    no ceph nbd
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_size.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_size.cfg
@@ -1,12 +1,11 @@
-# Storage backends:
-#   filesystem
 # The following testing scenario is covered:
 #   Estimate space utilization of bitmaps
 
 
 - blockdev_inc_backup_bitmap_size:
     only Linux
-    only filesystem iscsi_direct
+    #FIXME:add ceph back after qcow2 works normally on it
+    no ceph nbd
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_vm_crash_reboot.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_vm_crash_reboot.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   bitmap exists after vm reboot caused by crash
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_bitmap_vm_crash_reboot:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_granularity.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_granularity.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   bitmap with granularity test
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_bitmap_with_granularity:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_hotplug.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_bitmap_with_hotplug.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Add bitmap to a hot-plugged image
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_bitmap_with_hotplug:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     not_preprocess = yes
     kill_vm = yes

--- a/qemu/tests/cfg/blockdev_inc_backup_clear_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_clear_bitmap.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Clear enabled/disabled bitmaps after full backup
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_clear_bitmap:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_disable_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_disable_bitmap.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Disable bitmaps after full backup
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_disable_bitmap:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_disabled_persistent_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_disabled_persistent_bitmap.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, gluster_direct
 # The following testing scenario is covered:
 #   Disabled persistent bitmaps keep disabled after reload
 #     The backup images are local images(filesystem)
@@ -7,7 +5,7 @@
 - blockdev_inc_backup_disabled_persistent_bitmap:
     only Linux
     #FIXME:add ceph back after qcow2 works normally on it
-    only filesystem iscsi_direct gluster_direct
+    no ceph nbd
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_enable_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_enable_bitmap.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Enable disabled bitmaps after full backup
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_enable_bitmap:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_expose_active_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_expose_active_bitmap.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem iscsi_direct ceph nbd gluster_direct
 # The following testing scenario is covered:
 #   Expose an active bitmap
 #     The fleecing image must be a local fs image
@@ -7,7 +5,6 @@
 
 - blockdev_inc_backup_expose_active_bitmap:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     virt_test_type = qemu
     type = blockdev_inc_backup_expose_active_bitmap
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_filternode.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_filternode.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   live backup with filternode test
 #     The backup image is a local image(filesystem)
 
 - blockdev_inc_backup_filternode:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_inconsistent_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_inconsistent_bitmap.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, gluster_direct
 # The following testing scenario is covered:
 #   enable/disable/clear/remove an inconsistent bitmap with qmp command
 #   remove an inconsistent bitmap with qemu-img --repair
@@ -8,7 +6,7 @@
 - blockdev_inc_backup_inconsistent_bitmap:
     only Linux
     #FIXME:add ceph back after qcow2 works normally on it
-    only filesystem iscsi_direct gluster_direct
+    no ceph nbd
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_merge_bitmaps_with_diff_granularity.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_merge_bitmaps_with_diff_granularity.cfg
@@ -1,11 +1,8 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Merge bitmaps with different granularity
 
 - blockdev_inc_backup_merge_bitmaps_with_diff_granularity:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_merge_external_bitmaps.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_merge_external_bitmaps.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Merge external bitmaps
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_merge_external_bitmaps:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_migrate_without_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_migrate_without_bitmap.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, gluster_direct
 # The following testing scenario is covered:
 #   Migrate without persistent/non-persistent bitmap
 #     The backup images are local images(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_inc_backup_migrate_without_bitmap:
     only Linux
-    only filesystem iscsi_direct ceph gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_inc_backup_migrate_without_bitmap
@@ -55,7 +52,7 @@
             bitmap_debugged = yes
             full_backup_options = {"sync": "full", "persistent": "on"}
             #FIXME:add ceph back after qcow2 works normally on it
-            no ceph
+            no ceph nbd
         - non_persistent:
             bitmap_debugged = no
             full_backup_options = {"sync": "full", "persistent": "off"}

--- a/qemu/tests/cfg/blockdev_inc_backup_mod_readonly_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_mod_readonly_bitmap.cfg
@@ -1,12 +1,10 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Remove/Clear readonly bitmap
 
 - blockdev_inc_backup_mod_readonly_bitmap:
     only Linux
     #FIXME:add ceph back after qcow2 works normally on it
-    only filesystem iscsi_direct gluster_direct
+    no ceph nbd
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_no_space.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_no_space.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do full backup to an image without enough space
 #     The backup images are local images(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_inc_backup_no_space:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_nospace_with_bitmap_mode.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_nospace_with_bitmap_mode.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do incremental backup with bitmap:on-success/always
 #     The backup images are local images(filesystem)
@@ -8,7 +6,6 @@
 
 - blockdev_inc_backup_nospace_with_bitmap_mode:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_inc_backup_nospace_with_bitmap_mode

--- a/qemu/tests/cfg/blockdev_inc_backup_remove_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_remove_bitmap.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Test for removing bitmaps
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_remove_bitmap:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_resize.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_resize.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, gluster_direct, ceph
 # The following testing scenario is covered:
 #   resize a qcow2 image with persistent bitmap stored on it
 
@@ -33,7 +31,7 @@
     # settings for block_resize
     no RHEL.4
     #FIXME:add ceph back after qcow2 works normally on it
-    only filesystem gluster_direct
+    no ceph nbd
     extend_ratio = 1.5
     shrink_ratio = 0.75
     disk_change_ratio = "${extend_ratio} ${shrink_ratio}"

--- a/qemu/tests/cfg/blockdev_inc_backup_rm_persistent_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_rm_persistent_bitmap.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Remove persistent bitmaps
 #     The backup images are local images(filesystem)
@@ -7,7 +5,7 @@
 - blockdev_inc_backup_rm_persistent_bitmap:
     only Linux
     #FIXME:add ceph back after qcow2 works normally on it
-    only filesystem iscsi_direct gluster_direct
+    no ceph nbd
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_target_not_exist.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_target_not_exist.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do incremental backup with a non-existed target node
 # Note:
@@ -8,7 +6,6 @@
 
 - blockdev_inc_backup_target_not_exist:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/blockdev_inc_backup_with_complete_mode.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_with_complete_mode.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do incremental backup with complete mode:
 #     The backup images are local images(filesystem)
@@ -8,7 +6,6 @@
 
 - blockdev_inc_backup_with_complete_mode:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_inc_backup_with_complete_mode

--- a/qemu/tests/cfg/blockdev_inc_backup_with_migration.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_with_migration.cfg
@@ -1,12 +1,9 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do incremental live backup with bitmap after migrated on shared storage
 #     The backup images are local images(filesystem)
 
 - blockdev_inc_backup_with_migration:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     qemu_force_use_drive_expression = no
     type = blockdev_inc_backup_with_migration

--- a/qemu/tests/cfg/blockdev_inc_backup_with_throttling.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_with_throttling.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do incremental backup with throttling
 #     The backup images are local images(filesystem)
@@ -7,7 +5,6 @@
 
 - blockdev_inc_backup_with_throttling:
     only Linux
-    only filesystem, iscsi_direct, ceph, nbd, gluster_direct
     qemu_force_use_drive_expression = no
     type = blockdev_inc_backup_test
     virt_test_type = qemu

--- a/qemu/tests/cfg/blockdev_inc_backup_without_bitmap.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_without_bitmap.cfg
@@ -1,5 +1,3 @@
-# Storage backends:
-#   filesystem, iscsi_direct, ceph, nbd, gluster_direct
 # The following testing scenario is covered:
 #   Do incremental backup without bitmap
 # Note:
@@ -8,7 +6,6 @@
 
 - blockdev_inc_backup_without_bitmap:
     only Linux
-    only filesystem iscsi_direct ceph nbd gluster_direct
     start_vm = no
     kill_vm = yes
     qemu_force_use_drive_expression = no

--- a/qemu/tests/cfg/qemu_img_convert_with_inconsistent_bitmap.cfg
+++ b/qemu/tests/cfg/qemu_img_convert_with_inconsistent_bitmap.cfg
@@ -1,6 +1,7 @@
 - qemu_img_convert_with_inconsistent_bitmap:
-    only filesystem iscsi_direct
     only linux
+    ##FIXME:will add ceph back if qcow2 supported on it
+    no ceph nbd
     virt_test_type = qemu
     type = qemu_img_convert_with_inconsistent_bitmap
     required_qemu = [6.0.0, )


### PR DESCRIPTION
Remove backend limitation from incremental backup cases,
excluse those defined under specific backends

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2097649