### PR TITLE
tpm_bind_luks: Reset TPM DA lockout counter before binding

### DIFF
--- a/qemu/tests/tpm_bind_luks.py
+++ b/qemu/tests/tpm_bind_luks.py
@@ -137,6 +137,8 @@ def run(test, params, env):
     md5_original = create_random_file()
     session.cmd(cryptsetup_close_cmd)
 
+    test.log.info("Reset TPM DA lockout counter before binding")
+    session.cmd("tpm2_dictionarylockout --clear-lockout")
     error_context.base_context("Bind %s using the TPM2 policy" % extra_disk,
                                test.log.info)
     session.cmd(clevis_bind_cmd % extra_disk)


### PR DESCRIPTION
Sometimes the guest will go to the DA lockout mode if the vTPM is not in
the right status, reset the DA lockout counter before binding to avoid
this issue.

ID: 2099993
Signed-off-by: Yihuang Yu <yihyu@redhat.com>