### PR TITLE
Cut out '-pci' from the namespace of virtio-rng device params

### DIFF
--- a/qemu/tests/cfg/rng_maxbytes_period.cfg
+++ b/qemu/tests/cfg/rng_maxbytes_period.cfg
@@ -16,34 +16,34 @@
             no rng_egd
             variants:
                 - maxbytes_512_period_1k:
-                    max-bytes_virtio-rng-pci = 512
-                    period_virtio-rng-pci = 1000
+                    max-bytes_virtio-rng = 512
+                    period_virtio-rng = 1000
                     expected_data_rate = 0.5
                 - maxbytes_1024_period_1k:
-                    max-bytes_virtio-rng-pci = 1024
-                    period_virtio-rng-pci = 1000
+                    max-bytes_virtio-rng = 1024
+                    period_virtio-rng = 1000
                     expected_data_rate = 1
                 - maxbytes_1024k_period_1m:
-                    max-bytes_virtio-rng-pci = 1024000
-                    period_virtio-rng-pci = 1000000
+                    max-bytes_virtio-rng = 1024000
+                    period_virtio-rng = 1000000
                     expected_data_rate = 1
                     read_rng_cmd = "dd if=/dev/hwrng of=/dev/null bs=1024 count=1024"
         - negative_test:
             variants:
                 - maxbytes_0:
                     no aarch64
-                    max-bytes_virtio-rng-pci = 0
+                    max-bytes_virtio-rng = 0
                     read_rng_timeout = 10
                     read_rng_cmd  = "dd if=/dev/hwrng of=/dev/null bs=1 count=1"
                 - maxbytes_negative:
                     not_preprocess = yes
-                    max-bytes_virtio-rng-pci = -1
+                    max-bytes_virtio-rng = -1
                     expected_error_info = "'max-bytes' parameter must be non-negative, and less than 2^63"
                 - period_0:
                     not_preprocess = yes
-                    period_virtio-rng-pci = 0
+                    period_virtio-rng = 0
                     expected_error_info = "'period' parameter expects a positive integer"
                 - period_negative:
                     not_preprocess = yes
-                    period_virtio-rng-pci = -1
+                    period_virtio-rng = -1
                     expected_error_info = "Parameter 'period' expects uint32_t"

--- a/qemu/tests/rng_maxbytes_period.py
+++ b/qemu/tests/rng_maxbytes_period.py
@@ -30,8 +30,8 @@ def run(test, params, env):
     timeout = params.get_numeric("login_timeout", 360)
     read_rng_timeout = float(params.get("read_rng_timeout", 3600))
     read_rng_cmd = params["read_rng_cmd"]
-    max_bytes = params.get("max-bytes_virtio-rng-pci")
-    period = params.get("period_virtio-rng-pci")
+    max_bytes = params.get("max-bytes_virtio-rng")
+    period = params.get("period_virtio-rng")
 
     if not max_bytes and not period:
         test.error("Please specify the expected max-bytes and/or period.")


### PR DESCRIPTION
'virtio-rng-pci' is one type of virtio rng devices, the real name is not
unique, we have "virtio-rng-pci", "virtio-rng-pci-non-transitional",
"virtio-rng-pci-transitional", etc. And the device name in some
platforms is not the same. So we should not use the params namespace
"xxx_virtio-rng-pci", otherwise we need to configure the same virtio-rng
device with different parameters in diff platforms.

ID: 2098066
Signed-off-by: Yihuang Yu <yihyu@redhat.com>