### PR TITLE
numa_opts:fix incorrect cpu numa allocation

### DIFF
--- a/qemu/tests/cfg/numa_opts.cfg
+++ b/qemu/tests/cfg/numa_opts.cfg
@@ -59,6 +59,9 @@
             numa_cpus_node0 = "0,1"
             numa_cpus_node1 = "2,3"
             numa_cpus_node2 = "4,5"
+            aarch64:
+                vcpu_sockets = 1
+                vcpu_threads = 2
         - nodes.8:
             only aarch64
             only Host_RHEL.m8


### PR DESCRIPTION
The internal default allocation of the current sockets is 2,
but cores in the same socket cannot be assigned to different
numa nodes.

ID:2097641
Signed-off-by: zhenyzha <zhenyzha@redhat.com>