### PR TITLE
ceph_image_mem_leak: new case of ceph_image_mem_leak

### DIFF
--- a/qemu/tests/ceph_image_mem_leak.py
+++ b/qemu/tests/ceph_image_mem_leak.py
@@ -1,0 +1,61 @@
+import time
+
+from avocado.utils import process
+
+from virttest import error_context
+from virttest.utils_numeric import normalize_data_size
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Start guest with 10 rbd data disks and system disk.
+    2) Check the block info for 1 hour
+    3) Check the used memory size is not increased
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    def _get_qemu_vmrss():
+        pid = vm.process.get_pid()
+        qemu_stat_file = "/proc/" + str(pid) + "/status"
+        used_mem_cmd = "cat %s | grep VmRSS | awk -F ':\t* *' '{print $2}'" % \
+                       qemu_stat_file
+        used_mem_size = process.system_output(used_mem_cmd, shell=True)
+        used_mem_size_byte = normalize_data_size(str(used_mem_size),
+                                                 order_magnitude='B')
+        return used_mem_size_byte
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    # Wait the guest boot up completely
+    login_timeout = int(params.get("login_timeout", 360))
+    vm.wait_for_login(timeout=login_timeout)
+
+    used_mem_size_before = _get_qemu_vmrss()
+    test.log.info(
+        "The qemu-kvm process used mem size before querying blocks is %s" %
+        used_mem_size_before)
+
+    test.log.info("Begin to query blocks for 1 hour.")
+    timeout = time.time() + 60 * 60 * 1  # 1 hour from now
+    while True:
+        if time.time() > timeout:
+            break
+        vm.monitor.cmd("query-blockstats")
+        vm.monitor.cmd("query-block")
+
+    used_mem_size_after = _get_qemu_vmrss()
+    test.log.info(
+        "The qemu-kvm process used mem size after querying blocks is %s" %
+        used_mem_size_after)
+    test.log.info("Check whether the used memory size is increased.")
+    if int(used_mem_size_after) > int(used_mem_size_before) * 1.2:
+        test.fail(
+            "The used memory size before is %s, but after checking the blocks "
+            "for 1 hour, it increased to %s. There should be memory leaks, "
+            "check please." % (
+                used_mem_size_before, used_mem_size_after))

--- a/qemu/tests/cfg/ceph_image_mem_leak.cfg
+++ b/qemu/tests/cfg/ceph_image_mem_leak.cfg
@@ -1,0 +1,51 @@
+- ceph_image_mem_leak:
+    only ceph
+    virt_test_type = qemu
+    type = ceph_image_mem_leak
+    start_vm = yes
+    kill_vm = yes
+    images += " disk1 disk2 disk3 disk4 disk5 disk6 disk7 disk8 disk9 disk10"
+    remove_image = yes
+    remove_image_image1 = no
+    force_create_image = yes
+    force_create_image_image1 = no
+    # disk1
+    image_name_disk1 = images/disk1
+    image_size_disk1 = 1G
+    image_format_disk1 = raw
+    # disk2
+    image_name_disk2 = images/disk2
+    image_size_disk2 = 1G
+    image_format_disk2 = raw
+    # disk3
+    image_name_disk3 = images/disk3
+    image_size_disk3 = 1G
+    image_format_disk3 = raw
+    # disk4
+    image_name_disk4 = images/disk4
+    image_size_disk4 = 1G
+    image_format_disk4 = raw
+    # disk5
+    image_name_disk5 = images/disk5
+    image_size_disk5 = 1G
+    image_format_disk5 = raw
+    # disk6
+    image_name_disk6 = images/disk6
+    image_size_disk6 = 1G
+    image_format_disk6 = raw
+    # disk7
+    image_name_disk7 = images/disk7
+    image_size_disk7 = 1G
+    image_format_disk7 = raw
+    # disk8
+    image_name_disk8 = images/disk8
+    image_size_disk8 = 1G
+    image_format_disk8 = raw
+    # disk9
+    image_name_disk9 = images/disk9
+    image_size_disk9 = 1G
+    image_format_disk9 = raw
+    # disk10
+    image_name_disk10 = images/disk10
+    image_size_disk10 = 1G
+    image_format_disk10 = raw


### PR DESCRIPTION
1. Start guest with 10 rbd data disks and system disk.
2. Check the block info for 2 hours
3. Check the used memory size is not increased

Signed-off-by: Tingting Mao <timao@redhat.com>

ID: 2101643