### PR TITLE
balloon_disable: avoid case execution rhel9 host

### DIFF
--- a/qemu/tests/cfg/balloon_disable.cfg
+++ b/qemu/tests/cfg/balloon_disable.cfg
@@ -2,6 +2,7 @@
     virt_test_type = qemu
     no RHEL.3.9
     no RHEL.4.9
+    no RHEL.9
     type = balloon_disable
     extra_params += " -balloon none"
     required_qemu = [, 3.1.0)


### PR DESCRIPTION
balloon_disable memory case is meant to be executed
on qemu-kvm 3.1.0, which it won't be possible on rhel9.
Case execution needs to be avoided on rhel9 host.

ID: 2101540
Signed-off-by: mcasquer <mcasquer@redhat.com>