### PR TITLE
qemu_img_check_data_integrity: fix leaked clusters issue

### DIFF
--- a/qemu/tests/cfg/qemu_img_check_data_integrity.cfg
+++ b/qemu/tests/cfg/qemu_img_check_data_integrity.cfg
@@ -4,6 +4,9 @@
     start_vm = no
     kill_vm = yes
     rm_testfile_cmd = "rm -f %s"
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
+    check_image = no
     Windows:
         rm_testfile_cmd = "del %s"
     variants:

--- a/qemu/tests/qemu_img_check_data_integrity.py
+++ b/qemu/tests/qemu_img_check_data_integrity.py
@@ -1,6 +1,8 @@
 import time
 
 from virttest import utils_misc
+from virttest import data_dir
+from virttest.qemu_storage import QemuImg
 
 from provider import qemu_img_utils as img_utils
 from provider.storage_benchmark import generate_instance
@@ -9,16 +11,19 @@ from provider.storage_benchmark import generate_instance
 def run(test, params, env):
     """
     Check data integrity after qemu unexpectedly quit
-    1. Boot a guest
-    2. If tmp_file_check == yes
-    2.1 Create temporary file in the guest
-    2.2 Get md5 value of the temporary file
-    3. Kill qemu process after finishing writing data in the guest
-    4. Boot the guest again, check the md5 value of the temporary file
+    1. Backup the guest image before testing
+    2. Boot a guest
+    3. If tmp_file_check == yes
+    3.1 Create temporary file in the guest
+    3.2 Get md5 value of the temporary file
+    4. Kill qemu process after finishing writing data in the guest
+    5. Boot the guest again, check the md5 value of the temporary file
        Make sure the values are the same
-    5. If tmp_file_check == no
-    5.1 Kill qemu process during writing data in the guest
-    6. Boot the guest again, make sure it could boot successfully
+    6. If tmp_file_check == no
+    6.1 Kill qemu process during writing data in the guest
+    7. Boot the guest again, make sure it could boot successfully
+    8. Check the testing image and repair the leaked clusters
+    9. Restore the guest image
 
     :param test: VT test object.
     :param params: Dictionary with the test parameters.
@@ -89,3 +94,21 @@ def run(test, params, env):
         session = vm.wait_for_login()
         session.cmd(params["rm_testfile_cmd"] % iozone_testfile)
     session.close()
+    vm.destroy()
+
+    # Check the testing image and repair the leaked clusters
+    root_dir = data_dir.get_data_dir()
+    img = params.objects("images")[0]
+    img_param = params.object_params(img)
+    img = QemuImg(img_param, root_dir, img)
+    res = img.check(params, root_dir)
+    if res.exit_status == 2:
+        test.fail("Image is corrupted, check please.")
+    elif res.exit_status == 3:
+        test.log.info("Leaked clusters found in the image, repair them now.")
+        res = img.check(params, root_dir, check_repair="leaks")
+        if res.exit_status != 0:
+            test.fail("Repair the leaked image failed, check please.")
+        # Boot guest again to double check the image works fine
+        vm = img_utils.boot_vm_with_images(test, params, env)
+        vm.wait_for_login()


### PR DESCRIPTION
1. Backup image before testing and restore after
2. Check the image and repair the leaked clusters after
data integrity testing

Signed-off-by: Tingting Mao <timao@redhat.com>

ID: 2103037