### PR TITLE
single_driver_install: use the cloned image for all steps

### DIFF
--- a/qemu/tests/single_driver_install.py
+++ b/qemu/tests/single_driver_install.py
@@ -138,7 +138,7 @@ def run(test, params, env):
 
         if params.get_boolean('need_destroy'):
             vm.destroy()
-            vm.create(params=params)
+            vm.create()
             vm = env.get_vm(params["main_vm"])
             session = vm.wait_for_login()
         else:


### PR DESCRIPTION
Now after guest shutdown then boot again, the guest will not use
the cloned image as code issue which result in unexpected issue.
After the fix, we can confirm all steps run in the same image.

ID: 2106243
Signed-off-by: Menghuan Li menli@redhat.com