### PR TITLE
virtio_fs: create dir with winapi in windows guest

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -81,42 +81,49 @@
                 git_init_cmd = '"c:\Program Files\Git\bin\git.exe" init %s\test'
                 cdrom_cd1= "/home/winutil.iso"
                 git_check_cmd = '"c:\Program Files\Git\bin\git.exe" init %TEMP%\test'
+        - create_dir_winapi:
+            only Windows
+            only default.default.with_cache.auto.default
+            no Host_RHEL.m8
+            fs_binary_extra_options += " --log-level debug"
+            create_dir_winapi_cmd = python2.7 -c "import ctypes; dll=ctypes.windll.kernel32;dll.CreateDirectoryA('%s:\\test_winapi', 0)"
+
     variants:
         - @default:
         - @extra_parameters:
             variants:
                 - lock_posix_off:
-                    fs_binary_extra_options += ",no_posix_lock"
+                    fs_binary_extra_options += " -o no_posix_lock"
                 - lock_posix_on:
                     only Host_RHEL.m8
-                    fs_binary_extra_options += ",posix_lock"
+                    fs_binary_extra_options += " -o posix_lock"
             variants:
                 - flock_on:
                     only Host_RHEL.m8
-                    fs_binary_extra_options += ",flock"
+                    fs_binary_extra_options += " -o flock"
                 - flock_off:
-                    fs_binary_extra_options += ",no_flock"
+                    fs_binary_extra_options += " -o no_flock"
             variants:
                 - xattr_on:
-                    fs_binary_extra_options += ",xattr"
+                    fs_binary_extra_options += " -o xattr"
                 - xattr_off:
-                    fs_binary_extra_options += ",no_xattr"
+                    fs_binary_extra_options += " -o no_xattr"
         - with_writeback:
             only with_cache
             # Since in writeback-cache mode writes go to the cache only, A large number of dirty pages will be generated.
             # When the memory is insufficient, the performance will be seriously degraded, so increase the memory to 8G.
             mem = 8192
             size_mem1 = 8G
-            fs_binary_extra_options += ",writeback"
+            fs_binary_extra_options += " -o writeback"
     variants:
         - with_cache:
             variants:
                 - auto:
-                    fs_binary_extra_options += ",cache=auto"
+                    fs_binary_extra_options += " -o cache=auto"
                 - always:
-                    fs_binary_extra_options += ",cache=always"
+                    fs_binary_extra_options += " -o cache=always"
                 - none:
-                    fs_binary_extra_options += ",cache=none"
+                    fs_binary_extra_options += " -o cache=none"
         - socket_group:
             no extra_parameters
             socket_group_test = yes


### PR DESCRIPTION
New case about 'Create new directory with WinAPI's CreateDirectory', it is only for windows guest and virtiofsd-rs version.
    1. Create directory on shared dir with Winapi command.
    2. Check virtiofsd output to make sure there is no error.
ID: 2102452
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>