### PR TITLE
virtio_fs: extend timeout of creating big file on host

### DIFF
--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -192,7 +192,7 @@ def run(test, params, env):
         # create partition on host
         dd_of_on_host = params.get("dd_of_on_host")
         cmd_dd_on_host = params.get("cmd_dd_on_host")
-        process.system(cmd_dd_on_host % dd_of_on_host, timeout=120)
+        process.system(cmd_dd_on_host % dd_of_on_host, timeout=300)
 
         cmd_losetup_query_on_host = params.get("cmd_losetup_query_on_host")
         loop_device = process.run(


### PR DESCRIPTION
When using ext3/ext4 as the fs backend,sometimes creating
the big file(about 5G) will fail due to the performance.
Extend the timeout to make it successful on the most host.
ID: 2101340
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>