### PR TITLE
balloon_memhp: Increases threshold value for SoC platform

### DIFF
--- a/qemu/tests/cfg/balloon_memhp.cfg
+++ b/qemu/tests/cfg/balloon_memhp.cfg
@@ -23,8 +23,6 @@
     balloon_dev_devid = balloon0
     balloon_dev_add_bus = yes
     threshold = 0.19
-    aarch64,ppc64,ppc64le:
-        threshold = 0.15
     # Due to known issue
     RHEL.9.0.0:
         aarch64:


### PR DESCRIPTION
Due to product changes, the threshold value has been
increased for x86 platforms.
So synchronously adjust the SoC platform.

ID: 2106982
Signed-off-by: zhenyzha <zhenyzha@redhat.com>