### PR TITLE
Adjust some timeout values in some vsock test cases.

### DIFF
--- a/qemu/tests/vsock_hotplug.py
+++ b/qemu/tests/vsock_hotplug.py
@@ -83,7 +83,7 @@ def run(test, params, env):
             tool_bin = path.find_command("ncat")
         tmp_file = "/tmp/vsock_file_%s" % utils_misc.generate_random_string(6)
         rec_session = vsock_test.send_data_from_guest_to_host(
-            session, tool_bin, guest_cid, tmp_file, file_size=10000)
+            session, tool_bin, guest_cid, tmp_file)
         vsock_negative_test.check_data_received(test, rec_session, tmp_file)
         vm.devices.simple_unplug(dev_vsock, vm.monitor)
         vsock_negative_test.kill_host_receive_process(test, rec_session)

--- a/qemu/tests/vsock_negative_test.py
+++ b/qemu/tests/vsock_negative_test.py
@@ -20,13 +20,13 @@ def check_data_received(test, rec_session, file):
     :param file: file to receive data
     """
     if not utils_misc.wait_for(lambda: rec_session.is_alive(),
-                               timeout=3, step=0.1):
+                               timeout=20, step=1):
         test.error("Host connection failed.")
     if not utils_misc.wait_for(lambda: os.path.exists(file),
-                               timeout=3, step=0.1):
+                               timeout=20, step=1):
         test.fail("Host does not create receive file successfully.")
     elif not utils_misc.wait_for(lambda: os.path.getsize(file) > 0,
-                                 timeout=10, step=0.1):
+                                 timeout=300, step=5):
         test.fail('Host does not receive data successfully.')
 
 
@@ -93,7 +93,7 @@ def run(test, params, env):
     session = vm.wait_for_login()
     tmp_file = "/tmp/vsock_file_%s" % utils_misc.generate_random_string(6)
     rec_session = vsock_test.send_data_from_guest_to_host(
-        session, tool_bin, guest_cid, tmp_file, file_size=10000)
+        session, tool_bin, guest_cid, tmp_file)
     try:
         check_data_received(test, rec_session, tmp_file)
         kill_host_receive_process(test, rec_session)

--- a/qemu/tests/vsock_test.py
+++ b/qemu/tests/vsock_test.py
@@ -1,6 +1,7 @@
 import os
 import random
 import logging
+import time
 import aexpect
 
 from avocado.utils import path
@@ -137,6 +138,7 @@ def send_data_from_guest_to_host(guest_session, tool_bin,
             tool_bin, guest_cid, port, tmp_file)
     if "nc-vsock" in tool_bin:
         cmd_receive = '%s %s %s > %s' % (tool_bin, guest_cid, port, tmp_file)
+    time.sleep(60)
     return aexpect.Expect(cmd_receive,
                           auto_close=True,
                           output_func=utils_misc.log_line,
@@ -152,7 +154,7 @@ def check_guest_vsock_conn_exit(test, session, close_session=False):
     :param close_session: close the session finally if True
     """
     try:
-        session.read_up_to_prompt(timeout=40)
+        session.read_up_to_prompt(timeout=120)
     except aexpect.ExpectTimeoutError:
         test.fail("vsock listening prcoess inside guest"
                   " does not exit after close host nc-vsock connection.")


### PR DESCRIPTION
1. Adjust some timeout values in vsock test cases to make them more stable on some old hosts.
2. Adjust big_file size to a more reasonable value.  

ID: 2071224
Signed-off-by: qcheng <qcheng@redhat.com>