### PR TITLE
ntttcp:use serial login instead of SSH/Netcat

### DIFF
--- a/generic/tests/ntttcp.py
+++ b/generic/tests/ntttcp.py
@@ -132,7 +132,7 @@ def run(test, params, env):
     def sender():
         """ Send side """
         test.log.info("Sarting sender process ...")
-        session = vm_sender.wait_for_login(timeout=login_timeout)
+        session = vm_sender.wait_for_serial_login(timeout=login_timeout)
         install_ntttcp(session)
         ntttcp_sender_cmd = params.get("ntttcp_sender_cmd")
         f = open(results_path + ".sender", 'a')


### PR DESCRIPTION
Currently,VM's session will be lost deue to Ncat reset
So I would like to replace it with serial login to improve it

ID:2076210
Signed-off-by: Leidong Wang <leidwang@redhat.com>