### PR TITLE
blockdev_snapshot: update data disk size to 2G

### DIFF
--- a/qemu/tests/cfg/blockdev_snapshot.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot.cfg
@@ -9,7 +9,7 @@
     storage_type_default = "directory"
     storage_pool = default
     base_tag = "data"
-    image_size_data = 100M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tag = sn1
     image_name_sn1 = sn1

--- a/qemu/tests/cfg/blockdev_snapshot_chains.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_chains.cfg
@@ -6,7 +6,7 @@
     storage_type_default = "directory"
     storage_pool = default
     images += " data1"
-    image_size_data1 = 500M
+    image_size_data1 = 2G
     image_name_data1 = "images/data1"
     force_create_image_data1 = yes
     force_remove_image_data1 = yes

--- a/qemu/tests/cfg/blockdev_snapshot_data_file.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_data_file.cfg
@@ -10,7 +10,7 @@
     storage_type_default = "directory"
     storage_pool = default
     base_tag = "data"
-    image_size_data = 100M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tag = sn2
     image_name_sn2 = sn2

--- a/qemu/tests/cfg/blockdev_snapshot_multi_disks.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_multi_disks.cfg
@@ -5,13 +5,13 @@
     storage_type_default = "directory"
     storage_pool = default
     images += " data1 data2"
-    image_size_data1 = 500M
+    image_size_data1 = 2G
     image_name_data1 = "images/data1"
     image_name_sn1 = "sn1"
     image_format_sn1 = qcow2
     force_create_image = yes
     force_remove_image = yes
-    image_size_data2 = 400M
+    image_size_data2 = 2G
     image_name_data2 = "images/data2"
     image_name_sn2 = "sn2"
     image_format_sn2 = qcow2


### PR DESCRIPTION
Update data disk size to 2G for test convenience.
Image creation for nbd and host_device test is
not allowed, and all cases share the same backend
image, so we should make sure all test disks are
the same size, here we use 2G.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2108963