### PR TITLE
blockdev_stream:update test data disk size to 2G

### DIFF
--- a/qemu/tests/cfg/blockdev_stream.cfg
+++ b/qemu/tests/cfg/blockdev_stream.cfg
@@ -9,7 +9,7 @@
     storage_type_default = "directory"
     storage_pool = default
     base_tag = "data"
-    image_size_data = 100M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tag = sn1
     image_name_sn1 = sn1

--- a/qemu/tests/cfg/blockdev_stream_remote_server_down.cfg
+++ b/qemu/tests/cfg/blockdev_stream_remote_server_down.cfg
@@ -26,20 +26,20 @@
 
     # Settings for a local fs image 'data',
     # which will be exported with qemu-nbd
-    local_image_tag = data
-    image_size_data = 2G
-    image_name_data = data
-    image_format_data = qcow2
-    preallocated_data = falloc
-    nbd_port_data = 10810
-    nbd_export_format_data = raw
-    nbd_server_tls_creds_data = ''
-    enable_iscsi_data = no
-    enable_ceph_data = no
-    enable_gluster_data = no
-    enable_nbd_data = no
-    image_raw_device_data = no
-    remove_image_data = yes
+    local_image_tag = nbddata
+    image_size_nbddata = 2G
+    image_name_nbddata = nbddata
+    image_format_nbddata = qcow2
+    preallocated_nbddata = falloc
+    nbd_port_nbddata = 10810
+    nbd_export_format_nbddata = raw
+    nbd_server_tls_creds_nbddata = ''
+    enable_iscsi_nbddata = no
+    enable_ceph_nbddata = no
+    enable_gluster_nbddata = no
+    enable_nbd_nbddata = no
+    image_raw_device_nbddata = no
+    remove_image_nbddata = yes
 
     # Settings for nbd image 'data1',
     # i.e. the exported 'data'
@@ -47,12 +47,12 @@
     enable_nbd_data1 = yes
     storage_type_data1 = nbd
     nbd_server_data1 = localhost
-    nbd_port_data1 = ${nbd_port_data}
+    nbd_port_data1 = ${nbd_port_nbddata}
     remove_image_data1 = no
     force_create_image_data1 = no
     image_create_support_data1 = no
-    image_format_data1 = ${image_format_data}
-    image_size_data1 = ${image_size_data}
+    image_format_data1 = ${image_format_nbddata}
+    image_size_data1 = ${image_size_nbddata}
     check_image_data1 = no
 
     # For local snapshot image
@@ -62,6 +62,6 @@
     enable_gluster_data1sn = no
     enable_nbd_data1sn = no
     image_raw_device_data1sn = no
-    image_size_data1sn = ${image_size_data}
+    image_size_data1sn = ${image_size_nbddata}
     image_format_data1sn = qcow2
     image_name_data1sn = data1sn

--- a/qemu/tests/cfg/blockdev_stream_with_ioerror.cfg
+++ b/qemu/tests/cfg/blockdev_stream_with_ioerror.cfg
@@ -10,10 +10,10 @@
     storage_type_default = "directory"
     storage_pool = default
     base_tag = "data"
-    image_size_data = 500M
+    image_size_data = 2G
     image_format_data = qcow2
     snapshot_tag = sn1
-    image_size_sn1 = 500M
+    image_size_sn1 = 2G
     image_name_sn1 = sn1
     image_format_sn1 = qcow2
     device = "drive_data"


### PR DESCRIPTION
Set test data disk size to 2G, for image creation
for host_device test is not allowed. Set the test
disk size the same with other cases for convenience.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2108980