### PR TITLE
rh_kernel_update:install kernel-devel during update kernel

### DIFF
--- a/qemu/tests/cfg/rh_kernel_update.cfg
+++ b/qemu/tests/cfg/rh_kernel_update.cfg
@@ -25,8 +25,8 @@
     RHEL.7:
         kernel_deps_pkgs += " kmod hmaccalc"
         upgrade_pkgs += " qemu-guest-agent"
-    RHEL.8:
-        kernel_pkgs += " kernel-core kernel-modules"
+    !RHEL.5, RHEL.6, RHEL.7:
+        kernel_pkgs += " kernel-core kernel-modules kernel-devel"
         upgrade_pkgs = ""
         kernel_deps_pkgs = ""
     x86_64:


### PR DESCRIPTION
rh_kernel_update does not install kernel-devel,it will affects
some testcases.So I would like to install it during update kernel
to avoid the issue.

ID:1993727
Signed-off-by: Leidong Wang <leidwang@redhat.com>