### PR TITLE
blockdev_commit:set test data disk size to 2G

### DIFF
--- a/qemu/tests/cfg/blockdev_commit.cfg
+++ b/qemu/tests/cfg/blockdev_commit.cfg
@@ -12,7 +12,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 100M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags = sn1 sn2 sn3 sn4
 
@@ -42,9 +42,9 @@
     variants:
         - @one_data_disk:
         - multi_data_disks:
-            image_size_data1 = 300M
-            image_name_data1 = data1
-            snapshot_tags_data1 = sn11 sn21 sn31 sn41
+            image_size_data2 = 2G
+            image_name_data2 = data2
+            snapshot_tags_data2 = sn11 sn21 sn31 sn41
 
             image_name_sn11 = sn11
             image_format_sn11 = qcow2
@@ -58,16 +58,16 @@
             image_name_sn41 = sn41
             image_format_sn41 = qcow2
 
-            device_tag += " data1"
-            images += " data1"
-            blk_extra_params_data1 = "serial=DATA_DISK2"
-            blk_extra_params_sn11 = ${blk_extra_params_data1}
-            blk_extra_params_sn21 = ${blk_extra_params_data1}
-            blk_extra_params_sn31 = ${blk_extra_params_data1}
-            blk_extra_params_sn41 = ${blk_extra_params_data1}
+            device_tag += " data2"
+            images += " data2"
+            blk_extra_params_data2 = "serial=DATA_DISK2"
+            blk_extra_params_sn11 = ${blk_extra_params_data2}
+            blk_extra_params_sn21 = ${blk_extra_params_data2}
+            blk_extra_params_sn31 = ${blk_extra_params_data2}
+            blk_extra_params_sn41 = ${blk_extra_params_data2}
     iscsi_direct:
         lun_data = 1
-        lun_data1 = 2
+        lun_data2 = 2
         enable_iscsi_sn1 = no
         image_raw_device_sn1 = no
         enable_iscsi_sn2 = no
@@ -86,7 +86,7 @@
         image_raw_device_sn41 = no
     ceph:
         image_format_data = raw
-        image_format_data1 = raw
+        image_format_data2 = raw
         enable_ceph_sn1 = no
         enable_ceph_sn2 = no
         enable_ceph_sn3 = no
@@ -97,11 +97,11 @@
         enable_ceph_sn41 = no
     nbd:
         image_format_data = raw
-        image_format_data1 = raw
+        image_format_data2 = raw
         image_size_data = 2G
-        image_size_data1 = 2G
+        image_size_data2 = 2G
         nbd_port_data = 10831
-        nbd_port_data1 = 10832
+        nbd_port_data2 = 10832
         enable_nbd_sn1 = no
         enable_nbd_sn2 = no
         enable_nbd_sn3 = no
@@ -112,13 +112,13 @@
         enable_nbd_sn41 = no
         force_create_image_data = no
         remove_image_data = no
-        force_create_image_data1 = no
-        remove_image_data1 = no
+        force_create_image_data2 = no
+        remove_image_data2 = no
     image_size_sn1 = ${image_size_data}
     image_size_sn2 = ${image_size_data}
     image_size_sn3 = ${image_size_data}
     image_size_sn4 = ${image_size_data}
-    image_size_sn11 = ${image_size_data1}
-    image_size_sn21 = ${image_size_data1}
-    image_size_sn31 = ${image_size_data1}
-    image_size_sn41 = ${image_size_data1}
+    image_size_sn11 = ${image_size_data2}
+    image_size_sn21 = ${image_size_data2}
+    image_size_sn31 = ${image_size_data2}
+    image_size_sn41 = ${image_size_data2}

--- a/qemu/tests/cfg/blockdev_commit_cor.cfg
+++ b/qemu/tests/cfg/blockdev_commit_cor.cfg
@@ -8,7 +8,7 @@
     images += " ${device_tag}"
     force_create_image_data = yes
     remove_image_data = yes
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     storage_pools = default
     storage_type_default = "directory"

--- a/qemu/tests/cfg/blockdev_commit_filter_node_name.cfg
+++ b/qemu/tests/cfg/blockdev_commit_filter_node_name.cfg
@@ -11,7 +11,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1
 

--- a/qemu/tests/cfg/blockdev_commit_firewall.cfg
+++ b/qemu/tests/cfg/blockdev_commit_firewall.cfg
@@ -13,29 +13,29 @@
     speed = 10000000
     qemu_force_use_drive_expression = no
 
-    # Settings for a local fs image 'data',
+    # Settings for a local fs image 'nbddata',
     # which will be exported by qemu-nbd
-    local_image_tag = data
-    image_size_data = 2G
-    image_name_data = data
-    image_format_data = qcow2
-    nbd_port_data = 10810
-    nbd_export_format_data = qcow2
+    local_image_tag = nbddata
+    image_size_nbddata = 2G
+    image_name_nbddata = nbddata
+    image_format_nbddata = qcow2
+    nbd_port_nbddata = 10810
+    nbd_export_format_nbddata = qcow2
 
     # Settings for nbd image 'base',
     nbd_image_tag = base
     enable_nbd_base = yes
     storage_type_base = nbd
-    nbd_port_base = ${nbd_port_data}
+    nbd_port_base = ${nbd_port_nbddata}
     force_create_image_base = no
     image_create_support_base = no
     image_format_base = raw
-    image_size_base = ${image_size_data}
+    image_size_base = ${image_size_nbddata}
 
     #Setting for snapshot image
     snapshot_tags_base = sn1
     image_name_sn1 = sn1
-    image_size_sn1 = ${image_size_data}
+    image_size_sn1 = ${image_size_nbddata}
     image_format_sn1 = qcow2
     device_tag = ${nbd_image_tag}
     images += ' ${nbd_image_tag}'

--- a/qemu/tests/cfg/blockdev_commit_forbidden_actions.cfg
+++ b/qemu/tests/cfg/blockdev_commit_forbidden_actions.cfg
@@ -11,7 +11,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1
     top_device_node = drive_sn1

--- a/qemu/tests/cfg/blockdev_commit_general_operation.cfg
+++ b/qemu/tests/cfg/blockdev_commit_general_operation.cfg
@@ -11,7 +11,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1
 

--- a/qemu/tests/cfg/blockdev_commit_hotunplug.cfg
+++ b/qemu/tests/cfg/blockdev_commit_hotunplug.cfg
@@ -11,7 +11,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1
 

--- a/qemu/tests/cfg/blockdev_commit_non_existed_node.cfg
+++ b/qemu/tests/cfg/blockdev_commit_non_existed_node.cfg
@@ -10,7 +10,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1
 

--- a/qemu/tests/cfg/blockdev_commit_powerdown.cfg
+++ b/qemu/tests/cfg/blockdev_commit_powerdown.cfg
@@ -11,7 +11,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1
 

--- a/qemu/tests/cfg/blockdev_commit_query_named_block_nodes.cfg
+++ b/qemu/tests/cfg/blockdev_commit_query_named_block_nodes.cfg
@@ -10,7 +10,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1 sn2 sn3 sn4
 

--- a/qemu/tests/cfg/blockdev_commit_server_down.cfg
+++ b/qemu/tests/cfg/blockdev_commit_server_down.cfg
@@ -11,25 +11,25 @@
     storage_type_default = "directory"
     storage_pool = default
 
-    # The following is specified for a local data image 'data',
+    # The following is specified for a local data image 'nbddata',
     # which will be exported by qemu-nbd
-    local_image_tag = data
-    image_size_data = 2G
-    image_name_data = data
-    nbd_port_data = 10810
+    local_image_tag = nbddata
+    image_size_nbddata = 2G
+    image_name_nbddata = nbddata
+    nbd_port_nbddata = 10810
 
     # The following is specified for nbd image 'nbddata',
-    # i.e. the exported 'data', used as a data disk in VM
-    nbd_image_tag = nbddata
-    enable_nbd_nbddata = yes
-    storage_type_nbddata = nbd
-    nbd_reconnect_delay_nbddata = 30
-    nbd_port_nbddata = ${nbd_port_data}
-    image_format_nbddata = raw
-    image_size_nbddata = ${image_size_data}
+    # i.e. the exported 'nbddata', used as a data disk in VM
+    nbd_image_tag = data
+    enable_nbd_data = yes
+    storage_type_data = nbd
+    nbd_reconnect_delay_data = 30
+    nbd_port_data = ${nbd_port_nbddata}
+    image_format_data = raw
+    image_size_data = ${image_size_nbddata}
 
     # snapshot of the nbd image 'nbddata'
-    snapshot_tags_nbddata = sn1
+    snapshot_tags_data = sn1
     image_size_sn1 = 2G
     image_name_sn1 = sn1
     image_format_sn1 = qcow2

--- a/qemu/tests/cfg/blockdev_commit_specify_node.cfg
+++ b/qemu/tests/cfg/blockdev_commit_specify_node.cfg
@@ -10,7 +10,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1 sn2 sn3 sn4
 

--- a/qemu/tests/cfg/blockdev_commit_speed_limit.cfg
+++ b/qemu/tests/cfg/blockdev_commit_speed_limit.cfg
@@ -11,7 +11,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1
 

--- a/qemu/tests/cfg/blockdev_commit_throttle.cfg
+++ b/qemu/tests/cfg/blockdev_commit_throttle.cfg
@@ -10,7 +10,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1 sn2 sn3 sn4 sn5
 

--- a/qemu/tests/cfg/blockdev_commit_top.cfg
+++ b/qemu/tests/cfg/blockdev_commit_top.cfg
@@ -10,7 +10,7 @@
     storage_pools = default
     storage_type_default = "directory"
     storage_pool = default
-    image_size_data = 500M
+    image_size_data = 2G
     image_name_data = data
     snapshot_tags_data = sn1 sn2 sn3 sn4
 


### PR DESCRIPTION
For host_device test, image creation is not allowed,
we should use the same size for test data disks, so
we set the size to 2G to make the same size with not
chaning cases.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2109332