### PR TITLE
blockdev_mirror:set test data disk size to 2G

### DIFF
--- a/qemu/tests/cfg/blockdev_full_mirror.cfg
+++ b/qemu/tests/cfg/blockdev_full_mirror.cfg
@@ -8,7 +8,7 @@
     images += " src1"
     start_vm = no
     storage_pool = default
-    image_size_src1 = 100M
+    image_size_src1 = 2G
     image_name_src1 = "sr1"
     image_name_dst1 = "dst1"
     image_format_dst1 = qcow2

--- a/qemu/tests/cfg/blockdev_mirror_firewall.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_firewall.cfg
@@ -42,31 +42,31 @@
     ceph:
         image_format_data1 = raw
 
-    # Settings for a local fs image 'data',
+    # Settings for a local fs image 'nbddata',
     # which will be exported by qemu-nbd
-    local_image_tag = data
+    local_image_tag = nbddata
     storage_type_default = directory
-    image_size_data = ${image_size_data1}
-    image_name_data = data
-    image_format_data = qcow2
-    preallocated_data = falloc
-    nbd_port_data = 10810
-    nbd_export_format_data = raw
-    nbd_server_tls_creds_data = ''
-    enable_iscsi_data = no
-    enable_ceph_data = no
-    enable_gluster_data = no
-    enable_nbd_data = no
-    image_raw_device_data = no
+    image_size_nbddata = ${image_size_data1}
+    image_name_nbddata = nbddata
+    image_format_nbddata = qcow2
+    preallocated_nbddata = falloc
+    nbd_port_nbddata = 10810
+    nbd_export_format_nbddata = raw
+    nbd_server_tls_creds_nbddata = ''
+    enable_iscsi_nbddata = no
+    enable_ceph_nbddata = no
+    enable_gluster_nbddata = no
+    enable_nbd_nbddata = no
+    image_raw_device_nbddata = no
 
     # Settings for nbd image 'mirror1',
     # i.e. the exported 'data'
     nbd_image_tag = mirror1
     enable_nbd_mirror1 = yes
     storage_type_mirror1 = nbd
-    nbd_port_mirror1 = ${nbd_port_data}
+    nbd_port_mirror1 = ${nbd_port_nbddata}
     force_create_image_mirror1 = no
-    image_format_mirror1 = ${image_format_data}
+    image_format_mirror1 = ${image_format_nbddata}
 
     # commands used for break connection to nbd image
     net_break_cmd = iptables -I INPUT -s {s} -p tcp --dport ${nbd_port_mirror1} -j REJECT

--- a/qemu/tests/cfg/blockdev_mirror_remote_server_down.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_remote_server_down.cfg
@@ -33,27 +33,27 @@
     ceph:
         image_format_data1 = raw
 
-    # Settings for a local fs image 'data',
+    # Settings for a local fs image 'nbddata',
     # which will be exported by qemu-nbd
-    local_image_tag = data
-    image_size_data = ${image_size_data1}
-    image_name_data = data
-    image_format_data = qcow2
-    preallocated_data = falloc
-    nbd_port_data = 10810
-    nbd_export_format_data = raw
-    nbd_server_tls_creds_data = ''
-    enable_iscsi_data = no
-    enable_ceph_data = no
-    enable_gluster_data = no
-    enable_nbd_data = no
-    image_raw_device_data = no
+    local_image_tag = nbddata
+    image_size_nbddata = ${image_size_data1}
+    image_name_nbddata = nbddata
+    image_format_nbddata = qcow2
+    preallocated_nbddata = falloc
+    nbd_port_nbddata = 10810
+    nbd_export_format_nbddata = raw
+    nbd_server_tls_creds_nbddata = ''
+    enable_iscsi_nbddata = no
+    enable_ceph_nbddata = no
+    enable_gluster_nbddata = no
+    enable_nbd_nbddata = no
+    image_raw_device_nbddata = no
 
     # Settings for nbd image 'mirror1',
     # i.e. the exported 'data'
     nbd_image_tag = mirror1
     enable_nbd_mirror1 = yes
     storage_type_mirror1 = nbd
-    nbd_port_mirror1 = ${nbd_port_data}
+    nbd_port_mirror1 = ${nbd_port_nbddata}
     force_create_image_mirror1 = no
-    image_format_mirror1 = ${image_format_data}
+    image_format_mirror1 = ${image_format_nbddata}


### PR DESCRIPTION
For host_device test, image creation is not allowed,
so we set data disk size to the same 2G for all cases.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2109371