### PR TITLE
Add bootindex to avoid guest boot with wrong order on s390x

### DIFF
--- a/generic/tests/cfg/nfs_corrupt.cfg
+++ b/generic/tests/cfg/nfs_corrupt.cfg
@@ -16,6 +16,9 @@
     post_command_noncritical = yes
     wait_paused_timeout = 240
     nfs_stat_chk_re = "running"
+    s390x:
+        bootindex_image1 = 0
+        bootindex_stg = 1
     variants:
         - with_qcow2_format:
             image_format_stg = "qcow2"


### PR DESCRIPTION
Virutal_block: sort the boot order, avoid boot from wrong disk on s390x

ID: 2087689

Signed-off-by: Boqiao Fu <bfu@redhat.com>