### PR TITLE
memhp_threads: reverts fix attribute error

### DIFF
--- a/qemu/tests/memhp_threads.py
+++ b/qemu/tests/memhp_threads.py
@@ -46,6 +46,8 @@ def run(test, params, env):
     pre_threads = get_qemu_threads(get_threads_cmd)
     mem = params.get("target_mems")
     new_params = params.object_params(mem).object_params("mem")
+    attrs = Memory.__attributes__[new_params["backend"]][:]
+    new_params = new_params.copy_from_keys(attrs)
     dev = Memory(new_params["backend"], new_params)
     dev.set_param("id", "%s-%s" % ("mem", mem))
     args = [vm.monitor, vm.devices.qemu_version]


### PR DESCRIPTION
Based on avocado-vt [commit  e6228fd6fd3b18d098669f26789eefc143b2cbdc,](https://github.com/avocado-framework/avocado-vt/commit/e6228fd6fd3b18d098669f26789eefc143b2cbdc)
it is needed to include again the call to Memory
\_\_attributes\_\_ in order to get the proper params
when executing the hotplug.

ID: 2101305

Signed-off-by: mcasquer <mcasquer@redhat.com>