### PR TITLE
blockdev_backup:set test data disk size to 2G

### DIFF
--- a/qemu/tests/cfg/blockdev_full_backup.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup.cfg
@@ -9,7 +9,7 @@
     images += " src1"
     start_vm = no
     storage_pool = default
-    image_size_src1 = 200M
+    image_size_src1 = 2G
     image_name_src1 = "sr1"
     image_name_dst1 = "dst1"
     image_format_dst1 = qcow2

--- a/qemu/tests/cfg/blockdev_full_backup_invalid_max_workers.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_invalid_max_workers.cfg
@@ -8,7 +8,7 @@
     images += " data1"
     start_vm = no
     storage_pool = default
-    image_size_data1 = 500M
+    image_size_data1 = 2G
     image_name_data1 = data1
     force_create_image_data1 = yes
     remove_image_data1 = yes

--- a/qemu/tests/cfg/blockdev_full_backup_multi_disks.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_multi_disks.cfg
@@ -9,13 +9,13 @@
     images += " src1 src2"
     start_vm = no
     storage_pool = default
-    image_size_src1 = 200M
+    image_size_src1 = 2G
     image_name_src1 = "sr1"
     image_name_dst1 = "dst1"
     image_format_dst1 = qcow2
     force_create_image_src1 = yes
     force_remove_image_src1 = yes
-    image_size_src2 = 300M
+    image_size_src2 = 2G
     image_name_src2 = "src2"
     image_name_dst2 = "dst2"
     image_format_dst2 = qcow2

--- a/qemu/tests/cfg/blockdev_full_backup_nonexist_target.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_nonexist_target.cfg
@@ -8,7 +8,7 @@
     images += " src1"
     start_vm = no
     storage_pool = default
-    image_size_src1 = 200M
+    image_size_src1 = 2G
     image_name_src1 = "src1"
     force_create_image_src1 = yes
     remove_image_src1 = yes

--- a/qemu/tests/cfg/blockdev_full_backup_x_perf.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_x_perf.cfg
@@ -8,7 +8,7 @@
     images += " data1"
     start_vm = no
     storage_pool = default
-    image_size_data1 = 500M
+    image_size_data1 = 2G
     image_name_data1 = data1
     force_create_image_data1 = yes
     remove_image_data1 = yes

--- a/qemu/tests/cfg/blockdev_inc_backup_test.cfg
+++ b/qemu/tests/cfg/blockdev_inc_backup_test.cfg
@@ -52,9 +52,9 @@
             image_backup_chain_data2 = "base2 inc2"
             force_create_image_data2 = yes
             force_remove_image_data2 = yes
-            image_size_data2 = 3G
-            image_size_base2 = 3G
-            image_size_inc2 = 3G
+            image_size_data2 = 2G
+            image_size_base2 = 2G
+            image_size_inc2 = 2G
             image_format_data2 = qcow2
             image_format_base2 = qcow2
             image_format_inc2 = qcow2


### PR DESCRIPTION
For host_device test, image creation is not allowed,
all test data disks size should keep the same,
so we set it to 2G.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2109814