### PR TITLE
rng_maxbytes_period: fix " 'NoneType' object.." error

### DIFF
--- a/qemu/tests/rng_maxbytes_period.py
+++ b/qemu/tests/rng_maxbytes_period.py
@@ -74,7 +74,7 @@ def run(test, params, env):
         if s:
             test.error(o)
         test.log.info(o)
-        data_rate = re.search(r'\s(\d+\.\d+) kB/s', o, re.M)
+        data_rate = re.search(r'\s(\d+\.\d+)|(\d+) kB/s', o, re.M)
         expected_data_rate = float(params["expected_data_rate"])
         if float(data_rate.group(1)) > expected_data_rate * 1.1:
             test.error("Read data rate is not as expected. "


### PR DESCRIPTION
rng_maxbytes_period:  fix 'NoneType' object has no attribute 'group' error for s390x platform.
In string 77 of 'rng_maxbytes_period.py' file 
**data_rate = re.search(r'\s(\d+\.\d+) kB/s', o, re.M)**
parameter _data_rate_ was shown only if the number included '**.**' cheracter.
So I add variant without '**.**' character as an option for this parameter.

ID: 2105929
Signed-off-by: Bogdan Marcynkov <bmarcynk@redhat.com>