### PR TITLE
fio_perf: add some options to virtiofsd

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -93,13 +93,17 @@
             fs_dest = '/mnt/${fs_target}'
             fio_options = "--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=${fs_dest}/%s --name=job1 --ioengine=libaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=${guest_result_file} &> /dev/null"
             order_list = "Block_size Iodepth Threads BW(MB/S) IOPS Latency(ms) Host_CPU BW/CPU KVM_Exits"
+            fs_binary_extra_options = " --thread-pool-size=32"
+            !Host_RHEL.m8:
+                # The below option isn't supported on RHEL8.
+                fs_binary_extra_options += " --allow-direct-io"
             variants:
                 - auto:
-                    fs_binary_extra_options = " -o cache=auto"
+                    fs_binary_extra_options += " -o cache=auto"
                 - always:
-                    fs_binary_extra_options = " -o cache=always"
+                    fs_binary_extra_options += " -o cache=always"
                 - none:
-                    fs_binary_extra_options = " -o cache=none"
+                    fs_binary_extra_options += " -o cache=none"
     variants:
         - single_disk:
             no virtio_fs_perf


### PR DESCRIPTION
To make the better comparison of virtiofs performance,
we are supposed to use the following two options:
--thread-pool-size and --allow-direct-io(rhel8 doesn't support).
ID: 2075728
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>