### PR TITLE
virtio_fs: add generic/531 to blacklist for xfstest on nfs

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -176,7 +176,8 @@
                     # generic/426 467 477: https://gitlab.com/virtio-fs/qemu/-/issues/10
                     # generic/551: Costs a lot of time
                     # generic/035 nfs specific: https://gitlab.com/virtio-fs/qemu/-/issues/12
-                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551 generic/035'
+                    # generic/531 nfs specific,id1938936
+                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551 generic/035 generic/531'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.


### PR DESCRIPTION
Generic/531 always fail due to produce bz and it will block
the latter test cases.So add it to blacklist until the product
bz is fixed.
ID: 2111391
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>