### PR TITLE
Add variants to check_block_size for more coverage

### DIFF
--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -28,6 +28,8 @@
             unattended_delivery_method = cdrom
             default_bios:
                 no 4096_4096
+                x86_64:
+                    no 4096_4096_cluster_install
             Windows:
                 i440fx:
                     cd_format_cd1 = ide
@@ -88,3 +90,16 @@
             nic_mode = tap
             physical_block_size_stg = 512
             logical_block_size_stg = 512
+        - 4096_4096_cluster_install:
+            image_cluster_size = 4096
+            need_install = yes
+            start_vm = no
+            images = "stg"
+            boot_drive_stg = yes
+            medium = cdrom
+            installation = cdrom
+            kernel = vmlinuz
+            initrd = initrd.img
+            nic_mode = tap
+            physical_block_size_stg = 4096
+            logical_block_size_stg = 4096


### PR DESCRIPTION
Virtual_block: add a variant with install guest into a 4096k size of
image with physical_block_size&logical_block_size both equal to 4096k

ID: 2112278

Signed-off-by: Boqiao Fu <bfu@redhat.com>