### PR TITLE
virtio_fs: some optimization and bug fix

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -52,7 +52,6 @@
         viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath="%s" start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
-        viofs_sc_stop_cmd = 'sc stop ${viofs_svc_name}'
         viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
@@ -92,6 +91,7 @@
         - viofs_service_stop_start:
             only Windows
             only default.default.with_cache.auto.default
+            viofs_sc_stop_cmd = 'sc stop ${viofs_svc_name}'
             stop_start_repeats = 10
 
     variants:

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -409,10 +409,7 @@ def run(test, params, env):
                         if os_type == "linux":
                             session.cmd("cd -")
                         else:
-                            # there is no exit status for this cmd,so when getting
-                            # the exit status, it actually get the status of last cmd.
-                            # So use sendline function here.
-                            session.sendline("C:")
+                            session.cmd("cd /d C:\\")
 
                 if cmd_symblic_file:
                     error_context.context("Symbolic test under %s inside "
@@ -425,10 +422,7 @@ def run(test, params, env):
                     if os_type == "linux":
                         session.cmd("cd -")
                     else:
-                        # there is no exit status for this cmd,so when getting
-                        # the exit status, it actually get the status of last cmd.
-                        # So use sendline function here.
-                        session.sendline("C:")
+                        session.cmd("cd /d C:\\")
 
                 if fio_options:
                     error_context.context("Run fio on %s." % fs_dest, test.log.info)

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -123,8 +123,9 @@ def run(test, params, env):
         """
         error_context.context("Try to %s VirtioFsSvc service." % action,
                               test.log.info)
-        status, ouput = session.cmd_status_output(cmd)
-        if status != 0 or expect_status not in output:
+        session.cmd(cmd)
+        output = session.cmd_output(viofs_sc_query_cmd)
+        if expect_status not in output:
             test.fail("Could not %s VirtioFsSvc service, "
                       "detail: '%s'" % (action, output))
 
@@ -318,7 +319,6 @@ def run(test, params, env):
                 error_context.context("Start virtiofs service in guest.", test.log.info)
                 viofs_sc_create_cmd = params["viofs_sc_create_cmd"]
                 viofs_sc_start_cmd = params["viofs_sc_start_cmd"]
-                viofs_sc_stop_cmd = params["viofs_sc_stop_cmd"]
                 viofs_sc_query_cmd = params["viofs_sc_query_cmd"]
 
                 test.log.info("Check if virtiofs service is registered.")
@@ -547,6 +547,7 @@ def run(test, params, env):
                                 test.fail("CreateDirectory cause virtiofsd-rs ERROR reply.")
 
                 if params.get("stop_start_repeats") and os_type == "windows":
+                    viofs_sc_stop_cmd = params["viofs_sc_stop_cmd"]
                     repeats = int(params.get("stop_start_repeats", 1))
                     for i in range(repeats):
                         error_context.context("Repeat stop/start VirtioFsSvc:"


### PR DESCRIPTION
1. virtio_fs: use session.cmd to instead of session.sendline
 Using "cd /d c:\" to instead of "C:", because the previous one
    has exit code. So can use session.cmd() directory which
    is more usable than session.sendline().

2.  virtio_fs: some update of virtio_servic_stop_start
 This viofs_sc_stop_cmd is only for viofs_service_stop_start test
    case, we should limit it to it's work scope to avoid
    other cases' error. And for stop/start steps, use a more resonable way to check
    the service status.

ID: 2112744,  2112791
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>