### PR TITLE
openflow_acl_test..ftp:Change the windows ftp server settings cmd

### DIFF
--- a/qemu/tests/cfg/openflow_acl_test.cfg
+++ b/qemu/tests/cfg/openflow_acl_test.cfg
@@ -29,11 +29,11 @@
             guest_port_remote_shell = ${target_port}
             service_linux = vsftpd
             service_windows = ftp
-            prepare_cmd_linux = dd if=/dev/zero of=/var/ftp/pub/autotest-test bs=1M count=2
-            cleanup_cmd_linux = rm -rf /var/ftp/pub/autotest-test
-            access_cmd_linux =  rm -rf autotest-test; wget -t 1 -T 10 ftp://ACCESS_TARGET/pub/autotest-test
+            prepare_cmd_linux = dd if=/dev/zero of=/var/ftp/autotest-test bs=1M count=2
+            cleanup_cmd_linux = rm -rf /var/ftp/autotest-test
+            access_cmd_linux =  rm -rf autotest-test; wget -t 1 -T 10 ftp://ACCESS_TARGET/autotest-test
             clean_guest_linux = rm -rf autotest-test
-            setup_cmd_windows = Dism /Online /Enable-Feature /FeatureName:IIS-ManagementConsole /FeatureName:IIS-WebServerRole /FeatureName:IIS-FTPServer /FeatureName:IIS-FTPSvc /FeatureName:IIS-FTPExtensibility
+            setup_cmd_windows = dism.exe /Online /Enable-Feature /ALL /FeatureName:IIS-FTPExtensibility /FeatureName:IIS-FTPServer /FeatureName:IIS-FTPSvc /FeatureName:IIS-IIS6ManagementCompatibility /FeatureName:IIS-ManagementConsole /FeatureName:IIS-ManagementScriptingTools /FeatureName:IIS-ManagementService /FeatureName:IIS-Metabase /FeatureName:IIS-WebServer /FeatureName:IIS-WebServerManagementTools /FeatureName:IIS-WebServerRole /FeatureName:IIS-WindowsAuthentication
             stop_cmd_windows =
             prepare_cmd_windows = C:\dd.py C:\inetpub\ftproot\autotest-test 2
             cleanup_cmd_windows =
@@ -87,7 +87,9 @@
             acl_disabled = yes
             acl_extra_options = "tp_dst=TARGET_PORT"
             ftp:
-                setup_targets = localhost
+                image_snapshot = no
+                vms = "virt-tests-vm1"
+                setup_targets = localhost virt-tests-vm1
             website:
                 access_cmd_linux = curl -L www.redhat.com --connect-timeout 10
                 access_cmd_windows = cd C:\curl\ && curl.exe -k -L www.redhat.com --connect-timeout 10


### PR DESCRIPTION
1.Change the windows ftp server settings cmd and modified the ftp
path and target server.To solve the problem that windows guests
cannot access the other party's ftp service

ID:2052847

Signed-off-by: Lei Yang <leiayang@redhat.com>