### PR TITLE
Tweak 2 multi queues network cases

### DIFF
--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -17,11 +17,8 @@
         - @default:
         - with_multiqueue:
             only nic_virtio
-            smp ~= ${vcpu_maxcpus}
-            queues = ${smp}
+            queues = 4
             vt_ulimit_nofile = 10240
             Windows:
-                # Windows product limit, it will fail when queues is too large
-                queues = 4
                 i386:
                     nics_num = 8

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -16,6 +16,7 @@
             only nic_virtio
             queues = 4
             repeat_times = 100
+            vt_ulimit_nofile = 8192
         - with_reboot:
             only one_pci
             only nic_virtio


### PR DESCRIPTION
1. nic_hotplug..with_repetition: it will repeat 100 times, this means it
will open more than 400 fds in the qemu process, so extend maximum
number of open file descriptors.
2. multi_nics_verify.with_multiqueue: the queues equal to smp, when the
smp is too large, this case will open thousands of fds, and maybe beyond
the support of qemu.

ID: 2115341
Signed-off-by: Yihuang Yu <yihyu@redhat.com>