### PR TITLE
qemu_guest_agent: Add reboot/halt support for RHEL 7

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -106,6 +106,8 @@
                 gagent_guest_reboot_pattern = ""
             s390x:
                 gagent_guest_reboot_pattern = "System Reboot"
+                RHEL.7:
+                    gagent_guest_reboot_pattern = "Rebooting"
                 RHEL.8:
                     gagent_guest_reboot_pattern = "Started Reboot"
         - check_halt:
@@ -116,6 +118,8 @@
                 gagent_guest_shutdown_pattern = ""
             s390x:
                 gagent_guest_shutdown_pattern = "System Halt"
+                RHEL.7:
+                    gagent_guest_reboot_pattern = "Halting"
                 RHEL.8:
                     gagent_guest_shutdown_pattern = "Starting Halt"
         - check_sync_delimited:


### PR DESCRIPTION
Qemu_guest_agent: add 'reboot' and 'halt' support for RHEL 7 on s390x platform.
ID:2111006

Signed-off-by: Bogdan Marcynkov [bmarcynk@redhat.com]