### PR TITLE
win_virtio_driver_update: add compare_threshold and mem_ratio for balloon

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -63,6 +63,8 @@
             bg_stress_run_flag = balloon_test
             set_bg_stress_flag = yes
             wait_bg_time = 720
+            guest_compare_threshold = 300
+            guest_mem_ratio = 0.025
         - with_netkvm:
             driver_name = netkvm
             driver_verifier = ${driver_name}


### PR DESCRIPTION
For balloon driver update test,as it calls balloon_check
function and do memory check after balloon test, which need
to add guest_compare_threshold and guest_mem_ratio to make
windows guest works.
ID: 2116238
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>