### PR TITLE
x86_cpu_flags:add new case to test AMX on Sapphire Rapids

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -62,19 +62,29 @@
                                 cpu_model_flags += ",intel_pt=on,min-level=0x14"
                 - test_SPR_flags:
                     required_qemu = [5.2.0, )
-                    flags = "serialize avx512_vp2intersect avx512_fp16 tsxldtr"
+                    flags = "serialize avx512_vp2intersect avx512_fp16 tsxldtrk"
                     variants:
                         - host_model:
                             auto_cpu_model = no
                             cpu_model = host
                         - default_model:
-                            cpu_model_flags = ",+serialize,+avx512-vp2intersect,+avx512-fp16,+tsxldtr"
+                            cpu_model_flags = ",+serialize,+avx512-vp2intersect,+avx512-fp16,+tsx-ldtrk"
                 - avx_vnni:
                     # support since RHEL.8.5 kernel
                     no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1 RHEL.8.2 RHEL.8.3 RHEL.8.4
                     required_qemu = [6.0.0-26, )
                     flags = "avx_vnni"
                     cpu_model_flags += ",avx_vnni=on"
+                - test_SPR_AMX:
+                    no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1 RHEL.8.2 RHEL.8.3 RHEL.8.4 RHEL.8.5
+                    required_qemu = [6.2.0-15, )
+                    flags = "amx_bf16 amx_tile amx_int8"
+                    variants:
+                        - host_model:
+                            auto_cpu_model = no
+                            cpu_model = host
+                        - default_model:
+                            cpu_model_flags = ",+xfd,+amx-bf16,+amx-int8,+amx-tile"
         - amd:
             only HostCpuVendor.amd
             variants:


### PR DESCRIPTION
ID: 2117101

Sapphire Rapids (SPR) supports AMX Instructions.
And also fix one little issue about one wrong flag parameter.

Signed-off-by: nanliu <nanliu@redhat.com>