### PR TITLE
job_utils: avoid waiting for 'ready' status while job completed alredy

### DIFF
--- a/provider/job_utils.py
+++ b/provider/job_utils.py
@@ -51,7 +51,11 @@ def wait_until_block_job_completed(vm, job_id, timeout=900):
         if status == "pending":
             block_job_finalize(vm, job_id)
         if status == "ready":
-            block_job_complete(vm, job_id, timeout)
+            try:
+                arguments = {"id": job_id}
+                vm.monitor.cmd("job-complete", arguments)
+            except Exception as err:
+                LOG_JOB.debug("'job-complete' hit error: %s", err.data["desc"])
         try:
             for event in vm.monitor.get_events():
                 if event.get("event") != BLOCK_JOB_COMPLETED_EVENT:


### PR DESCRIPTION
The function 'wait_until_block_job_completed' call 'block_job_complete'
while job is in 'ready' status, while 'block_job_complete' wait for
'ready' status again. Sometimes, job completed already before checking
status in 'block_job_complete' and cause timeout error.

id: 2111720
Signed-off-by: Yanan Fu <yfu@redhat.com>