### PR TITLE
win_driver_install_by_installer: Add new test case

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
@@ -37,53 +37,77 @@
         virtio_rngs += " rng0"
         backend_rng0 = rng-builtin
         backend_type = builtin
-    nics += " nic2"
-    nic_model_nic1 = rtl8139
-    q35:
-        nic_model_nic1 = e1000e
-    nic_model_nic2 = virtio
-    images += " stg0 stg1"
-    image_name_stg0 = "images/stg0"
-    image_name_stg1 = "images/stg1"
-    image_size_stg0 = 5G
-    image_size_stg1 = 5G
-    drive_format_stg0 = virtio
-    drive_format_stg1 = scsi-hd
-    remove_image_stg0 = yes
-    remove_image_stg1 = yes
-    force_create_image_stg0 = yes
-    force_create_image_stg1 = yes
-    serials += " vs"
-    serial_type_vs = virtserialport
-    balloon = balloon0
-    balloon_dev_devid = balloon0
-    balloon_dev_add_bus = yes
-    inputs = input1
-    input_dev_bus_type_input1 = virtio
-    input_dev_type_input1 = mouse
-    filesystems = fs
-    fs_driver = virtio-fs
-    fs_source_type = mount
-    fs_source_dir = virtio_fs_test/
-    force_create_fs_source = yes
-    remove_fs_source = yes
-    fs_target = 'myfs'
-    fs_driver_props = {"queue-size": 1024}
-    mem = 4096
-    mem_devs = mem1
-    backend_mem_mem1 = memory-backend-file
-    mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
-    use_mem_mem1 = no
-    share_mem = yes
-    guest_numa_nodes = shm0
-    numa_memdev_shm0 = mem-mem1
-    numa_nodeid_shm0 = 0
-    fs_binary_extra_options = " -o cache=auto"
     Win10, Win2016, Win2019:
         check_qemufwcfg = yes
     Win8, Win2012, Win2012..r2:
         need_reboot = yes
+    variants:
+        - @all_drivers:
+            nics += " nic2"
+            nic_model_nic1 = rtl8139
+            q35:
+                nic_model_nic1 = e1000e
+            nic_model_nic2 = virtio
+            images += " stg0 stg1"
+            image_name_stg0 = "images/stg0"
+            image_name_stg1 = "images/stg1"
+            image_size_stg0 = 5G
+            image_size_stg1 = 10G
+            drive_format_stg0 = virtio
+            drive_format_stg1 = scsi-hd
+            remove_image_stg0 = yes
+            remove_image_stg1 = yes
+            force_create_image_stg0 = yes
+            force_create_image_stg1 = yes
+            serials += " vs"
+            serial_type_vs = virtserialport
+            balloon = balloon0
+            balloon_dev_devid = balloon0
+            balloon_dev_add_bus = yes
+            inputs = input1
+            input_dev_bus_type_input1 = virtio
+            input_dev_type_input1 = mouse
+            filesystems = fs
+            fs_driver = virtio-fs
+            fs_source_type = mount
+            fs_source_dir = virtio_fs_test/
+            force_create_fs_source = yes
+            remove_fs_source = yes
+            fs_target = 'myfs'
+            fs_driver_props = {"queue-size": 1024}
+            mem = 4096
+            mem_devs = mem1
+            backend_mem_mem1 = memory-backend-file
+            mem-path_mem1 = /dev/shm
+            size_mem1 = 4G
+            use_mem_mem1 = no
+            share_mem = yes
+            guest_numa_nodes = shm0
+            numa_memdev_shm0 = mem-mem1
+            numa_nodeid_shm0 = 0
+            fs_binary_extra_options = " -o cache=auto"
+            driver_test_names = 'rng iozone'
+            driver_test_params = {'images': 'stg0 stg1'}
+            iozone_cmd_opitons = " -azR -r 64k -n 512M -g 1G -M -I -i 0 -i 1 -b iozone.xls -f %s:\testfile"
+        - single_driver:
+            variants:
+                - with_viorng:
+                    read_rng_cmd = "WIN_UTILS:\\random_%PROCESSOR_ARCHITECTURE%.exe"
+                    driver_test_names = 'rng'
+                - @with_storage:
+                   images += " stg0"
+                   image_name_stg0 = "images/stg0"
+                   image_size_stg0 = 5G
+                   remove_image_stg0 = yes
+                   force_create_image_stg0 = yes
+                   driver_test_names = 'iozone'
+                   driver_test_params = {'images': 'stg0'}
+                   iozone_cmd_opitons = " -azR -r 64k -n 512M -g 1G -M -I -i 0 -i 1 -b iozone.xls -f %s:\testfile"
+                   variants:
+                        - with_viostor:
+                            drive_format_stg0 = virtio
+                        - with_vioscsi:
+                            drive_format_stg0 = scsi-hd
     variants:
         - installer_version_check:
             # note that need to have virtio-win rpm pkg installed on host
@@ -95,11 +119,16 @@
             iso_label_chk_cmd = 'wmic logicaldisk get VolumeName |findstr -i ${pkg_name}'
             installer_chk_cmd = 'powershell -command "(Get-Item -path "%s:\\virtio-win-guest-tools.exe").VersionInfo.ProductVersion"'
         - driver_install:
+            only single_driver
         - driver_repair:
+            only all_drivers
             type = win_virtio_driver_installer_repair
         - driver_uninstall:
+            only all_drivers
+            driver_test_names = ''
             type = win_virtio_driver_installer_uninstall
         - driver_update:
+            only all_drivers
             type = win_virtio_driver_update_by_installer
             variants:
                 - from_old_installer:


### PR DESCRIPTION
Add driver function test if the driver installed by installer.
As the guest should start both viostor and vioscsi data disks in
this case, so we should use image size to distingguish which disk
to format and do the iozone test in subtest.

Signed-off-by: Menghuan Li menli@redhat.com