### PR TITLE
virtio_fs: change virtiofs bin path for windows guest

### DIFF
--- a/qemu/tests/cfg/virtio_fs_hotplug.cfg
+++ b/qemu/tests/cfg/virtio_fs_hotplug.cfg
@@ -51,7 +51,9 @@
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.9.21096.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s" start=auto'
+        viofs_exe_path = C:\virtiofs.exe
+        viofs_exe_copy_cmd = xcopy %s C:\
+        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start VirtioFsSvc'
         viofs_sc_query_cmd = 'sc query VirtioFsSvc'

--- a/qemu/tests/cfg/virtio_fs_multi_vms.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_vms.cfg
@@ -58,7 +58,9 @@
         wfsp_install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.9.21096.msi /qn'
         check_installed_cmd = 'dir "${install_path}" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s" start=auto'
+        viofs_exe_path = C:\virtiofs.exe
+        viofs_exe_copy_cmd = xcopy %s C:\
+        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start VirtioFsSvc'
         viofs_sc_query_cmd = 'sc query VirtioFsSvc'

--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -46,7 +46,9 @@
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.9.21096.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s" start=auto'
+        viofs_exe_path = C:\virtiofs.exe
+        viofs_exe_copy_cmd = xcopy %s C:\
+        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start VirtioFsSvc'
         viofs_sc_query_cmd = 'sc query VirtioFsSvc'

--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -49,7 +49,9 @@
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
         viofs_svc_name = VirtioFsSvc
-        viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath="%s" start=auto'
+        viofs_exe_path = C:\virtiofs.exe
+        viofs_exe_copy_cmd = xcopy %s C:\
+        viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
         viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'

--- a/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
@@ -34,7 +34,9 @@
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.9.21096.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s" start=auto'
+        viofs_exe_path = C:\virtiofs.exe
+        viofs_exe_copy_cmd = xcopy %s C:\
+        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start VirtioFsSvc'
         viofs_sc_query_cmd = 'sc query VirtioFsSvc'

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -48,7 +48,9 @@
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.9.21096.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s" start=auto'
+        viofs_exe_path = C:\virtiofs.exe
+        viofs_exe_copy_cmd = xcopy %s C:\
+        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start VirtioFsSvc'
         viofs_sc_query_cmd = 'sc query VirtioFsSvc'

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -258,7 +258,9 @@
             install_cmd = 'msiexec /i WIN_UTILS:\winfsp-1.9.21096.msi /qn'
             check_installed_cmd = 'dir "%s" |findstr /I winfsp'
             viofs_log_file = C:\\viofs_log.txt
-            viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s -d -1 -D ${viofs_log_file}" start=auto'
+            viofs_exe_path = C:\\virtiofs.exe
+            viofs_exe_copy_cmd = xcopy %s C:\
+            viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
             viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
             viofs_sc_start_cmd = 'sc start VirtioFsSvc'
             viofs_sc_query_cmd = 'sc query VirtioFsSvc'

--- a/qemu/tests/virtio_fs_hotplug.py
+++ b/qemu/tests/virtio_fs_hotplug.py
@@ -114,11 +114,13 @@ def run(test, params, env):
         if "not exist as an installed service" in output:
             test.log.info("Register virtiofs service in windows guest.")
             exe_path = get_viofs_exe(session)
-            viofs_service_cmd = viofs_sc_create_cmd % exe_path
-            sc_create_s, sc_create_o = session.cmd_status_output(viofs_service_cmd)
+            # copy virtiofs.exe to c: in case the virtio-win cdrom volume name
+            # is changed in other cases of a loop.
+            session.cmd(params.get("viofs_exe_copy_cmd") % exe_path)
+            sc_create_s, sc_create_o = session.cmd_status_output(viofs_sc_create_cmd)
             if sc_create_s != 0:
                 test.fail("Failed to register virtiofs service, output is %s" % sc_create_o)
-                test.log.info("Check if virtiofs service is started.")
+        test.log.info("Check if virtiofs service is started.")
         status, output = session.cmd_status_output(viofs_sc_query_cmd)
         if "RUNNING" not in output:
             test.log.info("Start virtiofs service.")

--- a/qemu/tests/virtio_fs_multi_vms.py
+++ b/qemu/tests/virtio_fs_multi_vms.py
@@ -113,7 +113,9 @@ def run(test, params, env):
             if "not exist as an installed service" in output:
                 test.log.info("Register virtiofs service in windows guest.")
                 exe_path = get_viofs_exe(session)
-                viofs_sc_create_cmd = viofs_sc_create_cmd % exe_path
+                # copy virtiofs.exe to c: in case the virtio-win cdrom volume name
+                # is changed in other cases of a loop.
+                session.cmd(params.get("viofs_exe_copy_cmd") % exe_path)
                 sc_create_s, sc_create_o = session.cmd_status_output(viofs_sc_create_cmd)
                 if sc_create_s != 0:
                     test.fail("Failed to register virtiofs service, output is %s" % sc_create_o)

--- a/qemu/tests/virtio_fs_set_capability.py
+++ b/qemu/tests/virtio_fs_set_capability.py
@@ -175,7 +175,9 @@ def run(test, params, env):
         if "not exist as an installed service" in output:
             test.log.info("Register virtiofs service in windows guest.")
             exe_path = get_viofs_exe(session)
-            viofs_sc_create_cmd = viofs_sc_create_cmd % exe_path
+            # copy virtiofs.exe to c: in case the virtio-win cdrom volume name
+            # is changed in other cases of a loop.
+            session.cmd(params.get("viofs_exe_copy_cmd") % exe_path)
             sc_create_s, sc_create_o = session.cmd_status_output(viofs_sc_create_cmd)
             if sc_create_s != 0:
                 test.fail("Failed to register virtiofs service, output is %s" % sc_create_o)

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -109,7 +109,10 @@ def run(test, params, env):
         """
         test.log.info("Register virtiofs service in Windows guest.")
         exe_path = get_viofs_exe(session)
-        sc_create_s, sc_create_o = session.cmd_status_output(cmd % exe_path)
+        # copy virtiofs.exe to c: in case the virtio-win cdrom volume name
+        # is changed in other cases of a loop.
+        session.cmd(params.get("viofs_exe_copy_cmd") % exe_path)
+        sc_create_s, sc_create_o = session.cmd_status_output(cmd)
         if sc_create_s != 0:
             test.fail("Failed to register virtiofs service, output is %s" % sc_create_o)
 


### PR DESCRIPTION
Copy virtiofs.exe from virtio-win cdrom to c: in case
the virtio-win cdrom volume name is changed in a test loop.
ID: 2079196
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>