### PR TITLE
Add label for stage disk, delete the bootindex on s390x

### DIFF
--- a/generic/tests/cfg/nfs_corrupt.cfg
+++ b/generic/tests/cfg/nfs_corrupt.cfg
@@ -16,9 +16,8 @@
     post_command_noncritical = yes
     wait_paused_timeout = 240
     nfs_stat_chk_re = "running"
-    s390x:
-        bootindex_image1 = 0
-        bootindex_stg = 1
+    nfs_serial = TARGET_DISK
+    blk_extra_params_stg += ",serial=${nfs_serial}"
     variants:
         - with_qcow2_format:
             image_format_stg = "qcow2"

--- a/generic/tests/nfs_corrupt.py
+++ b/generic/tests/nfs_corrupt.py
@@ -215,7 +215,8 @@ def run(test, params, env):
         test.error("failed to create VM")
     session = vm.wait_for_login(timeout=int(params.get("login_timeout", 360)))
 
-    nfs_devname = get_nfs_devname(params, session)
+    nfs_devname = utils_misc.get_linux_drive_path(session, stg_params[
+        "nfs_serial"])
     # Write disk on NFS server
     error_context.context("Write disk that image on NFS", test.log.info)
     write_disk_cmd = "dd if=/dev/zero of=%s oflag=direct" % nfs_devname


### PR DESCRIPTION
Virtual_blk: add label for stage disk to make sure right drive was tested while
dd testing

ID: 2119690

Signed-off-by: Boqiao Fu <bfu@redhat.com>