### PR TITLE
check_block_size: Remove '4096_4096_cluster_install' on i386 of seabios

### DIFF
--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -28,7 +28,7 @@
             unattended_delivery_method = cdrom
             default_bios:
                 no 4096_4096
-                x86_64:
+                x86_64, i386:
                     no 4096_4096_cluster_install
             Windows:
                 i440fx:


### PR DESCRIPTION
Remove '4096_4096_cluster_install' on i386 platform of seabios.
As Seabios only supports logical_block_size = 512. It is a
regression issue introduced by another patch.

ID: 2119702
Signed-off-by: Menghuan Li menli@redhat.com