### PR TITLE
virtio_fs: add inode-file-handles for virtiofsd

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -123,6 +123,11 @@
             mem = 8192
             size_mem1 = 8G
             fs_binary_extra_options += " -o writeback"
+        - sandbox:
+            variants:
+                - chroot:
+                    only inode_file_handles
+                    fs_binary_extra_options += " --sandbox=chroot"
     variants:
         - with_cache:
             variants:
@@ -149,6 +154,14 @@
                     cmd_create_fs_source = 'mkdir -p /tmp/virtio_fs1_test'
                     cmd_run_virtiofsd = '/usr/libexec/virtiofsd --socket-path=%s'
                     result_pattern = "unable to find group"
+        - inode_file_handles:
+            no extra_parameters
+            no Host_RHEL.m8
+            variants:
+                - prefer:
+                    fs_binary_extra_options += " --inode-file-handles=prefer"
+                - mandatory:
+                    fs_binary_extra_options += " --inode-file-handles=mandatory"
     variants:
         - @default:
             cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'
@@ -176,7 +189,7 @@
             variants:
                 - @default:
                 - with_multi_fs_sources:
-                    no socket_group
+                    only with_cache
                     no Windows
                     with_multi_fs_sources.with_cache.none:
                         io_timeout = 600
@@ -205,7 +218,8 @@
                         cmd_symblic_file = 'mklink ${test_file}_link ${test_file}'
                         cmd_symblic_folder = 'mklink /d ${test_folder}_link ${test_folder}'
         - run_stress:
-            no run_stress..extra_parameters,socket_group
+            only with_cache
+            no extra_parameters
             variants:
                 - with_fio:
                     smp = 8

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -77,6 +77,7 @@
                     nfs_mount_src_fs1 = 127.0.0.1:/mnt/virtio_fs1_test_nfs
                     nfs_mount_src_fs2 = 127.0.0.1:/mnt/virtio_fs2_test_nfs
         - with_ext_fs:
+            no inode_file_handles
             setup_filesystem_on_host = yes
             dd_of_on_host = '/home/extdisk_virtiofs_test'
             cmd_losetup_query_on_host = 'losetup -f'
@@ -89,7 +90,6 @@
                     fs_on_host = ext3
                 - with_ext4:
                     fs_on_host = ext4
-
     variants:
         - @default:
         - with_stdev_check:
@@ -126,6 +126,11 @@
             mem = 8192
             size_mem1 = 8G
             fs_binary_extra_options += " -o writeback"
+        - sandbox:
+            variants:
+                - chroot:
+                    only inode_file_handles
+                    fs_binary_extra_options += " --sandbox=chroot"
     variants:
         - with_cache:
             variants:
@@ -135,6 +140,14 @@
                     fs_binary_extra_options += " -o cache=always"
                 - none:
                     fs_binary_extra_options += " -o cache=none"
+        - inode_file_handles:
+            no extra_parameters,with_writeback
+            no Host_RHEL.m8
+            variants:
+                - prefer:
+                    fs_binary_extra_options += " --inode-file-handles=prefer"
+                - mandatory:
+                    fs_binary_extra_options += " --inode-file-handles=mandatory"
     variants:
         - @default:
             cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'
@@ -167,7 +180,7 @@
         - run_stress:
             variants:
                 - with_xfstest:
-                    only with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs
+                    only with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs,inode_file_handles.prefer.sandbox
                     no s390 s390x
                     no Windows
                     image_snapshot = yes


### PR DESCRIPTION
Add inode-file-handles parameters test for general file
system and nfs file system. Also compatible testing with
sandbox.
ID: 2090128
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>