### PR TITLE
remove s390x with rdma and add wait time before check vm status

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -61,10 +61,10 @@
                 - @tcp:
                     migration_protocol = tcp
                 - x_rdma:
-                    no ppc64, ppc64le
+                    no ppc64, ppc64le, s390x
                     migration_protocol = x-rdma
                 - rdma:
-                    no ppc64, ppc64le
+                    no ppc64, ppc64le, s390x
                     migration_protocol = rdma
         - hotplug_unplug_watchdog_device:
              only i6300esb

--- a/qemu/tests/watchdog.py
+++ b/qemu/tests/watchdog.py
@@ -145,7 +145,7 @@ def run(test, params, env):
 
             if not utils_misc.wait_for(
                 lambda: vm.monitor.verify_status(f_param),
-                    response_timeout, 0, 1):
+                    response_timeout, 5, 1):
                 test.log.debug("Monitor status is:%s", vm.monitor.get_status())
                 txt = "It seems action '%s' took no effect" % watchdog_action
                 txt += " , Wrong monitor status!"


### PR DESCRIPTION
watchdog: remove s390x with rdma since it's not supported right now; and
according to the performance issue on z13, add 5 sec before checking the
VM status.

ID: 2121647

Signed-off-by: Boqiao Fu <bfu@redhat.com>