### PR TITLE
rng_maxbytes_period: guest report driver is s390-trng , expect is 'virtio_rng'

### DIFF
--- a/qemu/tests/cfg/rng_maxbytes_period.cfg
+++ b/qemu/tests/cfg/rng_maxbytes_period.cfg
@@ -11,6 +11,9 @@
     RHEL.6:
         check_rngd_service = "service rngd status"
         start_rngd_service = "service rngd start"
+    s390x:
+        RHEL.9:
+            update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:
         - positive_test:
             no rng_egd

--- a/qemu/tests/rng_maxbytes_period.py
+++ b/qemu/tests/rng_maxbytes_period.py
@@ -29,6 +29,7 @@ def run(test, params, env):
 
     timeout = params.get_numeric("login_timeout", 360)
     read_rng_timeout = float(params.get("read_rng_timeout", 3600))
+    cmd_timeout = float(params.get("session_cmd_timeout", "360"))
     read_rng_cmd = params["read_rng_cmd"]
     max_bytes = params.get("max-bytes_virtio-rng-pci")
     period = params.get("period_virtio-rng-pci")
@@ -54,6 +55,9 @@ def run(test, params, env):
 
     error_context.context("Read virtio-rng device to get random number",
                           test.log.info)
+    update_driver = params.get("update_driver")
+    if update_driver:
+        session.cmd(update_driver, timeout=cmd_timeout)
     check_rngd_service = params.get("check_rngd_service")
     if check_rngd_service:
         if not utils_misc.wait_for(_is_rngd_running, 30, first=5):


### PR DESCRIPTION
Updates for 'rng_maxbytes_period' case on s390x platform - fixed 'expect driver error' in cases.
Also, this patch fixed next 2 errors in this case:

1) "Read data rate is not as expected. data rate: 79.2 kB/s, max-bytes: 512, period: 1000",
2) "Unexpected dd result, status: 0, output: 1+0 records in"
ID: 2111454

Signed-off-by: Bogdan Marcynkov <bmarcynk@redhat.com>