### PR TITLE
x86_cpu_model: disable some unsupported models

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -123,6 +123,7 @@
         - others:
             variants:
                 - test_default_model:
+                    no RHEL.9
                     auto_cpu_model = no
                     # will use the default variable 'default_cpu_model' in avocado-vt
                     flags = ""

--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -81,6 +81,7 @@
             model_pattern = "AMD Opteron 62xx class CPU%s"
         - Opteron_G3:
             only HostCpuVendor.amd
+            no RHEL.9
             flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de  popcnt cx16 lm nx syscall misalignsse sse4a abm lahf_lm fpu"
             model_pattern = "AMD Opteron 23xx \(Gen 3 Class Opteron%s\)"
         - Snowridge:
@@ -202,6 +203,7 @@
                 flags = ""
         - Icelake-Client:
             only HostCpuVendor.intel
+            no RHEL.9
             required_qemu = (, 5.2.0)
             flags = "wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512_bitalg avx512_vpopcntdq"
             model_pattern = "Intel Core Processor \(Icelake%s\)"
@@ -209,6 +211,7 @@
                 flags = ""
         - Icelake-Client-noTSX:
             only HostCpuVendor.intel
+            no RHEL.9
             required_qemu = (, 5.2.0)
             flags = "wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512_bitalg avx512_vpopcntdq"
             model_pattern = "Intel Core Processor \(Icelake%s\)"


### PR DESCRIPTION
ID: 2084388

Disable deprecated many named CPU models which may
have some problems while booting a RHEL9 guest.

Signed-off-by: nanliu <nanliu@redhat.com>