### PR TITLE
virtio_fs_share_data.py: ignore some errors which do NOT belong to pjdfstest

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -247,6 +247,10 @@
                     with_pjdfstest..with_cache.none:
                         io_timeout = 7200
                     pjdfstest_pkg = pjdfstest-0.1.tar.bz2
+                    pjdfstest_blacklist  = "pjdfstest/tests/rename/21.t"
+                    pjdfstest_blacklist += " pjdfstest/tests/symlink/03.t"
+                    RHEL.8:
+                        pjdfstest_blacklist += " pjdfstest/tests/utimensat/09.t"
                     cmd_unpack = 'tar -zxvf {0}/${pjdfstest_pkg} -C {0}'
                     cmd_yum_deps = 'yum install -y perl-Test-Harness'
                     cmd_autoreconf = 'autoreconf -ifs %s/pjdfstest/'


### PR DESCRIPTION
virtio_fs_share_data.py: ignore some errors which do NOT belong to pjdfstest

ID: 2076950

Signed-off-by: Houqi (Nick) Zuo hzuo@redhat.com