### PR TITLE
virtio_fs: logic change of checking dir created by winapi

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -89,7 +89,9 @@
             only default.default.with_cache.auto.default
             no Host_RHEL.m8
             fs_binary_extra_options += " --log-level debug"
-            create_dir_winapi_cmd = python2.7 -c "import ctypes; dll=ctypes.windll.kernel32;dll.CreateDirectoryA('%s:\\test_winapi', 0)"
+            winapi_dir_name = test_winapi
+            create_dir_winapi_cmd = python2.7 -c "import ctypes; dll=ctypes.windll.kernel32;dll.CreateDirectoryA('%s\\${winapi_dir_name}', 0)"
+            check_winapi_dir_cmd = "dir %s\${winapi_dir_name}"
         - viofs_service_stop_start:
             only Windows
             only default.default.with_cache.auto.default

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -188,6 +188,7 @@ def run(test, params, env):
 
     # create dir by winapi config
     create_dir_winapi_cmd = params.get("create_dir_winapi_cmd")
+    check_winapi_dir_cmd = params.get("check_winapi_dir_cmd")
 
     # nfs config
     setup_local_nfs = params.get('setup_local_nfs')
@@ -526,9 +527,13 @@ def run(test, params, env):
                 if create_dir_winapi_cmd:
                     error_context.context("Create new directory with WinAPI's "
                                           "CreateDirectory.", test.log.info)
-                    s, o = session.cmd_status_output(create_dir_winapi_cmd)
-                    if s:
-                        test.fail("Create dir failed, output is %s", o)
+                    session.cmd(create_dir_winapi_cmd % fs_dest)
+
+                    ret = utils_misc.wait_for(lambda: not bool(session.cmd_status(
+                        check_winapi_dir_cmd % fs_dest)), timeout=60)
+                    if not ret:
+                        test.fail("Create dir failed in 60s, output is %s" %
+                                  session.cmd_output(check_winapi_dir_cmd % fs_dest))
 
                     error_context.context("Get virtiofsd log file.", test.log.info)
                     vfsd_dev = vm.devices.get_by_params({"source": fs_source})[0]


### PR DESCRIPTION
The cmd to create dir by winpi has no exit code, so it's better
to use another cmd to check if the dir was created successfully.
ID: 2112799
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>