### PR TITLE
nested_block_resize: cancel test if `ansible-playbook` is not available

### DIFF
--- a/qemu/tests/nested_block_resize.py
+++ b/qemu/tests/nested_block_resize.py
@@ -28,6 +28,10 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
 
+    # Check if ansible-playbook program is available
+    if not ansible.check_ansible_playbook(params):
+        test.cancel("No available ansible-playbook program")
+
     def _on_exit(obj, msg):
         test.log.info("Receive exit msg:%s", msg)
         obj.set_msg_loop(False)


### PR DESCRIPTION
Change aligns test logic with `ansible_test` using the same approach.

ID: 2124295

Signed-off-by: Lukas Kotek <lkotek@redhat.com>