### PR TITLE
blockdev_full_backup_multi_disks:correct blk_extra_param setting

### DIFF
--- a/qemu/tests/cfg/blockdev_full_backup_multi_disks.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup_multi_disks.cfg
@@ -29,8 +29,6 @@
     rebase_mode = unsafe
     blk_extra_params_src1 = "serial=DATA_DISK1"
     blk_extra_params_src2 = "serial=DATA_DISK2"
-    blk_extra_params_dst1 = ${blk_extra_params_src1}
-    blk_extra_params_dst2 = ${blk_extra_params_src2}
     variants:
         - with_data_plane:
            only Host_RHEL
@@ -39,8 +37,8 @@
            iothreads = "iothread0 iothread1 iothread2"
            virtio_blk:
                blk_extra_params_image1 = "iothread=iothread0"
-               blk_extra_params_src1 = "iothread=iothread1"
-               blk_extra_params_src2 = "iothread=iothread2"
+               blk_extra_params_src1 += ",iothread=iothread1"
+               blk_extra_params_src2 += ",iothread=iothread2"
            virtio_scsi:
                no Host_RHEL.m7.u0, Host_RHEL.m7.u1, Host_RHEL.m7.u2
                bus_extra_params_image1 = "iothread=iothread0"
@@ -74,3 +72,5 @@
         remove_image_src2 = no
     image_size_dst1 = ${image_size_src1}
     image_size_dst2 = ${image_size_src2}
+    blk_extra_params_dst1 = ${blk_extra_params_src1}
+    blk_extra_params_dst2 = ${blk_extra_params_src2}


### PR DESCRIPTION
Correct blk_extra_params setting for virtio_blk

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2124464