### PR TITLE
update the default resolution for rhel9.1 and higher version

### DIFF
--- a/qemu/tests/cfg/uefi_check_resolution.cfg
+++ b/qemu/tests/cfg/uefi_check_resolution.cfg
@@ -8,6 +8,8 @@
     boot_menu_hint = "Boot Options"
     enter_change_preferred = "esc;down;kp_enter;down;down;down;down;kp_enter"
     default_resolution_key = "f9;y"
+    ! Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0:
+        default_resolution = "1280 x 800"
     variants:
         - save_with_f10:
             esc_boot_menu_key = "esc;esc;down;down;down;kp_enter"

--- a/qemu/tests/uefi_check_resolution.py
+++ b/qemu/tests/uefi_check_resolution.py
@@ -57,6 +57,12 @@ def run(test, params, env):
     default_resolution_key = params["default_resolution_key"].split(";")
     save_change_key = params["save_change"].split(";")
     esc_boot_menu_key = params["esc_boot_menu_key"].split(";")
+    default_resolution = params.get("default_resolution")
+    if default_resolution:
+        index = change_prefered.index(default_resolution)
+        if index != 0:
+            del change_prefered[index]
+            change_prefered = [default_resolution] + change_prefered
     change_resolution_key, check_info, resolution = choose_resolution()
     if not utils_misc.wait_for(lambda: boot_check(boot_menu_hint),
                                timeout, 1):


### PR DESCRIPTION
1. the default value before rhel9.1: 640 x 480
2. the default value from rhel9.1: 1280 x 800

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2125105