### PR TITLE
x86_cpu_protection_key: update microarchitecture level

### DIFF
--- a/qemu/tests/cfg/x86_cpu_protection_key.cfg
+++ b/qemu/tests/cfg/x86_cpu_protection_key.cfg
@@ -5,13 +5,17 @@
     only HostCpuVendor.amd
     no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1 RHEL.8.2 RHEL.8.3 RHEL.8.4 RHEL.8.5 RHEL.8.6
     required_qemu = [6.2, )
+    RHEL.8:
+        x86-64-march = x86-64
+    RHEL.9:
+        x86-64-march = x86-64-v3
     start_vm = no
     timeout = 120
-    unsupported_models = [EPYC-Rome, EPYC, Opteron_G5, Opteron_G4, Opteron_G3, Opteron_G2, Opteron_G1]
+    unsupported_models = "EPYC-Rome EPYC Opteron_G5 Opteron_G4 Opteron_G3 Opteron_G2 Opteron_G1"
     guest_dir = '/home/tpm-test/'
     test_dir = '/tools/testing/selftests/vm/'
     download_rpm_cmd = brew download-build --rpm %s
     uncompress_cmd_src = rpm2cpio *.src.rpm |cpio -iv
     uncompress_cmd = tar -xvJf *.tar.xz
-    compile_cmd = gcc -o protection_keys -O2 -g -std=gnu99 -pthread -Wall protection_keys.c -lrt -ldl -lm -march=x86-64-v3
+    compile_cmd = gcc -o protection_keys -O2 -g -std=gnu99 -pthread -Wall protection_keys.c -lrt -ldl -lm -march=${x86-64-march}
     run_cmd =  ./protection_keys


### PR DESCRIPTION
ID: 2126254

RHEL8 and RHEL9 have different microarchitecture supports, need to use them separately.

Signed-off-by: nanliu <nanliu@redhat.com>