### PR TITLE
virtio_mem_numa_basic: new auto case for basic numa test with two virtio-mem devices.

### DIFF
--- a/provider/virtio_mem_utils.py
+++ b/provider/virtio_mem_utils.py
@@ -1,0 +1,99 @@
+"""
+virtio_mem useful functions.
+
+This module is meant to reduce code size on virtio_mem cases avoiding
+repeat functions implementation.
+"""
+from virttest import error_context
+from virttest.utils_misc import normalize_data_size
+
+
+def get_node_plugged_size(node, vm, test):
+    """"
+    get numa node plugged size from HMP info command
+    :param node: numa node number
+    :param vm: vm object
+    :param test: qemu test object
+    """
+    output = vm.monitor.info("numa").splitlines()
+    for numa_info in output:
+        if "node " + str(node) + " plugged: " in numa_info:
+            node_plugged = numa_info.split("node " + str(node) + " plugged: ").pop().split(" ")[0]
+            if node_plugged is None:
+                test.fail("Error, unexpected numa node plugged info at node %d" % node)
+            error_context.context("node %d plugged: %s" % (node, node_plugged), test.log.debug)
+    return int(node_plugged)
+
+
+def get_node_size(node, vm, test):
+    """"
+    get numa node size from HMP info command
+    :param node: numa node number
+    :param vm: vm object
+    :param test: qemu test object
+    """
+    output = vm.monitor.info("numa").splitlines()
+    for numa_info in output:
+        if "node " + str(node) + " size: " in numa_info:
+            node_size = numa_info.split("node " + str(node) + " size: ").pop().split(" ")[0]
+            if node_size is None:
+                test.fail("Error, unexpected numa node size info at node %d" % node)
+            error_context.context("node %d size: %s" % (node, node_size), test.log.debug)
+    return int(node_size)
+
+
+def check_numa_plugged_mem(node_id, requested_size, threshold, vm, test):
+    """"
+    Compares numa node plugged memory with the memory requested size from virtio_mem device
+    allowing a little difference defined by mem_limit
+    :param node_id: id of the node to be checked
+    :param requested_size: requested-size configuration parameter
+    :param threshold: memory threshold
+    :param vm: vm object
+    :param test: qemu test object
+    """
+    node_plugged_memory = get_node_plugged_size(node_id, vm, test)
+    node_size = get_node_size(node_id, vm, test)
+    mem_limit = (node_size - node_plugged_memory) * threshold
+    requested_size = int(float(normalize_data_size(requested_size, 'M')))
+    error_context.context("requested_size: %d, node_plugged_memory: %d"
+                          % (requested_size, node_plugged_memory), test.log.debug)
+    if node_plugged_memory != requested_size and float(node_plugged_memory) > mem_limit:
+        test.fail("Error, requested-size: %d does not match with plugged memory: %d."
+                  % (requested_size, node_plugged_memory))
+
+
+def check_memory_devices(device_id, cfg_req_size_param, threshold, vm, test):
+    """"
+    Compares virtio_mem device memory size with the memory requested size
+    allowing a little difference defined by mem_limit
+    :param device_id: id of the device to be checked
+    :param cfg_req_size_param: requested-size configuration parameter
+    :param threshold: memory threshold
+    :param vm: vm object
+    :param test: qemu test object
+    """
+    output = vm.monitor.info("memory-devices")
+    for dev_info in output:
+        data = dev_info.get("data")
+        id = data.get("id")
+        if device_id == id:
+            size = int(data.get("size"))
+            node = int(data.get("node"))
+            requested_size = int(data.get("requested-size"))
+            error_context.context("node: %d, id: %s, size: %d and requested-size: %d"
+                                  % (node, id, size, requested_size), test.log.debug)
+            node_size = float(get_node_size(node, vm, test))
+            normalized_size = float(normalize_data_size(str(size), 'M'))
+            mem_limit = (node_size - normalized_size) * threshold
+            if size != requested_size and normalized_size > mem_limit:
+                test.fail("Error, size: %d and requested-size: %d are not equals."
+                          % (size, requested_size))
+            if cfg_req_size_param != "0":
+                req_size_param = int(float(normalize_data_size(cfg_req_size_param, 'B')))
+            else:
+                req_size_param = int(cfg_req_size_param)
+            error_context.context("req_size_param: %d" % req_size_param, test.log.debug)
+            if requested_size != req_size_param:
+                test.fail("Error, requested-size: %d is not the specified in the cfg: %d."
+                          % (requested_size, req_size_param))

--- a/qemu/tests/cfg/virtio_mem_numa_basic.cfg
+++ b/qemu/tests/cfg/virtio_mem_numa_basic.cfg
@@ -1,0 +1,40 @@
+- virtio_mem_numa_basic:
+    only Linux
+    only Host_RHEL.m9
+    only RHEL.9
+    no s390x
+    type = virtio_mem_numa_basic
+    virt_test_type = qemu
+    login_timeout = 240
+    threshold = 0.025
+    smp = 8
+    vcpu_maxcpus = ${smp}
+    slots_mem = 20
+    maxmem_mem = 80G
+    mem = 4096
+    mem_devs = 'mem0 mem1 vmem0 vmem1'
+    vm_memdev_model_vmem0 = "virtio-mem"
+    vm_memdev_model_vmem1 = "virtio-mem"
+    guest_numa_nodes = 'node0 node1'
+    numa_memdev_node0 = mem-mem0
+    numa_memdev_node1 = mem-mem1
+    numa_cpus_node0 = "0-3"
+    numa_cpus_node1 = "4-7"
+    size_mem_mem0 = 2G
+    use_mem_mem0 = no
+    size_mem_mem1 = 2G
+    use_mem_mem1 = no
+    size_mem_vmem0 = 8G
+    use_mem_vmem0 = yes
+    size_mem_vmem1 = 8G
+    use_mem_vmem1 = yes
+    requested-size_memory_vmem0 = 1G
+    requested-size_memory_vmem1 = 2G
+    node_memory_vmem0 = "0"
+    node_memory_vmem1 = "1"
+    memdev_memory_vmem0 = "mem-vmem0"
+    memdev_memory_vmem1 = "mem-vmem1"
+    kernel_extra_params_add = "memhp_default_state=online_movable"
+    pcie_extra_root_port = 0
+    requested-size_test_vmem0 = "4G 8G 0"
+    requested-size_test_vmem1 = "1G 8G 0"

--- a/qemu/tests/virtio_mem_numa_basic.py
+++ b/qemu/tests/virtio_mem_numa_basic.py
@@ -1,0 +1,48 @@
+import time
+
+from virttest import error_context
+
+from virttest.utils_misc import normalize_data_size
+from provider import virtio_mem_utils
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Memory share and discard-data hotplug test
+    1) Boot guest with two virtio-mem devices
+    2) Check virtio-mem devices
+    3) Resize virtio-mem devices
+    4) Check virtio-mem devices
+    5) Resize virtio-mem devices to the maximum
+    6) Check virtio-mem devices
+    7) Resize virtio-mem devices to the minimum
+    8) Check virtio-mem devices
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    timeout = int(params.get("login_timeout", 240))
+    threshold = params.get_numeric("threshold", target_type=float)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=timeout)
+    virtio_mem_model = 'virtio-mem-pci'
+    if '-mmio:' in params.get("machine_type"):
+        virtio_mem_model = 'virtio-mem-device'
+    for i, vmem_dev in enumerate(vm.devices.get_by_params({'driver': virtio_mem_model})):
+        device_id = vmem_dev.get_qid()
+        requested_size_vmem = params.get("requested-size_test_vmem%d" % i)
+        node_id = int(vmem_dev.params.get("node"))
+        for requested_size in requested_size_vmem.split():
+            req_size_normalized = int(float(normalize_data_size(requested_size, 'B')))
+            vm.monitor.qom_set(device_id, "requested-size", req_size_normalized)
+            time.sleep(30)
+            virtio_mem_utils.check_memory_devices(device_id, requested_size, threshold, vm, test)
+            virtio_mem_utils.check_numa_plugged_mem(node_id, requested_size, threshold, vm, test)
+
+    session.close()
+    error_context.context("Shutdown guest...", test.log.debug)
+    vm.destroy()


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3510

virtio_mem_numa_basic: new auto case for basic numa test with two virtio-mem devices.

Creates a new case that boots up a guest with two numa nodes and two virtio-mem devices, it resizes several times the virtio-mem devices and checks its sizes.

ID: 2121669
Signed-off-by: mcasquer <mcasquer@redhat.com>