### PR TITLE
Update 'crashkernel=' in kdump.cfg for RHEL9

### DIFF
--- a/generic/tests/cfg/kdump.cfg
+++ b/generic/tests/cfg/kdump.cfg
@@ -16,6 +16,20 @@
     # crash_cmd = "echo c > /proc/sysrq-trigger"
     # If you want configure multiline, split lines with ";", like:
     # kdump_config = configure line1; config line2
+    # "crashkernel=" pattern changed after RHEL.9
+    # Setting the crashkernel default parameters based on different arches
+    # Pls modify the params if needed
+    x86_64:
+        crashkernel_default_params = 1G-4G:192M,4G-64G:256M,64G-:512M
+    aarch64:
+        crashkernel_default_params = 1G-4G:256M,4G-64G:320M,64G-:576M
+    ppc64le, ppc64:
+        crashkernel_default_params = 2G-4G:384M,4G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G
+    s390x:
+        crashkernel_default_params = 1G-4G:192M,4G-64G:256M,64G-:512M
+    kdump_enable_cmd = "systemctl enable --now kdump.service"
+    kdump_restart_cmd = "systemctl restart kdump.service"
+    kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args=crashkernel=${crashkernel_default_params}"
     RHEL.5:
         kdump_config = core_collector makedumpfile -c -d 31
     RHEL.6:
@@ -29,11 +43,14 @@
         kdump_propagate_cmd = "kdumpctl propagate"
         kdump_restart_cmd = "systemctl restart kdump.service"
     RHEL.8:
+        x86_64:
+            kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args=crashkernel=auto"
+            kdump_enable_cmd = "systemctl enable --now kdump.service"
+            kdump_restart_cmd = "systemctl restart kdump.service"
         ppc64le, ppc64:
             kernel_param_cmd = "grubby --update-kernel=`grubby --default-kernel` --args=crashkernel=512M@64M"
+            kdump_enable_cmd = "systemctl enable --now kdump.service"
             kdump_restart_cmd = "systemctl restart kdump.service"
-    RHEL.9:
-        kdump_enable_cmd = "systemctl restart kdump.service"
 
     variants:
         - @default:

--- a/generic/tests/kdump.py
+++ b/generic/tests/kdump.py
@@ -265,9 +265,7 @@ def run(test, params, env):
 
     timeout = float(params.get("login_timeout", 240))
     crash_timeout = float(params.get("crash_timeout", 360))
-    def_kernel_param_cmd = ("grubby --update-kernel=`grubby --default-kernel`"
-                            " --args=crashkernel=128M")
-    kernel_param_cmd = params.get("kernel_param_cmd", def_kernel_param_cmd)
+    kernel_param_cmd = params.get("kernel_param_cmd")
     def_kdump_enable_cmd = "chkconfig kdump on && service kdump restart"
     kdump_enable_cmd = params.get("kdump_enable_cmd", def_kdump_enable_cmd)
     def_crash_kernel_prob_cmd = "grep -q 1 /sys/kernel/kexec_crash_loaded"

--- a/qemu/tests/kdump_with_stress.py
+++ b/qemu/tests/kdump_with_stress.py
@@ -79,9 +79,7 @@ def run(test, params, env):
 
     timeout = float(params.get("login_timeout", 240))
     crash_timeout = float(params.get("crash_timeout", 360))
-    def_kernel_param_cmd = ("grubby --update-kernel=`grubby --default-kernel`"
-                            " --args=crashkernel=128M@16M")
-    kernel_param_cmd = params.get("kernel_param_cmd", def_kernel_param_cmd)
+    kernel_param_cmd = params.get("kernel_param_cmd")
     def_kdump_enable_cmd = "chkconfig kdump on && service kdump restart"
     kdump_enable_cmd = params.get("kdump_enable_cmd", def_kdump_enable_cmd)
     def_crash_kernel_prob_cmd = "grep -q 1 /sys/kernel/kexec_crash_loaded"


### PR DESCRIPTION
1. Setting crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M for RHEL9 or later releases
2. Setting crashkernel=256M for RHEL8 (x86_64)

ID: 2127790
Signed-off-by: Ke MA <mama@redhat.com>