### PR TITLE
uefi_secureboot: update sign_keyword for rhel9 and higher version

### DIFF
--- a/qemu/tests/cfg/uefi_secureboot.cfg
+++ b/qemu/tests/cfg/uefi_secureboot.cfg
@@ -26,7 +26,7 @@
     medium = cdrom
     redirs += ' unattended_install'
     RHEL:
-        sign_keyword = ' Red Hat Secure Boot \(signing key 1\)'
+        sign_keyword = ' Red Hat Secure Boot (\(signing key 1\)|Signing 501)'
         pesign_install_cmd = 'yum install -y pesign'
     Windows:
         no WinXP Win2000 Win2003 WinVista


### PR DESCRIPTION
The signer's common name is Red Hat Secure Boot Signing 501 from rhel9, so update the pattern in the config file.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2129120