### PR TITLE
cpu_info_check:remove checking deprecated cpu models

### DIFF
--- a/qemu/tests/cfg/cpu_info_check.cfg
+++ b/qemu/tests/cfg/cpu_info_check.cfg
@@ -13,3 +13,4 @@
         remove_list = ${cpu_model_8_3}
     Host_RHEL.m7, Host_RHEL.m6:
         remove_list = ${cpu_model_8}
+    remove_list_deprecated = 'Icelake-Client Icelake-Client-noTSX'

--- a/qemu/tests/cpu_info_check.py
+++ b/qemu/tests/cpu_info_check.py
@@ -54,6 +54,9 @@ def run(test, params, env):
     match = re.search(r'[0-9]+\.[0-9]+\.[0-9]+(\-[0-9]+)?',
                       qemu_version)
     host_qemu = match.group(0)
+    remove_list_deprecated = params.get('remove_list_deprecated', '')
+    if host_qemu in VersionInterval('[7.0.0-8, )') and remove_list_deprecated:
+        params['remove_list'] = remove_list_deprecated
     remove_models(params.objects('remove_list'))
     if host_qemu in VersionInterval('[,4.2.0)'):
         remove_models(params.objects('cpu_model_8'))


### PR DESCRIPTION
ID: 2130748

These deprecated cpu models aren't supported since qemu 7.0.

Signed-off-by: nanliu <nanliu@redhat.com>