### PR TITLE
migrate:Delete the check of ksmtuned for migration scenarios

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -11,8 +11,7 @@
     mig_timeout = 3600
     ping_pong = 1
     pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
-    !Host_RHEL.m6,Host_RHEL.m7,Host_RHEL.m8:
-        depends_pkgs = "ksmtuned"
+    cmds_installed_host = "ksmtuned"
     # you can uncomment the following line to enable the state
     # check
     # vmstate_check = yes

--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -11,7 +11,6 @@
     mig_timeout = 3600
     ping_pong = 1
     pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
-    cmds_installed_host = "ksmtuned"
     # you can uncomment the following line to enable the state
     # check
     # vmstate_check = yes

--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -165,10 +165,6 @@ def run(test, params, env):
     check = params.get("vmstate_check", "no") == "yes"
     living_guest_os = params.get("migration_living_guest", "yes") == "yes"
     deamon_thread = None
-    depends_pkgs = params.objects("depends_pkgs")
-    test.log.info("Install packages: %s in host", depends_pkgs)
-    if not utils_package.package_install(depends_pkgs):
-        test.cancel("Install dependency packages failed")
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()

--- a/qemu/tests/migration_with_file_transfer.py
+++ b/qemu/tests/migration_with_file_transfer.py
@@ -5,7 +5,6 @@ from avocado.utils import process
 
 from virttest import error_context
 from virttest import utils_misc
-from virttest import utils_package
 
 
 @error_context.context_aware
@@ -24,10 +23,6 @@ def run(test, params, env):
     :param params: Dictionary with test parameters.
     :param env: Dictionary with the test environment.
     """
-    depends_pkgs = params.objects("depends_pkgs")
-    test.log.info("Install packages: %s in host", depends_pkgs)
-    if not utils_package.package_install(depends_pkgs):
-        test.cancel("Install dependency packages failed")
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     login_timeout = int(params.get("login_timeout", 360))

--- a/qemu/tests/migration_with_netperf.py
+++ b/qemu/tests/migration_with_netperf.py
@@ -4,7 +4,6 @@ from virttest import error_context
 from virttest import utils_netperf
 from virttest import data_dir
 from virttest import utils_net
-from virttest import utils_package
 
 
 @error_context.context_aware
@@ -27,10 +26,6 @@ def run(test, params, env):
     mig_cancel_delay = int(params.get("mig_cancel") == "yes") * 2
     netperf_timeout = int(params.get("netperf_timeout", "300"))
     client_num = int(params.get("client_num", "100"))
-    depends_pkgs = params.objects("depends_pkgs")
-    test.log.info("Install packages: %s in host", depends_pkgs)
-    if not utils_package.package_install(depends_pkgs):
-        test.cancel("Install dependency packages failed")
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()


### PR DESCRIPTION
After confirm with developer,ksmtuned package not a strong dependency for migration scenarios, so delete the check of ksmtuned for migration scenarios.

ID:2134053
Signed-off-by: Lei Yang <leiayang@redhat.com>