### PR TITLE
uefishell.check_network: disable winutils iso for windows guest

### DIFF
--- a/qemu/tests/cfg/uefishell.cfg
+++ b/qemu/tests/cfg/uefishell.cfg
@@ -29,6 +29,8 @@
             memmap_output_handler = "handle_memory_map"
         - check_network:
             bootindex_nic1 = 1
+            Windows:
+                cdroms = ""
             time_interval = 9
             variants:
                 - with_ipv4:


### PR DESCRIPTION
For windows guest, no need to winutils iso in the case, so set cdroms to null string.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2134607