### PR TITLE
hv_check_cpu_utilization: change stop service method for win11

### DIFF
--- a/qemu/tests/cfg/hv_check_cpu_utilization.cfg
+++ b/qemu/tests/cfg/hv_check_cpu_utilization.cfg
@@ -16,6 +16,7 @@
         set_owner_cmd += 'SecurityHealthService" -ot reg -actn setowner -ownr "n:Administrators"'
         set_full_control_cmd = 'WIN_UTILS:\SetACL -on "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\'
         set_full_control_cmd += 'SecurityHealthService" -ot reg -actn ace -ace "n:Administrators;p:full"'
+        service_stop_cmd = sc stop {0} & reg add "HKLM\SYSTEM\CurrentControlSet\Services\{0}" /v Start /d 4 /t REG_DWORD /f
     reg_cmd = reg add "HKLM\SYSTEM\CurrentControlSet\Services\SecurityHealthService" /v Start /d 4 /t REG_DWORD /f
     host_check_cmd = top -H -p %s -n ${host_check_times} -d ${host_check_interval} -b > fixed-top-pc-result
     vcpn_thread_pattern = r'thread_id.?[:|=]\s*(\d+)'


### PR DESCRIPTION
We can not change service config via sc comamnd for win11 currently, so use reg command instead.

ID: 2125132
Signed-off-by: Menghuan Li menli@redhat.com