### PR TITLE
block_with_iommu:enable verify_enabled since RHEL8

### DIFF
--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -11,8 +11,8 @@
     variants:
         - verify_enabled:
             only Linux
-            only RHEL.8
-            only Host_RHEL.m8
+            no RHEL.7
+            no Host_RHEL.m7
             only virtio_scsi
             virtio_dev_disable_legacy = on
             virtio_dev_disable_modern = off


### PR DESCRIPTION
iommu is support since RHEL8
The limitation only affect on old version.
ID:2135707
Signed-off-by: qingwangrh <qinwang@redhat.com>