### PR TITLE
virtio_scsi_cdrom:add serial on disks

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_cdrom.cfg
+++ b/qemu/tests/cfg/virtio_scsi_cdrom.cfg
@@ -98,6 +98,31 @@
                     image_size_stg22 = 1G
                     image_size_stg23 = 1G
                     image_size_stg24 = 1G
+                    blk_extra_params_stg += ",serial=TARGET_DISK0"
+                    blk_extra_params_stg1 += ",serial=TARGET_DISK1"
+                    blk_extra_params_stg2 += ",serial=TARGET_DISK2"
+                    blk_extra_params_stg3 += ",serial=TARGET_DISK3"
+                    blk_extra_params_stg4 += ",serial=TARGET_DISK4"
+                    blk_extra_params_stg5 += ",serial=TARGET_DISK5"
+                    blk_extra_params_stg6 += ",serial=TARGET_DISK6"
+                    blk_extra_params_stg7 += ",serial=TARGET_DISK7"
+                    blk_extra_params_stg8 += ",serial=TARGET_DISK8"
+                    blk_extra_params_stg9 += ",serial=TARGET_DISK9"
+                    blk_extra_params_stg10 += ",serial=TARGET_DISK10"
+                    blk_extra_params_stg11 += ",serial=TARGET_DISK11"
+                    blk_extra_params_stg12 += ",serial=TARGET_DISK12"
+                    blk_extra_params_stg13 += ",serial=TARGET_DISK13"
+                    blk_extra_params_stg14 += ",serial=TARGET_DISK14"
+                    blk_extra_params_stg15 += ",serial=TARGET_DISK15"
+                    blk_extra_params_stg16 += ",serial=TARGET_DISK16"
+                    blk_extra_params_stg17 += ",serial=TARGET_DISK17"
+                    blk_extra_params_stg18 += ",serial=TARGET_DISK18"
+                    blk_extra_params_stg19 += ",serial=TARGET_DISK19"
+                    blk_extra_params_stg20 += ",serial=TARGET_DISK20"
+                    blk_extra_params_stg21 += ",serial=TARGET_DISK21"
+                    blk_extra_params_stg22 += ",serial=TARGET_DISK22"
+                    blk_extra_params_stg23 += ",serial=TARGET_DISK23"
+                    blk_extra_params_stg24 += ",serial=TARGET_DISK24"
                     ahci:
                         images = "image1 stg stg2 stg3 stg4 stg5"
                     Windows:


### PR DESCRIPTION
The installation can not find the system disk
if no serial on multi-disks.
Adding serial for each disk to make sure installation may find the target disk.
ID:2125192
Signed-off-by: qingwangrh <qinwang@redhat.com>