### PR TITLE
hotplug_mem: reduces crashkernel value for 4G-64G range

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_repeat.cfg
+++ b/qemu/tests/cfg/hotplug_mem_repeat.cfg
@@ -26,3 +26,4 @@
         - repeat_256:
             only Linux
         - scalability_test:
+            kernel_extra_params_add = "crashkernel=1G-4G:192M4G-64G:192M64G-:512M"

--- a/qemu/tests/cfg/hotplug_mem_stress_ng.cfg
+++ b/qemu/tests/cfg/hotplug_mem_stress_ng.cfg
@@ -12,6 +12,7 @@
     #    since crashkernel size is much bigger than x86
     aarch64,ppc64,ppc64le:
         threshold = 0.15
+    kernel_extra_params_add = "crashkernel=1G-4G:192M4G-64G:192M64G-:512M"
     guest_numa_nodes = "node0"
     mem_devs = "mem0"
     use_mem_mem0 = "no"


### PR DESCRIPTION
Reduces crashkernel kernel command line option from 256MB to 192MB since 256MB consumes too much memory for the 4GB memory limit value leading memory hotplug cases to fail.

ID: 2136387
Signed-off-by: mcasquer <mcasquer@redhat.com>