### PR TITLE
virtio_scsi_cdrom: Remove platform restrictions

### DIFF
--- a/qemu/tests/cfg/virtio_scsi_cdrom.cfg
+++ b/qemu/tests/cfg/virtio_scsi_cdrom.cfg
@@ -17,7 +17,6 @@
     # Inactivity treshold to error the test
     inactivity_treshold = 1800
     image_verify_bootable = no
-    only x86_64, i386, ppc64, ppc64le
     only virtio_scsi, virtio_blk
     virtio_drive_letter = 'D'
     virtio_scsi:


### PR DESCRIPTION
After testing, both s390 and aarch64 support this scenario,
So remove platform restrictions.

ID: 2137477
Signed-off-by: zhenyzha <zhenyzha@redhat.com>