### PR TITLE
block_check_memory_leak:change threshold to 0

### DIFF
--- a/qemu/tests/block_check_memory_leak.py
+++ b/qemu/tests/block_check_memory_leak.py
@@ -66,7 +66,7 @@ def run(test, params, env):
     process.system_output(cp_cmd, shell=True)
     check_cmd = params["check_cmd"]
     out = process.system_output(check_cmd, shell=True).decode()
-    logger.info("Find leak:%s", out)
-
-    if len(out) and int(out) > 1000:
+    leak_threshold = params.get_numeric('leak_threshold')
+    logger.info("Find leak:%s,threshold: %d", out, leak_threshold)
+    if len(out) and int(out) > leak_threshold:
         test.fail("Find memory leak %s,Please check valgrind.log" % out)

--- a/qemu/tests/cfg/block_check_memory_leak.cfg
+++ b/qemu/tests/cfg/block_check_memory_leak.cfg
@@ -49,4 +49,7 @@
     host_script = block_device/${name_script}
     guest_io_cmd = "${guest_dir}/${name_script} -n 10 -s 10g -d '%s'"
     guest_cancel_io_cmd = "cat /tmp/mpid|xargs kill -SIGINT;pgrep fio|xargs kill -9;sleep 2"
-    check_cmd= "cat ${valgrind_log}|grep -a "definitely lost:"|tail -n 1|awk '{print $4}'|tr -d ','"
+    check_cmd = "cat ${valgrind_log}|grep -a "definitely lost:"|tail -n 1|awk '{print $4}'|tr -d ','"
+    leak_threshold = 0
+    arm64-pci, arm64-mmio:
+        leak_threshold = 1000


### PR DESCRIPTION
There is no memoey leak in recent testing.
So change the threahold to 0.
ID:2138099
Signed-off-by: qingwangrh <qinwang@redhat.com>