### PR TITLE
virtio_fs: add memory check steps with verifier enabled

### DIFF
--- a/qemu/tests/cfg/virtio_fs_hotplug.cfg
+++ b/qemu/tests/cfg/virtio_fs_hotplug.cfg
@@ -45,8 +45,10 @@
         # install winfsp tool
         i386, i686:
             install_path = 'C:\Program Files'
+            devcon_dirname = 'x86'
         x86_64:
             install_path = 'C:\Program Files (x86)'
+            devcon_dirname = 'amd64'
         driver_name = viofs
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
@@ -64,6 +66,7 @@
         cdroms += " virtio"
         cmd_dd = 'dd if=/dev/random of=%s bs=1M count=200'
         cmd_md5 = "%s: && md5sum.exe %s && c:"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - @default:
         - with_repetition:

--- a/qemu/tests/cfg/virtio_fs_multi_vms.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_vms.cfg
@@ -53,8 +53,10 @@
         # install winfsp tool
         i386, i686:
             install_path = 'C:\Program Files'
+            devcon_dirname = 'x86'
         x86_64:
             install_path = 'C:\Program Files (x86)'
+            devcon_dirname = 'amd64'
         wfsp_install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "${install_path}" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
@@ -71,6 +73,7 @@
         cdroms += " virtio"
         cmd_dd = 'dd if=/dev/random of=%s bs=1M count=200'
         cmd_md5 = "%s: && md5sum.exe %s"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - with_multi_fs_sources:
             no Windows

--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -41,8 +41,10 @@
         # install winfsp tool
         i386, i686:
             install_path = 'C:\Program Files'
+            devcon_dirname = 'x86'
         x86_64:
             install_path = 'C:\Program Files (x86)'
+            devcon_dirname = 'amd64'
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
@@ -57,6 +59,7 @@
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'
         virtio_win_media_type = iso
         cdroms += " virtio"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - with_cache:
             variants:

--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -43,8 +43,10 @@
         # install winfsp tool
         i386, i686:
             install_path = 'C:\Program Files'
+            devcon_dirname = 'x86'
         x86_64:
             install_path = 'C:\Program Files (x86)'
+            devcon_dirname = 'amd64'
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
@@ -60,6 +62,7 @@
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'
         virtio_win_media_type = iso
         cdroms += " virtio"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - @default:
         - with_reboot:

--- a/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
@@ -29,8 +29,10 @@
         # install winfsp tool
         i386, i686:
             install_path = 'C:\Program Files'
+            devcon_dirname = 'x86'
         x86_64:
             install_path = 'C:\Program Files (x86)'
+            devcon_dirname = 'amd64'
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
@@ -45,6 +47,7 @@
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'
         virtio_win_media_type = iso
         cdroms += " virtio"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - with_cache:
             variants:

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -43,8 +43,10 @@
         # install winfsp tool
         i386, i686:
             install_path = 'C:\Program Files'
+            devcon_dirname = 'x86'
         x86_64:
             install_path = 'C:\Program Files (x86)'
+            devcon_dirname = 'amd64'
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
@@ -59,6 +61,7 @@
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'
         virtio_win_media_type = iso
         cdroms += " virtio"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - with_nfs_source:
             setup_local_nfs = yes

--- a/qemu/tests/virtio_fs_hotplug.py
+++ b/qemu/tests/virtio_fs_hotplug.py
@@ -12,6 +12,8 @@ from virttest import utils_test
 from virttest.utils_windows import virtio_win
 from virttest.qemu_devices import qdevices
 
+from provider import win_driver_utils
+
 
 @error_context.context_aware
 def run(test, params, env):
@@ -296,6 +298,11 @@ def run(test, params, env):
                                    get_fs_devices(fs_target))
             plug_fs_devices('unplug', unplug_devs)
             del unplug_devs[:]
+        # for windows guest, disable/uninstall driver to get memory leak based on
+        # driver verifier is enabled
+        if os_type == "windows" and need_plug:
+            plug_fs_devices('hotplug', fs_devs)
+            win_driver_utils.memory_leak_check(vm, test, params)
     finally:
         if os_type == "linux":
             utils_disk.umount(fs_target, fs_dest, 'virtiofs', session=session)

--- a/qemu/tests/virtio_fs_multi_vms.py
+++ b/qemu/tests/virtio_fs_multi_vms.py
@@ -6,6 +6,8 @@ from virttest import utils_misc
 from virttest import utils_test
 from virttest.utils_windows import virtio_win
 
+from provider import win_driver_utils
+
 
 @error_context.context_aware
 def run(test, params, env):
@@ -200,7 +202,10 @@ def run(test, params, env):
                                       (vm, fs_target), test.log.info)
                 utils_disk.umount(fs_target, fs_dest, 'virtiofs',
                                   session=session)
-
+        # for windows guest, disable/uninstall driver to get memory leak based on
+        # driver verifier is enabled
+        if os_type == "windows":
+            win_driver_utils.memory_leak_check(vm_obj, test, vm_params)
     if shared_fs_source_dir:
         error_context.context("Compare the md5 among VMs.", test.log.info)
 

--- a/qemu/tests/virtio_fs_set_capability.py
+++ b/qemu/tests/virtio_fs_set_capability.py
@@ -14,6 +14,8 @@ from virttest import utils_test
 
 from virttest.utils_windows import virtio_win
 
+from provider import win_driver_utils
+
 
 @error_context.context_aware
 def run(test, params, env):
@@ -283,7 +285,10 @@ def run(test, params, env):
                                    io_timeout).stdout_text.strip().split()[0]
             if md5_guest != md5_host:
                 test.fail('The md5 value of host is not same to guest.')
-
+        # for windows guest, disable/uninstall driver to get memory leak based on
+        # driver verifier is enabled
+        if is_windows:
+            win_driver_utils.memory_leak_check(vm, test, params)
     finally:
         if not is_windows:
             utils_disk.umount(fs_target, fs_dest, 'virtiofs', session=session)

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -20,6 +20,8 @@ from virttest import utils_selinux
 
 from provider.storage_benchmark import generate_instance
 
+from provider import win_driver_utils
+
 
 @error_context.context_aware
 def run(test, params, env):
@@ -695,6 +697,10 @@ def run(test, params, env):
                 if os_type == "linux":
                     utils_disk.umount(fs_target, fs_dest, 'virtiofs', session=session)
                     utils_misc.safe_rmdir(fs_dest, session=session)
+        # for windows guest, disable/uninstall driver to get memory leak based on
+        # driver verifier is enabled
+        if os_type == "windows":
+            win_driver_utils.memory_leak_check(vm, test, params)
     finally:
         if setup_local_nfs:
             if vm and vm.is_alive():


### PR DESCRIPTION
For driver test, if driver verifier is enabled, to get memory leak, it's better to disable or uninstall driver after driver test.
ID: 2138792
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>