### PR TITLE
chardev_tls_encryption:update checkpoint of boot entry

### DIFF
--- a/qemu/tests/cfg/chardev_tls_encryption.cfg
+++ b/qemu/tests/cfg/chardev_tls_encryption.cfg
@@ -34,7 +34,7 @@
             no aarch64
             vms = 'vm1 vm2'
             image_snapshot = yes
-            expected_msg = "BOOT_IMAGE"
+            expected_msg = "The selected entry will be started"
             guest_cmd = "cat /dev/ttyS0 &"
             ppc64, ppc64le:
                 expected_msg = "SLOF"

--- a/qemu/tests/chardev_tls_encryption.py
+++ b/qemu/tests/chardev_tls_encryption.py
@@ -105,7 +105,10 @@ def run(test, params, env):
             vm1.destroy()
             vm2.destroy()
     finally:
-        gnutls_pid = process.getoutput("pgrep -f gnutls", shell=True)
-        if gnutls_pid:
-            process.run("pkill -9 gnutls")
+        gnutls_serv_pid = process.getoutput("pgrep -f gnutls-serv", shell=True)
+        if gnutls_serv_pid:
+            process.run("pkill -9 gnutls-serv")
+        gnutls_cli_pid = process.getoutput("pgrep -f gnutls-cli", shell=True)
+        if gnutls_cli_pid:
+            process.run("pkill -9 gnutls-cli")
         process.run(clean_cmd)


### PR DESCRIPTION
ID: 2095105

OVMF has a different boot entry message from seabios, fix this. And change the cleaning steps since it is conflict with the information 'depends_pkgs=gnutls-utils'.

Signed-off-by: nanliu <nanliu@redhat.com>