### PR TITLE
blockdev_snapshot_reboot:to get correct backing     for test with nfs backend

### DIFF
--- a/qemu/tests/blockdev_snapshot_guest_agent.py
+++ b/qemu/tests/blockdev_snapshot_guest_agent.py
@@ -63,8 +63,7 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
     base_image = params.get("images", "image1").split()[0]
-    params.update(
-        {"image_name_%s" % base_image: params["image_name"],
-         "image_format_%s" % base_image: params["image_format"]})
+    params.setdefault("image_name_%s" % base_image, params["image_name"])
+    params.setdefault("image_format_%s" % base_image, params["image_format"])
     snapshot_guest_agent = BlockdevSnapshotGuestAgentTest(test, params, env)
     snapshot_guest_agent.run_test()

--- a/qemu/tests/blockdev_snapshot_reboot.py
+++ b/qemu/tests/blockdev_snapshot_reboot.py
@@ -43,8 +43,7 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
     base_image = params.get("images", "image1").split()[0]
-    params.update(
-        {"image_name_%s" % base_image: params["image_name"],
-         "image_format_%s" % base_image: params["image_format"]})
+    params.setdefault("image_name_%s" % base_image, params["image_name"])
+    params.setdefault("image_format_%s" % base_image, params["image_format"])
     snapshot_reboot = BlockdevSnapshotRebootTest(test, params, env)
     snapshot_reboot.run_test()

--- a/qemu/tests/blockdev_snapshot_stop_cont.py
+++ b/qemu/tests/blockdev_snapshot_stop_cont.py
@@ -33,8 +33,7 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
     base_image = params.get("images", "image1").split()[0]
-    params.update(
-        {"image_name_%s" % base_image: params["image_name"],
-         "image_format_%s" % base_image: params["image_format"]})
+    params.setdefault("image_name_%s" % base_image, params["image_name"])
+    params.setdefault("image_format_%s" % base_image, params["image_format"])
     snapshot_stop_cont = BlockdevSnapshotStopContTest(test, params, env)
     snapshot_stop_cont.run_test()

--- a/qemu/tests/blockdev_snapshot_stress.py
+++ b/qemu/tests/blockdev_snapshot_stress.py
@@ -34,8 +34,7 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
     base_image = params.get("images", "image1").split()[0]
-    params.update(
-        {"image_name_%s" % base_image: params["image_name"],
-         "image_format_%s" % base_image: params["image_format"]})
+    params.setdefault("image_name_%s" % base_image, params["image_name"])
+    params.setdefault("image_format_%s" % base_image, params["image_format"])
     snapshot_stress = BlockdevSnapshotStressTest(test, params, env)
     snapshot_stress.run_test()


### PR DESCRIPTION
for test with nfs backend

When run test with system disk, with original case design, backing file's path that on nfs will be
replaced by the local path, which will cause rebasing to an not existed backing file, update code to correct it.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2139585