### PR TITLE
balloon: add memory check steps with verifier enabled

### DIFF
--- a/qemu/tests/balloon_boot_in_pause.py
+++ b/qemu/tests/balloon_boot_in_pause.py
@@ -4,6 +4,8 @@ from avocado.core import exceptions
 
 from virttest import error_context
 from virttest import utils_misc
+
+from provider import win_driver_utils
 from qemu.tests.balloon_check import BallooningTest
 
 
@@ -234,3 +236,7 @@ def run(test, params, env):
     error_context.context("Reset guest memory to original one after all the "
                           "test", test.log.info)
     balloon_test.reset_memory()
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if params.get("os_type") == "windows":
+        win_driver_utils.memory_leak_check(vm, test, params)

--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -11,6 +11,7 @@ from virttest import utils_misc
 from virttest import error_context
 from virttest.utils_numeric import normalize_data_size
 from virttest.utils_test.qemu import MemoryBaseTest
+from provider import win_driver_utils
 
 
 class BallooningTest(MemoryBaseTest):
@@ -645,5 +646,9 @@ def run(test, params, env):
                 test.error("QEMU should consume more memory")
             if res3 - res1 > res1 * 0.1:
                 test.fail("QEMU should consume same memory as before memhog ")
+        # for windows guest, disable/uninstall driver to get memory leak based on
+        # driver verifier is enabled
+        if params.get("os_type") == "windows":
+            win_driver_utils.memory_leak_check(balloon_test.vm, test, params)
     finally:
         balloon_test.close_sessions()

--- a/qemu/tests/balloon_memhp.py
+++ b/qemu/tests/balloon_memhp.py
@@ -6,6 +6,7 @@ from virttest import utils_numeric
 from virttest.utils_test.qemu import MemoryHotplugTest
 from qemu.tests.balloon_check import BallooningTestWin
 from qemu.tests.balloon_check import BallooningTestLinux
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -73,10 +74,9 @@ def run(test, params, env):
         min_sz, max_sz = balloon_test.get_memory_boundary()
         new_mem = int(random.uniform(min_sz, max_sz))
         balloon_test.balloon_memory(new_mem)
-
+        # for windows guest, disable/uninstall driver to get memory leak based on
+        # driver verifier is enabled
+        if params.get("os_type") == "windows":
+            win_driver_utils.memory_leak_check(vm, test, params)
     finally:
-        if params['os_type'] == 'windows':
-            error_context.context("Clear balloon service in guest",
-                                  test.log.info)
-            balloon_test.operate_balloon_service(session, "uninstall")
         session.close()

--- a/qemu/tests/balloon_minimum.py
+++ b/qemu/tests/balloon_minimum.py
@@ -4,6 +4,7 @@ from virttest import utils_test
 from virttest import error_context
 from virttest.qemu_monitor import QMPEventError
 from qemu.tests.balloon_check import BallooningTestWin
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -44,4 +45,8 @@ def run(test, params, env):
 
     ballooned_memory = expect_mem - balloon_test.pre_mem
     balloon_test.memory_check("after balloon guest memory 10 times", ballooned_memory)
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if params.get("os_type") == "windows":
+        win_driver_utils.memory_leak_check(vm, test, params)
     session.close()

--- a/qemu/tests/balloon_service.py
+++ b/qemu/tests/balloon_service.py
@@ -5,6 +5,7 @@ from virttest import utils_test
 from virttest import error_context
 from qemu.tests.balloon_check import BallooningTestWin
 from qemu.tests.balloon_check import BallooningTestLinux
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -93,10 +94,9 @@ def run(test, params, env):
                                   % bln_oper, test.log.info)
             balloon_memory(vm, mem_check, min_sz, max_sz)
             mem_stat_working = True
-
+        # for windows guest, disable/uninstall driver to get memory leak based on
+        # driver verifier is enabled
+        if params.get("os_type") == "windows":
+            win_driver_utils.memory_leak_check(vm, test, params)
     finally:
-        if params['os_type'] == 'windows':
-            error_context.context("Clear balloon service in guest",
-                                  test.log.info)
-            balloon_test.operate_balloon_service(session, "uninstall")
         session.close()

--- a/qemu/tests/balloon_stress.py
+++ b/qemu/tests/balloon_stress.py
@@ -6,6 +6,7 @@ from virttest import utils_test
 from virttest import error_context
 from qemu.tests.balloon_check import BallooningTestWin
 from qemu.tests.balloon_check import BallooningTestLinux
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -73,6 +74,10 @@ def run(test, params, env):
             balloon_test.balloon_memory(int(random.uniform(min_sz, max_sz)))
             if not check_bg_running():
                 test.error("Background stress process is not alive")
+        # for windows guest, disable/uninstall driver to get memory leak based on
+        # driver verifier is enabled
+        if params.get("os_type") == "windows":
+            win_driver_utils.memory_leak_check(vm, test, params)
     finally:
         if session:
             session.close()

--- a/qemu/tests/cfg/balloon_boot_in_pause.cfg
+++ b/qemu/tests/cfg/balloon_boot_in_pause.cfg
@@ -11,6 +11,14 @@
     balloon_type_evict = evict
     balloon_type_enlarge = enlarge
     paused_after_start_vm = yes
+    Windows:
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        driver_name = balloon
+        cdroms += " virtio"
     variants:
         - @balloon-base:
 

--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -10,6 +10,13 @@
     Windows:
         guest_compare_threshold = 300
         guest_mem_ratio = 0.025
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        driver_name = balloon
+        cdroms += " virtio"
     variants:
         - balloon_base:
         - balloon_oom:

--- a/qemu/tests/cfg/balloon_hotplug.cfg
+++ b/qemu/tests/cfg/balloon_hotplug.cfg
@@ -22,6 +22,12 @@
         run_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe -r"
         stop_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe -s"
         unplug_timeout = 90
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        driver_name = balloon
     s390x:
         balloon_device = virtio-balloon-ccw
         balloon_bus = virtual-css

--- a/qemu/tests/cfg/balloon_illegal.cfg
+++ b/qemu/tests/cfg/balloon_illegal.cfg
@@ -9,3 +9,11 @@
     illegal_value_check = yes
     test_tags = "enlarge"
     balloon_type_enlarge = enlarge
+    Windows:
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        driver_name = balloon
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        cdroms += " virtio"

--- a/qemu/tests/cfg/balloon_in_use.cfg
+++ b/qemu/tests/cfg/balloon_in_use.cfg
@@ -25,6 +25,13 @@
         check_guest_bsod = yes
         migration_test_command = ver && vol
         balloon_buffer = 700
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        memory_leak_check = yes
+        cdroms += " virtio"
     Linux:
         # Use a low stress to make sure guest can response during stress
         driver_name = "virtio_balloon"
@@ -47,6 +54,7 @@
             sub_test = shutdown
             suppress_exception = yes
             shutdown_method = shell
+            memory_leak_check = no
         - with_reboot:
             sub_test = boot
             suppress_exception = yes

--- a/qemu/tests/cfg/balloon_memhp.cfg
+++ b/qemu/tests/cfg/balloon_memhp.cfg
@@ -44,6 +44,11 @@
         status_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe status"
         run_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe -r"
         stop_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe -s"
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - backend_ram:
             backend_mem = memory-backend-ram

--- a/qemu/tests/cfg/balloon_minimum.cfg
+++ b/qemu/tests/cfg/balloon_minimum.cfg
@@ -9,6 +9,14 @@
     balloon_type = evict
     test_tags = "evict"
     kill_vm_on_error = yes
+    Windows:
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        driver_name = balloon
+        cdroms += " virtio"
     variants:
         - negative:
             type = balloon_minimum

--- a/qemu/tests/cfg/balloon_service.cfg
+++ b/qemu/tests/cfg/balloon_service.cfg
@@ -24,6 +24,12 @@
         run_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe -r"
         stop_balloon_service = "%s:\Balloon\GUEST_OS\amd64\blnsvr.exe -s"
         check_mem_diff = 300
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        driver_name = balloon
     repeat_times = 5
     base_path = "/machine/peripheral/"
     polling_property = "guest-stats-polling-interval"

--- a/qemu/tests/cfg/balloon_stress.cfg
+++ b/qemu/tests/cfg/balloon_stress.cfg
@@ -14,6 +14,12 @@
         play_video_cmd = "start /MIN %s %s -loop 0 -fs"
         video_url = http://FILESHARE.COM/pub/section2/kvmauto/video/big_buck_bunny_480p_stereo.avi
         balloon_buffer = 700
+        i386, i686:
+            devcon_dirname = 'x86'
+        x86_64:
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        cdroms += " virtio"
     Linux:
         # Use a low stress to make sure guest can response during stress
         stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"

--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -14,11 +14,14 @@
         driver_unload_cmd = "WIN_UTILS:\devcon\wnet_x86\devcon.exe disable @DRIVER_ID"
         driver_id_cmd = 'WIN_UTILS:\devcon\wnet_x86\devcon.exe find * | find "VirtIO"'
         driver_check_cmd = "WIN_UTILS:\devcon\wnet_x86\devcon.exe status @DRIVER_ID"
+        devcon_dirname = 'x86'
     x86_64:
         driver_load_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe enable @DRIVER_ID"
         driver_unload_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe disable @DRIVER_ID"
         driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
         driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
+        devcon_dirname = 'amd64'
+    devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - before_bg_test:
             run_bg_flag = "before_bg_test"


### PR DESCRIPTION
For windows balloon driver test, if driver verifier is enabled, to get memory leak, it's better to disable or uninstall driver after driver test.
ID: 2139570
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>