### PR TITLE
viorng: Add memory leak check steps with verifier enabled

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -12,6 +12,13 @@
         read_rng_cmd  = ${rng_dst}
         driver_name = "viorng"
         rng_data_rex = "0x\w"
+        cdroms += " virtio"
+        i386:
+            devcon_dirname = "x86"
+        x86_64:
+            devcon_dirname = "amd64"
+    	devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        need_memory_leak_check = yes
     Linux:
         session_cmd_timeout = 360
         read_rng_cmd  = "dd if=/dev/random  bs=1 count=10 2>/dev/null|hexdump"

--- a/qemu/tests/cfg/rng_host_guest_read.cfg
+++ b/qemu/tests/cfg/rng_host_guest_read.cfg
@@ -10,13 +10,17 @@
         read_rng_cmd  = ${rng_dst}
         driver_name = "viorng"
         rng_data_rex = "0x\w"
+        cdroms += " virtio"
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
         i386:
             driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+            devcon_dirname = "x86"
         x86_64:
             driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
+            devcon_dirname = "amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     Linux:
         read_rng_cmd  = "dd if=/dev/random  bs=1 count=10 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"

--- a/qemu/tests/cfg/rng_hotplug.cfg
+++ b/qemu/tests/cfg/rng_hotplug.cfg
@@ -18,12 +18,16 @@
         driver_name = "viorng"
         rng_data_rex = "0x\w"
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
+        cdroms += " virtio"
         i386:
             driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+            devcon_dirname = 'x86'
         x86_64:
             driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     Linux:
         session_cmd_timeout = 360
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"

--- a/qemu/tests/cfg/rng_read_longtime.cfg
+++ b/qemu/tests/cfg/rng_read_longtime.cfg
@@ -14,12 +14,17 @@
         driver_name = "viorng"
         rng_data_rex = "0x\w"
         driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
+        cdroms += " virtio"
         i386:
             driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+            devcon_dirname = 'x86'
         x86_64:
             driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
+            devcon_dirname = 'amd64'
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        need_memory_leak_check = yes
     Linux:
         session_cmd_timeout = 360
         read_rng_cmd = "dd if=/dev/random bs=4 count=1000 2>/dev/null|hexdump"

--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -17,12 +17,17 @@
         rng_dst = "c:\random_%PROCESSOR_ARCHITECTURE%.exe"
         read_rng_cmd = ${rng_dst}
         list_cmd = "wmic process get name"
+        cdroms += " virtio"
         i386:
             driver_id_cmd = 'WIN_UTILS:\devcon\wxp_x86\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wxp_x86\devcon.exe status @DRIVER_ID"
+            devcon_dirname = "x86"
         x86_64:
             driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
             driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
+            devcon_dirname = "amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        memory_leak_check = yes
     Linux:
         read_rng_cmd  = "dd if=/dev/random bs=10 count=10 2>/dev/null|hexdump"
         driver_verifier_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_current"
@@ -61,6 +66,7 @@
         - with_shutdown:
             sub_test = shutdown
             shutdown_method = shell
+            memory_leak_check = no
         - with_reboot:
             sub_test = boot
             reboot_count = 1

--- a/qemu/tests/rng_bat.py
+++ b/qemu/tests/rng_bat.py
@@ -7,6 +7,7 @@ from virttest import error_context
 from virttest import utils_test
 from virttest.utils_windows import system
 from avocado.utils import process
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -124,3 +125,7 @@ def run(test, params, env):
         if len(re.findall(rng_data_rex, output, re.M)) < 2:
             test.fail("Unable to read random numbers from guest: %s" % output)
     session.close()
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if params.get("need_memory_leak_check", "no") == "yes":
+        win_driver_utils.memory_leak_check(vm, test, params)

--- a/qemu/tests/rng_host_guest_read.py
+++ b/qemu/tests/rng_host_guest_read.py
@@ -1,6 +1,7 @@
 from virttest import error_context
 from virttest import utils_test
 from avocado.utils import process
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -37,6 +38,7 @@ def run(test, params, env):
 
     host_read_cmd = params.get("host_read_cmd")
     guest_rng_test = params.get("guest_rng_test")
+    os_type = params["os_type"]
     vm = env.get_vm(params["main_vm"])
     vm.wait_for_login()
 
@@ -54,3 +56,7 @@ def run(test, params, env):
     finally:
         error_context.context("Clean host read process", test.log.info)
         host_read_clean(host_read_process)
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if os_type == "windows":
+        win_driver_utils.memory_leak_check(vm, test, params)

--- a/qemu/tests/rng_hotplug.py
+++ b/qemu/tests/rng_hotplug.py
@@ -4,6 +4,7 @@ from virttest import error_context
 from virttest.qemu_devices import qdevices
 from virttest import utils_test
 from avocado.core import exceptions
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -85,6 +86,7 @@ def run(test, params, env):
     pm_test_after_plug = params.get("pm_test_after_plug")
     pm_test_after_unplug = params.get("pm_test_after_unplug")
     rng_driver = params["rng_driver"]
+    os_type = params["os_type"]
 
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
@@ -138,3 +140,8 @@ def run(test, params, env):
             run_subtest(pm_test_after_unplug)
             if not vm.is_alive():
                 return
+    # for windows guest, disable/uninstall driver to get memory
+    # leak based on driver verifier is enabled
+    if os_type == "windows":
+        hotplug_rng(vm, new_dev)
+        win_driver_utils.memory_leak_check(vm, test, params)


### PR DESCRIPTION
For driver test, if driver verifier is enabled, to get memory leak, it's better to disable or uninstall driver after driver test.

ID:2113798
Signed-off-by: Menghuan Li menli@redhat.com