### PR TITLE
watchdog: Remove rdma related case on x86_64

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -61,10 +61,10 @@
                 - @tcp:
                     migration_protocol = tcp
                 - x_rdma:
-                    no ppc64, ppc64le, s390x
+                    no ppc64, ppc64le, s390x, x86_64
                     migration_protocol = x-rdma
                 - rdma:
-                    no ppc64, ppc64le, s390x
+                    no ppc64, ppc64le, s390x, x86_64
                     migration_protocol = rdma
         - hotplug_unplug_watchdog_device:
              only i6300esb


### PR DESCRIPTION
Reason for remove:
1.The rdma-related case priority is low in migration 
2.Requires rdma-related machines

ID: 2141601

Signed-off-by: Yiqian Wei <yiwei@redhat.com>