### PR TITLE
virtio_fs: add limitation for xfstest on nfs

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -180,7 +180,7 @@
         - run_stress:
             variants:
                 - with_xfstest:
-                    only with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs,inode_file_handles.prefer.sandbox
+                    only with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs,inode_file_handles.prefer.sandbox..with_nfs_source.multi_fs
                     no s390 s390x
                     no Windows
                     image_snapshot = yes


### PR DESCRIPTION
xfstest only run on two nfs backend.
ID: 2143865
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>