### PR TITLE
boot_nbdimage_with_qsd: new case

### DIFF
--- a/qemu/tests/boot_nbdimage_with_qsd.py
+++ b/qemu/tests/boot_nbdimage_with_qsd.py
@@ -1,0 +1,70 @@
+import os
+
+from virttest import data_dir
+from virttest import qemu_storage
+
+from avocado.utils import process
+from provider import qemu_img_utils as img_utils
+from provider.qsd import QsdDaemonDev
+
+
+def run(test, params, env):
+    """
+    Boot nbd image with qsd plus unix.
+
+    1) Prepare an installed OS image via converting
+    2) Export the OS image via QSD plus unix
+    3) Start VM from the exported image
+    """
+    def pre_test():
+        # prepare an installed OS image
+        test.log.info(
+            "Prepare an installed OS image file via converting, "
+            "and exporting it via QSD")
+        source = params["convert_source"]
+        target = params["convert_target"]
+        source_params = params.object_params(source)
+        target_params = params.object_params(target)
+        root_dir = data_dir.get_data_dir()
+        source_image = qemu_storage.QemuImg(source_params, root_dir, source)
+        target_image = qemu_storage.QemuImg(target_params, root_dir, target)
+
+        test.log.info("Convert %s to %s", source, target)
+        try:
+            source_image.convert(params, root_dir)
+        except process.CmdError as detail:
+            target_image.remove()
+            test.fail("Convert %s to %s failed for '%s', check please." %
+                      (source, target, detail))
+
+        # export the OS image over QSD
+        qsd.start_daemon()
+
+    def run_test():
+        # boot up a guest from the exported OS image
+        test.log.info("Boot up a guest from the exported OS image.")
+        login_timeout = params.get_numeric("login_timeout", 360)
+        vm = None
+        try:
+            vm = img_utils.boot_vm_with_images(test, params, env,
+                                               (params['nbd_image_tag'],))
+            vm.wait_for_login(timeout=login_timeout)
+        finally:
+            if vm:
+                vm.destroy()
+
+    def post_test():
+        qsd.stop_daemon()
+
+    # set socket path of the exporting image over nbd
+    socket_path = os.path.join(data_dir.get_tmp_dir(), "nbd_stg1.sock")
+    params["nbd_unix_socket_nbd1"] = socket_path
+    params["qsd_image_export_nbd_stg1"] = '{"type":"unix","path":"%s"}' % \
+                                          socket_path
+
+    qsd = QsdDaemonDev(params.objects('qsd_namespaces')[0], params)
+    pre_test()
+    try:
+        run_test()
+    finally:
+        post_test()

--- a/qemu/tests/cfg/boot_nbdimage_with_qsd.cfg
+++ b/qemu/tests/cfg/boot_nbdimage_with_qsd.cfg
@@ -1,0 +1,37 @@
+- boot_nbdimage_with_qsd:
+    only nbd filesystem
+    virt_test_type = qemu
+    type = boot_nbdimage_with_qsd
+    required_qemu = [6.0, )
+    start_vm = no
+    kill_vm = yes
+    # prepare an installed os image via converting
+    convert_source = ${images}
+    convert_target = stg1
+    image_name_stg1 = "images/stg1"
+    image_format_stg1 = raw
+    storage_type_stg1 = filesystem
+    enable_nbd_stg1 = no
+    qsd_create_image_stg1 = no
+    qsd_remove_image_stg1 = yes
+    # Declare QSD (name), multi QSD separated with blank
+    qsd_namespaces = "qsd1"
+    # Declare specified QSD contains which images
+    qsd_images_qsd1 = "stg1"
+    qsd_daemonize_qsd1 = yes
+    # Run QSD in daemon mode ,default is n
+    # Force create QSD even if find same name QSD,default is yes
+    qsd_force_create_qsd1 = yes
+    # Auto adding --pidfile into QSD command line, default is yes
+    qsd_enable_pidfile_qsd1 = yes
+    # Raw command line of QSD daemon,QSD concat them
+    qsd_image_format = {"driver":"raw","read-only":false,"discard":"unmap"}
+    # Declare one image export with nbd unix
+    qsd_image_export_stg1 = {"type":"nbd"}
+    # NBD client based on unix
+    nbd_image_tag = nbd1
+    nbd_server_nbd1 = ''
+    storage_type_nbd1 = nbd
+    image_format_nbd1 = raw
+    enable_nbd_nbd1 = yes
+    check_image_nbd1 = no


### PR DESCRIPTION
1.Prepare an installed OS image via converting
2.Export the OS image via QSD plus unix
3.Start VM from the exported image

Signed-off-by: Tingting Mao <timao@redhat.com>

ID: 2143881