### PR TITLE
qemu_guest_agent: json format change affect one command line

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent_hotplug.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent_hotplug.cfg
@@ -15,12 +15,11 @@
     gagent_check_type = sync
     # /qga_setup_fail.log is saved during guest preinstall phase, if you don't have this file, please skip this parameter.
     cmd_check_qga_installlog = "ls /qga_setup_fail.log"
-    extra_params = "-device virtio-serial-pci,id=qga-virtio-serial0,bus=pci.0"
     q35:
         # temporary workaround since currently no virtio-serial-pci bus object provided in the framework
         pci_controllers += " pcie_root_port_qga"
         type_pcie_root_port_qga = "pcie-root-port"
-        extra_params = "-device virtio-serial-pci,id=qga-virtio-serial0,bus=pcie_root_port_qga"
+    serial_type = "virtserialport"
     backend_char_plug = "socket"
     id_char_plug = "qga-serial0"
     dev_driver = "virtserialport"


### PR DESCRIPTION
qemu/tests/cfg/qemu_guest_agent_hotplug.cfg: change original
 qemu-cli to json format "-device '{"id": "virtio_serial_pci0",
"driver": "virtio-serial-pci", "bus": "pcie-root-port-1", "addr": "0x0"}'"

ID: 2145141
Signed-off-by: demeng <demeng@redhat.com>