### PR TITLE
block_diskcard: add sleep time between mklabel and mkpart

### DIFF
--- a/qemu/tests/cfg/block_discard.cfg
+++ b/qemu/tests/cfg/block_discard.cfg
@@ -22,11 +22,11 @@
     variants:
         - xfs:
             no RHEL.3 RHEL.4 RHEL.5 RHEL.6
-            create_partition_cmd = "parted -s DISK mklabel msdos && "
+            create_partition_cmd = "parted -s DISK mklabel msdos && sleep 1s && "
             create_partition_cmd += "parted -s DISK mkpart primary xfs 2048s 100%"
             format_disk_cmd = "mkfs.xfs -f DISK1"
         - ext4:
             no RHEL.3 RHEL.4 RHEL.5
-            create_partition_cmd = "parted -s DISK mklabel msdos && "
+            create_partition_cmd = "parted -s DISK mklabel msdos && sleep 1s && "
             create_partition_cmd += "parted -s DISK mkpart primary ext4 2048s 100%"
             format_disk_cmd = "yes|mkfs.ext4 DISK1"


### PR DESCRIPTION
Sometimes it will fail to mkpart just after mklabel, it says that: "Partition(s) 1 on /dev/sdb have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use. As a result, the old partition(s) will remain in use. You should reboot now before making further changes."

Wait a little time can fix this problem.

Test Result:
```
 (1/4) Host_RHEL.m8.u8.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.8.0.aarch64.io-github-autotest-qemu.block_discard.xfs.unmap.arm64-pci: STARTED                                                                              
 (1/4) Host_RHEL.m8.u8.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.8.0.aarch64.io-github-autotest-qemu.block_discard.xfs.unmap.arm64-pci: PASS (81.48 s)                                                                       
 (2/4) Host_RHEL.m8.u8.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.8.0.aarch64.io-github-autotest-qemu.block_discard.xfs.writesame.arm64-pci: STARTED                                                                          
 (2/4) Host_RHEL.m8.u8.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.8.0.aarch64.io-github-autotest-qemu.block_discard.xfs.writesame.arm64-pci: PASS (85.51 s)                                                                   
 (3/4) Host_RHEL.m8.u8.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.8.0.aarch64.io-github-autotest-qemu.block_discard.ext4.unmap.arm64-pci: STARTED                                                                             
 (3/4) Host_RHEL.m8.u8.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.8.0.aarch64.io-github-autotest-qemu.block_discard.ext4.unmap.arm64-pci: PASS (74.94 s)                                                                      
 (4/4) Host_RHEL.m8.u8.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.8.0.aarch64.io-github-autotest-qemu.block_discard.ext4.writesame.arm64-pci: STARTED                                                                         
 (4/4) Host_RHEL.m8.u8.product_rhel.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.8.8.0.aarch64.io-github-autotest-qemu.block_discard.ext4.writesame.arm64-pci: PASS (75.94 s)
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>