### PR TITLE
boot_nic_with_iommu:Add one case to support viommu device

### DIFF
--- a/qemu/tests/cfg/boot_nic_with_iommu.cfg
+++ b/qemu/tests/cfg/boot_nic_with_iommu.cfg
@@ -1,23 +1,35 @@
 - boot_nic_with_iommu:
-    x86_64, i386:
-        only q35
-        no WinXP WinVista Win7 Win8 Win8.1 Win2003
-        no Win2008 Win2008..r2 Win2012 Win2012..r2
-        machine_type_extra_params = "kernel-irqchip=split"
-        HostCpuVendor.intel:
-            intel_iommu = yes
-            iommu_caching_mode = on
-        Linux:
-            clone_master = yes
-            master_images_clone = image1
-            remove_image_image1 = yes
-            enable_guest_iommu = yes
+    virt_test_type = qemu
     only virtio_net
+    clone_master = yes
+    master_images_clone = image1
+    remove_image_image1 = yes
     type = boot_nic_with_iommu
-    nic_extra_params = ",disable-legacy=on,disable-modern=off,iommu_platform=on,ats=on"
-    aarch64:
-        machine_type_extra_params += ",iommu=smmuv3"
-        nic_extra_params = ",iommu_platform=on,ats=on"
-    s390x:
-        nic_extra_params = ",iommu_platform=on"
-    vhostforce = on
+    variants:
+        - iommu:
+            x86_64, i386:
+                only q35
+                no WinXP WinVista Win7 Win8 Win8.1 Win2003
+                no Win2008 Win2008..r2 Win2012 Win2012..r2
+                machine_type_extra_params = "kernel-irqchip=split"
+                HostCpuVendor.intel:
+                    intel_iommu = yes
+                    iommu_caching_mode = on
+                Linux:
+                    enable_guest_iommu = yes
+            nic_extra_params = ",disable-legacy=on,disable-modern=off,iommu_platform=on,ats=on"
+            aarch64:
+                machine_type_extra_params += ",iommu=smmuv3"
+                nic_extra_params = ",iommu_platform=on,ats=on"
+            s390x:
+                nic_extra_params = ",iommu_platform=on"
+            vhostforce = on
+        - virtio_iommu:
+            required_qemu= [7.0.0,)
+            only aarch64 x86_64
+            x86_64:
+                only q35
+            only Linux
+            virtio_iommu = yes
+            nic_extra_params = ",iommu_platform=on"
+            virtio_iommu_direct_plug = yes


### PR DESCRIPTION
Boot nic with iommu_platform=on based on virtio iommu device

ID:2148335
Signed-off-by: Lei Yang <leiayang@redhat.com>