### PR TITLE
ansible: update provider with optional custom dnf repository

### DIFF
--- a/qemu/tests/cfg/ansible_test.cfg
+++ b/qemu/tests/cfg/ansible_test.cfg
@@ -7,6 +7,7 @@
     playbook_timeout = 600
     ansible_callback_plugin = debug
     ansible_ssh_extra_args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    ansible_repo = ""
     # Here we can define an extra set of variables for the playbook with json format
     #ansible_extra_vars = '{"debug_msg": "Hello Ansible!", "force_handlers": true}'
     # Sometimes we have a fixed ansible_extra_vars, but also one or more flexibly configurable vars

--- a/qemu/tests/cfg/nested_block_resize.cfg
+++ b/qemu/tests/cfg/nested_block_resize.cfg
@@ -5,6 +5,7 @@
     playbook_timeout = 600
     ansible_callback_plugin = debug
     ansible_ssh_extra_args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    ansible_repo = ""
     only virtio_scsi
     wait_response_timeout = 1800
     mq_port = 5000


### PR DESCRIPTION
Provide optional custom dnf repo containing ansible. This change is relevant for system like RHEL 8.5 and older.

**Note:** This change depends on https://github.com/avocado-framework/avocado/pull/5527.

ID: 2143263

Signed-off-by: Lukas Kotek <lkotek@redhat.com>