### PR TITLE
blockdev_mirror_to_rbd:remove image1 ceph set limiation

### DIFF
--- a/qemu/tests/cfg/blockdev_mirror_to_rbd.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_to_rbd.cfg
@@ -29,7 +29,6 @@
     storage_type_local = directory
     enable_ceph_mirror1 = yes
     enable_ceph_data1 = no
-    enable_ceph_image1 = no
     ceph:
         enable_ceph_data1 = yes
         image_format_data1 = raw


### PR DESCRIPTION
Remove ceph set limitation on system disk to make it possible to start system disk under ceph.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2150701