### PR TITLE
blockdev_mirror_with_ignore:extend lv to 2.5G

### DIFF
--- a/qemu/tests/cfg/blockdev_mirror_with_ignore.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_with_ignore.cfg
@@ -53,7 +53,7 @@
     post_command += "rm -rf ${mount_dir} &&"
     post_command += "rm -rf ${tmpdir} "
     pre_command_timeout = 30
-    lv_extend_cmd = 'lvextend -L ${image_size_data1} /dev/${vgname}/${lvname} && resize2fs /dev/${vgname}/${lvname}'
+    lv_extend_cmd = 'lvextend -L 2.5G /dev/${vgname}/${lvname} && resize2fs /dev/${vgname}/${lvname}'
     iscsi_direct:
         lun_data1 = 1
         enable_iscsi_mirror1 = no


### PR DESCRIPTION
For passthrough device, extension to 2G is not
enough for mirror completion, which will still
cause block_job_io_error. So extend lv to 2.5G
then tests under all scenarios can be met.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2151096