### PR TITLE
sve_suite: Use kernel src.rpm for get_reg_list and sve_stress test

### DIFF
--- a/qemu/tests/cfg/sve_suite.cfg
+++ b/qemu/tests/cfg/sve_suite.cfg
@@ -3,14 +3,17 @@
     only aarch64
     image_snapshot = yes
     dst_dir = /home/test_suite
-    git_repo = https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux
+    get_suite_cmd = cd {0} && brew download-build --rpm {1} && rpm2cpio {1} | cpio -idm
+    uncompress_cmd = cd {0} && tar Jxf {1}.tar.xz --strip-components 1 -C ${dst_dir}
     required_pkgs = kernel-devel kernel-headers rsync
+    tmp_dir = /var/tmp
     suite_timeout = 360
     variants suite_type:
         - optimized_routines:
+            del uncompress_cmd
             required_pkgs = glibc-static mpfr-devel libmpc-devel
-            git_repo = https://github.com/ARM-software/optimized-routines
-            suite_dir = ${dst_dir}/
+            get_suite_cmd = git clone --depth=1 https://github.com/ARM-software/optimized-routines.git ${dst_dir}
+            suite_dir = ${dst_dir}
             compile_cmd = 'cd ${suite_dir}; cp config.mk.dist config.mk; '
             compile_cmd += 'echo "CFLAGS += -march=armv8.2-a+sve" >> config.mk; make'
             execute_suite_cmd = 'make check 2>/dev/null'
@@ -20,8 +23,8 @@
             start_vm = no
             suite_dir = ${dst_dir}/tools/testing/selftests/kvm/
             execute_suite_cmd = '${suite_dir}/aarch64/get-reg-list'
-            compile_cmd = 'cd ${suite_dir}; make'
+            compile_cmd = 'make -C ${suite_dir}'
         - sve_stress:
-            suite_dir = ${dst_dir}/tools/testing/selftests/arm64/fp/
-            execute_suite_cmd = 'timeout ${suite_timeout} ./vlset --inherit {} ./sve-stress 2>/dev/null'
+            suite_dir = ${dst_dir}/tools/testing/selftests/arm64/fp
+            execute_suite_cmd = 'timeout ${suite_timeout} ${suite_dir}/vlset --inherit {} ./sve-stress 2>/dev/null'
             compile_cmd = 'cd ${suite_dir}; make'

--- a/qemu/tests/sve_host_suite.py
+++ b/qemu/tests/sve_host_suite.py
@@ -13,28 +13,40 @@ from provider import cpu_utils
 @error_context.context_aware
 def run(test, params, env):
     def compile_kernel_selftests():
-        git_cmd = 'git clone --depth=1 {} {} 2>/dev/null'.format(git_repo,
-                                                                 dst_dir)
+        error_context.context(
+            'Download the kernel src.rpm package and uncompress it',
+            test.log.info)
+        process.run(get_suite_cmd, shell=True)
         if os.path.exists(dst_dir):
             shutil.rmtree(dst_dir)
-        process.run(git_cmd, timeout=360, shell=True)
+        os.mkdir(dst_dir)
+        process.run(uncompress_cmd.format(tmp_dir, linux_name), shell=True)
+
+        error_context.context('Compile kernel selftests', test.log.info)
         s, o = process.getstatusoutput(compile_cmd, timeout=180)
         if s:
             test.log.error('Compile output: %s', o)
             test.error('Failed to compile the test suite.')
 
-    dst_dir = params['dst_dir']
-    git_repo = params['git_repo']
     compile_cmd = params['compile_cmd']
+    dst_dir = params['dst_dir']
     execute_suite_cmd = params['execute_suite_cmd']
+    get_suite_cmd = params['get_suite_cmd']
     required_pkgs = params.objects('required_pkgs')
     suite_timeout = params.get_numeric('suite_timeout')
+    uncompress_cmd = params['uncompress_cmd']
+    tmp_dir = test.tmpdir
 
     if not utils_package.package_install(required_pkgs):
         test.error("Failed to install required packages in host")
     error_context.base_context('Check if the CPU of host supports SVE',
                                test.log.info)
     cpu_utils.check_cpu_flags(params, 'sve', test)
+
+    kernel_version = os.uname()[2].rsplit('.', 1)[0]
+    srpm = f"kernel-{kernel_version}.src.rpm"
+    linux_name = f"linux-{kernel_version}"
+    get_suite_cmd = get_suite_cmd.format(tmp_dir, srpm)
 
     try:
         compile_kernel_selftests()


### PR DESCRIPTION
Use the upstream git repo for testing is not stable, use the src.rpm for sve testing, the version is as same as the system.

ID: 2153676
Signed-off-by: Yihuang Yu <yihyu@redhat.com>