### PR TITLE
memhp_threads: Update check point for prealloc-threads default

### DIFF
--- a/qemu/tests/cfg/memhp_threads.cfg
+++ b/qemu/tests/cfg/memhp_threads.cfg
@@ -29,5 +29,5 @@
     backend_mem_plug2 = memory-backend-file
     prealloc_mem_plug1 = yes
     prealloc_mem_plug2 = yes
-    prealloc-threads_mem_plug2 = 6
+    prealloc-threads_mem_plug2 = 4
     get_threads_cmd = "pstree -p %s | wc -l"

--- a/qemu/tests/memhp_threads.py
+++ b/qemu/tests/memhp_threads.py
@@ -47,12 +47,12 @@ def run(test, params, env):
     get_threads_cmd = params["get_threads_cmd"] % vm.get_pid()
     qemu_binary = utils_misc.get_qemu_binary(params)
     qemu_version = utils_qemu.get_qemu_version(qemu_binary)[0]
+    target_mems = params.get("target_mems").split()
     if qemu_version in VersionInterval('[7.1.0,)'):
         threads_default = params.get_numeric("smp")
     else:
-        threads_default = 0
-    target_mems = params.get("target_mems")
-    for target_mem in target_mems.split():
+        target_mems.remove('plug1')
+    for target_mem in target_mems:
         test.log.info("Get qemu threads number at beginning")
         pre_threads = get_qemu_threads(get_threads_cmd)
         test.log.info("QEMU boot threads number is %s" % pre_threads)


### PR DESCRIPTION
Some old version rhel8 hosts will create a thread when adding one memory-backend-file default, but the thread creation is not due to the setting of the qemu source code.
We can see that before qemu7.1 on rhel9, adding a memory-backend-file default will not create one thread.
This was fixed after qemu7.1, anyway, Our test point is that after 7.1, the default value of the thread is equal to the number of smps, so as to achieve performance improvement.
So remove pre-7.1 default checks.

ID: 2152530
Signed-off-by: zhenyzha <zhenyzha@redhat.com>