### PR TITLE
virtio_mem_numa_basic: changes docstring test description

### DIFF
--- a/qemu/tests/virtio_mem_numa_basic.py
+++ b/qemu/tests/virtio_mem_numa_basic.py
@@ -9,7 +9,7 @@ from provider import virtio_mem_utils
 @error_context.context_aware
 def run(test, params, env):
     """
-    Memory share and discard-data hotplug test
+    Boot a guest with two virtio-mem devices and resize them
     1) Boot guest with two virtio-mem devices
     2) Check virtio-mem devices
     3) Resize virtio-mem devices


### PR DESCRIPTION
virtio_mem_numa_basic: changes docstring test description

There is a typo at the beginning of the case docstring that it needs to be updated to the correct case functionality

ID: 2153689
Signed-off-by: mcasquer <mcasquer@redhat.com>