### PR TITLE
Add memory leak check for vioscsi IO/block_resize/hotplug tests

### DIFF
--- a/qemu/tests/block_hotplug_scsi_hba.py
+++ b/qemu/tests/block_hotplug_scsi_hba.py
@@ -5,6 +5,7 @@ from virttest import utils_misc
 from virttest.utils_test import qemu
 
 from provider.block_devices_plug import BlockDevicesPlug
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -73,4 +74,6 @@ def run(test, params, env):
             test.fail('Found a new disk with virtio-scsi-pci.hotplug=off '
                       'before rescan scsi hba controller.')
         rescan_hba_controller(session)
+    if not is_linux:
+        win_driver_utils.memory_leak_check(vm, test, params)
     plug.unplug_devs_serial()

--- a/qemu/tests/block_resize_unplug.py
+++ b/qemu/tests/block_resize_unplug.py
@@ -11,6 +11,7 @@ from virttest.qemu_capabilities import Flags
 from virttest.utils_numeric import normalize_data_size
 
 from provider.block_devices_plug import BlockDevicesPlug
+from provider import win_driver_utils
 
 
 ENLARGE, SHRINK = ("enlarge", "shrink")
@@ -103,4 +104,6 @@ def run(test, params, env):
     if reboot:
         _change_vm_power()
         _check_vm_status()
+    if is_windows:
+        win_driver_utils.memory_leak_check(vm, test, params)
     plug.unplug_devs_serial()

--- a/qemu/tests/cfg/block_hotplug_scsi_hba.cfg
+++ b/qemu/tests/cfg/block_hotplug_scsi_hba.cfg
@@ -10,6 +10,17 @@
     force_create_image_stg0 = yes
     drive_bus_stg0 = 1
     hotplug_interval = 2
+    i386:
+        devcon_dirname = "x86"
+    x86_64:
+        devcon_dirname = "amd64"
+    devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+    driver_enable_cmd = '${devcon_path} enable "@DEVICE_ID"'
+    driver_disable_cmd = '${devcon_path} disable "@DEVICE_ID"'
+    drive_bus_cd1 = 0
+    driver_name = "vioscsi"
+    device_name = "Red Hat VirtIO SCSI pass-through controller"
+    device_hwid = '"PCI\VEN_1AF4&DEV_1004" "PCI\VEN_1AF4&DEV_1048"'
     Windows:
         hotplug_interval = 10
         driver_name = vioscsi

--- a/qemu/tests/cfg/block_resize_unplug.cfg
+++ b/qemu/tests/cfg/block_resize_unplug.cfg
@@ -8,11 +8,24 @@
     boot_drive_stg0 = yes
     force_create_image_stg0 = yes
     kill_vm = yes
+    i386:
+        devcon_dirname = "x86"
+    x86_64:
+        devcon_dirname = "amd64"
+    devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+    driver_enable_cmd = '${devcon_path} enable "@DEVICE_ID"'
+    driver_disable_cmd = '${devcon_path} disable "@DEVICE_ID"'
     Windows:
         virtio_blk:
             driver_name = viostor
+            device_name = "Red Hat VirtIO SCSI controller"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1001" "PCI\VEN_1AF4&DEV_1042"'
         virtio_scsi:
             driver_name = vioscsi
+            drive_bus_stg0 = 1
+            drive_bus_cd1 = 0
+            device_name = "Red Hat VirtIO SCSI pass-through controller"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1004" "PCI\VEN_1AF4&DEV_1048"'
     variants:
         - reboot_vm:
             reboot_vm = yes

--- a/qemu/tests/cfg/fio_windows.cfg
+++ b/qemu/tests/cfg/fio_windows.cfg
@@ -9,6 +9,16 @@
     disk_index = 1
     disk_letter = I
     fio_file_name = "C\:\\fio_system_disk_test:I\:\\fio_data_disk_test"
+    virtio_scsi:
+        drive_bus_disk1 = 1
+        drive_bus_cd1 = 0
+        driver_name = "vioscsi"
+        device_name = "Red Hat VirtIO SCSI pass-through controller"
+        device_hwid = '"PCI\VEN_1AF4&DEV_1004" "PCI\VEN_1AF4&DEV_1048"'
+    virtio_blk:
+        driver_name = viostor
+        device_name = "Red Hat VirtIO SCSI controller"
+        device_hwid = '"PCI\VEN_1AF4&DEV_1001" "PCI\VEN_1AF4&DEV_1042"'
     nvme_direct:
         fio_file_name = "C\:\\fio_system_disk_test
         boot_drive_disk1 = no
@@ -21,11 +31,16 @@
         - aio_threads:
             image_aio = threads
     i386, i686:
+        devcon_dirname += "x86"
         install_path = "C:\Program Files\fio"
         install_cmd = 'msiexec /a DRIVE:\fio-3.1-x86.msi /qn TARGETDIR="${install_path}"'
     x86_64:
+        devcon_dirname += "amd64"
         install_path = "C:\Program Files (x86)\fio"
         install_cmd = 'msiexec /a DRIVE:\fio-3.1-x64.msi /qn TARGETDIR="${install_path}"'
+    devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+    driver_enable_cmd = '${devcon_path} enable "@DEVICE_ID"'
+    driver_disable_cmd = '${devcon_path} disable "@DEVICE_ID"'
     #config_cmd = 'setx -m path "%PATH%;${install_path}\fio;"'
     fio_cmd = '"${install_path}\fio\fio.exe" --rw=randrw --bs=4k --iodepth=4 --direct=1'
     fio_cmd += ' --filename=${fio_file_name} --name=fiotest --ioengine=windowsaio --thread --group_reporting'

--- a/qemu/tests/fio_windows.py
+++ b/qemu/tests/fio_windows.py
@@ -3,6 +3,7 @@ import time
 
 from virttest import error_context
 from virttest import utils_misc
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -63,3 +64,4 @@ def run(test, params, env):
             test.log.warn("Log file copy failed: %s", err)
         if session:
             session.close()
+        win_driver_utils.memory_leak_check(vm, test, params)


### PR DESCRIPTION
Select 3 cases to add memory-leak check steps:
1) fio_windows
2) block_resize_unplug
3) block_hotplug_scsi_hba

ID: 2128921
Signed-off-by: Peixiu Hou <phou@redhat.com>