### PR TITLE
hotplug_mem_migration: Add memory and migration cross-test

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_migration.cfg
+++ b/qemu/tests/cfg/hotplug_mem_migration.cfg
@@ -1,0 +1,91 @@
+- hotplug_mem_migration:
+    type = hotplug_mem_migration
+    mem_fixed = 8192
+    smp = 4
+    slots_mem = 4
+    size_mem = 2G
+    maxmem_mem = 32G
+    login_timeout = 600
+    pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
+    no Host_RHEL.6 Host_RHEL.7 Host_RHEL.8
+    no RHEL.6 RHEL.7 RHEL.8
+    no Windows
+    threshold = 0.12
+    # Notes:
+    #    The threshold on arm and ppc was confirmed with developer
+    #    since crashkernel size is much bigger than x86
+    aarch64,ppc64,ppc64le:
+        threshold = 0.15
+    max_vms = 2
+    migration_test_command = help
+    migration_bg_command = "cd /tmp; nohup tcpdump -q -i any -t ip host localhost"
+    migration_bg_check_command = pgrep tcpdump
+    migration_bg_kill_command = pkill -9 tcpdump
+    kill_vm_on_error = yes
+    iterations = 2
+    mig_timeout = 1200
+    ping_pong = 1
+    migration_protocol = "tcp"
+    target_mems = "plug1 plug2"
+    cmd_check_online_mem = lsmem
+    cmd_new_folder = ' rm -rf /tmp/numa_test/ && mkdir /tmp/numa_test'
+    numa_test = 'numactl -m %s dd if=/dev/urandom of=/tmp/numa_test/test '
+    numa_test += 'bs=1k count=5242880 && rm -rf /tmp/numa_test/'
+    stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 4096M'
+    variants numa_nodes:
+        - with_single_numa_node:
+            guest_numa_nodes = "node0"
+            mem_devs = "memN0"
+            use_mem_memN0 = "no"
+            size_mem_memN0 = 8192M
+            backend_mem_memN0 = memory-backend-ram
+            numa_memdev_node0 = mem-memN0
+            del numa_mem
+            del numa_cpus
+            del numa_nodeid
+        - with_multi_numa_nodes:
+            guest_numa_nodes = "node0 node1"
+            del numa_mem
+            del numa_cpus
+            numa_nodeid = 0
+            mem_devs = "memN0 memN1"
+            numa_memdev_node0 = mem-memN0
+            numa_memdev_node1 = mem-memN1
+            use_mem_memN0 = "no"
+            use_mem_memN1 = "no"
+            size_mem_memN0 = 4096M
+            size_mem_memN1 = 4096M
+            backend_mem_memN0 = memory-backend-ram
+            backend_mem_memN1 = memory-backend-ram
+            node_dimm_mem2 = 0
+            node_dimm_mem1 = 1
+            numa_nodeid_node0 = 0
+            numa_nodeid_node1 = 1
+            node_dimm_plug1 = 0
+            node_dimm_plug2 = 1
+            # Due to known issue
+            RHEL.9.0.0:
+                aarch64:
+                    numa_cpus_node0 = "0,1"
+                    numa_cpus_node1 = "2,3"
+    variants:
+        - backend_ram:
+            backend_mem = memory-backend-ram
+            del discard-data
+        - backend_file:
+            # Notes:
+            #     Before start testing, please ensure your host
+            # kernel has support hugpage and have enough memory
+            # to create guest memory
+            backend_mem = memory-backend-file
+            setup_hugepages = yes
+            # mem path should be the hugpage path
+            mem-path = /mnt/kvm_hugepage
+            pre_command = "echo 3 > /proc/sys/vm/drop_caches"
+            pre_command_noncritical = yes
+        - backend_memfd:
+            no Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1 Host_RHEL.m8.u2
+            backend_mem = memory-backend-memfd
+            setup_hugepages = yes
+            hugetlb_mem = yes
+            only with_multi_numa_nodes

--- a/qemu/tests/hotplug_mem_migration.py
+++ b/qemu/tests/hotplug_mem_migration.py
@@ -1,0 +1,86 @@
+import logging
+import re
+import time
+
+from decimal import Decimal
+
+from virttest import utils_test
+from virttest.utils_test.qemu import MemoryHotplugTest
+
+LOG_JOB = logging.getLogger('avocado.test')
+
+
+def run(test, params, env):
+    """
+    Qemu memory hotplug test:
+    1) Boot guest with -m option
+    2) Hotplug memory to guest and check memory inside guest
+    3) Run stress tests inside guest
+    4) Send a migration command to the source VM and wait until it's finished
+    5) Check if memory size is correct inside guest in destination
+    6）Unplug memory device and check it
+    7) Reboot guest
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def _check_online_mem(session):
+        mem_device = session.cmd_output(cmd_check_online_mem, timeout=10)
+        LOG_JOB.info(mem_device)
+        online_mem = re.search(r'online memory:\s+\d+(\.\d*)?G', mem_device).group()
+        online_mem = re.search(r'\d+(\.\d*)?', online_mem).group()
+        return Decimal(online_mem)
+
+    def _compare_mem_size(online_mem, expect_mem_size):
+        if Decimal(online_mem) != expect_mem_size:
+            test.fail("The online mem size is %sG not match expected memory"
+                      " %sG" % (online_mem, expect_mem_size))
+
+    cmd_check_online_mem = params.get('cmd_check_online_mem')
+    cmd_new_folder = params.get('cmd_new_folder')
+    numa_test = params.get('numa_test')
+    mem_plug_size = params.get("size_mem")
+    target_mems = params["target_mems"]
+    guest_numa_nodes = params["guest_numa_nodes"]
+
+    vm = env.get_vm(params["main_vm"])
+    session = vm.wait_for_login()
+    utils_test.update_boot_option(vm, args_added="movable_node")
+
+    mem_plug_size = Decimal(re.search(r'\d+', mem_plug_size).group())
+    expect_mem_size = _check_online_mem(session)
+    hotplug_test = MemoryHotplugTest(test, params, env)
+    for target_mem in target_mems.split():
+        hotplug_test.hotplug_memory(vm, target_mem)
+        hotplug_test.check_memory(vm)
+        expect_mem_size += mem_plug_size
+
+    online_mem = _check_online_mem(session)
+    _compare_mem_size(online_mem, expect_mem_size)
+    for node in guest_numa_nodes.split():
+        LOG_JOB.info("Use the hotplug memory by numa %s.", node)
+        session.cmd(cmd_new_folder)
+        session.cmd(numa_test % re.search(r'\d+', node).group())
+    try:
+        stress_args = params.get("stress_args")
+        stress_test = utils_test.VMStress(vm, "stress", params,
+                                          stress_args=stress_args)
+        stress_test.load_stress_tool()
+    except utils_test.StressError as info:
+        test.error(info)
+    time.sleep(60)
+    stress_test.unload_stress()
+    stress_test.clean()
+    # do migration
+    mig_timeout = params.get_numeric("mig_timeout", 1200, float)
+    mig_protocol = params.get("migration_protocol", "tcp")
+    vm.migrate(mig_timeout, mig_protocol, env=env)
+    for target_mem in target_mems.split():
+        hotplug_test.unplug_memory(vm, target_mem)
+        hotplug_test.check_memory(vm)
+        expect_mem_size -= mem_plug_size
+
+    online_mem = _check_online_mem(session)
+    _compare_mem_size(online_mem, expect_mem_size)
+    vm.reboot()


### PR DESCRIPTION
Add memory and migration cross-test scenarios,
This scenario simulates the migration of hot-inserted memory after use, and then unplugs it after the migration is complete.

ID: 2152804
Signed-off-by: zhenyzha <zhenyzha@redhat.com>