### PR TITLE
viostor: Add memory leak check steps with verifier enabled

### DIFF
--- a/generic/tests/cfg/iometer_windows.cfg
+++ b/generic/tests/cfg/iometer_windows.cfg
@@ -36,6 +36,14 @@
     set_online_cmd += " echo exit >> cmd &&"
     set_online_cmd += " diskpart /s cmd"
     readfile_cmd = "type"
+    virtio_blk:
+        driver_name = viostor
+        memory_leak_check = yes
+    i386:
+        devcon_dirname = "x86"
+    x86_64:
+        devcon_dirname = "amd64"
+    devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - @default:
             run_timeout = 1000
@@ -52,6 +60,7 @@
                     cpu_family = "0xf"
                 - msi_off:
                     cpu_family = "0xe"
+            memory_leak_check = no
         - pm_test:
             run_timeout = 1000
             variants:
@@ -59,6 +68,7 @@
                     shutdown_vm = yes
                     command_qmp = system_powerdown
                     command_shell = shutdown /s /f /t 0
+                    memory_leak_check = no
                 - reboot_vm:
                     reboot_vm = yes
                     command_qmp = system_reset

--- a/generic/tests/iometer_windows.py
+++ b/generic/tests/iometer_windows.py
@@ -10,6 +10,7 @@ from virttest import data_dir
 from virttest import error_context
 from virttest import utils_misc
 from virttest import utils_test
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -128,3 +129,7 @@ def run(test, params, env):
     if shutdown_vm or reboot_vm:
         change_vm_status()
         check_vm_status()
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if params.get("memory_leak_check", "no") == "yes":
+        win_driver_utils.memory_leak_check(vm, test, params)

--- a/qemu/tests/block_during_io.py
+++ b/qemu/tests/block_during_io.py
@@ -6,6 +6,7 @@ from virttest import utils_misc
 from virttest import utils_disk
 from virttest import error_context
 from provider.storage_benchmark import generate_instance
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -164,3 +165,8 @@ def run(test, params, env):
             # XXX: The data disk letters will be changed after system reset in windows.
             mount_points = get_win_drive_letters_after_reboot()
         run_stress(stress_name, mount_points)
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if windows:
+        if params.get("memory_leak_check", "no") == "yes":
+            win_driver_utils.memory_leak_check(vm, test, params)

--- a/qemu/tests/block_hotplug_in_pause.py
+++ b/qemu/tests/block_hotplug_in_pause.py
@@ -7,6 +7,7 @@ from virttest import utils_disk
 from virttest.qemu_devices import qdevices
 from virttest.qemu_capabilities import Flags
 from virttest.qemu_devices.utils import (DeviceError, DeviceUnplugError)
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -304,5 +305,11 @@ def run(test, params, env):
 
         block_check_in_guest(session, disks_before_unplug,
                              blk_num, get_disk_cmd, plug_tag="unplug")
+
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if params.get("os_type") == "windows":
+        if params.get("memory_leak_check", "no") == "yes":
+            win_driver_utils.memory_leak_check(vm, test, params)
 
     session.close()

--- a/qemu/tests/cfg/block_during_io.cfg
+++ b/qemu/tests/cfg/block_during_io.cfg
@@ -6,8 +6,14 @@
     Windows:
         virtio_blk:
             driver_name = viostor
+            memory_leak_check = yes
         virtio_scsi:
             driver_name = vioscsi
+        i386:
+            devcon_dirname = "x86"
+        x86_64:
+            devcon_dirname = "amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - with_reboot:
             no send_qmp.with_reboot
@@ -19,6 +25,7 @@
                 command_shell = reboot
         - with_shutdown:
             no send_qmp.with_shutdown
+            memory_leak_check = no
             shutdown_vm = yes
             shutdown_method = shell
             Windows:
@@ -38,6 +45,7 @@
     variants:
         - system_disk:
             with_data_disks = no
+            memory_leak_check = no
         - data_disks:
             images += " stg"
             image_name_stg = "images/storage"

--- a/qemu/tests/cfg/block_hotplug_in_pause.cfg
+++ b/qemu/tests/cfg/block_hotplug_in_pause.cfg
@@ -23,6 +23,14 @@
             cd_format_cd1 = ide
         q35:
             cd_format_cd1 = ahci
+        virtio_blk:
+            driver_name = viostor
+            memory_leak_check = yes
+        i386:
+            devcon_dirname = "x86"
+        x86_64:
+            devcon_dirname = "amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
 
     variants:
         - one_pci:

--- a/qemu/tests/cfg/migration_with_block.cfg
+++ b/qemu/tests/cfg/migration_with_block.cfg
@@ -12,6 +12,12 @@
         driver_name = vioscsi
     virtio_blk:
         driver_name = viostor
+        memory_leak_check = yes
+    i386:
+        devcon_dirname = "x86"
+    x86_64:
+        devcon_dirname = "amd64"
+    devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     variants:
         - @default:
             variants:
@@ -22,6 +28,7 @@
                         command_shell = shutdown -t 0 -s
                     Linux:
                         command_shell = shutdown -h now
+                    memory_leak_check = no
                 - reboot_vm:
                     reboot_vm = yes
                     command_qmp = system_reset

--- a/qemu/tests/cfg/trim_support_test.cfg
+++ b/qemu/tests/cfg/trim_support_test.cfg
@@ -18,6 +18,13 @@
     image_boot_stg1 = no
     virtio_blk:
         blk_extra_params_stg1 = "discard=on"
+        driver_name = viostor
+        memory_leak_check = yes
+    i386:
+        devcon_dirname = "x86"
+    x86_64:
+        devcon_dirname = "amd64"
+    devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     drv_extra_params_stg1 = "discard=unmap"
     host_check_cmd = "du --block-size=1 %s/${stg_name}.%s"
     guest_trim_cmd = "defrag.exe %s: /l /u /v"

--- a/qemu/tests/cfg/virtio_storage_in_use.cfg
+++ b/qemu/tests/cfg/virtio_storage_in_use.cfg
@@ -9,6 +9,14 @@
         run_bgstress = iozone_windows
         target_process = iozone.exe
         cdrom_cd1 = isos/windows/winutils.iso
+        virtio_blk:
+            driver_name = viostor
+            memory_leak_check = yes
+        i386:
+            devcon_dirname = "x86"
+        x86_64:
+            devcon_dirname = "amd64"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     Linux:
         run_bgstress = iozone_linux
         target_process = iozone
@@ -29,6 +37,7 @@
             sub_test_shutdown_vm = yes
             sub_test = shutdown
             shutdown_method = shell
+            memory_leak_check = no
         - with_reboot:
             sub_test = boot
             reboot_count = 1
@@ -45,6 +54,7 @@
         - system_disk:
             Windows:
                 disk_letter = C
+            memory_leak_check = no
         - data_disk:
             Windows:
                 disk_letter = I

--- a/qemu/tests/driver_in_use.py
+++ b/qemu/tests/driver_in_use.py
@@ -173,5 +173,6 @@ def run(test, params, env):
         utils_test.run_virt_sub_test(test, params, env, main_test)
         if vm.is_alive():
             run_bg_test_sep(bg_stress_test)
-    if params.get("memory_leak_check", "no") == "yes":
-        win_driver_utils.memory_leak_check(vm, test, params)
+    if params.get("os_type") == "windows":
+        if params.get("memory_leak_check", "no") == "yes":
+            win_driver_utils.memory_leak_check(vm, test, params)

--- a/qemu/tests/migration_with_block.py
+++ b/qemu/tests/migration_with_block.py
@@ -16,6 +16,7 @@ from avocado.utils import process
 
 from provider.storage_benchmark import generate_instance
 from provider.cdrom import QMPEventCheckCDEject, QMPEventCheckCDChange
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -371,3 +372,8 @@ def run(test, params, env):
     if shutdown_vm or reboot:
         change_vm_power()
         check_vm_status()
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if windows:
+        if params.get("memory_leak_check", "no") == "yes":
+            win_driver_utils.memory_leak_check(vm, test, params)

--- a/qemu/tests/trim_support_test.py
+++ b/qemu/tests/trim_support_test.py
@@ -7,6 +7,7 @@ from virttest import error_context
 from virttest import data_dir
 from virttest import utils_disk
 from virttest import utils_misc
+from provider import win_driver_utils
 
 
 @error_context.context_aware
@@ -114,3 +115,8 @@ def run(test, params, env):
 
         if new_size is None:
             test.error("Data disk size is not smaller than: %sMB" % ori_size)
+
+    # for windows guest, disable/uninstall driver to get memory leak based on
+    # driver verifier is enabled
+    if params.get("memory_leak_check", "no") == "yes":
+        win_driver_utils.memory_leak_check(vm, test, params)


### PR DESCRIPTION
For driver test, if driver verifier is enabled, to get memory leak, it's better to disable or uninstall driver after driver test.

ID:2154890
Signed-off-by: Menghuan Li menli@redhat.com