### PR TITLE
hotplug_virtio_mem: new virtio_mem hotplug auto case

### DIFF
--- a/qemu/tests/cfg/hotplug_virtio_mem.cfg
+++ b/qemu/tests/cfg/hotplug_virtio_mem.cfg
@@ -1,0 +1,30 @@
+- hotplug_virtio_mem:
+    only Linux
+    no RHEL.6 RHEL.7 RHEL.8
+    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+    no s390x
+    type = hotplug_virtio_mem
+    virt_test_type = qemu
+    login_timeout = 240
+    threshold = 0.025
+    slots_mem = 20
+    maxmem_mem = 80G
+    mem_fixed = 4096
+    mem_devs = 'mem0 mem1'
+    guest_numa_nodes = 'node0 node1'
+    numa_memdev_node0 = mem-mem0
+    numa_memdev_node1 = mem-mem1
+    size_mem_mem0 = 2G
+    use_mem_mem0 = no
+    size_mem_mem1 = 2G
+    use_mem_mem1 = no
+    target_mems = "vmem0"
+    vm_memdev_model_vmem0 = "virtio-mem"
+    size_mem_vmem0 = 8G
+    use_mem_vmem0 = yes
+    requested-size_memory_vmem0 = 0G
+    node_memory_vmem0 = "1"
+    memdev_memory_vmem0 = "mem-vmem0"
+    kernel_extra_params_add = "memhp_default_state=online_movable"
+    pcie_extra_root_port = 1
+    requested-size_test_vmem0 = "4G 2G"

--- a/qemu/tests/hotplug_virtio_mem.py
+++ b/qemu/tests/hotplug_virtio_mem.py
@@ -1,0 +1,56 @@
+import time
+
+from virttest import error_context
+
+from virttest.utils_misc import normalize_data_size
+from virttest.utils_test.qemu import MemoryHotplugTest
+from provider import virtio_mem_utils
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Virtio-mem hotplug test
+    1) Boot guest
+    2) Hotplug virtio-mem device
+    3) Check virtio-mem device
+    4) Resize virtio-mem device twice
+    5) Check virtio-mem device
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    timeout = params.get_numeric("login_timeout", 240)
+    threshold = params.get_numeric("threshold", target_type=float)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login(timeout=timeout)
+
+    target_mem = params.get("target_mems")
+    hotplug_test = MemoryHotplugTest(test, params, env)
+    _, vmem_dev = hotplug_test.hotplug_memory(vm, target_mem)
+
+    device_id = vmem_dev.get_qid()
+    requested_size_vmem_test = params.get("requested-size_test_%s" % target_mem)
+
+    node_id = int(vmem_dev.get_param('node'))
+    req_size = vmem_dev.get_param('requested-size')
+    initial_req_size = str(int(float(normalize_data_size(req_size, 'B'))))
+
+    virtio_mem_utils.check_memory_devices(device_id, initial_req_size,
+                                          threshold, vm, test)
+    virtio_mem_utils.check_numa_plugged_mem(node_id, initial_req_size,
+                                            threshold, vm, test)
+    for requested_size in requested_size_vmem_test.split():
+        req_size_normalized = int(float(normalize_data_size(requested_size,
+                                  'B')))
+        vm.monitor.qom_set(device_id, "requested-size",
+                           req_size_normalized)
+        time.sleep(30)
+        virtio_mem_utils.check_memory_devices(device_id, requested_size,
+                                              threshold, vm, test)
+        virtio_mem_utils.check_numa_plugged_mem(node_id, requested_size,
+                                                threshold, vm, test)
+    session.close()


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3593

Creates a new auto case that boots up a guest and
hotplugs a memory object and a virtio-mem device
resizes the device and check the size is correct.

ID: 2127829
Signed-off-by: mcasquer <mcasquer@redhat.com>