### PR TITLE
Add capability for watchdog since -watchdog is deprecated

### DIFF
--- a/qemu/tests/watchdog.py
+++ b/qemu/tests/watchdog.py
@@ -168,7 +168,7 @@ def run(test, params, env):
         qemu_binary = utils_misc.get_qemu_binary(params)
 
         watchdog_type_check = params.get(
-            "watchdog_type_check", " -watchdog '?'")
+            "watchdog_type_check", " -device '?'")
         qemu_cmd = qemu_binary + watchdog_type_check
 
         # check the host support watchdog types.


### PR DESCRIPTION
Watchdog: switch -watchdog to -device since -watchdog is deprecated.

ID: 2155430

Signed-off-by: Boqiao Fu <bfu@redhat.com>