### PR TITLE
Add tls expected msg with RHEL9 on s390x

### DIFF
--- a/qemu/tests/cfg/chardev_tls_encryption.cfg
+++ b/qemu/tests/cfg/chardev_tls_encryption.cfg
@@ -22,6 +22,9 @@
             extra_params = " -object tls-creds-x509,id=tls0,dir=${cert_dir},endpoint=client"
             extra_params += " -chardev socket,id=tls_chardev,host=%s,port=%s,tls-creds=tls0"
             extra_params += " -device ${serial_device},chardev=tls_chardev,id=tls_serial"
+            s390x:
+                RHEL.9:
+                    expected_msg = "Channel binding 'tls-exporter'"
         - guest_to_host:
             expected_msg = "Simple Client Mode:"
             gnutls_cmd_client = "cd ${cert_dir} &&"


### PR DESCRIPTION
Chardev: Add tls expected msg with RHEL9 on s390x

ID: 2152902

Signed-off-by: Boqiao Fu <bfu@redhat.com>