### PR TITLE
Add 3 new cases for trim with discard_granularity

### DIFF
--- a/qemu/tests/cfg/trim_support_test.cfg
+++ b/qemu/tests/cfg/trim_support_test.cfg
@@ -21,6 +21,8 @@
     drv_extra_params_stg1 = "discard=unmap"
     host_check_cmd = "du --block-size=1 %s/${stg_name}.%s"
     guest_trim_cmd = "defrag.exe %s: /l /u /v"
+    defrag_timeout = 600
+    retrim_size_check = yes
     driver_verifier = netkvm
     Win2016, Win2019, Win8..1, Win2012..r2:
         driver_verifier += " ndis"
@@ -37,4 +39,16 @@
              filter_options = "<QueryList><Query Id='0' Path='System'><Select Path='System'>"
              filter_options += "*[System[(Level=2) and (EventID=${event_id})]]</Select></Query></QueryList>"
              query_cmd = 'wevtutil qe system /q:"%s" /f:text'
-
+         - with_discard_granularity:
+             retrim_size_check = no
+             guest_trim_cmd = "defrag.exe %s: /u /v /h /o"
+             variants:
+                  - 4K:
+                      blk_extra_params_stg1 = "discard_granularity=4096"
+                      defrag_timeout = 630
+                  - 256K:
+                      blk_extra_params_stg1 = "discard_granularity=262144"
+                      defrag_timeout = 20
+                  - 32M:
+                      blk_extra_params_stg1 = "discard_granularity=33554432"
+                      defrag_timeout = 10


### PR DESCRIPTION
Including 3 cases:
1. trim_support_test.with_discard_granularity.4K
2. trim_support_test.with_discard_granularity.256K
3. trim_support_test.with_discard_granularity.32M

id: 2137732
Signed-off-by: Peixiu Hou <phou@redhat.com>