### PR TITLE
Limit block_with_iommu test for windows on Intel CPU only

### DIFF
--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -34,6 +34,9 @@
             type = unattended_install
             only Windows
             only virtio_scsi, virtio_blk
+            # Since the iommu does not support on AMD CPU for windows guest.
+            # So limits test on Intel CPU only here.
+            only cpu.intel
             no WinXP WinVista Win7 Win8 Win8.1 Win2000 Win2003
             no Win2008 Win2008..r2 Win2012 Win2012..r2
             shutdown_cleanly = yes


### PR DESCRIPTION
As Iommu does not support for windows on AMD host.
Change this case only run on Intel CPU.

id: 2155736
Signed-off-by: Peixiu Hou <phou@redhat.com>