### PR TITLE
Change "clone_master" to "image_snapshot"

### DIFF
--- a/qemu/tests/cfg/boot_nic_with_iommu.cfg
+++ b/qemu/tests/cfg/boot_nic_with_iommu.cfg
@@ -1,9 +1,7 @@
 - boot_nic_with_iommu:
     virt_test_type = qemu
     only virtio_net
-    clone_master = yes
-    master_images_clone = image1
-    remove_image_image1 = yes
+    image_snapshot = yes
     type = boot_nic_with_iommu
     variants:
         - iommu:

--- a/qemu/tests/cfg/hotplug_unplug_nic_with_viommu.cfg
+++ b/qemu/tests/cfg/hotplug_unplug_nic_with_viommu.cfg
@@ -8,9 +8,7 @@
     only Linux
     only virtio_net
     login_timeout = 360
-    clone_master = yes
-    master_images_clone = image1
-    remove_image_image1 = yes
+    image_snapshot = yes
     repeat_times = 1
     virtio_iommu = yes
     pci_model = virtio-net-pci

--- a/qemu/tests/cfg/migrate_nic_with_iommu.cfg
+++ b/qemu/tests/cfg/migrate_nic_with_iommu.cfg
@@ -1,9 +1,7 @@
 - migrate_nic_with_iommu:
     virt_test_type = qemu
     only virtio_net
-    clone_master = yes
-    master_images_clone = image1
-    remove_image_image1 = yes
+    image_snapshot = yes
     iterations = 1
     ping_pong = 1
     type = migration_with_file_transfer


### PR DESCRIPTION
Change "clone_master" to "image_snapshot". The reason is that when limited the qemu version, the case needs to be canceled when the current qemu version does not meet the conditions, but the parameter "clone_master" has not completed the backup image before the case cancel, so the original image is deleted, resulting in an error

ID:2160312

Signed-off-by: Lei Yang <leiayang@redhat.com>