### PR TITLE
qmp_event_notification: fix watchdog cases issue

### DIFF
--- a/qemu/tests/cfg/qmp_event_notification.cfg
+++ b/qemu/tests/cfg/qmp_event_notification.cfg
@@ -58,27 +58,23 @@
             aarch64:
                 no Host_RHEL
             no Windows
+            enable_watchdog = yes
+            watchdog_device_type = i6300esb
             event_cmd = echo 0 > /dev/watchdog
             event_check = "WATCHDOG"
             variants:
                 - qmp_pause:
-                    extra_params += " -watchdog i6300esb -watchdog-action pause "
-                    action_check = "pause"
+                    watchdog_action = "pause"
                 - qmp_reset:
-                    extra_params += " -watchdog i6300esb -watchdog-action reset "
-                    action_check = "reset"
+                    watchdog_action = "reset"
                 - qmp_poweroff:
-                    extra_params += " -watchdog i6300esb -watchdog-action poweroff "
-                    action_check = "poweroff"
+                    watchdog_action = "poweroff"
                 - qmp_shutdown:
-                    extra_params += " -watchdog i6300esb -watchdog-action shutdown "
-                    action_check = "shutdown"
+                    watchdog_action = "shutdown"
                 - qmp_debug:
-                    extra_params += " -watchdog i6300esb -watchdog-action debug "
-                    action_check = "debug"
+                    watchdog_action = "debug"
                 - qmp_none:
-                    extra_params += " -watchdog i6300esb -watchdog-action none "
-                    action_check = "none"
+                    watchdog_action = "none"
         - qmp_guest_panicked:
             no Windows
             # Just confirm GUEST_PANICKED event, no need to care about system

--- a/qemu/tests/qmp_event_notification.py
+++ b/qemu/tests/qmp_event_notification.py
@@ -57,7 +57,7 @@ def run(test, params, env):
         "dict({0})".format(params.get("post_event_cmd_options", "")))
     event_check = params.get("event_check")
     timeout = int(params.get("check_timeout", 360))
-    action_check = params.get("action_check")
+    watchdog_action = params.get("watchdog_action")
 
     if pre_event_cmd:
         send_cmd(pre_event_cmd, pre_event_cmd_type,
@@ -73,9 +73,9 @@ def run(test, params, env):
         for monitor in qmp_monitors:
             event = monitor.get_event(event_check)
             if event_check == "WATCHDOG":
-                if event and event['data']['action'] == action_check:
+                if event and event['data']['action'] == watchdog_action:
                     test.log.info("Receive watchdog %s event notification",
-                                  action_check)
+                                  watchdog_action)
                     qmp_num -= 1
                     qmp_monitors.remove(monitor)
             else:


### PR DESCRIPTION
1.Fix connection method of watchdog device in Q35
2.Remove '-watchdog' option and use '-device' instead

ID: 2155958

Signed-off-by: Yiqian Wei <yiwei@redhat.com>