### PR TITLE
Add related leapp veriosn & grubby version for debugging in the future

### DIFF
--- a/provider/in_place_upgrade_base.py
+++ b/provider/in_place_upgrade_base.py
@@ -109,6 +109,11 @@ class IpuTest(object):
         Fix known issues after executing pre-upgrade
         """
         try:
+            # Leapp and grubby's version
+            le = self.session.cmd_output("rpm -qa|grep ^leapp")
+            test.log.info("leapp version: %s", str(le))
+            gr = self.session.cmd_output("rpm -qa|grep grubby")
+            test.log.info("grubby version: %s", str(gr))
             # Firewalld Configuration AllowZoneDrifting Is Unsupported
             self.session.cmd(self.params.get("fix_firewalld"))
             # Possible problems with remote login using root account

--- a/qemu/tests/in_place_upgrade_legacy.py
+++ b/qemu/tests/in_place_upgrade_legacy.py
@@ -27,6 +27,11 @@ class IpuLegacyTest(IpuTest):
 
         """
         try:
+            # Leapp and grubby's version
+            le = self.session.cmd_output("rpm -qa|grep ^leapp")
+            test.log.info("leapp version: %s", str(le))
+            gr = self.session.cmd_output("rpm -qa|grep ^grubby")
+            test.log.info("grubby version: %s", str(gr))
             # Possible problems with remote login using root account
             self.session.cmd(self.params.get("fix_permit"))
             # Answer file missing will be fixed


### PR DESCRIPTION
ID:2160644
a.there' no related leapp version in the code, and while we need to debug issues, it's hassle so we need such a function to recorder it.
b.we need to know which version has been used.
Signed-off-by: MiriamDeng <mdeng@redhat.com>