### PR TITLE
numa_hmat: updates case initiator option

### DIFF
--- a/qemu/tests/cfg/numa_hmat.cfg
+++ b/qemu/tests/cfg/numa_hmat.cfg
@@ -1,7 +1,7 @@
 - numa_hmat:
     type = numa_hmat
-    only x86_64
-    required_qemu = [4.2.0,)
+    only x86_64, aarch64
+    required_qemu = [7.2.0,)
     start_vm = no
     machine_type_extra_params = 'hmat=on'
     mem_fixed = 5120
@@ -14,8 +14,7 @@
     numa_nodeid_node0 = 0
     numa_nodeid_node1 = 1
     numa_nodeid_node2 = 2
-    numa_initiator_node1 = 0
-    numa_initiator_node2 = 0
+    numa_hmat_lb_initiator = 0
     mem_devs = "mem0 mem1 mem2"
     size_mem_mem0 = 1024M
     size_mem_mem1 = 2048M
@@ -79,3 +78,10 @@
     numa_hmat_caches_associativity_hmat_cache5 = complex
     numa_hmat_caches_policy_hmat_cache5 = write-back
     numa_hmat_caches_line_hmat_cache5 = 16
+    variants:
+        - default:
+        - with_node_initiator:
+            only x86_64
+            required_qemu = [4.2.0, 7.2.0)
+            numa_initiator_node1 = 0
+            numa_initiator_node2 = 0


### PR DESCRIPTION
numa_hmat: updates case initiator option

Depends on: https://github.com/avocado-framework/avocado-vt/pull/3605

According to the qemu-7.2 rebase the initiator
value is not mandatory anymore fot the -numa node
option. Updates the case to provide only the
initiator to the -numa hmat-lb option when qemu version is higher than 7.2

ID: 2158423
Signed-off-by: mcasquer <mcasquer@redhat.com>