### PR TITLE
virtio_fs:  virtiofs code update/add after including functions in provided unit

### DIFF
--- a/provider/virtio_fs_utils.py
+++ b/provider/virtio_fs_utils.py
@@ -308,10 +308,10 @@ def create_viofs_service(test, params, session, service="VirtioFsSvc"):
                 test.fail("Failed to create virtiofs service, "
                           "output is %s" % sc_create_o)
     if service == "WinFSP.Launcher":
-        error_context.context("Delete virtiofs own service, "
+        error_context.context("Stop virtiofs own service, "
                               "using WinFsp.Launcher service instead.",
                               test.log.info)
-        delete_viofs_serivce(test, params, session)
+        stop_viofs_service(test, params, session)
         session.cmd(viofs_exe_copy_cmd % exe_path)
         error_context.context("Config WinFsp.Launcher for multifs.",
                               test.log.info)
@@ -399,14 +399,12 @@ def stop_viofs_service(test, params, session):
     :param session: the session of guest
     """
     viofs_sc_stop_cmd = params.get("viofs_sc_stop_cmd", "sc stop VirtioFsSvc")
-    session.cmd(viofs_sc_stop_cmd)
-
-    test.log.info("Query status of the virtiofs service...")
+    test.log.info("Check if virtiofs service status.")
     output = query_viofs_service(test, params, session)
     if "RUNNING" in output:
-        test.error("Virtiofs service is still running.")
+        session.cmd(viofs_sc_stop_cmd)
     else:
-        test.log.info("Virtiofs service is stopped.")
+        test.log.info("Virtiofs service isn't running.")
 
 
 def install_winfsp(test, params, session):

--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -181,18 +181,23 @@
             target_process = fio.exe
             run_bgstress = virtio_fs_share_data
             driver_id_pattern = "(.*?):.*?VirtIO FS Device"
+            reboot_after_delete_service = yes
             # install winfsp tool
             i386, i686:
-                install_path = 'C:\Program Files'
+                install_winfsp_path = 'C:\Program Files'
             x86_64:
-                install_path = 'C:\Program Files (x86)'
-            install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
+                install_winfsp_path = 'C:\Program Files (x86)'
+            install_winfsp_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
             check_installed_cmd = 'dir "%s" |findstr /I winfsp'
-            viofs_log_file = C:\\viofs_log.txt
-            viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath="%s -d -1 -D ${viofs_log_file}" start=auto'
+            viofs_log_file = C:\viofs_log.txt
+            viofs_svc_name = VirtioFsSvc
+            viofs_exe_path = C:\virtiofs.exe
+            viofs_exe_copy_cmd = xcopy %s C:\ /Y
+            viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath=${viofs_exe_path} start=auto'
             viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
-            viofs_sc_start_cmd = 'sc start VirtioFsSvc'
-            viofs_sc_query_cmd = 'sc query VirtioFsSvc'
+            viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
+            viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
+            viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
             fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
             fio_options += '--bs=4K --size=1G --iodepth=16 --numjobs=8 --runtime=600 --thread'
             io_timeout = 700

--- a/qemu/tests/cfg/virtio_fs_hotplug.cfg
+++ b/qemu/tests/cfg/virtio_fs_hotplug.cfg
@@ -5,6 +5,9 @@
     type = virtio_fs_hotplug
     virt_test_type = qemu
     required_qemu = [4.2.0,)
+    clone_master = yes
+    master_images_clone = image1
+    remove_image_image1 = yes
     kill_vm = yes
     start_vm = yes
     extra_filesystems = fs
@@ -54,7 +57,7 @@
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
         viofs_exe_path = C:\virtiofs.exe
-        viofs_exe_copy_cmd = xcopy %s C:\
+        viofs_exe_copy_cmd = xcopy %s C:\ /Y
         viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start VirtioFsSvc'

--- a/qemu/tests/cfg/virtio_fs_multi_vms.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_vms.cfg
@@ -6,6 +6,9 @@
     required_qemu = [4.2.0,)
     kill_vm = yes
     start_vm = yes
+    clone_master = yes
+    master_images_clone = image1
+    remove_image_image1 = yes
     mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
@@ -60,12 +63,13 @@
         wfsp_install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "${install_path}" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
+        viofs_svc_name = VirtioFsSvc
         viofs_exe_path = C:\virtiofs.exe
-        viofs_exe_copy_cmd = xcopy %s C:\
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
+        viofs_exe_copy_cmd = xcopy %s C:\ /Y
+        viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
-        viofs_sc_start_cmd = 'sc start VirtioFsSvc'
-        viofs_sc_query_cmd = 'sc query VirtioFsSvc'
+        viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
+        viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -48,12 +48,14 @@
         install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
+        viofs_svc_name = VirtioFsSvc
         viofs_exe_path = C:\virtiofs.exe
-        viofs_exe_copy_cmd = xcopy %s C:\
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
+        viofs_exe_copy_cmd = xcopy %s C:\ /Y
+        viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
-        viofs_sc_start_cmd = 'sc start VirtioFsSvc'
-        viofs_sc_query_cmd = 'sc query VirtioFsSvc'
+        viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
+        viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
+        viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -52,11 +52,12 @@
         viofs_log_file = C:\viofs_log.txt
         viofs_svc_name = VirtioFsSvc
         viofs_exe_path = C:\virtiofs.exe
-        viofs_exe_copy_cmd = 'xcopy %s C:\ /Y'
+        viofs_exe_copy_cmd = xcopy %s C:\ /Y
         viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
         viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
         viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
+        viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
@@ -28,20 +28,22 @@
     Windows:
         # install winfsp tool
         i386, i686:
-            install_path = 'C:\Program Files'
+            install_winfsp_path = 'C:\Program Files'
             devcon_dirname = 'x86'
         x86_64:
-            install_path = 'C:\Program Files (x86)'
+            install_winfsp_path = 'C:\Program Files (x86)'
             devcon_dirname = 'amd64'
-        install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
+        install_winfsp_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
+        viofs_svc_name = VirtioFsSvc
         viofs_exe_path = C:\virtiofs.exe
-        viofs_exe_copy_cmd = xcopy %s C:\
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
+        viofs_exe_copy_cmd = xcopy %s C:\ /Y
+        viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
-        viofs_sc_start_cmd = 'sc start VirtioFsSvc'
-        viofs_sc_query_cmd = 'sc query VirtioFsSvc'
+        viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
+        viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
+        viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -42,20 +42,22 @@
     Windows:
         # install winfsp tool
         i386, i686:
-            install_path = 'C:\Program Files'
+            install_winfsp_path = 'C:\Program Files'
             devcon_dirname = 'x86'
         x86_64:
-            install_path = 'C:\Program Files (x86)'
+            install_winfsp_path = 'C:\Program Files (x86)'
             devcon_dirname = 'amd64'
-        install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
+        install_winfsp_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
         check_installed_cmd = 'dir "%s" |findstr /I winfsp'
         viofs_log_file = C:\viofs_log.txt
+        viofs_svc_name = VirtioFsSvc
         viofs_exe_path = C:\virtiofs.exe
-        viofs_exe_copy_cmd = xcopy %s C:\
-        viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
+        viofs_exe_copy_cmd = xcopy %s C:\ /Y
+        viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath=${viofs_exe_path} start=auto'
         viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
-        viofs_sc_start_cmd = 'sc start VirtioFsSvc'
-        viofs_sc_query_cmd = 'sc query VirtioFsSvc'
+        viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
+        viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
+        viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/virtio_fs_winfsp_test.cfg
+++ b/qemu/tests/cfg/virtio_fs_winfsp_test.cfg
@@ -31,12 +31,15 @@
     driver_name = viofs
     # install winfsp tool
     i386, i686:
-        install_path = 'C:\Program Files'
+        install_winfsp_path = 'C:\Program Files'
         winfsp_exe_name = 'winfsp-tests-x86.exe'
+        devcon_dirname = 'x86'
     x86_64:
-        install_path = 'C:\Program Files (x86)'
+        install_winfsp_path = 'C:\Program Files (x86)'
         winfsp_exe_name = 'winfsp-tests-x64.exe'
-    install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
+        devcon_dirname = 'amd64'
+    devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+    install_winfsp_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
     check_installed_cmd = 'dir "%s" |findstr /I winfsp'
     viofs_log_file = C:\viofs_log.txt
     viofs_svc_name = VirtioFsSvc
@@ -46,13 +49,14 @@
     viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
     viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
     viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
+    viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
     viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
     viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
     viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'
     virtio_win_media_type = iso
     cdroms += " virtio"
-    winfsp_copy_cmd = 'xcopy "WIN_UTILS:\${winfsp_exe_name}" "${install_path}\WinFsp\bin" /y'
-    winfsp_test_cmd = '%s && "${install_path}\WinFsp\bin\${winfsp_exe_name}" --resilient --external -reparse* -stream* -create_fileattr_test '
+    winfsp_copy_cmd = 'xcopy "WIN_UTILS:\${winfsp_exe_name}" "${install_winfsp_path}\WinFsp\bin" /y'
+    winfsp_test_cmd = '%s && "${install_winfsp_path}\WinFsp\bin\${winfsp_exe_name}" --resilient --external -reparse* -stream* -create_fileattr_test '
     winfsp_test_cmd += '-create_readonlydir_test -create_allocation_test -create_notraverse_test -create_backup_test '
     winfsp_test_cmd += '-create_restore_test -create_share_test -getfileattr_test -getfileinfo_name_test -setfileinfo_test '
     winfsp_test_cmd += '-setsecurity_test -getfileinfo_test'

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -250,20 +250,21 @@
             target_process = fio.exe
             run_bgstress = virtio_fs_share_data
             driver_id_pattern = "(.*?):.*?VirtIO FS Device"
+            viofs_svc_name = VirtioFsSvc
             # install winfsp tool
             i386, i686:
-                install_path = 'C:\Program Files'
+                install_winfsp_path = 'C:\Program Files'
             x86_64:
-                install_path = 'C:\Program Files (x86)'
-            install_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
+                install_winfsp_path = 'C:\Program Files (x86)'
+            install_winfsp_cmd = 'msiexec /i WIN_UTILS:\winfsp.msi /qn'
             check_installed_cmd = 'dir "%s" |findstr /I winfsp'
             viofs_log_file = C:\\viofs_log.txt
             viofs_exe_path = C:\\virtiofs.exe
-            viofs_exe_copy_cmd = xcopy %s C:\
-            viofs_sc_create_cmd = 'sc create VirtioFsSvc binpath=${viofs_exe_path} start=auto'
+            viofs_exe_copy_cmd = xcopy %s C:\ /Y
+            viofs_sc_create_cmd = 'sc create ${viofs_svc_name} binpath=${viofs_exe_path} start=auto'
             viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
-            viofs_sc_start_cmd = 'sc start VirtioFsSvc'
-            viofs_sc_query_cmd = 'sc query VirtioFsSvc'
+            viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
+            viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
             fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
             fio_options += '--bs=4K --size=1G --iodepth=16 --numjobs=8 --runtime=1800 --thread'
             io_timeout = 2000

--- a/qemu/tests/virtio_fs_set_capability.py
+++ b/qemu/tests/virtio_fs_set_capability.py
@@ -14,7 +14,7 @@ from virttest import utils_test
 
 from virttest.utils_windows import virtio_win
 
-from provider import win_driver_installer_test
+from provider import virtio_fs_utils
 from provider import win_driver_utils
 
 
@@ -296,5 +296,4 @@ def run(test, params, env):
                 utils_misc.safe_rmdir(fs_dest, session=session)
     finally:
         if is_windows:
-            win_driver_installer_test.delete_viofs_serivce(
-                test, params, session)
+            virtio_fs_utils.delete_viofs_serivce(test, params, session)

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -811,8 +811,7 @@ def run(test, params, env):
             win_driver_utils.memory_leak_check(vm, test, params)
     finally:
         if os_type == 'windows' and vm and vm.is_alive():
-            win_driver_installer_test.delete_viofs_serivce(
-                test, params, session)
+            virtio_fs_utils.delete_viofs_serivce(test, params, session)
             if params.get("reboot_after_delete_service", "no") == "yes":
                 session = vm.reboot(session)
         if setup_local_nfs:


### PR DESCRIPTION
1.For virtiofs service test, it's better to clear the virtiofs service at the end. For virtiofs device hotplug/unplug test, deleting virtiofs service will fail after unplugging the virtiofs device, so use the image backend method for it.
2. Do some code update when using functions in provided unit
    1.Update parameters as creating/deleting virtiofs
    service is using function unit that implemented
    in provider/win_driver_installer_test.py instead.
    2.Use stop virtiofs service instead of delete service
    when creating multi virtiofs service

ID: 2156433, 2169907
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>