### PR TITLE
qemu_guest_agent: Add new api 'guest-get-cpustats'

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -546,6 +546,11 @@
             cmd_get_hostkey = "cat ~/.ssh/id_rsa.pub"
             cmd_del_key_file = "rm -rf ${guest_homepath}/.ssh/authorized_keys"
             test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls /home
+        - check_get_cpustats:
+          only Linux
+          gagent_check_type = get_cpustats
+          cpustats_info_list = user,nice,system,idle,iowait,irq,softirq,steal,guest,guestnice
+          cpu_num_guest = cat /proc/stat | grep "cpu" -c
         - gagent_run_qga_as_program:
             only Windows
             gagent_check_type = run_qga_as_program


### PR DESCRIPTION
1. Add new guest agent command 'guest-get-cpustats' to get guest CPU statistics, we can know the guest workload and how busy the CPU is.
2. Check number of cpus as well.

ID: 2166558
Signed-off-by: demeng <demeng@redhat.com>