### PR TITLE
x86_cpu_protection_key:Add unsupported 'EPYC-IBPB'

### DIFF
--- a/qemu/tests/cfg/x86_cpu_protection_key.cfg
+++ b/qemu/tests/cfg/x86_cpu_protection_key.cfg
@@ -11,7 +11,7 @@
         x86-64-march = x86-64-v3
     start_vm = no
     timeout = 120
-    unsupported_models = "EPYC-Rome EPYC Opteron_G5 Opteron_G4 Opteron_G3 Opteron_G2 Opteron_G1"
+    unsupported_models = "EPYC-Rome EPYC EPYC-IBPB Opteron_G5 Opteron_G4 Opteron_G3 Opteron_G2 Opteron_G1"
     guest_dir = '/home/tpm-test/'
     test_dir = '/tools/testing/selftests/vm/'
     download_rpm_cmd = brew download-build --rpm %s


### PR DESCRIPTION
ID: 2169083

Script 'x86_cpu_protection_key' only supports EPYC-Milan or newer cpu model.

Signed-off-by: nanliu <nanliu@redhat.com>