### PR TITLE
nvdimm_readonly: updates nvdimm_readonly unarmed subcases

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -116,14 +116,14 @@
             readonly_mem_mem1 = on
             required_qemu = [6, )
             variants:
-                - unarmed_on:
-                    type = nvdimm_negative
-                    unarmed_dimm_mem1 = on
-                    start_vm = no
-                    error_msg = "'unarmed' property must be off since memdev mem-${mem_devs} is read-only"
                 - unarmed_off:
-                    type = boot
+                    type = nvdimm_negative
                     unarmed_dimm_mem1 = off
+                    start_vm = no
+                    error_msg = "\'unarmed\' property must be \'on\' since memdev mem-${mem_devs} is read-only"
+                - unarmed_on:
+                    type = boot
+                    unarmed_dimm_mem1 = on
         - nvdimm_nvml:
             depends_pkgs += ndctl-devel daxctl-devel pandoc
             ppc64le, ppc64:

--- a/qemu/tests/nvdimm_negative.py
+++ b/qemu/tests/nvdimm_negative.py
@@ -1,5 +1,3 @@
-import re
-
 from virttest import error_context
 from virttest import virt_vm
 
@@ -27,5 +25,5 @@ def run(test, params, env):
 
     error_context.context("Check the expected error message: %s"
                           % error_msg, test.log.info)
-    if not re.search(error_msg, output):
+    if error_msg not in output:
         test.fail("Can not get expected error message: %s" % error_msg)


### PR DESCRIPTION
nvdimm_readonly: updates nvdimm_readonly unarmed subcases

Changes for unarmed readonly variants the structure because the negative case should be the unarmed_off one, also updates the error message including the backslashes and changes the if condition since the search method was not working.

ID: 2169373
Signed-off-by: mcasquer <mcasquer@redhat.com>