### PR TITLE
lvm:fix lvremove /dev/vg_kvm_test/lv_kvm_test failed issue

### DIFF
--- a/generic/tests/cfg/lvm.cfg
+++ b/generic/tests/cfg/lvm.cfg
@@ -9,7 +9,7 @@
     image_format_stg1 = qcow2
     image_name_stg2 = images/storage_64k
     image_cluster_size_stg2 = 65536
-    image_size_stg2 = 1G
+    image_size_stg2 = 2G
     image_format_stg2 = qcow2
     remove_image_stg1 = no
     remove_image_stg2 = no
@@ -18,18 +18,18 @@
     clean = no
     check_mount = "mountpoint /mnt/kvm_test_lvm"
     fs_type = xfs
+    blk_extra_params_stg1 = "serial=TARGET_DISK1"
+    blk_extra_params_stg2 = "serial=TARGET_DISK2"
+    Host_RHEL.m6..ide:
+        blk_extra_params_stg1 = "wwn=0x5000123456789abc"
+        blk_extra_params_stg2 = "wwn=0x5000cba987654321"
     RHEL.6:
         fs_type = ext4
     variants:
         - lvm_create:
             sub_type = lvm_create
             force_create_image_stg1 = yes
-            blk_extra_params_stg1 = "serial=TARGET_DISK1"
             force_create_image_stg2 = yes
-            blk_extra_params_stg2 = "serial=TARGET_DISK2"
-            Host_RHEL.m6..ide:
-                blk_extra_params_stg1 = "wwn=0x5000123456789abc"
-                blk_extra_params_stg2 = "wwn=0x5000cba987654321"
         - lvm_fill: lvm_create
             sub_type = fillup_disk
             force_create_image_stg1 = no


### PR DESCRIPTION
The lvm relevant cases include LV creation, io, and clean sub-cases. 
The creation case uses serial on disk, but the other sub-cases 
do not use same serial on disk, it is invalid usage if LV needs to rescan disks.

It results in the lvm can not find LV.

ID:2069578