### PR TITLE
qemu_guest_agent: Add new api 'guest-get-diskstats'

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -547,16 +547,24 @@
             cmd_del_key_file = "rm -rf ${guest_homepath}/.ssh/authorized_keys"
             test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls /home
         - check_get_cpustats:
-          only Linux
-          gagent_check_type = get_cpustats
-          cpustats_info_list = user,nice,system,idle,iowait,irq,softirq,steal,guest,guestnice
-          cpu_num_guest = cat /proc/stat | grep "cpu" -c
+            only Linux
+            gagent_check_type = get_cpustats
+            cpustats_info_list = user,nice,system,idle,iowait,irq,softirq,steal,guest,guestnice
+            cpu_num_guest = cat /proc/stat | grep "cpu" -c
         - gagent_run_qga_as_program:
             only Windows
             gagent_check_type = run_qga_as_program
             run_gagent_program_cmd = 'cd "C:\Program Files\Qemu-ga\"&'
             run_gagent_program_cmd += 'start /b qemu-ga.exe'
             kill_qga_program_cmd = taskkill /im qemu-ga.exe /t /f
+        - check_get_diskstats:
+            only Linux
+            gagent_check_type = get_diskstats
+            count_num_arg = head -n 1 /proc/diskstats | awk '{print NF; exit}'
+            disk_num_guest = cat /proc/diskstats |wc -l
+            cmd_ds_major = cat /proc/diskstats | grep -m 1 %s | awk '{print $1}'
+            cmd_ds_minor = cat /proc/diskstats | grep -m 1 %s | awk '{print $2}'
+            diskstats_info_list = name,read-sectors,read-ios,read-merges,write-sectors,write-ios,write-merges,discard-sectors,discard-ios,discard-merges,flush-ios,read-ticks,write-ticks,discard-ticks,flush-ticks,ios-pgr,total-ticks,weight-ticks,major,minor
         - gagent_driver_update_via_installer_tool:
             only Windows
             no isa_serial


### PR DESCRIPTION
Add new guest agent command 'guest-get-diskstats' to get guest disk statistics for Linux guests. This can be useful for getting io flow or handling IO fault, no need to enter guests.

ID: 2166559
Signed-off-by: demeng <demeng@redhat.com>