### PR TITLE
x86_cpu_L3_cache:limit 'vcpu_maxcpus' for old machine type

### DIFF
--- a/qemu/tests/x86_cpu_L3_cache.py
+++ b/qemu/tests/x86_cpu_L3_cache.py
@@ -31,6 +31,9 @@ def run(test, params, env):
         params['machine_type'] = machine_type
         params['start_vm'] = 'yes'
         vm_name = params['main_vm']
+        if max(params.get_numeric('smp'),
+               params.get_numeric('vcpu_maxcpus')) > 128:
+            params['smp'] = params['vcpu_maxcpus'] = '128'
         L3_existence = 'present' if check_L3 else 'not present'
         test.log.info('Boot guest with machine type %s and expect L3 cache %s'
                       ' inside guest', machine_type, L3_existence)


### PR DESCRIPTION
ID: 2170807

limit 'vcpu_maxcpus' pc-q35-rhel7.3.0 machine type when testing it on large cpus(>=256) host.