### PR TITLE
x86_cpu_flags:extend cpu vendor for 'la57' test

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -32,19 +32,6 @@
                     flags = "arch_capabilities"
                     check_guest_cmd = "cat /sys/devices/system/cpu/vulnerabilities/mds | grep '%s'"
                     expect_items = 'Not affected'
-                - test_la57:
-                    # support RHEL.8 guest or later
-                    no RHEL.6 RHEL.7
-                    flags = "la57"
-                    check_guest_cmd = 'grep "address sizes" /proc/cpuinfo | uniq | grep "%s bits virtual"'
-                    variants:
-                        - with_la57:
-                            expect_items = 57
-                            cpu_model_flags = ",+la57"
-                        - without_la57:
-                            expect_items = 48
-                            cpu_model_flags = ",-la57"
-                            no_flags = "la57"
                 - intel_pt:
                     type = x86_cpu_flag_intel_pt
                     flags = "intel_pt"
@@ -177,3 +164,16 @@
                             only HostCpuVendor.amd
                             auto_cpu_model = no
                             cpu_model = host
+                - test_la57:
+                    # support RHEL.8 guest or later
+                    no RHEL.6 RHEL.7
+                    flags = "la57"
+                    check_guest_cmd = 'grep "address sizes" /proc/cpuinfo | uniq | grep "%s bits virtual"'
+                    variants:
+                        - with_la57:
+                            expect_items = 57
+                            cpu_model_flags = ",+la57"
+                        - without_la57:
+                            expect_items = 48
+                            cpu_model_flags = ",-la57"
+                            no_flags = "la57"


### PR DESCRIPTION
ID: 2171277

AMD supports 'la57' on Genoa now.