### PR TITLE
ioquit:fix adding timeout after killing process

### DIFF
--- a/generic/tests/cfg/lvm.cfg
+++ b/generic/tests/cfg/lvm.cfg
@@ -45,11 +45,13 @@
             sub_type = ioquit
             force_create_image_stg1 = no
             force_create_image_stg2 = no
-            backup_image_before_testing = yes
-            restore_image_after_testing = yes
             skip_cluster_leak_warn = yes
             background_cmd = "for i in 1 2 3 4; do (dd if=/dev/urandom of=/mnt/kvm_test_lvm/file bs=102400 count=10000000 &); done"
             check_cmd = pgrep dd
+            clone_master = yes
+            master_images_clone = image1
+            force_image_clone = yes
+            remove_image_image1 = yes
         - lvm_clean: lvm_create
             sub_type = lvm_clean
             clean = yes

--- a/generic/tests/ioquit.py
+++ b/generic/tests/ioquit.py
@@ -44,6 +44,7 @@ def run(test, params, env):
 
     error_context.context("Kill the VM", test.log.info)
     utils_misc.kill_process_tree(vm.process.get_pid(), timeout=60)
+    time.sleep(3)
     error_context.context("Check img after kill VM", test.log.info)
     base_dir = data_dir.get_data_dir()
     image_name = params.get("image_name")


### PR DESCRIPTION
1. The process is interrupted by forced killing.
There is no time delay before checking the image file.
Maybe there are processes still using the image file.

2. Remove the backup system image file setting.
The backup operation is not necessary for testing.
The image file may be restored by an unexpected image
file if other cases generate a backup file in advance.


ID:2169902,2176367