### PR TITLE
block_multifunction_scale:fix syntax error for 'or'

### DIFF
--- a/qemu/tests/block_multifunction_scale.py
+++ b/qemu/tests/block_multifunction_scale.py
@@ -68,7 +68,7 @@ def run(test, params, env):
     disk_op_cmd = params.get("disk_op_cmd")
     session = vm.wait_for_login()
     pcie = False
-    if "q35" or "arm64-pci" in params['machine_type']:
+    if "q35" in params['machine_type'] or "arm64-pci" in params['machine_type']:
         pcie = True
     dev_slots = range(0, 3) if pcie else (7, 10)
 


### PR DESCRIPTION
Add separate 'in' item for both condition
ID:2168474