### PR TITLE
virtio_fs_utils: migrate the related virtio functions

### DIFF
--- a/provider/virtio_fs_utils.py
+++ b/provider/virtio_fs_utils.py
@@ -40,8 +40,6 @@ def basic_io_test(test, params, session):
     """
     error_context.context("Running viofs basic io test", LOG_JOB.info)
     test_file = params.get('virtio_fs_test_file', "virtio_fs_test_file")
-    cmd_dd = params.get("virtio_fs_cmd_dd", 'dd if=/dev/urandom of=%s bs=1M '
-                                            'count=100 iflag=fullblock')
     windows = params.get("os_type", "windows") == "windows"
     io_timeout = params.get_numeric("fs_io_timeout", 120)
     fs_source = params.get("fs_source_dir", "virtio_fs_test/")
@@ -53,9 +51,14 @@ def basic_io_test(test, params, session):
     host_data = os.path.join(fs_source, test_file)
     try:
         if windows:
+            cmd_dd = params.get("virtio_fs_cmd_dd",
+                                'dd if=/dev/random of=%s bs=1M count=100')
             driver_letter = get_virtiofs_driver_letter(test, fs_target, session)
             fs_dest = "%s:" % driver_letter
         else:
+            cmd_dd = params.get("virtio_fs_cmd_dd",
+                                'dd if=/dev/urandom of=%s bs=1M '
+                                'count=100 iflag=fullblock')
             fs_dest = params.get("fs_dest", "/mnt/" + fs_target)
         guest_file = os.path.join(fs_dest, test_file)
         error_context.context("The guest file in shared dir is %s" %

--- a/provider/virtio_fs_utils.py
+++ b/provider/virtio_fs_utils.py
@@ -7,6 +7,8 @@ from virttest import data_dir
 from virttest import error_context
 from virttest import utils_misc
 
+from virttest.utils_windows import virtio_win
+
 LOG_JOB = logging.getLogger('avocado.test')
 
 
@@ -231,3 +233,202 @@ def basic_io_test_via_psexec(test, params, vm, usernm, pwd):
             error_context.context("Delete the sub folder on shared directory "
                                   "of guest: ", LOG_JOB.info)
             session.cmd("rmdir /s /q %s" % (fs_dest + "\\" + folder_name))
+
+
+def get_viofs_exe_path(test, params, session):
+    """
+    Get viofs.exe from virtio win iso,such as E:\viofs\2k19\amd64
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param session: the session of guest
+    """
+    error_context.context("Get virtiofs exe full path.", test.log.info)
+    media_type = params["virtio_win_media_type"]
+    try:
+        get_drive_letter = getattr(virtio_win, "drive_letter_%s" % media_type)
+        get_product_dirname = getattr(virtio_win,
+                                      "product_dirname_%s" % media_type)
+        get_arch_dirname = getattr(virtio_win, "arch_dirname_%s" % media_type)
+    except AttributeError:
+        test.error("Not supported virtio win media type '%s'", media_type)
+    viowin_ltr = get_drive_letter(session)
+    if not viowin_ltr:
+        test.error("Could not find virtio-win drive in guest")
+    guest_name = get_product_dirname(session)
+    if not guest_name:
+        test.error("Could not get product dirname of the vm")
+    guest_arch = get_arch_dirname(session)
+    if not guest_arch:
+        test.error("Could not get architecture dirname of the vm")
+
+    exe_middle_path = ("{name}\\{arch}" if media_type == "iso"
+                       else "{arch}\\{name}").format(name=guest_name,
+                                                     arch=guest_arch)
+    exe_file_name = "virtiofs.exe"
+    exe_find_cmd = 'dir /b /s %s\\%s | findstr "\\%s\\\\"'
+    exe_find_cmd %= (viowin_ltr, exe_file_name, exe_middle_path)
+    exe_path = session.cmd(exe_find_cmd).strip()
+    test.log.info("Found exe file '%s'", exe_path)
+    return exe_path
+
+
+def create_viofs_service(test, params, session, service="VirtioFsSvc"):
+    """
+    Only for windows guest, to create a virtiofs service
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param session: the session of guest
+    """
+    install_winfsp(test, params, session)
+    exe_path = get_viofs_exe_path(test, params, session)
+    viofs_exe_copy_cmd_default = 'xcopy %s C:\\ /Y'
+    viofs_exe_copy_cmd = params.get("viofs_exe_copy_cmd",
+                                    viofs_exe_copy_cmd_default)
+    if service == "VirtioFsSvc":
+        error_context.context("Create virtiofs own service in"
+                              " Windows guest.",
+                              test.log.info)
+        output = query_viofs_service(test, params, session)
+        if "not exist as an installed service" in output:
+            session.cmd(viofs_exe_copy_cmd % exe_path)
+            viofs_sc_create_cmd_default = 'sc create VirtioFsSvc ' \
+                                          'binpath="c:\\virtiofs.exe" ' \
+                                          'start=auto  ' \
+                                          'depend="WinFsp.Launcher/VirtioFsDrv" ' \
+                                          'DisplayName="Virtio FS Service"'
+            viofs_sc_create_cmd = params.get("viofs_sc_create_cmd",
+                                             viofs_sc_create_cmd_default)
+            sc_create_s, sc_create_o = session.cmd_status_output(
+                viofs_sc_create_cmd)
+            if sc_create_s != 0:
+                test.fail("Failed to create virtiofs service, "
+                          "output is %s" % sc_create_o)
+    if service == "WinFSP.Launcher":
+        error_context.context("Delete virtiofs own service, "
+                              "using WinFsp.Launcher service instead.",
+                              test.log.info)
+        delete_viofs_serivce(test, params, session)
+        session.cmd(viofs_exe_copy_cmd % exe_path)
+        error_context.context("Config WinFsp.Launcher for multifs.",
+                              test.log.info)
+        output = session.cmd_output(params["viofs_sc_create_cmd"])
+        if "completed successfully" not in output.lower():
+            test.fail("MultiFS: Config WinFsp.Launcher failed, "
+                      "the output is %s." % output)
+
+
+def delete_viofs_serivce(test, params, session):
+    """
+    Delete the virtiofs service on Windows guest
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param session: the session of guest
+    """
+    viofs_sc_delete_cmd = params.get("viofs_sc_delete_cmd",
+                                     "sc delete VirtioFsSvc")
+    error_context.context("Deleting the viofs service...", test.log.info)
+    output = query_viofs_service(test, params, session)
+    if "not exist as an installed service" in output:
+        test.log.info("The viofs service was NOT found at the guest."
+                      " Skipping delete...")
+    else:
+        status = session.cmd_status(viofs_sc_delete_cmd)
+        if status == 0:
+            test.log.info("Done to delete the viofs service...")
+        else:
+            test.error("Failed to delete the viofs service...")
+
+
+def start_viofs_service(test, params, session):
+    """
+    Start the virtiofs service on Windows guest
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param session: the session of guest
+    """
+    viofs_sc_start_cmd = params.get("viofs_sc_start_cmd",
+                                    "sc start VirtioFsSvc")
+    error_context.context("Start the viofs service...", test.log.info)
+    test.log.info("Check if virtiofs service is started.")
+    output = query_viofs_service(test, params, session)
+    if "RUNNING" not in output:
+        status = session.cmd_status(viofs_sc_start_cmd)
+        if status == 0:
+            test.log.info("Done to start the viofs service.")
+        else:
+            test.error("Failed to start the viofs service...")
+    else:
+        test.log.info("Virtiofs service is running.")
+
+
+def query_viofs_service(test, params, session):
+    """
+    Query the virtiofs service on Windows guest
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param session: the session of guest
+    :return output: the output of cmd return
+    """
+    viofs_sc_query_cmd = params.get("viofs_sc_query_cmd",
+                                    "sc query VirtioFsSvc")
+    error_context.context("Query the status of viofs service...",
+                          test.log.info)
+    return session.cmd_output(viofs_sc_query_cmd)
+
+
+def run_viofs_service(test, params, session):
+    """
+    Run the virtiofs service on Windows guest
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param session: the session of guest
+    """
+    create_viofs_service(test, params, session)
+    start_viofs_service(test, params, session)
+
+
+def stop_viofs_service(test, params, session):
+    """
+    Stop the virtiofs service on Windows guest
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param session: the session of guest
+    """
+    viofs_sc_stop_cmd = params.get("viofs_sc_stop_cmd", "sc stop VirtioFsSvc")
+    session.cmd(viofs_sc_stop_cmd)
+
+    test.log.info("Query status of the virtiofs service...")
+    output = query_viofs_service(test, params, session)
+    if "RUNNING" in output:
+        test.error("Virtiofs service is still running.")
+    else:
+        test.log.info("Virtiofs service is stopped.")
+
+
+def install_winfsp(test, params, session):
+    """
+    Install the winfsp on Windows guest
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param session: the session of guest
+    """
+    cmd_timeout = params.get_numeric("cmd_timeout", 120)
+    install_path = params["install_winfsp_path"]
+    check_installed_cmd = params.get("check_winfsp_installed_cmd",
+                                     r'dir "%s" |findstr /I winfsp')
+    check_installed_cmd = check_installed_cmd % install_path
+    install_winfsp_cmd = r'msiexec /i WIN_UTILS:\winfsp.msi /qn'
+    install_cmd = params.get("install_winfsp_cmd",
+                             install_winfsp_cmd)
+    # install winfsp tool
+    test.log.info("Install winfsp for windows guest.")
+    installed = session.cmd_status(check_installed_cmd) == 0
+    if installed:
+        test.log.info("Winfsp tool is already installed.")
+    else:
+        install_cmd = utils_misc.set_winutils_letter(session, install_cmd)
+        session.cmd(install_cmd, cmd_timeout)
+        if not utils_misc.wait_for(lambda: not session.cmd_status(
+                check_installed_cmd), 60):
+            test.error("Winfsp tool is not installed.")

--- a/provider/win_driver_installer_test.py
+++ b/provider/win_driver_installer_test.py
@@ -7,13 +7,12 @@ import os
 from avocado.utils import process
 
 from virttest import utils_net
-from virttest import data_dir
 from virttest import error_context
 from virttest import utils_disk
 from virttest import utils_misc
-from virttest.utils_windows import virtio_win
 
 from provider import win_driver_utils
+from provider import virtio_fs_utils
 from provider.storage_benchmark import generate_instance
 from qemu.tests.virtio_serial_file_transfer import transfer_data
 
@@ -269,229 +268,6 @@ def iozone_test(test, params, vm, images):
             iozone.clean()
 
 
-@error_context.context_aware
-def get_viofs_exe_path(test, params, session):
-    """
-    Get viofs.exe from virtio win iso,such as E:\viofs\2k19\amd64
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
-    :param session: the session of guest
-    """
-    error_context.context("Get virtiofs exe full path.", test.log.info)
-    media_type = params["virtio_win_media_type"]
-    try:
-        get_drive_letter = getattr(virtio_win, "drive_letter_%s" % media_type)
-        get_product_dirname = getattr(virtio_win,
-                                      "product_dirname_%s" % media_type)
-        get_arch_dirname = getattr(virtio_win, "arch_dirname_%s" % media_type)
-    except AttributeError:
-        test.error("Not supported virtio win media type '%s'", media_type)
-    viowin_ltr = get_drive_letter(session)
-    if not viowin_ltr:
-        test.error("Could not find virtio-win drive in guest")
-    guest_name = get_product_dirname(session)
-    if not guest_name:
-        test.error("Could not get product dirname of the vm")
-    guest_arch = get_arch_dirname(session)
-    if not guest_arch:
-        test.error("Could not get architecture dirname of the vm")
-
-    exe_middle_path = ("{name}\\{arch}" if media_type == "iso"
-                       else "{arch}\\{name}").format(name=guest_name,
-                                                     arch=guest_arch)
-    exe_file_name = "virtiofs.exe"
-    exe_find_cmd = 'dir /b /s %s\\%s | findstr "\\%s\\\\"'
-    exe_find_cmd %= (viowin_ltr, exe_file_name, exe_middle_path)
-    exe_path = session.cmd(exe_find_cmd).strip()
-    test.log.info("Found exe file '%s'", exe_path)
-    return exe_path
-
-
-def create_viofs_service(test, params, session, service="VirtioFsSvc"):
-    """
-    Only for windows guest, to create a virtiofs service
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
-    :param session: the session of guest
-    """
-    install_winfsp(test, params, session)
-    exe_path = get_viofs_exe_path(test, params, session)
-    viofs_exe_copy_cmd_default = 'xcopy %s C:\\ /Y'
-    viofs_exe_copy_cmd = params.get("viofs_exe_copy_cmd",
-                                    viofs_exe_copy_cmd_default)
-    if service == "VirtioFsSvc":
-        error_context.context("Create virtiofs own service in"
-                              " Windows guest.",
-                              test.log.info)
-        output = query_viofs_service(test, params, session)
-        if "not exist as an installed service" in output:
-            session.cmd(viofs_exe_copy_cmd % exe_path)
-            viofs_sc_create_cmd_default = 'sc create VirtioFsSvc ' \
-                                          'binpath="c:\\virtiofs.exe" ' \
-                                          'start=auto  ' \
-                                          'depend="WinFsp.Launcher/VirtioFsDrv" ' \
-                                          'DisplayName="Virtio FS Service"'
-            viofs_sc_create_cmd = params.get("viofs_sc_create_cmd",
-                                             viofs_sc_create_cmd_default)
-            sc_create_s, sc_create_o = session.cmd_status_output(
-                viofs_sc_create_cmd)
-            if sc_create_s != 0:
-                test.fail("Failed to create virtiofs service, "
-                          "output is %s" % sc_create_o)
-    if service == "WinFSP.Launcher":
-        error_context.context("Delete virtiofs own service, "
-                              "using WinFsp.Launcher service instead.",
-                              test.log.info)
-        delete_viofs_serivce(test, params, session)
-        session.cmd(viofs_exe_copy_cmd % exe_path)
-        error_context.context("Config WinFsp.Launcher for multifs.",
-                              test.log.info)
-        output = session.cmd_output(params["viofs_sc_create_cmd"])
-        if "completed successfully" not in output.lower():
-            test.fail("MultiFS: Config WinFsp.Launcher failed, "
-                      "the output is %s." % output)
-
-
-@error_context.context_aware
-def delete_viofs_serivce(test, params, session):
-    """
-    Delete the virtiofs service on Windows guest
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
-    :param session: the session of guest
-    """
-    viofs_sc_delete_cmd = params.get("viofs_sc_delete_cmd",
-                                     "sc delete VirtioFsSvc")
-    error_context.context("Deleting the viofs service...", test.log.info)
-    output = query_viofs_service(test, params, session)
-    if "not exist as an installed service" in output:
-        test.log.info("The viofs service was NOT found at the guest."
-                      " Skipping delete...")
-    else:
-        status = session.cmd_status(viofs_sc_delete_cmd)
-        if status == 0:
-            test.log.info("Done to delete the viofs service...")
-        else:
-            test.error("Failed to delete the viofs service...")
-
-
-@error_context.context_aware
-def start_viofs_service(test, params, session):
-    """
-    Start the virtiofs service on Windows guest
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
-    :param session: the session of guest
-    """
-    viofs_sc_start_cmd = params.get("viofs_sc_start_cmd",
-                                    "sc start VirtioFsSvc")
-    error_context.context("Start the viofs service...", test.log.info)
-    test.log.info("Check if virtiofs service is started.")
-    output = query_viofs_service(test, params, session)
-    if "RUNNING" not in output:
-        status = session.cmd_status(viofs_sc_start_cmd)
-        if status == 0:
-            test.log.info("Done to start the viofs service.")
-        else:
-            test.error("Failed to start the viofs service...")
-    else:
-        test.log.info("Virtiofs service is running.")
-
-
-@error_context.context_aware
-def query_viofs_service(test, params, session):
-    """
-    Query the virtiofs service on Windows guest
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
-    :param session: the session of guest
-    :return output: the output of cmd return
-    """
-    viofs_sc_query_cmd = params.get("viofs_sc_query_cmd",
-                                    "sc query VirtioFsSvc")
-    error_context.context("Query the status of viofs service...",
-                          test.log.info)
-    return session.cmd_output(viofs_sc_query_cmd)
-
-
-@error_context.context_aware
-def run_viofs_service(test, params, session):
-    """
-    Run the virtiofs service on Windows guest
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
-    :param session: the session of guest
-    """
-    create_viofs_service(test, params, session)
-    start_viofs_service(test, params, session)
-
-
-@error_context.context_aware
-def stop_viofs_service(test, params, session):
-    """
-    Stop the virtiofs service on Windows guest
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
-    :param session: the session of guest
-    """
-    viofs_sc_stop_cmd = params.get("viofs_sc_stop_cmd", "sc stop VirtioFsSvc")
-    session.cmd(viofs_sc_stop_cmd)
-
-    test.log.info("Query status of the virtiofs service...")
-    output = query_viofs_service(test, params, session)
-    if "RUNNING" in output:
-        test.error("Virtiofs service is still running.")
-    else:
-        test.log.info("Virtiofs service is stopped.")
-
-
-def install_winfsp(test, params, session):
-    """
-    Install the winfsp on Windows guest
-    :param test: QEMU test object
-    :param params: Dictionary with the test parameters
-    :param session: the session of guest
-    """
-    cmd_timeout = params.get_numeric("cmd_timeout", 120)
-    install_path = params["install_winfsp_path"]
-    check_installed_cmd = params.get("check_winfsp_installed_cmd",
-                                     r'dir "%s" |findstr /I winfsp')
-    check_installed_cmd = check_installed_cmd % install_path
-    install_winfsp_cmd = r'msiexec /i WIN_UTILS:\winfsp.msi /qn'
-    install_cmd = params.get("install_winfsp_cmd",
-                             install_winfsp_cmd)
-    # install winfsp tool
-    test.log.info("Install winfsp for windows guest.")
-    installed = session.cmd_status(check_installed_cmd) == 0
-    if installed:
-        test.log.info("Winfsp tool is already installed.")
-    else:
-        install_cmd = utils_misc.set_winutils_letter(session, install_cmd)
-        session.cmd(install_cmd, cmd_timeout)
-        if not utils_misc.wait_for(lambda: not session.cmd_status(
-                check_installed_cmd), 60):
-            test.error("Winfsp tool is not installed.")
-
-
-def get_virtiofs_driver_letter(test, fs_target, session):
-    """
-    Get the virtiofs driver letter( Windows guest only )
-    :param test: QEMU test object
-    :param fs_target: virtio fs target
-    :param session: the session of guest
-    :return driver_letter: the driver letter of the virtiofs
-    """
-    test.log.info("Get driver letter of virtio fs target, the driver label is "
-                  "%s." % fs_target)
-    vol_con = "VolumeName='%s'" % fs_target
-    driver_letter = utils_misc.wait_for(
-        lambda: utils_misc.get_win_disk_vol(session, condition=vol_con),
-        timeout=120)
-    if driver_letter is None:
-        test.fail("Could not get virtio-fs mounted driver letter.")
-    return driver_letter
-
-
 def viofs_basic_io_test(test, params, vm):
     """
     Basic io test in Windows guest
@@ -499,40 +275,9 @@ def viofs_basic_io_test(test, params, vm):
     :param params: Dictionary with the test parameters
     :param vm: the vm object
     """
-    error_context.context("Running viofs basic io test", LOG_JOB.info)
     session = vm.wait_for_login()
-    test_file = params.get('test_file', "virtio_fs_test_file")
-    cmd_dd = params.get("cmd_dd", 'dd if=/dev/random of=%s bs=1M count=200')
-    io_timeout = params.get("timeout", 120)
-    cmd_md5 = params.get("cmd_md5", '%s: && md5sum.exe %s')
-    fs_source = params.get("fs_source_dir")
-    base_dir = params.get("fs_source_base_dir",
-                          data_dir.get_data_dir())
-    if not os.path.isabs(fs_source):
-        fs_source = os.path.join(base_dir, fs_source)
-
-    host_data = os.path.join(fs_source, test_file)
-
-    fs_target = params.get("fs_target")
-    driver_letter = get_virtiofs_driver_letter(test, fs_target, session)
-    fs_dest = "%s:" % driver_letter
-    guest_file = os.path.join(fs_dest, test_file)
-
-    test.log.info("Creating file under %s inside guest." % fs_dest)
-    session.cmd(cmd_dd % guest_file, io_timeout)
-
-    guest_file_win = guest_file.replace("/", "\\")
-    cmd_md5_vm = cmd_md5 % (driver_letter, guest_file_win)
-    md5_guest = session.cmd_output(cmd_md5_vm, io_timeout).strip().split()[0]
-
-    test.log.info("md5 of the guest file: " + md5_guest)
-    md5_host = process.run("md5sum %s" % host_data,
-                           io_timeout).stdout_text.strip().split()[0]
-    test.log.info("md5 of the host file: " + md5_host)
-    if md5_guest != md5_host:
-        test.fail('The md5 value of host is not same to guest.')
-    else:
-        test.log.info("The md5 of host is as same as md5 of guest.")
+    virtio_fs_utils.basic_io_test(test, params, session)
+    session.close()
 
 
 def balloon_test(test, params, vm, balloon_test_win):

--- a/qemu/tests/virtio_fs_multi_users_access.py
+++ b/qemu/tests/virtio_fs_multi_users_access.py
@@ -1,6 +1,6 @@
 from virttest import error_context, utils_test, utils_disk, utils_misc
 
-from provider import win_driver_installer_test, virtio_fs_utils
+from provider import virtio_fs_utils
 
 
 @error_context.context_aware
@@ -114,7 +114,7 @@ def run(test, params, env):
         if os_type == "windows":
             session = utils_test.qemu. \
                 windrv_check_running_verifier(session, vm, test, driver_name)
-            win_driver_installer_test.run_viofs_service(test, params, session)
+            virtio_fs_utils.run_viofs_service(test, params, session)
             vm.reboot(session)
         else:
             error_context.context("Create a destination directory %s "

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -19,8 +19,8 @@ from virttest.qemu_devices import qdevices
 from virttest import utils_selinux
 
 from provider.storage_benchmark import generate_instance
-from provider import win_driver_installer_test
 from provider import win_driver_utils
+from provider import virtio_fs_utils
 
 
 @error_context.context_aware
@@ -380,9 +380,8 @@ def run(test, params, env):
             # create virtiofs service
             viofs_svc_name = params["viofs_svc_name"]
             viofs_sc_create_cmd = params["viofs_sc_create_cmd"]
-            win_driver_installer_test.create_viofs_service(test, params,
-                                                           session,
-                                                           service=viofs_svc_name)
+            virtio_fs_utils.create_viofs_service(test, params, session,
+                                                 service=viofs_svc_name)
         for fs in params.objects("filesystems"):
             fs_params = params.object_params(fs)
             fs_target = fs_params.get("fs_target")
@@ -410,7 +409,7 @@ def run(test, params, env):
                 if params.get("viofs_svc_name") == "VirtioFsSvc":
                     error_context.context("Start virtiofs service in guest.",
                                           test.log.info)
-                    win_driver_installer_test.start_viofs_service(test, params, session)
+                    virtio_fs_utils.start_viofs_service(test, params, session)
                     session = enable_debug_log(session)
                 else:
                     error_context.context("Start winfsp.launcher"

--- a/qemu/tests/win_virtio_driver_install_by_installer.py
+++ b/qemu/tests/win_virtio_driver_install_by_installer.py
@@ -4,6 +4,7 @@ from virttest import error_context
 
 from provider import win_driver_installer_test
 from provider import win_driver_utils
+from provider import virtio_fs_utils
 
 from qemu.tests.balloon_check import BallooningTestWin
 
@@ -70,7 +71,7 @@ def run(test, params, env):
 
     driver_test_names = params.objects("driver_test_names")
     if "viofs_basic_io" in driver_test_names:
-        win_driver_installer_test.run_viofs_service(test, params, session)
+        virtio_fs_utils.run_viofs_service(test, params, session)
     elif "balloon" in driver_test_names:
         balloon_test_win = BallooningTestWin(test, params, env)
         driver_test_params = {"balloon_test_win": balloon_test_win}

--- a/qemu/tests/win_virtio_driver_installer_repair.py
+++ b/qemu/tests/win_virtio_driver_installer_repair.py
@@ -6,6 +6,7 @@ from virttest import utils_misc
 
 from provider import win_driver_utils
 from provider import win_driver_installer_test
+from provider import virtio_fs_utils
 
 from qemu.tests.balloon_check import BallooningTestWin
 
@@ -101,8 +102,7 @@ def run(test, params, env):
             driver_test_params = params.get('driver_test_params_%s'
                                             % driver_name, '{}')
             if driver_name == "viofs":
-                win_driver_installer_test.run_viofs_service(test, params,
-                                                            session)
+                virtio_fs_utils.run_viofs_service(test, params, session)
             if driver_name != "balloon":
                 driver_test_params = ast.literal_eval(driver_test_params)
             else:

--- a/qemu/tests/win_virtio_driver_update_by_installer.py
+++ b/qemu/tests/win_virtio_driver_update_by_installer.py
@@ -8,6 +8,7 @@ from qemu.tests.balloon_check import BallooningTestWin
 
 from provider import win_driver_utils
 from provider import win_driver_installer_test
+from provider import virtio_fs_utils
 
 
 @error_context.context_aware
@@ -67,7 +68,7 @@ def run(test, params, env):
                                                gagent_uninstall_cmd)
 
     error_context.context("Delete the viofs service at guest...")
-    win_driver_installer_test.delete_viofs_serivce(test, params, session)
+    virtio_fs_utils.delete_viofs_serivce(test, params, session)
 
     win_driver_installer_test.win_uninstall_all_drivers(session,
                                                         test, params)
@@ -98,7 +99,7 @@ def run(test, params, env):
                                                  gagent_pkg_info_cmd)
 
     error_context.context("Run viofs service...")
-    win_driver_installer_test.run_viofs_service(test, params, session)
+    virtio_fs_utils.run_viofs_service(test, params, session)
 
     error_context.context("Upgrade virtio driver to original",
                           test.log.info)
@@ -114,7 +115,7 @@ def run(test, params, env):
         session = vm.reboot(session)
 
     error_context.context("Run viofs service after upgrade...")
-    win_driver_installer_test.run_viofs_service(test, params, session)
+    virtio_fs_utils.run_viofs_service(test, params, session)
 
     win_driver_installer_test.check_gagent_version(session, test,
                                                    gagent_pkg_info_cmd,


### PR DESCRIPTION
virtio_fs_utils: migrate the related virtio functions
from win_driver_installer_test.py to virtio_fs_utils.py

ID: 2152054

Signed-off-by: Houqi (Nick) Zuo hzuo@redhat.com