### PR TITLE
live_backup_add_bitmap:persistent bitmap failed to store

### DIFF
--- a/qemu/tests/live_backup_add_bitmap.py
+++ b/qemu/tests/live_backup_add_bitmap.py
@@ -53,7 +53,8 @@ def run(test, params, env):
     check_bitmap_existence_as_expected(bitmaps, "existence")
 
     error_context.context("system powerdown", test.log.info)
-    vm.monitor.system_powerdown()
+    #Fixme if the "guest refuse to go down" issue resolved
+    vm.monitor.quit()
     if not vm.wait_for_shutdown(int(params.get("shutdown_timeout", 360))):
         test.fail("guest refuses to go down")
 


### PR DESCRIPTION
persistent bitmap failed to store in qcow2 image for "guest refuse to go down" issue, make a workaround here to quit vm instead.
Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2173499