### PR TITLE
blockdev_mirror_firewall:omit host dmesg check

### DIFF
--- a/qemu/tests/cfg/blockdev_mirror_firewall.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_firewall.cfg
@@ -31,6 +31,8 @@
     image_name_data1 = data1
     image_name_mirror1 = mirror1
     rebase_mode = unsafe
+    #Fixme if no driver deprecated warning in host_dmesg.log
+    expected_host_dmesg = Warning: Deprecated Driver is detected
 
     nbd:
         nbd_port_data1 = 10831


### PR DESCRIPTION
Omit driver deprecated warning in host_dmesg.log
Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2173502