### PR TITLE
hotplug_mem_migration:Update the pressure size with dynamic grabbing

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_migration.cfg
+++ b/qemu/tests/cfg/hotplug_mem_migration.cfg
@@ -30,7 +30,7 @@
     cmd_check_online_mem = lsmem
     cmd_new_folder = ' rm -rf /tmp/numa_test/ && mkdir /tmp/numa_test'
     numa_test = 'numactl -m %s dd if=/dev/urandom of=/tmp/numa_test/test '
-    numa_test += 'bs=1k count=5242880 && rm -rf /tmp/numa_test/'
+    numa_test += 'bs=1k count=%d && rm -rf /tmp/numa_test/'
     stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 4096M'
     variants numa_nodes:
         - with_single_numa_node:


### PR DESCRIPTION
The memory used by the guest is not equal for each numa. 
In order to equalize the pressure on each numa.
Update the pressure size with dynamic grabbing.

ID: 2172056
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)