### PR TITLE
sve_invalid: Add scenarios to cover more invalid use cases

### DIFF
--- a/qemu/tests/cfg/sve_basic.cfg
+++ b/qemu/tests/cfg/sve_basic.cfg
@@ -5,11 +5,19 @@
         - @supported_length:
         - unsupported_length:
             type = sve_invalid
-            variants:
+            variants sve_invalid:
                 - @default:
+                    active_length = no
                     error_msg = does not support the vector length {}-bits
                 - invalid_length:
                     start_vm = no
                     invalid_length = sve127
                     cpu_model_flags = "sve=on,${invalid_length}=on"
                     error_msg = Property '\S*.${invalid_length}' not found
+                - skip_length:
+                    active_length = yes
+                    error_msg = The KVM host requires all supported vector lengths smaller than {} bits to also be enabled
+                - non_sve_host:
+                    start_vm = no
+                    no_flags = "sve"
+                    error_msg = can't apply global host-arm-cpu.${no_flags}=on: '${no_flags}' feature not supported by KVM on this host

--- a/qemu/tests/sve_invalid.py
+++ b/qemu/tests/sve_invalid.py
@@ -1,20 +1,20 @@
 import re
 
+from avocado.utils import cpu
+
 from virttest import error_context
 from virttest.virt_vm import VMCreateError
-
-from provider import cpu_utils
 
 
 @error_context.context_aware
 def run(test, params, env):
-    def get_sve_unsupported_lengths():
+    def get_sve_lengths(supported=True):
         """
         Get unsupported SVE lengths of host.
         """
         output = vm.monitor.query_cpu_model_expansion(vm.cpuinfo.model)
         output.pop('sve')
-        sve_list = [sve for sve in output if output[sve] is False and
+        sve_list = [sve for sve in output if output[sve] is supported and
                     sve.startswith('sve')]
         sve_list.sort(key=lambda x: int(x[3:]))
 
@@ -22,20 +22,39 @@ def run(test, params, env):
 
     error_msg = params['error_msg']
     invalid_length = params.get('invalid_length')
-
-    cpu_utils.check_cpu_flags(params, 'sve', test)
+    invalid_type = params.get('sve_invalid')
 
     vm = env.get_vm(params["main_vm"])
-    if not invalid_length:
-        sve_lengths = get_sve_unsupported_lengths()
-        invalid_length = sve_lengths[-1]
-        error_msg = error_msg.format(invalid_length[3:])
-        vm.destroy()
-        params['cpu_model_flags'] = 'sve=on,{}=on'.format(invalid_length)
+    sve_flag = cpu.cpu_has_flags(('sve'))
+    if invalid_type != 'non_sve_host':
+        if not sve_flag:
+            test.cancel("The host doesn't support SVE feature")
+        if not invalid_length:
+            active_length = params.get_boolean('active_length')
+            sve_lengths = get_sve_lengths(active_length)
+            if active_length:
+                if sve_lengths == 1:
+                    test.cancel("The host only supports one sve length")
+                disabled_length = sve_lengths[-2]
+                flags = ('{}={}'.format(
+                    sve, 'on' if sve != disabled_length else 'off')
+                    for sve in sve_lengths)
+                flags = ','.join(flags)
+                error_msg = error_msg.format(sve_lengths[-1][3:])
+            else:
+                invalid_length = sve_lengths[-1]
+                error_msg = error_msg.format(invalid_length[3:])
+                flags = '{}=on'.format(invalid_length)
+            vm.destroy()
+            params['cpu_model_flags'] = 'sve=on,' + flags
+    else:
+        if sve_flag:
+            test.cancel('The host supports SVE feature, cancel the test...')
+        params['cpu_model_flags'] = 'sve=on'
 
     params['start_vm'] = 'yes'
     try:
-        error_context.context('Launch a guest with invalid SVE length',
+        error_context.context('Launch a guest with invalid SVE scenario',
                               test.log.info)
         vm.create(params=params)
     except VMCreateError as err:


### PR DESCRIPTION
1. Try to launch an SVE guest in a non-sve host.
2. Try to launch an SVE guest but disable the middle vector length.

ID: 2173807
Signed-off-by: Yihuang Yu <yihyu@redhat.com>