### PR TITLE
Re-write zipl file for secure guest

### DIFF
--- a/qemu/tests/cfg/secure_img.cfg
+++ b/qemu/tests/cfg/secure_img.cfg
@@ -12,6 +12,6 @@
     secure_params_cmd = 'echo "$(cat /proc/cmdline) swiotlb=262144" > /home/parmfile'
     # For HKD.crt in boot_img, it's a private cerfitication for specific s390x machines
     boot_img_cmd = 'genprotimg -k /home/HKD.crt -p /home/parmfile -i %s -r %s -o /boot/secure-linux --no-verify'
-    zipl_config_cmd = 'echo -e "[secure]\ntarget=/boot\nimage=/boot/secure-linux">> /etc/zipl.conf'
+    zipl_config_cmd = 'echo -e "[defaultboot]\ndefaultauto\nprompt=1\ntimeout=5\ntarget=/boot\nsecure=auto\n[secure]\ntarget=/boot\nimage=/boot/secure-linux"> /etc/zipl.conf'
     zipl_cmd = 'zipl'
     check_se_cmd = 'cat /sys/firmware/uv/prot_virt_guest'


### PR DESCRIPTION
SE: re-write zipl.config file to avoid the 'default' param will make this test failed

ID: 2168885

Signed-off-by: Boqiao Fu <bfu@redhat.com>