### PR TITLE
virtio_fs: test the empty list of xattr on virtiofs

### DIFF
--- a/qemu/tests/cfg/virtio_fs_security_label.cfg
+++ b/qemu/tests/cfg/virtio_fs_security_label.cfg
@@ -41,6 +41,7 @@
     selinux_xattr_name = security.selinux
     trust_selinux_attr_name = trusted.virtiofsd.security.selinux
     context_pattern = '\"[a-z,_]*_u:[a-z,_]*_r:([a-z,_]*_t)(?:\:[s,\-,0-9,:[c,\,,0-9]*]*)?\"'
+    getfattr_list_cmd = "getfattr -m '' %s"
     s390, s390x:
         required_qemu = [5.2.0,)
         vm_mem_share = yes

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -741,6 +741,14 @@ def run(test, params, env):
                     time.sleep(1)
                     check_security_label(file_share_in_guest, fs_dest, selinux_xattr_name)
 
+                    error_context.context("The list of xattr for the file is empty "
+                                          "in guest, let's check it.", test.log.info)
+                    getfattr_list_cmd = params.get("getfattr_list_cmd")
+                    s, o = session.cmd_status_output(getfattr_list_cmd % file_new_in_guest)
+                    if s:
+                        test.fail("Getting the empty list of xattr failed"
+                                  " on virtiofs fs, the output is %s" % o)
+
                 if winfsp_test_cmd:
                     # only for windows guest.
                     error_context.context("Run winfsp-tests suit on windows"


### PR DESCRIPTION
ID: 2172739
For some file in virtiofs who has no xattr, when getting the xattr, virtiofs should not output any error info.