### PR TITLE
qemu_guest_agent: Add USB disk support for apis on windows/linux

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -339,16 +339,41 @@
             image_snapshot = yes
         - check_fsinfo:
             gagent_check_type = fsinfo
+            images += " stg"
+            image_name_stg = "images/stg"
+            image_size_stg = 100M
+            force_create_image_stg = yes
+            remove_image_stg = yes
+            usbs = usb1
+            usb_type_usb1 = nec-usb-xhci
+            drive_format_stg = "usb3"
             blk_extra_params_image1 = "serial=GAGENT_TEST"
             cmd_get_disk = cat /proc/mounts |grep -v rootfs |awk '$2~/^%s$/{print $1,$3}'
             cmd_get_disk_usage = df -hlk | egrep "%s$" | awk '{print$2*1024,$3*1024}'
+            fdisk_txt_value = n,p,1,2048,20480,w
+            cmd_get_usb_disk = lsblk | grep %s | awk '{print $1}'
+            cmd_fdisk = fdisk /dev/%s < /root/fdisk.txt
+            cmd_format_disk = "mkfs.ext4 /dev/%s%d; partprobe"
+            cmd_mount_fs = mount /dev/%s%d usbmountpoint
             Windows:
                 cmd_get_disk = wmic volume where "DeviceID='%s'" get FileSystem,DeviceID |findstr /v /i FileSystem
                 cmd_get_disk_usage = wmic volume where "DriveLetter='%s'" get Capacity,FreeSpace |findstr /v /i FreeSpace
+                cmd_diskpart = "diskpart /s C:\\diskpart.txt"
+                cmd_get_usb_index = wmic diskdrive get index,interfacetype | findstr /i USB
+                cmd_get_usb_serial = wmic diskdrive where "DeviceID='%s'" get SerialNumber | findstr /v /i SerialNumber
+                diskpart_txt_value = select disk %s,clean,convert gpt,create partition primary size=50,format fs=ntfs label="New Volume" quick compress,assign letter=U
         - check_get_disks:
             no Host_RHEL.m6 Host_RHEL.m7
             no Host_RHEL.m8.u0 Host_RHEL.m8.u1 Host_RHEL.m8.u2 Host_RHEL.m8.u3
             gagent_check_type = get_disks
+            images += " stg stg0"
+            image_name_stg = "images/stg"
+            image_size_stg = 100M
+            force_create_image_stg = yes
+            remove_image_stg = yes
+            usbs = usb1
+            usb_type_usb1 = nec-usb-xhci
+            drive_format_stg = "usb3"
             force_create_image_stg0 = yes
             remove_image_stg0 = yes
             images += " stg0"
@@ -356,8 +381,10 @@
             image_size_stg0 = 1G
             diskinfo_guest_cmd = 'lsblk -Jp -o KNAME,PKNAME,TYPE'
             cmd_get_disk_alias = 'lsblk -o NAME %s |grep -v NAME'
+            cmd_bustype_guest = "ls -lF /dev/disk/by-path/| grep -m 1 %s | awk -F[:-] '{print $6}'"
             Windows:
                 cmd_get_diskinfo = wmic diskdrive where "DeviceID='%s'" get Name | findstr /v /i Name
+                cmd_bustype_guest = wmic diskdrive where "DeviceID='%s'" get interfaceType | findstr /v /i interfaceType
         - check_nonexistent_cmd:
             gagent_check_type = nonexistent_cmd
             wrong_cmd = "system_reset"


### PR DESCRIPTION
1. Add USB disk support for qemu-ga apis 'guest-get-fsinfo' and 'guest-get-disks'.
2. Additionally, add a new checkpoint 'bus-type' for command 'guest-get-disks'.
3. Adjust some checkpoint for USB.

ID: 2167309
Signed-off-by: demeng <demeng@redhat.com>