### PR TITLE
arm_gic: Check if guest GIC version can match the value in command line

### DIFF
--- a/qemu/tests/arm_gic.py
+++ b/qemu/tests/arm_gic.py
@@ -1,0 +1,34 @@
+from avocado.utils import process
+
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    1) Boot a guest with the specified GIC version
+    2) Check the GIC version in the guest
+
+    :param test: QEMU test object.
+    :type  test: avocado_vt.test.VirtTest
+    :param params: Dictionary with the test parameters.
+    :type  params: virttest.utils_params.Params
+    :param env: Dictionary with test environment.
+    :type  env: virttest.utils_env.Env
+    """
+    gic_version = params['gic_version']
+    irq_cmd = params['irq_cmd']
+    gic_version = (gic_version if gic_version != 'host' else
+                   process.getoutput(irq_cmd).strip())
+
+    vm = env.get_vm(params['main_vm'])
+    vm.verify_alive()
+    session = vm.wait_for_login()
+    error_context.context('Get GIC version in the guest', test.log.info)
+    guest_gic_version = session.cmd_output(irq_cmd).strip()
+    test.log.info(f'Guest GIC version: {guest_gic_version}')
+
+    if guest_gic_version != gic_version:
+        test.fail(f'GIC version mismatch, expected version is "{gic_version}" '
+                  f'but the guest GIC version is "{guest_gic_version}"')
+    test.log.info('GIC version match')

--- a/qemu/tests/cfg/arm_gic.cfg
+++ b/qemu/tests/cfg/arm_gic.cfg
@@ -1,0 +1,12 @@
+- arm_gic:
+    virt_test_type = qemu
+    type = arm_gic
+    only aarch64
+    irq_cmd = lsirq -o NAME | grep GIC | head -1 | awk '{print $1}'
+    variants:
+        - gic_host:
+            gic_version = host
+            machine_type_extra_params = gic-version=host
+        - gic_v3:
+            gic_version = GICv3
+            machine_type_extra_params = gic-version=3


### PR DESCRIPTION
QEMU can define vgic version for guest, this test case gives a value of gic-version, after the guest is starts, we should check the version in the guest and compare it with the qemu command line.

ID: 2176742
Signed-off-by: Yihuang Yu <yihyu@redhat.com>