### PR TITLE
nvdimm_readonly: updates unarmed_off error message and limits vm memory

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -100,6 +100,7 @@
         - nvdimm_negative:
             type = nvdimm_negative
             start_vm = no
+            vm_mem_limit = 8G
             size_mem = 8G
             pre_command = "dd if=/dev/zero of=${nv_backend} bs=1M count=8192"
             variants:
@@ -118,9 +119,10 @@
             variants:
                 - unarmed_off:
                     type = nvdimm_negative
+                    required_qemu = [7.2.0, )
                     unarmed_dimm_mem1 = off
                     start_vm = no
-                    error_msg = "\'unarmed\' property must be \'on\' since memdev mem-${mem_devs} is read-only"
+                    error_msg = "\\'unarmed\\' property must be \\'on\\' since memdev mem-${mem_devs} is read-only"
                 - unarmed_on:
                     type = boot
                     unarmed_dimm_mem1 = on

--- a/qemu/tests/nvdimm_negative.py
+++ b/qemu/tests/nvdimm_negative.py
@@ -1,3 +1,4 @@
+import re
 from virttest import error_context
 from virttest import virt_vm
 
@@ -17,13 +18,13 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     params['start_vm'] = 'yes'
     error_msg = params.get('error_msg', '')
+
     try:
         vm.create(params=params)
         output = vm.process.get_output()
     except virt_vm.VMCreateError as e:
         output = str(e)
-
     error_context.context("Check the expected error message: %s"
                           % error_msg, test.log.info)
-    if error_msg not in output:
+    if not re.search(error_msg, output):
         test.fail("Can not get expected error message: %s" % error_msg)


### PR DESCRIPTION
nvdimm_readonly: updates unarmed_off error message and limits vm memory 

Updates unarmed_off subcase error message and applies vm memory limit
to be the same as the nvdimm device. Also changes back to the regex
search for the error messages.

ID: 2178025
Signed-off-by: mcasquer <mcasquer@redhat.com>