### PR TITLE
boot_with_different_vectors: Changed the match string

### DIFF
--- a/qemu/tests/boot_with_different_vectors.py
+++ b/qemu/tests/boot_with_different_vectors.py
@@ -36,7 +36,7 @@ def run(test, params, env):
         except virt_vm.VMError as err:
             if int(vectors) < 0:
                 txt = "Parameter 'vectors' expects uint32_t"
-                if re.findall(txt, str(err)):
+                if re.findall(txt, err.output):
                     return
         if int(vectors) < 0:
             msg = "Qemu did not raise correct error"


### PR DESCRIPTION
Change the match string, because after changing from raw format to json format,the exception error messages caught by automation different.So directly replace the matching condition with its error output without any escaping

ID:2178525

Signed-off-by: Lei Yang leiayang@redhat.com