### PR TITLE
nvdimm_nvml: fix dependent packages typo and include cmake for x86_64

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -39,7 +39,12 @@
     share_mem = yes
     nv_file = "${mount_dir}/nv0"
     depends_pkgs = "ndctl "
-
+    RHEL.9:
+        repo_install_cmd = "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+    RHEL.8:
+        repo_install_cmd = "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+    RHEL.7:
+        repo_install_cmd = "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
     variants:
         - nvdimm_basic:
         - nvdimm_emulate:
@@ -125,9 +130,7 @@
                     type = boot
                     unarmed_dimm_mem1 = on
         - nvdimm_nvml:
-            depends_pkgs += ndctl-devel daxctl-devel pandoc
-            ppc64le, ppc64:
-                depends_pkgs += " cmake"
+            depends_pkgs += ndctl-devel daxctl-devel pandoc cmake
             nvml_test = yes
             nvml_dir = /tmp/nvml
             get_nvml = "[ -d ${nvml_dir} ] && rm -rf ${nvml_dir}"

--- a/qemu/tests/nvdimm.py
+++ b/qemu/tests/nvdimm.py
@@ -154,8 +154,9 @@ def run(test, params, env):
                 hotplug_test.hotplug_memory(vm, mem)
             time.sleep(10)
             mems += target_mems
+        nvdimm_test.run_guest_cmd(params["repo_install_cmd"])
         error_context.context("Verify nvdimm in monitor and guest", test.log.info)
-        pkgs = params.objects("depends_pks")
+        pkgs = params.objects("depends_pkgs")
         if not utils_package.package_install(pkgs, nvdimm_test.session):
             test.cancel("Install dependency packages failed")
         nvdimm_ns_create_cmd = params.get("nvdimm_ns_create_cmd")


### PR DESCRIPTION
nvdimm_nvml: fix dependent packages typo and include cmake for x86_64

Fix the typo 'depends_pks' and include the installation of the epel-release inside the guest as well as cmake for x86_64.

ID: 2178166
Signed-off-by: mcasquer <mcasquer@redhat.com>
