### PR TITLE
Change the parameter to "device-iotlb=false" for rhel 7.9 guest

### DIFF
--- a/qemu/tests/cfg/boot_nic_with_iommu.cfg
+++ b/qemu/tests/cfg/boot_nic_with_iommu.cfg
@@ -13,6 +13,8 @@
                 HostCpuVendor.intel:
                     intel_iommu = yes
                     iommu_caching_mode = on
+                    RHEL.7.9:
+                        iommu_device_iotlb = off
                 Linux:
                     enable_guest_iommu = yes
             nic_extra_params = ",disable-legacy=on,disable-modern=off,iommu_platform=on,ats=on"


### PR DESCRIPTION
According to product bug 2156876, QE changed the parameter to "device-iotlb=false" for rhel 7.9 guest.

ID:2179868

Signed-off-by: Lei Yang leiayang@redhat.com