### PR TITLE
VMDeadKernelCrashError: Replace exception call type

### DIFF
--- a/generic/tests/iofuzz.py
+++ b/generic/tests/iofuzz.py
@@ -95,7 +95,7 @@ def run(test, params, env):
                     vm.verify_alive()
                 except qemu_vm.QemuSegFaultError as err:
                     test.fail("Qemu crash, error info: %s" % err)
-                except virt_vm.VMDeadKernelCrashError as err:
+                except virt_vm.VMKernelCrashError as err:
                     test.fail("Guest kernel crash, info: %s" % err)
                 else:
                     test.log.warn("Guest is not alive during test")

--- a/qemu/tests/timedrift_check_when_crash.py
+++ b/qemu/tests/timedrift_check_when_crash.py
@@ -3,7 +3,7 @@ import re
 
 from avocado.utils import process
 from virttest.env_process import preprocess
-from virttest.virt_vm import VMDeadKernelCrashError
+from virttest.virt_vm import VMKernelCrashError
 from virttest import error_context
 from virttest import utils_test
 from virttest import utils_time
@@ -74,7 +74,7 @@ def run(test, params, env):
     vm.resume()
     try:
         session = vm.reboot(method="system_reset")
-    except VMDeadKernelCrashError as details:
+    except VMKernelCrashError as details:
         details = str(details)
         if (re.findall(r"Trigger a crash\s.*BUG:", details, re.M) and
                 details.count("BUG:") != 1):
@@ -86,7 +86,7 @@ def run(test, params, env):
         while time.time() < end_time:
             try:
                 session = vm.wait_for_login(timeout=timeout)
-            except VMDeadKernelCrashError as details:
+            except VMKernelCrashError as details:
                 details = str(details)
                 if (re.findall(r"Trigger a crash\s.*BUG:", details,
                                re.M) and details.count("BUG:") != 1):


### PR DESCRIPTION
Since the exception type in verify_kernel_crash is updated, 
the exception called by cases is updated synchronously.

ID: 2179828
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)