### PR TITLE
uefi_boot_from_device: attach scsi-cd to a new virtio-scsi-pci

### DIFF
--- a/qemu/tests/cfg/uefi_boot_from_device.cfg
+++ b/qemu/tests/cfg/uefi_boot_from_device.cfg
@@ -29,6 +29,7 @@
                 - ahci_cd:
                     cd_format_test = ahci
                 - scsi_cd:
+                    drive_bus_test = 4
                     cd_format_test = scsi-cd
         - ahci_disk:
             drive_format_stg = ahci


### PR DESCRIPTION
Attach scsi-hd and scsi-cd to the same virtio-scsi-pci without bootindex, only one is listed in boot menu, the change in behavior was caused by a scsi bugfix. So attach scsi-cd to a new virtio-scsi-pci, and then the cdrom is listed in boot menu.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2180729