### PR TITLE
ovmf_check_efi: update efi string for windows guest

### DIFF
--- a/qemu/tests/cfg/ovmf_check_efi.cfg
+++ b/qemu/tests/cfg/ovmf_check_efi.cfg
@@ -7,4 +7,6 @@
     dmesg_cmd = "dmesg | grep EFI"
     Windows:
         check_cmd = "systeminfo | findstr BIOS"
-        efi_info = "EFI Development Kit"
+        efi_info = "EDK II edk2"
+        Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1:
+            efi_info = "EFI Development Kit"


### PR DESCRIPTION
From the new edk2 build in rhel9.2, the string is "EDK II edk2***" instead of "EFI Development Kit***", so update the check string.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2181065