### PR TITLE
qmp_command: fix 'query-stats' and 'query-stats-schema' version issue

### DIFF
--- a/qemu/tests/cfg/qmp_command.cfg
+++ b/qemu/tests/cfg/qmp_command.cfg
@@ -204,14 +204,17 @@
             aarch64:
                 cmd_return_value = "[{'name': 'vfio-pci'}, {'name': 'qemu-xhci'}, {'name': 'virtio-blk-pci'}]"
         - qmp_query-stats_vm:
+            required_qemu = [7.1.0,)
             qmp_cmd = "query-stats target=vm"
             cmd_result_check = "contain"
             cmd_return_value = "['provider', 'stats', 'name', 'value']"
         - qmp_query-stats_vcpu:
+            required_qemu = [7.1.0,)
             qmp_cmd = "query-stats target=vcpu"
             cmd_result_check = "contain"
             cmd_return_value = "['provider', 'stats', 'name', 'value', 'qom-path']"
         - qmp_query-stats-schemas:
+            required_qemu = [7.1.0,)
             qmp_cmd = "query-stats-schemas"
             cmd_result_check = "contain"
             cmd_return_value = "['provider', 'stats', 'name', 'exponent', 'type', 'unit', 'target', 'base']"


### PR DESCRIPTION
Supported 'query-stats' and 'query-stats-schema' command in the new version(qemu-kvm-7.1),old version not supported it.

ID: 2181141