### PR TITLE
uefishell.check_smbios: add support for smbios-entry-point-type

### DIFF
--- a/qemu/tests/cfg/uefishell.cfg
+++ b/qemu/tests/cfg/uefishell.cfg
@@ -81,6 +81,19 @@
             command_smbios = "smbiosview"
             variants:
                 - @default:
+                    check_result_smbios = "Version.*:\s+2\.\d+"
+                - with_entry_point:
+                    no Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9.u0 Host_RHEL.m9.u1
+                    smbios_output_handler = "handle_smbiosview"
+                    bios_version = "BiosVersion.*:.*edk2-([0-9]{8})"
+                    bios_release_date = "BiosReleaseDate.*:.*(?P<month>[0-9]{2})/(?P<day>[0-9]{2})/(?P<year>[0-9]{4})"
+                    variants:
+                        - type_32:
+                            machine_type_extra_params = "smbios-entry-point-type=32"
+                            smbios_version = "Version.*:\s+2\.\d+"
+                        - type_64:
+                            machine_type_extra_params = "smbios-entry-point-type=64"
+                            smbios_version = "Version.*:\s+3\.\d+"
                 - updated_type_0:
                     extra_params += "-smbios type=0,vendor=test_redhat,version=test_v1,date=06/01/2018,uefi=on"
                     check_result_smbios = "Vendor.*:.*test_redhat, BiosVersion.*:.*test_v1, BiosReleaseDate.*:.*06/01/2018"

--- a/qemu/tests/uefishell.py
+++ b/qemu/tests/uefishell.py
@@ -199,6 +199,42 @@ def run(test, params, env):
                       "The range of 'RT_Code' should be covered by just one"
                       " entry. The command output is %s" % output[0])
 
+    def handle_smbiosview(output):
+        """
+        check the following 3 values from output
+        smbios version: if smbios-entry-point-type=32, the version is 2.*
+                        e.g. 2.8
+                        if smbios-entry-point-type=64, the version is 3.*
+                        e.g. 3.0
+        bios version: show the build version
+                      e.g. edk2-20221207gitfff6d81270b5-1.el9
+        bios release date: show the release date, e.g. 12/07/2022
+                           it should be equal to the date string in
+                           bios version
+        """
+        smbios_version = re.findall(params["smbios_version"], output[0], re.S)
+        if not smbios_version:
+            test.fail("Failed to find smbios version. "
+                      "The command output is %s" % output[0])
+        bios_version = re.findall(params["bios_version"], output[0], re.S)
+        if not bios_version:
+            test.fail("Failed to find bios version. "
+                      "The command output is %s" % output[0])
+        bios_release_date = re.search(params["bios_release_date"], output[0], re.S)
+        if not bios_release_date:
+            test.fail("Failed to find bios_release_date. "
+                      "The command output is %s" % output[0])
+        date_year = bios_version[0][:4]
+        date_month = bios_version[0][4:6]
+        date_day = bios_version[0][6:]
+        if date_year != bios_release_date.group("year") or date_month != \
+                bios_release_date.group("month") or date_day != \
+                bios_release_date.group("day"):
+            test.fail("The bios release dates are not equal between "
+                      "bios_version and bios_release_date. The date from "
+                      "bios_version is %s, the date from bios_release_date "
+                      "is %s." % (bios_version[0], bios_release_date[0]))
+
     uefishell_test = UEFIShellTest(test, params, env)
     time_interval = float(params["time_interval"])
     under_fs0 = params.get("under_fs0", "yes")


### PR DESCRIPTION
1. check the default value of smbios version
2. boot a vm with smbios-entry-point-type=32/64 and check smbios version, bios version, bios release date. make sure the bios release dates are equal between bios version and bios release date.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2181709