### PR TITLE
hugepage_specify_node:add set specify hugepage test

### DIFF
--- a/generic/tests/cfg/boot_vm_in_hugepage.cfg
+++ b/generic/tests/cfg/boot_vm_in_hugepage.cfg
@@ -19,7 +19,12 @@
             expected_hugepage_size = 1024
         - 2M:
             no s390x
-            expected_hugepage_size = 2048
+            variants:
+                - @default:
+                    expected_hugepage_size = 2048
+                - specify_hp_file:
+                    only aarch64
+                    kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
         - 16M:
             no s390x
             expected_hugepage_size = 16384

--- a/qemu/tests/cfg/hugepage_specify_node.cfg
+++ b/qemu/tests/cfg/hugepage_specify_node.cfg
@@ -6,3 +6,56 @@
     not_preprocess = yes
     mem = 4096
     idle_node_mem = 1024
+    variants:
+        - 64k:
+            only aarch64
+            kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-64kB/nr_hugepages"
+            hugepage_size = 64
+        - 1M:
+            only s390x
+            expected_hugepage_size = 1024
+        - 2M:
+            no s390x
+            variants:
+                - @default:
+                    expected_hugepage_size = 2048
+                - specify_hp_file:
+                    only aarch64
+                    kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
+                    hugepage_size = 2048
+        - 16M:
+            no s390x
+            expected_hugepage_size = 16384
+        - 32M:
+            only aarch64
+            kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-32768kB/nr_hugepages"
+            hugepage_size = 32768
+        - 512M:
+            no s390x
+            variants:
+                - @default:
+                    expected_hugepage_size = 524288
+                - specify_hp_file:
+                    only aarch64
+                    kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-524288kB/nr_hugepages"
+                    hugepage_size = 524288
+        - 1G:
+            # Notes:
+            #    Before start testing, please ensure your host OS support 1G hugepage.
+            #    Please don't forget to update host kernel line to enable 1G hugepage
+            #    Please ensure your host have enough memory to create guest memory.
+            no s390x
+            variants:
+                - @default:
+                    expected_hugepage_size = 1048576
+                - specify_hp_file:
+                    kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages"
+                    hugepage_size = 1048576
+        - 16G:
+            # Notes:
+            #    Before start testing, please ensure your host OS support 16G hugepage.
+            #    Please don't forget to update host kernel line to enable 16G hugepage
+            #    Please ensure your host have enough memory to create guest memory.
+            only aarch64
+            kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-16777216kB/nr_hugepagess"
+            hugepage_size = 16777216

--- a/qemu/tests/hugepage_specify_node.py
+++ b/qemu/tests/hugepage_specify_node.py
@@ -1,4 +1,5 @@
 import math
+import re
 
 from avocado.utils import memory
 
@@ -25,7 +26,7 @@ def run(test, params, env):
     :params env: Dictionary with test environment.
     """
     memory.drop_caches()
-    hugepage_size = memory.get_huge_page_size()
+    hugepage_size = params.get_numeric("hugepage_size", memory.get_huge_page_size())
     mem_size = int(normalize_data_size("%sM" % params["mem"], "K"))
     idle_node_mem = int(normalize_data_size("%sM" % params["idle_node_mem"], "K"))
 
@@ -52,7 +53,8 @@ def run(test, params, env):
         error_context.base_context("Specify qemu process only allocate "
                                    "HugePages from node%s." % node_id, test.log.info)
         params["target_nodes"] = "%s" % node_id
-        params["target_num_node%s" % node_id] = math.ceil(mem_size / hugepage_size)
+        huge_pages_num = math.ceil(mem_size / hugepage_size)
+        params["target_num_node%s" % node_id] = huge_pages_num
         error_context.context("Setup huge pages for specify node%s." %
                               node_id, test.log.info)
         check_list = [_ for _ in idle_node_list if _ != node_id]
@@ -61,26 +63,37 @@ def run(test, params, env):
             params["target_num_node%s" % idle_node] = math.ceil(idle_node_mem / hugepage_size)
             error_context.context("Setup huge pages for idle node%s." %
                                   idle_node, test.log.info)
-        params["setup_hugepages"] = "yes"
         hp_config = test_setup.HugePageConfig(params)
-        hp_config.setup()
-        params["qemu_command_prefix"] = "numactl --membind=%s" % node_id
-        params["start_vm"] = "yes"
-        params["hugepage_path"] = hp_config.hugepage_path
-        env_process.preprocess_vm(test, params, env, params["main_vm"])
         try:
+            hp_config.setup()
+            params["qemu_command_prefix"] = "numactl --membind=%s" % node_id
+            params["start_vm"] = "yes"
+            params["hugepage_path"] = hp_config.hugepage_path
+            env_process.preprocess_vm(test, params, env, params["main_vm"])
             vm = env.get_vm(params["main_vm"])
-            vm.verify_alive()
-            vm.wait_for_login()
+            try:
+                vm.verify_alive()
+                vm.wait_for_login()
 
-            meminfo = host_numa_node.get_all_node_meminfo()
-            for index in check_list:
-                error_context.base_context("Check process HugePages Free on host "
-                                           "numa node %s." % index, test.log.info)
-                hugepages_free = int(meminfo[index]["HugePages_Free"])
-                if int(node_meminfo[index]["HugePages_Free"]) > hugepages_free:
-                    test.fail("Qemu still use HugePages from other node."
-                              "Expect: node%s, used: node%s." % (node_id, index))
+                meminfo = host_numa_node.get_all_node_meminfo()
+                for index in check_list:
+                    error_context.base_context("Check process HugePages Free on host "
+                                               "numa node %s." % index, test.log.info)
+                    hugepages_free = int(meminfo[index]["HugePages_Free"])
+                    if int(node_meminfo[index]["HugePages_Free"]) > hugepages_free:
+                        test.fail("Qemu still use HugePages from other node."
+                                  "Expect: node%s, used: node%s." % (node_id, index))
+            finally:
+                vm.destroy()
+        except Exception as details:
+            # Check if there have enough contiguous Memory on the host node
+            details = str(details)
+            if re.findall(r"Cannot set %s hugepages" % huge_pages_num, details):
+                test.cancel("Host node does not have enough contiguous memory "
+                            "to run the test, skipping test...")
+            test.error(details)
         finally:
-            vm.destroy()
             hp_config.cleanup()
+            utils_misc.wait_for(
+                lambda: int(hp_config.get_node_num_huge_pages(node_id, hugepage_size)) == 0,
+                first=2.0, timeout=10)


### PR DESCRIPTION
Currently, hugepage_specify_node can only be tested 
with the host's default huge page size.
Add test scenarios so that users can specify
the huge page size they want to test.

ID: 2178867
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)