### PR TITLE
migrate_nic_with_iommu:image_snapshot doesn't support migrate scenario

### DIFF
--- a/qemu/tests/cfg/migrate_nic_with_iommu.cfg
+++ b/qemu/tests/cfg/migrate_nic_with_iommu.cfg
@@ -1,7 +1,10 @@
 - migrate_nic_with_iommu:
     virt_test_type = qemu
     only virtio_net
-    image_snapshot = yes
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
+    Windows:
+        guest_path = C:\file
     iterations = 1
     ping_pong = 1
     type = migration_with_file_transfer
@@ -40,3 +43,5 @@
                   mem = 1536
               ppc64, ppc64le:
                   mem = 3072
+              Windows:
+                  mem = 4096


### PR DESCRIPTION
image_snapshot doesn't support migrate scenario, so changed to another backup method. Also add support for windows guest minimal mem and windows guest path.

ID:2182744

Signed-off-by: Lei Yang leiayang@redhat.com