### PR TITLE
chardev_acpi: limit qemu version for deprecated device 'tty'

### DIFF
--- a/qemu/tests/cfg/chardev_acpi.cfg
+++ b/qemu/tests/cfg/chardev_acpi.cfg
@@ -1,6 +1,8 @@
 - chardev_acpi:
     only x86_64, i386
     only RHEL
+    # deprecated since qemu6.0 and removed since qemu8.0
+    required_qemu = (, 8.0)
     type = chardev_acpi
     serials += ' vs1 '
     chardev_backend_vs1 = tty


### PR DESCRIPTION
ID: 2183442

This device is deprecated since qemu 6.0, and removed
since qemu8.0.