### PR TITLE
uefi_pkg.check_descriptor_meta_files: update the checkpoints

### DIFF
--- a/qemu/tests/cfg/uefi_pkg.cfg
+++ b/qemu/tests/cfg/uefi_pkg.cfg
@@ -8,10 +8,16 @@
     Host_RHEL.m7:
         query_package = "rpm -qa | grep OVMF"
         ovmf_package_name = "OVMF.*el7.*"
-    Host_RHEL.m8, Host_RHEL.m9:
+    ! Host_RHEL.m7:
         query_package = "rpm -qa | grep edk2-ovmf"
-        ovmf_package_name = "edk2-ovmf.*(el8|el9).*"
+        ovmf_package_name = "edk2-ovmf.*el\d+.*"
     variants:
         - check_descriptor_meta_files:
             file_suffix = ".json"
-            number_of_files = 3
+            number_of_files = 5
+            Host_RHEL.m7:
+                number_of_files = 2
+            Host_RHEL.m8:
+                number_of_files = 3
+            Host_RHEL.m9.u0, Host_RHEL.m9.u1:
+                number_of_files = 4


### PR DESCRIPTION
1. the number of meta_files is different in rhel8 and rhel9, update them
2. for amdsev and inteltdx json files, check that the 'mode' is 'stateless'

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2183604