### PR TITLE
virtio_mem_reboot: new virtio_mem reboot auto case

### DIFF
--- a/qemu/tests/cfg/virtio_mem_numa_basic.cfg
+++ b/qemu/tests/cfg/virtio_mem_numa_basic.cfg
@@ -1,11 +1,10 @@
 - virtio_mem_numa_basic:
     only Linux
-    only Host_RHEL.m9
-    only RHEL.9
+    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+    no RHEL.6 RHEL.7 RHEL.8
     no s390x
     type = virtio_mem_numa_basic
     virt_test_type = qemu
-    login_timeout = 240
     threshold = 0.025
     smp = 8
     vcpu_maxcpus = ${smp}
@@ -38,3 +37,6 @@
     pcie_extra_root_port = 0
     requested-size_test_vmem0 = "4G 8G 0"
     requested-size_test_vmem1 = "1G 8G 0"
+    variants operation:
+        - @default:
+        - with_reboot:


### PR DESCRIPTION
virtio_mem_reboot: new virtio_mem reboot auto case

Creates a new auto case that boots up a guest, resizes several times the virtio-mem device, reboots the guest and checks if the size is correct.

ID: 2182968
Signed-off-by: mcasquer <mcasquer@redhat.com>