### PR TITLE
x86:chardev_tls_encryption:limit host for gnutls' version

### DIFF
--- a/qemu/tests/cfg/chardev_tls_encryption.cfg
+++ b/qemu/tests/cfg/chardev_tls_encryption.cfg
@@ -16,15 +16,14 @@
         serial_device = "sclpconsole"
     variants:
         - host_to_guest:
-            expected_msg = "Channel binding 'tls-unique'"
+            expected_msg = "Channel binding 'tls-exporter'"
             gnutls_cmd_server = "cd ${cert_dir} &&"
             gnutls_cmd_server += " gnutls-serv --echo --x509cafile ca-cert.pem --x509keyfile server-key.pem --x509certfile server-cert.pem -p %s"
             extra_params = " -object tls-creds-x509,id=tls0,dir=${cert_dir},endpoint=client"
             extra_params += " -chardev socket,id=tls_chardev,host=%s,port=%s,tls-creds=tls0"
             extra_params += " -device ${serial_device},chardev=tls_chardev,id=tls_serial"
-            s390x:
-                RHEL.9:
-                    expected_msg = "Channel binding 'tls-exporter'"
+            Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8:
+                expected_msg = "Channel binding 'tls-unique'"
         - guest_to_host:
             expected_msg = "Simple Client Mode:"
             gnutls_cmd_client = "cd ${cert_dir} &&"


### PR DESCRIPTION
ID: 2184088

RHEL9 has a different policy to connect TLS, which will show the different message.