### PR TITLE
virtio_mem_migration: new virtio_mem migration auto case

### DIFF
--- a/qemu/tests/cfg/virtio_mem_numa_basic.cfg
+++ b/qemu/tests/cfg/virtio_mem_numa_basic.cfg
@@ -40,3 +40,7 @@
     variants operation:
         - @default:
         - with_reboot:
+        - with_migration:
+            kill_vm_on_error = yes
+            mig_timeout = 1200
+            migration_protocol = "tcp"

--- a/qemu/tests/virtio_mem_numa_basic.py
+++ b/qemu/tests/virtio_mem_numa_basic.py
@@ -28,6 +28,14 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     vm.wait_for_login()
+    operation_type = params.get("operation")
+
+    if operation_type == "with_migration":
+        # migration
+        mig_timeout = params.get_numeric("mig_timeout", 1200, float)
+        mig_protocol = params.get("migration_protocol", "tcp")
+        vm.migrate(mig_timeout, mig_protocol, env=env)
+
     virtio_mem_model = 'virtio-mem-pci'
     if '-mmio:' in params.get("machine_type"):
         virtio_mem_model = 'virtio-mem-device'
@@ -42,7 +50,6 @@ def run(test, params, env):
             virtio_mem_utils.check_memory_devices(device_id, requested_size, threshold, vm, test)
             virtio_mem_utils.check_numa_plugged_mem(node_id, requested_size, threshold, vm, test)
 
-    operation_type = params.get("operation")
     if operation_type == "with_reboot":
         vm.reboot()
         error_context.context("Verify virtio-mem device after reboot",


### PR DESCRIPTION
virtio_mem_migration: new virtio_mem migration auto case

Adapts existing numa virtio_mem auto case to cover a new one
that boots up a guest in source and destinations hosts,
migrates from src to dst, finally resizes the virtio-mem
devices and check the size is correct.

ID: 2184289
Signed-off-by: mcasquer <mcasquer@redhat.com>