### PR TITLE
Boot guest with iommu and devices insert into pcie-pci-bridge

### DIFF
--- a/qemu/tests/cfg/iommu_pcie_pci_bridge.cfg
+++ b/qemu/tests/cfg/iommu_pcie_pci_bridge.cfg
@@ -1,0 +1,22 @@
+- iommu_pcie_pci_bridge:
+    virt_test_type = qemu
+    type = boot
+    no Host_RHEL.m7
+    only Linux
+    x86_64:
+        only q35
+    virtio_dev_iommu_platform = on
+    virtio_dev_filter = "^(?:(?:virtio-)|(?:vhost-))(?!(?:balloon)|(?:user)|(?:iommu))"
+    pci_bus = pcie-pci-bridge-0
+    virtio_dev_disable_legacy = on
+    virtio_dev_disable_modern = off
+    verify_guest_dmesg = yes
+    variants:
+        - virtio_iommu:
+            only aarch64 x86_64
+            required_qemu= [7.0.0,)
+            virtio_iommu = yes
+            kernel_extra_params_add = "iommu.strict=1"
+        - smmu:
+            only aarch64
+            machine_type_extra_params += ",iommu=smmuv3"


### PR DESCRIPTION
Launch a guest with iommu, and all supported devices should insert into pcie-pci-bridge bus.

Depends on: https://github.com/avocado-framework/avocado-vt/pull/3659
ID: 2185698
Signed-off-by: Yihuang Yu <yihyu@redhat.com>