### PR TITLE
virt_firmware_basic_test: update the test steps

### DIFF
--- a/qemu/tests/cfg/virt_firmware_basic_test.cfg
+++ b/qemu/tests/cfg/virt_firmware_basic_test.cfg
@@ -5,7 +5,10 @@
     type = virt_firmware_basic_test
     start_vm = no
     cmds_installed_host = virt-fw-vars
-    virt_firmware_dirname = "/var/tmp/virt-firmware"
-    virt_firmware_test_repo = "https://gitlab.com/kraxel/virt-firmware.git"
+    cmd_queried_test_package = "rpm -qa | grep python3-virt-firmware-tests"
+    virt_firmware_test_package_dir = "/usr/share/python-virt-firmware"
+    virt_firmware_repo_dst_dir = "/var/tmp/virt-firmware"
+    virt_firmware_repo_addr = "https://gitlab.com/kraxel/virt-firmware.git"
+    test_file_black_list = "test-pe.sh"
     shell_cmd = "sh %s"
     test_file_pattern = "test(-|s)\w*.(sh|py)"

--- a/qemu/tests/virt_firmware_basic_test.py
+++ b/qemu/tests/virt_firmware_basic_test.py
@@ -15,9 +15,11 @@ def run(test, params, env):
     Test check for virt-firmware.
 
     The tests contain test-dump, test-vars,
-    test-sigdb, test-pe and test-unittest.
+    test-sigdb and test-unittest.
 
-    Clone the virt-firmware repo and run the following scripts.
+    If the package 'python3-virt-firmware-tests' has been installed,
+    run the scripts under '/usr/share/python-virt-firmware/tests'.
+    Otherwise, clone the virt-firmware repo and run the following scripts.
 
     test-dump:
         tests/test-dump.sh
@@ -25,6 +27,8 @@ def run(test, params, env):
         tests/test-vars.sh
     test-sigdb:
         tests/test-sigdb.sh
+    peutils has been dropped from version 1.6,
+    so adding 'test-pe' to blacklist
     test-pe:
         tests/test-pe.sh
     test-unittest:
@@ -35,20 +39,36 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
 
-    virt_firmware_dirname = params["virt_firmware_dirname"]
-    virt_firmware_repo_addr = params["virt_firmware_test_repo"]
+    query_cmd = params["cmd_queried_test_package"]
+    status = process.getstatusoutput(query_cmd,
+                                     ignore_status=True,
+                                     shell=True)[0]
+    if status:
+        test.log.info("Package 'python3-virt-firmware-tests' "
+                      "has not been installed. "
+                      "Run the test with virt firmware repo.")
+        virt_firmware_dirname = params["virt_firmware_repo_dst_dir"]
+        virt_firmware_repo_addr = params["virt_firmware_repo_addr"]
+        test_file_black_list = params["test_file_black_list"].split()
+        if os.path.exists(virt_firmware_dirname):
+            shutil.rmtree(virt_firmware_dirname, ignore_errors=True)
+        try:
+            git.get_repo(uri=virt_firmware_repo_addr,
+                         destination_dir=virt_firmware_dirname)
+        except Exception as e:
+            test.error("Failed to clone the virt-firmware repo,"
+                       "the error message is '%s'." % six.text_type(e))
+    else:
+        test.log.info("Run the test with package "
+                      "'python3-virt-firmware-tests'.")
+        virt_firmware_dirname = params["virt_firmware_test_package_dir"]
+        test_file_black_list = []
     test_file_pattern = params["test_file_pattern"]
-    if os.path.exists(virt_firmware_dirname):
-        shutil.rmtree(virt_firmware_dirname, ignore_errors=True)
-    try:
-        git.get_repo(uri=virt_firmware_repo_addr,
-                     destination_dir=virt_firmware_dirname)
-    except Exception as e:
-        test.error("Failed to clone the virt-firmware repo,"
-                   "the error message is '%s'." % six.text_type(e))
     test_dirname = os.path.join(virt_firmware_dirname, "tests")
     for file_name in os.listdir(test_dirname):
         if re.search(test_file_pattern, file_name, re.I):
+            if file_name in test_file_black_list:
+                continue
             test_file = os.path.join(test_dirname, file_name)
             if file_name.endswith("py"):
                 test_cmd = sys.executable + " " + test_file + " 2>&1"


### PR DESCRIPTION
1. If package python3-virt-firmware-tests has been installed, run the scripts under "/usr/share/python-virt-firmware/tests". Otherwise, run the scripts in virt-firmware repo.
2. peutils has been dropped from version 1.6, and it has been removed from python3-virt-firmware-tests. But it still in virt-firmware repo, so adding "test-pe.sh" to blacklist when testing with the repo accordingly.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2187097