### PR TITLE
qemu_img_check_fragmentation:add limitation for nfs

### DIFF
--- a/qemu/tests/cfg/qemu_img_check_fragmentation.cfg
+++ b/qemu/tests/cfg/qemu_img_check_fragmentation.cfg
@@ -1,5 +1,6 @@
 - qemu_img_check_fragmentation:
     only raw
+    no remote_nfs local_nfs
     virt_test_type = qemu
     type = qemu_img_check_fragmentation
     required_qemu = [5.1.0-2, )


### PR DESCRIPTION
filefrag is not supported on nfs, so add this
limitation for this case

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2187880