### PR TITLE
qemu_img_extent_size_hint:only supported on localfs

### DIFF
--- a/qemu/tests/cfg/qemu_img_extent_size_hint.cfg
+++ b/qemu/tests/cfg/qemu_img_extent_size_hint.cfg
@@ -1,4 +1,5 @@
 - qemu_img_extent_size_hint:
+    only filesystem
     virt_test_type = qemu
     type = qemu_img_extent_size_hint
     kill_vm = yes


### PR DESCRIPTION
This case only supported on localfs, so set the
 limitation
    
Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2187879