### PR TITLE
multi_disk_random_hotplug: change disks attaching mechanism

### DIFF
--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -75,8 +75,20 @@
                     Linux:
                         stg_image_num = 200
                         plug_timeout = 1800
-                    set_drive_bus = yes
                     pcie_extra_root_port = ${stg_image_num}
+            variants:
+                - shared_bus:
+                    q35, arm64-pci:
+                        virtio_scsi:
+                            pcie_extra_root_port = 1
+                - separated_bus:
+                    only virtio_scsi
+                    no i440fx
+                    set_drive_bus = yes
+                    q35, arm64-pci:
+                        Linux:
+                            stg_image_num = 64
+                        pcie_extra_root_port = ${stg_image_num}
     variants:
         - @serial:
         - parallel:

--- a/qemu/tests/multi_disk_random_hotplug.py
+++ b/qemu/tests/multi_disk_random_hotplug.py
@@ -152,7 +152,7 @@ def run(test, params, env):
         formats = _formats[:]
         usb_port_occupied = 0
         usb_max_port = params.get('usb_max_port', 6)
-        set_drive_bus = params.get('set_drive_bus', 'yes') == 'yes'
+        set_drive_bus = params.get('set_drive_bus', 'no') == 'yes'
         no_disks = int(params['stg_image_num'])
         i = 0
         while i < no_disks:


### PR DESCRIPTION
The previous mechanism attached 200 disks to the respective controller.One disk allocates one controller. It does not match real usage.

The new mechanism asks for attaching 200 disks under one controller. It reduces the number of disks to 64 for the case one disk to allocate one controller.

ID:2186098
Signed-off-by: qingwangrh <qinwang@redhat.com>