### PR TITLE
guest_iommu_test: set disable_legacy and disable_modern to virtio device

### DIFF
--- a/qemu/tests/cfg/guest_iommu_test.cfg
+++ b/qemu/tests/cfg/guest_iommu_test.cfg
@@ -10,6 +10,9 @@
     intel_iommu = yes
     virtio_dev_iommu_platform = on
     virtio_dev_ats = on
+    virtio_blk:
+        virtio_dev_disable_legacy = on
+        virtio_dev_disable_modern = false
     images += " stg0 stg1"
     image_name_stg0 = "images/stg0"
     image_name_stg1 = "images/stg1"


### PR DESCRIPTION
Because VIRTIO_F_IOMMU_PLATFORM was supported by neither legacy nor transitional device, adding limiting condition accordingly.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2188192