### PR TITLE
limit test version of check_get_cpustatus

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -554,6 +554,7 @@
             test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls /home
         - check_get_cpustats:
             only Linux
+            no  RHEL.7 RHEL.8 RHEL.9.1 RHEL.9.0
             gagent_check_type = get_cpustats
             cpustats_info_list = user,nice,system,idle,iowait,irq,softirq,steal,guest,guestnice
             cpu_num_guest = cat /proc/stat | grep "cpu" -c


### PR DESCRIPTION
QGA: limit RHEL and qemu version for check_get_cpustats

ID: 2178927

Signed-off-by: Boqiao Fu <bfu@redhat.com>
