### PR TITLE
enospc:fix resource clean issue

### DIFF
--- a/qemu/tests/enospc.py
+++ b/qemu/tests/enospc.py
@@ -96,7 +96,7 @@ class EnospcConfig(object):
         # Now, if we can, let's remove the physical volume from lvm list
         if self.loopback:
             p_result = process.run("pvdisplay")
-            if self.loopback in p_result.stdout:
+            if self.loopback in p_result.stdout.decode():
                 process.run("pvremove -f %s" % self.loopback)
         l_result = process.run('losetup -a')
         if self.loopback and (self.loopback in l_result.stdout.decode()):


### PR DESCRIPTION
The wrong bytes-like object is required, not 'str' result in the clean operation is broken.

ID:2182994
Signed-off-by: qingwangrh <qinwang@redhat.com>