### PR TITLE
dump_guest_core: backup config file and modify pre_command

### DIFF
--- a/qemu/tests/cfg/dump_guest_core.cfg
+++ b/qemu/tests/cfg/dump_guest_core.cfg
@@ -2,10 +2,14 @@
     type = dump_guest_core
     only x86_64 ppc64 ppc64le
     virt_test_type = qemu
-    pre_command = "echo "<domain>        <type>  <item>  <value>" >> /etc/security/limits.conf"
-    pre_command += "echo "@root          soft    core    unlimited" >> /etc/security/limits.conf"
+    limits_path = "/etc/security/limits.conf"
+    limits_backup_path = "/tmp/limits.conf"
+    pre_command = 'cp ${limits_path} ${limits_backup_path};'
+    pre_command += 'echo "<domain>        <type>  <item>  <value>" >> ${limits_path}'
+    pre_command += '&& echo "@root          soft    core    unlimited" >> ${limits_path}'
     core_file = "/var/core."
-    pre_command += "&& echo "${core_file}%p" > /proc/sys/kernel/core_pattern"
+    pre_command += '&& echo "${core_file}%p" > /proc/sys/kernel/core_pattern'
+    post_command = 'mv ${limits_backup_path} ${limits_path} -f'
     trigger_core_dump_command = "kill -s SIGSEGV %s"
     gdb_command_file = "/home/gdb_command"
     crash_script = "/home/crash.cmd"


### PR DESCRIPTION
ID:2188907

1.backup the file before the test and restore it after the test
2.make the pre_command modify the config file as expected

Signed-off-by: Leidong Wang <leidwang@redhat.com>