### PR TITLE
virtio_fs: some updates on xfstests

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -331,11 +331,14 @@
                         - @default:
                             # Clearing the private setting of falocate and support xattr
                             Host_RHEL.m9:
-                                fs_binary_extra_options += " --no-killpriv-v2 --xattr --modcaps=+sys_admin"
+                                # no_killpriv_v2 is set to the default one on RHEL9
+                                fs_binary_extra_options += " --xattr --modcaps=+sys_admin"
                             Host_RHEL.m8:
                                 fs_binary_extra_options += " -o no_killpriv_v2 -o xattr -o modcaps=+sys_admin"
                         - posix_acl:
                             only with_cache.auto.default
+                            # rhel8 kernel does not support FUSE_POSIX_ACL
+                            no RHEL.8
                             Host_RHEL.m9:
                                 fs_binary_extra_options += " --xattr --posix-acl"
                             Host_RHEL.m8:

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -191,7 +191,8 @@
                     size_mem1 = 32G
                     # Clearing the private setting of falocate and support xattr
                     Host_RHEL.m9:
-                        fs_binary_extra_options += " --no-killpriv-v2 --xattr --modcaps=+sys_admin"
+                        # no_killpriv_v2 is set to the default one on RHEL9
+                        fs_binary_extra_options += " --xattr --modcaps=+sys_admin"
                     Host_RHEL.m8:
                         fs_binary_extra_options += " -o no_killpriv_v2 -o xattr -o modcaps=+sys_admin"
                     # Skip tests in both xfs and nfs due to known issue
@@ -200,7 +201,10 @@
                     # generic/551: Costs a lot of time
                     # generic/035 nfs specific: https://gitlab.com/virtio-fs/qemu/-/issues/12
                     # generic/531 nfs specific,id1938936
+                    # generic/070 650: due to nfs+virtiofs limitation, skip them if no '--inode_file_handles' specified, id2018072 and id1908490
                     generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551 generic/035 generic/531'
+                    with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs:
+                        generic_blacklist += ' generic/070 generic/650'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.


### PR DESCRIPTION
ID: 2188874
1. rhel8 guest kernel not suppor '-o posix_acl', so remove rhel8 guest.
2. for virtiofsd on rhel9, --no-killpriv-v2 is set to a default one, so no need to add it additionally.
3. generic/070 generic/650 need to work with ' --inode-file-handles=prefer' for nfs backend, so add them to blacklist in common tests.