### PR TITLE
boot_option.splash_time*: it was supported from rhel8.3, add the constraints

### DIFF
--- a/qemu/tests/cfg/uefi_check_log_info.cfg
+++ b/qemu/tests/cfg/uefi_check_log_info.cfg
@@ -12,8 +12,10 @@
             splash_time_pattern = "SetVariable\(Timeout,\s%d\)"
             variants:
                 - splash_time_10:
+                    no Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1 Host_RHEL.m8.u2
                     boot_splash_time = 10000
                 - splash_time_12:
+                    no Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1 Host_RHEL.m8.u2
                     boot_splash_time = 12000
                 - bootindex:
                     cdroms = "test"


### PR DESCRIPTION

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2189723