### PR TITLE
smt_test: limit guest version for 'Opteron_G3'

### DIFF
--- a/qemu/tests/cfg/smt_test.cfg
+++ b/qemu/tests/cfg/smt_test.cfg
@@ -34,5 +34,6 @@
                     expected_threads = 1
                     cpu_model_flags += ",-topoext"
         - with_Opteron:
+            only Windows RHEL.6 RHEL.7 RHEL.8
             cpu_model = Opteron_G3
             expected_threads = 1


### PR DESCRIPTION
ID: 2189869

Opteron_G3 is deprecated on RHEL9 and RHEL9 guest can't boot up with it, so remove it.