### PR TITLE
numa_memdev_options: align auto case with the numa_maps format output

### DIFF
--- a/qemu/tests/numa_memdev_options.py
+++ b/qemu/tests/numa_memdev_options.py
@@ -88,6 +88,7 @@ def check_memory_in_procfs(test, params, vm):
         if mem_path and (mem_path not in numa_maps):
             test.fail("memdev = %s: mem-path '%s' is not in numa_maps '%s'!"
                       % (mem_dev, mem_path, numa_maps))
+        numa_maps = re.sub(r'\s+\(many\)', '', numa_maps)
         policy_numa = numa_maps.split()[1].split(':')
         if policy != policy_numa[0]:
             test.fail("memdev = %s:"


### PR DESCRIPTION
numa_memdev_options: align auto case with the numa_maps format output

Since qemu8 the memory preferred policy accepts a set of numa nodes.
Updates the numa_maps query to be compatible with this new 'many'
preferred policy and the previous supported one.

ID: 2189892
Signed-off-by: mcasquer <mcasquer@redhat.com>
