### PR TITLE
bitmaps_merge_with_nospace:limit to localfs

### DIFF
--- a/qemu/tests/cfg/bitmaps_merge_with_nospace.cfg
+++ b/qemu/tests/cfg/bitmaps_merge_with_nospace.cfg
@@ -1,5 +1,6 @@
 - bitmaps_merge_with_nospace:
     type = bitmaps_merge_with_nospace
+    only filesystem
     start_vm = no
     virt_test_type = qemu
     not_preprocess = yes


### PR DESCRIPTION
Add backend limitation to only localfs
Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2193331