### PR TITLE
qemu_guest_agent: BLACKLIST_RPC has to replaced with BLOCK_RPCS

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -12,13 +12,16 @@
     gagent_status_cmd = "systemctl status qemu-guest-agent.service"
     cmd_check_qgaservice = journalctl -e | grep -Ei "syslog is obsolete|ERROR|FAILED|WARNING|FAIL"
     gagent_pkg_check_cmd = "rpm -q qemu-guest-agent"
-    black_list_change_cmd = "sed -i 's/%s//g' /etc/sysconfig/qemu-ga"
-    black_list_check_cmd = "grep -nr 'BLACKLIST_RPC=.*%s' /etc/sysconfig/qemu-ga"
     setsebool_cmd = "setsebool virt_qemu_ga_read_nonsecurity_files %s"
     getsebool_cmd = "getsebool -a | grep virt_qemu_ga_read_nonsecurity_files |awk '{print$3}'"
     backup_file = /etc/sysconfig/qemu-ga-bk
     black_list_backup = /bin/cp -f /etc/sysconfig/qemu-ga ${backup_file}
     recovery_black_list = mv -f ${backup_file} /etc/sysconfig/qemu-ga
+    black_list_change_cmd = "sed -i 's/%s//g' /etc/sysconfig/qemu-ga"
+    black_list_spec = BLOCK_RPCS
+    Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1:
+        black_list_spec = BLACKLIST_RPC
+    black_list_check_cmd = "grep -nr '${black_list_spec}=.*%s' /etc/sysconfig/qemu-ga"
     # /qga_setup_fail.log is saved during guest preinstall phase, if you don't have this file, please skip this parameter.
     cmd_check_qga_installlog = "ls /qga_setup_fail.log"
     # please fill the 'qga_rpm_path' if want to install specified version, form like "qga_rpm_path = ' '"
@@ -435,14 +438,14 @@
                 time_pattern = " (\d+/\d+/\d+ \d+:\d+ [APap][Mm])"
                 cmd_time_trans = python2.7 -c "import time; dt='%s'; t=time.mktime(time.strptime(dt, '%%m/%%d/%%Y %%I:%%M %%p')); print(t)"
         - check_os_info:
-             no RHEL.6
-             gagent_check_type = os_info
-             os_id = rhel
-             cmd_get_full_name = cat /etc/redhat-release
-             cmd_get_kernel_ver = uname -v
-             cmd_get_kernel_rel = uname -r
-             cmd_get_machine_type = uname -m
-             Windows:
+            no RHEL.6
+            gagent_check_type = os_info
+            os_id = rhel
+            cmd_get_full_name = cat /etc/redhat-release
+            cmd_get_kernel_ver = uname -v
+            cmd_get_kernel_rel = uname -r
+            cmd_get_machine_type = uname -m
+            Windows:
                 os_id = mswindows
                 cmd_get_full_name = wmic os get caption |findstr /vi caption
                 cmd_get_kernel_ver = wmic os get version |findstr /vi version
@@ -450,7 +453,10 @@
         - gagent_check_blacklist:
             only Linux
             gagent_check_type = blacklist
-            black_list_change_cmd = "sed -i 's/BLACKLIST_RPC=.*/BLACKLIST_RPC=guest-info/g' /etc/sysconfig/qemu-ga"
+            black_list_spec = BLOCK_RPCS
+            Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1:
+                black_list_spec = BLACKLIST_RPC
+            black_list_change_cmd = "sed -i 's/${black_list_spec}.*/${black_list_spec}=guest-info/g' /etc/sysconfig/qemu-ga"
         - gagent_check_log:
             only isa_serial
             gagent_check_type = log


### PR DESCRIPTION
Since BLACKLIST_RPC has been replaced with BLOCK_RPCS after rebasing qemu to 7.2, change relevant code in automation script.

ID: 2165442
Signed-off-by: demeng demeng@redhat.com
