### PR TITLE
Add support for option "acpi-index" on q35 device

### DIFF
--- a/qemu/tests/cfg/nic_acpi_index.cfg
+++ b/qemu/tests/cfg/nic_acpi_index.cfg
@@ -2,14 +2,17 @@
     virt_test_type = qemu
     type = nic_acpi_index
     only Linux
-    only i440fx
+    only x86_64
     clone_master = yes
     master_images_clone = image1
     remove_image_image1 = yes
     nic_hotplug_count=1
     nic_name_number = 2
     nic_model = virtio-net-pci
-    required_qemu = [6.0.0,)
+    i440fx:
+        required_qemu = [6.0.0,)
+    q35:
+        required_qemu = [8.0.0,)
     kernel_extra_params_remove = biosdevname=0 net.ifnames=0
     kernel_extra_params_serial_login = yes
     variants:


### PR DESCRIPTION
1. Since it had been support on downstream from qemu-kvm-8.0.0, so add support for it on the q35 device.

ID: 2203643
Signed-off-by: Lei Yang <leiayang@redhat.com>