### PR TITLE
For rhel 7.9 guest disable option "dev-iotlb"

### DIFF
--- a/qemu/tests/cfg/migrate_nic_with_iommu.cfg
+++ b/qemu/tests/cfg/migrate_nic_with_iommu.cfg
@@ -10,23 +10,25 @@
     type = migration_with_file_transfer
     variants:
         - with_iommu:
-              x86_64, i386:
-                  only q35
-                  no WinXP WinVista Win7 Win8 Win8.1 Win2003
-                  no Win2008 Win2008..r2 Win2012 Win2012..r2
-                  machine_type_extra_params = "kernel-irqchip=split"
-                  HostCpuVendor.intel:
-                      intel_iommu = yes
-                      iommu_caching_mode = on
-                  Linux:
-                      enable_guest_iommu = yes
-              nic_extra_params = ",disable-legacy=on,disable-modern=off,iommu_platform=on,ats=on"
-              aarch64:
-                  machine_type_extra_params += ",iommu=smmuv3"
-                  nic_extra_params = ",iommu_platform=on,ats=on"
-              s390x:
-                  nic_extra_params = ",iommu_platform=on"
-              vhostforce = on
+            x86_64, i386:
+                only q35
+                no WinXP WinVista Win7 Win8 Win8.1 Win2003
+                no Win2008 Win2008..r2 Win2012 Win2012..r2
+                machine_type_extra_params = "kernel-irqchip=split"
+                HostCpuVendor.intel:
+                    intel_iommu = yes
+                    iommu_caching_mode = on
+                    RHEL.7.9:
+                        iommu_device_iotlb = off
+                Linux:
+                    enable_guest_iommu = yes
+            nic_extra_params = ",disable-legacy=on,disable-modern=off,iommu_platform=on,ats=on"
+            aarch64:
+                machine_type_extra_params += ",iommu=smmuv3"
+                nic_extra_params = ",iommu_platform=on,ats=on"
+            s390x:
+                nic_extra_params = ",iommu_platform=on"
+            vhostforce = on
         - with_virtio_iommu:
             required_qemu= [7.0.0,)
             only Linux
@@ -39,9 +41,9 @@
     variants:
         - default_mem:
         - mininum_mem:
-              x86_64, aarch64, s390, s390x:
-                  mem = 1536
-              ppc64, ppc64le:
-                  mem = 3072
-              Windows:
-                  mem = 4096
+            x86_64, aarch64, s390, s390x:
+                mem = 1536
+            ppc64, ppc64le:
+                mem = 3072
+            Windows:
+                mem = 4096

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -117,6 +117,8 @@
                 HostCpuVendor.intel:
                     intel_iommu = yes
                     iommu_caching_mode = on
+                    RHEL.7.9:
+                        iommu_device_iotlb = off
                 Linux:
                     enable_guest_iommu = yes
             aarch64:


### PR DESCRIPTION
1.According to Bug 2156876 Comment 12 to disable option "dev-iotlb" for rhel 7.9 guest.

ID:2203756
Signed-off-by: Lei Yang <leiayang@redhat.com>