### PR TITLE
x86_cpu_model:add new cpu model 'SapphireRapids'

### DIFF
--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -84,6 +84,16 @@
             no RHEL.9
             flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de  popcnt cx16 lm nx syscall misalignsse sse4a abm lahf_lm fpu"
             model_pattern = "AMD Opteron 23xx \(Gen 3 Class Opteron%s\)"
+        - SapphireRapids:
+            only HostCpuVendor.intel
+            required_qemu = [8.0.0,)
+            flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
+            model_pattern = "Intel Xeon Processor \(SapphireRapids\)"
+        - SapphireRapids-v1:
+            only HostCpuVendor.intel
+            required_qemu = [8.0.0,)
+            flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
+            model_pattern = "Intel Xeon Processor \(SapphireRapids\)"
         - Snowridge:
             only HostCpuVendor.intel
             flags = "split_lock_detect gfni movdiri movdiri64b cldemote umip"


### PR DESCRIPTION
ID: 2203027

QEMU8.0 support new cpu model 'SapphireRapids' and alias of cpu model 'SapphireRapids-v1'.