### PR TITLE
qemu_guest_agent: Add param 'discard_granularity' to scsi image

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -203,6 +203,7 @@
                 image_name_stg = "images/storage"
                 image_format_stg = "qcow2"
                 image_size_stg = 5G
+                blk_extra_params_stg = "discard_granularity=33554432"
                 drv_extra_params = "discard=on"
                 force_create_image_stg = yes
                 remove_image_stg = yes


### PR DESCRIPTION
Add param 'discard_granularity=33554432' to scsi-hd 
for qga command "guest-fstrim"

ID: 2207829
Signed-off-by: demeng <demeng@redhat.com>