### PR TITLE
Change the minimum mtu size from 68 to 576

### DIFF
--- a/generic/tests/cfg/jumbo.cfg
+++ b/generic/tests/cfg/jumbo.cfg
@@ -15,6 +15,6 @@
             mtu = 9000
         - min_mtu:
             hint = want
-            mtu = 68
+            mtu = 576
             Windows:
                 mtu = 590


### PR DESCRIPTION
1.In the past we confused with the minimum datagram size that host must
  be prepared to accept. 68 bytes is a minimum without further
fragmentation instead of must be able to receive a datagram.

ID:2208095
Signed-off-by: Lei Yang <leiayang@redhat.com>