### PR TITLE
qemu_img_lock_reject_boot: avoid timing issues

### DIFF
--- a/qemu/tests/cfg/qemu_img_lock.cfg
+++ b/qemu/tests/cfg/qemu_img_lock.cfg
@@ -11,6 +11,7 @@
         - reject_boot_same_img_twice:
             type = qemu_img_lock_reject_boot
             second_vm_name = avocado-vt-vm2
+            check_lock_timeout = 5
         - reject_boot_base_img_and_snapshot:
             type = qemu_img_lock_reject_boot
             create_snapshot = yes

--- a/qemu/tests/qemu_img_lock_reject_boot.py
+++ b/qemu/tests/qemu_img_lock_reject_boot.py
@@ -1,3 +1,5 @@
+import time
+
 from virttest import env_process
 
 from qemu.tests.qemu_disk_img import QemuImgTest
@@ -32,6 +34,9 @@ def run(test, params, env):
         test.log.info("Verify qemu-img write lock err msg.",)
         msgs = ['"write" lock',
                 'Is another process using the image']
+        # Avoid timing issues between writing to log and the check itself
+        check_lock_timeout = params.get_numeric('check_lock_timeout', 5)
+        time.sleep(check_lock_timeout)
         # Check expected error messages directly in the test log
         output = process.run(
             r"cat " + test.logfile + r"| grep '\[qemu output\]' | grep -v 'warning'",


### PR DESCRIPTION
If `reject_boot_same_img_twice` variant is used there may be timing issue between time of writing of the lock message into the log file and the check for presence of the error lock message.

1) This PR introduces timeout to avoid this problem. Observed timing issue is roughly 200 milliseconds, so the default value of timeout set to 5 seconds should suffice any possible scenario. 

2) PR also adds `ignore_status=True` for `process.run` method, so misleading exception is not raised in case error message is not found and correct logic to handle this situation is used.

ID: 2208479