### PR TITLE
netperf_udp_perf: add CFLAGS = -fcommon to a make

### DIFF
--- a/qemu/tests/cfg/netperf_udp_perf.cfg
+++ b/qemu/tests/cfg/netperf_udp_perf.cfg
@@ -26,7 +26,7 @@
     test_duration = 20
     netperf_version = 2.7.1
     netperf_pkg = netperf/netperf-2.7.1.tar.bz2
-    setup_cmd = "cd /tmp && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && ./configure --enable-burst --enable-demo=yes --enable-intervals=yes && make"
+    setup_cmd = "cd /tmp && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && ./configure --enable-burst --enable-demo=yes --enable-intervals=yes && make CFLAGS=-fcommon"
     log_hostinfo_script = scripts/rh_perf_log_hostinfo_script.sh
     host_tuned_profile = "tuned-adm profile virtual-host"
     client_tuned_profile = "tuned-adm profile virtual-host"
@@ -39,18 +39,18 @@
     env_setup_cmd += " setenforce 1"
     #client configuration
     #please fix client/client_public_ip/client_physical_nic base on environment
-    #client = 
-    #client_public_ip = 
-    #client_physical_nic = 
+    #client =
+    #client_public_ip =
+    #client_physical_nic =
     username_client = root
-    #password_client = 
+    #password_client =
     shell_client_client = ssh
     shell_port_client = 22
     shell_prompt_client =  \[root@.{0,50}][\#\$]
     #host configuration
     shell_port_host = 22
     username_host = root
-    #password_host = 
+    #password_host =
     os_type_client = linux
     os_type_host = linux
     shell_prompt_host =  \[root@.{0,50}][\#\$]


### PR DESCRIPTION
GCC 10 use -fno-common as defaults, so add CFLAGS = -fcommon to make

Signed-off-by: Wenli Quan wquan@redhat.com

id:1938657