### PR TITLE
Add test cases to check maximum vCPUs with SE guest

### DIFF
--- a/qemu/tests/cfg/secure_execution.cfg
+++ b/qemu/tests/cfg/secure_execution.cfg
@@ -1,0 +1,28 @@
+- secure_execution: secure_img
+    only s390x
+    virt_test_type = qemu
+    type = secure_execution
+    take_regular_screendumps = no
+    start_vm = yes
+    kill_vm_before_test = yes
+    kill_vm = yes
+    machine_type_extra_params = "usb=off,dump-guest-core=off,confidential-guest-support=lsec0"
+    extra_params = "-object s390-pv-guest,id=lsec0"
+    nic_extra_params = "devno=fe.0.0001"
+    virtio_serial_extra_params = "devno=fe.0.0002"
+    variants:
+        - 247_max_vCPUs:
+            smp = 247
+            vcpu_maxcpus = 247
+            vcpu_sockets = 13
+            vcpu_cores = 19
+            vcpu_threads = 1
+        - 248_vCPUs_error_check:
+            start_vm = no
+            smp = 248
+            vcpu_maxcpus = 248
+            RHEL.8:
+                required_qemu = [6.2.0-33,)
+            RHEL.9:
+                required_qemu = [7.2.0-6,)
+            error_msg = "qemu-kvm: Protected VMs support a maximum of 247 CPUs"

--- a/qemu/tests/secure_execution.py
+++ b/qemu/tests/secure_execution.py
@@ -1,0 +1,36 @@
+from virttest import error_context
+from virttest import virt_vm
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Secured guest boot test:
+    1) Log into a secure guest
+    2) Check if there's error messagein
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    vm = env.get_vm(params["main_vm"])
+    error_context.context("Try to log into guest '%s'." % vm.name,
+                          test.log.info)
+    if params.get("start_vm") == "yes":
+        session = vm.wait_for_serial_login()
+        session.close()
+        vm.destroy()
+    else:
+        error_msg = params.get("error_msg", "")
+        try:
+            vm.create(params=params)
+            vm.verify_alive()
+            output = vm.process.get_output()
+            vm.destroy()
+        except virt_vm.VMCreateError as detail:
+            output = detail.output
+        if error_msg not in output:
+            test.fail("Error message is not expected! "
+                      "Expected: {} Actual: {}"
+                      .format(error_msg, output))


### PR DESCRIPTION
Secure_execution: add test cases for both positive and negative to check
if SE guest could get 247 for maximum vCPU and the error message is
expected when it get 248 vCPUs

ID: 2209269

Signed-off-by: Boqiao Fu <bfu@redhat.com>
