### PR TITLE
win_driver_installer_test:fix a bug in fwcfg_test

### DIFF
--- a/provider/win_driver_installer_test.py
+++ b/provider/win_driver_installer_test.py
@@ -391,7 +391,7 @@ def fwcfg_test(test, params, vm):
 
     output = vm.monitor.human_monitor_cmd('dump-guest-memory -w %s'
                                           % dump_file)
-    if output:
+    if output and "warning" not in output:
         test.fail("Save dump file failed as: %s" % output)
     else:
         cmd = "ls -l %s | awk '{print $5}'" % dump_file


### PR DESCRIPTION
Dump-guest-memory will raise a warning when VM cpu>32, it is expected behavior.
ID:2211274

Signed-off-by: Leidong Wang <leidwang@redhat.com>