### PR TITLE
x86_cpu_flags:remove the invalid test scenario

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -117,7 +117,7 @@
                 - flag_disable:
                     only Linux
                     type = x86_cpu_flag_disable
-                    flags_list = "rdrand ssbd fsgsbase bmi1 bmi2 rdtscp movbe avx2 avx f16c abm kvmclock"
+                    flags_list = "rdrand ssbd fsgsbase bmi1 bmi2 rdtscp movbe f16c abm kvmclock"
                     check_clock = 'cat /sys/devices/system/clocksource/clocksource0/available_clocksource'
                 - test_smap:
                     # support RHEL.7 guest or later


### PR DESCRIPTION
ID: 2211798

The developer thinks this is not one valid test senario, and the related bug has been closed as WONTFIX, so remove it.