### PR TITLE
virtio_fs: use global variable to define guest  memory size

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -167,11 +167,10 @@
             remove_fs_source = yes
             fs_target = 'myfs'
             fs_driver_props = {"queue-size": 1024}
-            mem = 4096
             mem_devs = mem1
             backend_mem_mem1 = memory-backend-file
             mem-path_mem1 = /dev/shm
-            size_mem1 = 4G
+            size_mem1 = ${mem}M
             use_mem_mem1 = no
             share_mem = yes
             guest_numa_nodes = shm0

--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -131,11 +131,10 @@
             remove_fs_source = yes
             fs_target = 'myfs'
             fs_driver_props = {"queue-size": 1024}
-            mem = 4096
             mem_devs = mem1
             backend_mem_mem1 = memory-backend-file
             mem-path_mem1 = /dev/shm
-            size_mem1 = 4G
+            size_mem1 = ${mem}M
             use_mem_mem1 = no
             share_mem = yes
             guest_numa_nodes = shm0

--- a/qemu/tests/cfg/virtio_driver_sign_check.cfg
+++ b/qemu/tests/cfg/virtio_driver_sign_check.cfg
@@ -54,11 +54,10 @@
             remove_fs_source = yes
             fs_target = 'myfs'
             fs_driver_props = {"queue-size": 1024}
-            mem = 4096
             mem_devs = mem1
             backend_mem_mem1 = memory-backend-file
             mem-path_mem1 = /dev/shm
-            size_mem1 = 4G
+            size_mem1 = ${mem}M
             use_mem_mem1 = no
             share_mem = yes
             guest_numa_nodes = shm0

--- a/qemu/tests/cfg/virtio_fs_hotplug.cfg
+++ b/qemu/tests/cfg/virtio_fs_hotplug.cfg
@@ -21,11 +21,10 @@
     force_create_fs_source = no
     remove_fs_source = yes
     fs_driver_props = {"queue-size": 1024}
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'

--- a/qemu/tests/cfg/virtio_fs_multi_users_access.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_users_access.cfg
@@ -16,11 +16,10 @@
     fs_target = 'myfs'
     fs_dest = "/mnt/${fs_target}"
     fs_driver_props = {"queue-size": 1024}
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     !s390, s390x:

--- a/qemu/tests/cfg/virtio_fs_multi_vms.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_vms.cfg
@@ -9,10 +9,9 @@
     clone_master = yes
     master_images_clone = image1
     remove_image_image1 = yes
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     io_timeout = 600

--- a/qemu/tests/cfg/virtio_fs_readonly.cfg
+++ b/qemu/tests/cfg/virtio_fs_readonly.cfg
@@ -23,11 +23,10 @@
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
     fs_dest = '/mnt/${fs_target}'
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     !s390, s390x:

--- a/qemu/tests/cfg/virtio_fs_security_label.cfg
+++ b/qemu/tests/cfg/virtio_fs_security_label.cfg
@@ -18,11 +18,10 @@
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     test_file = 'test_file'

--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -23,11 +23,10 @@
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     !s390, s390x:

--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -15,11 +15,10 @@
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     s390, s390x:

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -15,11 +15,10 @@
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     s390, s390x:

--- a/qemu/tests/cfg/virtio_fs_winfsp_test.cfg
+++ b/qemu/tests/cfg/virtio_fs_winfsp_test.cfg
@@ -15,11 +15,10 @@
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
-    mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     mem-path_mem1 = /dev/shm
-    size_mem1 = 4G
+    size_mem1 = ${mem}M
     use_mem_mem1 = no
     share_mem = yes
     guest_numa_nodes = shm0

--- a/qemu/tests/cfg/win_sigverif.cfg
+++ b/qemu/tests/cfg/win_sigverif.cfg
@@ -10,9 +10,9 @@
     variants:
         - @default:
         - msft_sign_check:
-          type = win_msft_sign_check
-          vio_driver_chk_cmd = 'driverquery /si | find /i "%s"'
-          chk_timeout = 240
+            type = win_msft_sign_check
+            vio_driver_chk_cmd = 'driverquery /si | find /i "%s"'
+            chk_timeout = 240
     variants:
         - with_netkvm:
             only virtio_net
@@ -83,11 +83,10 @@
             remove_fs_source = yes
             fs_target = 'myfs'
             fs_driver_props = {"queue-size": 1024}
-            mem = 4096
             mem_devs = mem1
             backend_mem_mem1 = memory-backend-file
             mem-path_mem1 = /dev/shm
-            size_mem1 = 4G
+            size_mem1 = ${mem}M
             use_mem_mem1 = no
             share_mem = yes
             guest_numa_nodes = shm0

--- a/qemu/tests/cfg/win_virtio_driver_install_from_update.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_from_update.cfg
@@ -112,11 +112,10 @@
             remove_fs_source = yes
             fs_target = 'myfs'
             fs_driver_props = {"queue-size": 1024}
-            mem = 4096
             mem_devs = mem1
             backend_mem_mem1 = memory-backend-file
             mem-path_mem1 = /dev/shm
-            size_mem1 = 4G
+            size_mem1 = ${mem}M
             use_mem_mem1 = no
             share_mem = yes
             guest_numa_nodes = shm0

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -138,7 +138,7 @@
             driver_name = viorng
             device_name = "VirtIO RNG Device"
             device_hwid = '"PCI\VEN_1AF4&DEV_1005" "PCI\VEN_1AF4&DEV_1044"'
-            run_bgstress = rng_bat 
+            run_bgstress = rng_bat
             target_process = random\w*.exe
             session_cmd_timeout = 240
             rng_data_rex = "0x\w"
@@ -234,11 +234,10 @@
             remove_fs_source = yes
             fs_target = 'myfs'
             fs_driver_props = {"queue-size": 1024}
-            mem = 4096
             mem_devs = mem1
             backend_mem_mem1 = memory-backend-file
             mem-path_mem1 = /dev/shm
-            size_mem1 = 4G
+            size_mem1 = ${mem}M
             use_mem_mem1 = no
             share_mem = yes
             guest_numa_nodes = shm0


### PR DESCRIPTION
ID: 2211641
To make the test more flexible, use global variable
to instead of local variable for guest memory size.
