### PR TITLE
nicdriver_unload: `cmd_output_safe` timeout based on `random.randint`

### DIFF
--- a/generic/tests/nicdriver_unload.py
+++ b/generic/tests/nicdriver_unload.py
@@ -143,7 +143,9 @@ def run(test, params, env):
             session_serial.cmd_output_safe("modprobe %s" % driver)
             error_context.context("Activate NIC driver.", test.log.info)
             session_serial.cmd_output_safe("ifconfig %s up" % ethname)
-            session_serial.cmd_output_safe("sleep %s" % random.randint(10, 60))
+            sleep_time = random.randint(10, 60)
+            session_serial.cmd_output_safe("sleep %s" % sleep_time,
+                                           timeout=sleep_time + 5)
 
         # files md5sums check
         error_context.context("File transfer finished, checking files md5sums",


### PR DESCRIPTION
By default, timeout of session.cmd_output_safe is 60, when `random.randint(10, 60)` returns 60s, cmd_output_safe may time out, so the timeout value should base on the `random.randint`.

ID: 2213379