### PR TITLE
blockdev_snapshot_chains:update the method to get base format

### DIFF
--- a/qemu/tests/blockdev_snapshot_chains.py
+++ b/qemu/tests/blockdev_snapshot_chains.py
@@ -65,7 +65,7 @@ class BlockdevSnapshotChainsTest(BlockDevSnapshotTest):
         if self.main_vm.is_alive():
             self.main_vm.destroy()
         base_tag = self.base_tag
-        base_format = self.params.get("image_format", "qcow2")
+        base_format = self.base_image.get_format()
         self.params["image_format_%s" % base_tag] = base_format
         for snapshot_tag in self.snapshot_chains:
             snapshot_image = self.get_image_by_tag(snapshot_tag)


### PR DESCRIPTION
In original design, miss this scenario: we define an image format for base image that is different from the --imageformat we defined in kar cmdline. In this scenario, when we do some rebase for snapshot images, we will use an incorrect imageformat for the base image, which will lead to "can't find baking image" error when start guest with snapshot images.
id:2213432