### PR TITLE
watchdog.cfg: support for a 'TCO' watchdog

### DIFF
--- a/qemu/tests/cfg/watchdog.cfg
+++ b/qemu/tests/cfg/watchdog.cfg
@@ -22,6 +22,12 @@
             only s390x
             watchdog_device_type = diag288
             module_check_cmd = "lsmod | grep diag288"
+        -itco:
+            required_qemu = [8.0.0,)
+            only q35
+            watchdog_device_type = itco
+            module_check_cmd = "lsmod | grep iTCO_wdt"
+            only watchdog_action
     variants:
         - boot_with_watchdog:
             test_type = guest_boot_with_watchdog
@@ -67,40 +73,40 @@
                     no ppc64, ppc64le, s390x
                     migration_protocol = rdma
         - hotplug_unplug_watchdog_device:
-             only i6300esb
-             no RHEL.4 RHEL.5
-             no q35
-             del watchdog_device_type
-             plug_watchdog_device = i6300esb
-             watchdog_action = pause
-             test_type = hotplug_unplug_watchdog_device
+            only i6300esb
+            no RHEL.4 RHEL.5
+            no q35
+            del watchdog_device_type
+            plug_watchdog_device = i6300esb
+            watchdog_action = pause
+            test_type = hotplug_unplug_watchdog_device
         - stop_cont_test:
-             test_type = stop_cont_test
-             trigger_cmd = `command -v python python3 | head -1` -c "open('/dev/watchdog', 'w').close()"
-             watchdog_action = debug
-             response_timeout = 40
+            test_type = stop_cont_test
+            trigger_cmd = `command -v python python3 | head -1` -c "open('/dev/watchdog', 'w').close()"
+            watchdog_action = debug
+            response_timeout = 40
         - watchdog_test_suit:
-             test_type = watchdog_test_suit
-             watchdog_action = pause
-             watchdog_test_lib = "watchdog/watchdog-test-framework"
+            test_type = watchdog_test_suit
+            watchdog_action = pause
+            watchdog_test_lib = "watchdog/watchdog-test-framework"
         - heartbeat_test:
-           only i6300esb
-           test_type = heartbeat_test
-           del_module_cmd = "modprobe -r i6300esb"
-           reload_module_cmd = "modprobe i6300esb heartbeat=%s"
-           trigger_cmd = `command -v python python3 | head -1` -c "open('/dev/watchdog', 'w')"
-           watchdog_action = pause
-           dmesg_cmd = dmesg -c
-           variants:
-               - valid:
-                   heartbeat = random_value
-               - invalid_1:
-                   heartbeat = -1
-               - invalid_0:
-                   heartbeat = 0
-               - invalid_min:
-                   heartbeat = -2147483648
-               - invalid_max:
-                   heartbeat = 2147483647
-               - invalid_excp:
-                   heartbeat = 4294967296
+            only i6300esb
+            test_type = heartbeat_test
+            del_module_cmd = "modprobe -r i6300esb"
+            reload_module_cmd = "modprobe i6300esb heartbeat=%s"
+            trigger_cmd = `command -v python python3 | head -1` -c "open('/dev/watchdog', 'w')"
+            watchdog_action = pause
+            dmesg_cmd = dmesg -c
+            variants:
+                - valid:
+                    heartbeat = random_value
+                - invalid_1:
+                    heartbeat = -1
+                - invalid_0:
+                    heartbeat = 0
+                - invalid_min:
+                    heartbeat = -2147483648
+                - invalid_max:
+                    heartbeat = 2147483647
+                - invalid_excp:
+                    heartbeat = 4294967296

--- a/qemu/tests/watchdog.py
+++ b/qemu/tests/watchdog.py
@@ -40,11 +40,13 @@ def run(test, params, env):
         Check the watchdog device have been found and init successfully. if not
         will raise error.
         """
-        # when using ib700 or diag288, need modprobe it's driver manually.
+        # when using ib700 or diag288 or itco, need modprobe it's driver manually.
         if watchdog_device == "ib700":
             session.cmd("modprobe ib700wdt")
         if watchdog_device == "diag288":
             session.cmd("modprobe diag288_wdt")
+        if watchdog_device == "itco":
+            session.cmd("modprobe iTCO_wdt")
 
         # when wDT is 6300esb need check pci info
         if watchdog_device == "i6300esb":
@@ -436,7 +438,11 @@ def run(test, params, env):
 
     # main procedure
     test_type = params.get("test_type")
-    check_watchdog_support()
+    watchdog_device_type = params.get("watchdog_device_type")
+    if watchdog_device_type == "itco":
+        pass
+    else:
+        check_watchdog_support()
 
     error_context.context("'%s' test starting ... " % test_type, test.log.info)
     error_context.context("Boot VM with WDT(Device:'%s', Action:'%s'),"


### PR DESCRIPTION
The Q35 machine type chipset comes with unconditional support for a 'TCO' watchdog

ID: 1462