### PR TITLE
hotplug_mem_stress_ng: updates stress-ng repository source

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_stress_ng.cfg
+++ b/qemu/tests/cfg/hotplug_mem_stress_ng.cfg
@@ -26,7 +26,7 @@
     size_mem_plug1 = 1G
     stress_ng_dir = "/tmp/stress-ng"
     get_stress_ng = "[ -d ${stress_ng_dir} ] && rm -rf ${stress_ng_dir}"
-    get_stress_ng += ";git clone --depth=1 git://kernel.ubuntu.com/cking/stress-ng.git ${stress_ng_dir}"
+    get_stress_ng += ";git clone --depth=1 https://github.com/ColinIanKing/stress-ng.git ${stress_ng_dir}"
     compile_stress_ng = "cd ${stress_ng_dir} && make -j4"
     run_stress_ng = "cd ${stress_ng_dir} && ./stress-ng %s"
     stress_ng_args = "--page-in -r 4 -t 60s"


### PR DESCRIPTION
hotplug_mem_stress_ng: updates stress-ng repository source

Updates stress-ng repository to the github source, as the one from ubuntu seems to be no longer available.

ID: 2215785
Signed-off-by: mcasquer <mcasquer@redhat.com>