### PR TITLE
blockdev_commit_firewall:remove nbd image after test

### DIFF
--- a/qemu/tests/blockdev_commit_firewall.py
+++ b/qemu/tests/blockdev_commit_firewall.py
@@ -58,6 +58,10 @@ class BlockdevCommitFirewall(BlockDevCommitTest):
         # stop nbd image export
         self._nbd_export.stop_export()
 
+        # remove nbd image after test
+        nbd_image = self.get_image_by_tag(self.params["local_image_tag"])
+        nbd_image.remove()
+
     def generate_tempfile(self, root_dir, filename="data",
                           size="1000M", timeout=360):
         backup_utils.generate_tempfile(

--- a/qemu/tests/cfg/blockdev_commit_firewall.cfg
+++ b/qemu/tests/cfg/blockdev_commit_firewall.cfg
@@ -12,6 +12,8 @@
     rebase_mode = unsafe
     speed = 10000000
     qemu_force_use_drive_expression = no
+    #Fixme if no driver deprecated warning in host_dmesg.log
+    expected_host_dmesg = Warning: Deprecated Driver is detected
 
     # Settings for a local fs image 'nbddata',
     # which will be exported by qemu-nbd


### PR DESCRIPTION
Remove nbd image in clean_images() to keep an clean
test env
Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2216428