### PR TITLE
fio_perf: add allow_direct_io option for RHEL8.8 and later

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -111,9 +111,11 @@
             order_list = "Block_size Iodepth Threads BW(MB/S) IOPS Latency(ms) Host_CPU BW/CPU KVM_Exits"
             fs_binary_extra_options = " --thread-pool-size=32"
             !Host_RHEL.m8:
-                # The below option isn't supported on RHEL8.
                 fs_binary_extra_options += " --allow-direct-io"
                 vfsd_ver_chk_cmd = "rpm -q virtiofsd"
+            Host_RHEL.m8:
+                no Host_RHEL.m8.u2 Host_RHEL.m8.u3 Host_RHEL.m8.u4 Host_RHEL.m8.u5 Host_RHEL.m8.u6 Host_RHEL.m8.u7
+                fs_binary_extra_options += " -o allow_direct_io"
             variants:
                 - auto:
                     fs_binary_extra_options += " -o cache=auto"


### PR DESCRIPTION
ID: 2217203
From RHEL8.8, virtiofsd support allow_direct_io option.