### PR TITLE
numa_negative.threads_test: includes test_negative_thread cfg param

### DIFF
--- a/qemu/tests/cfg/numa_negative.cfg
+++ b/qemu/tests/cfg/numa_negative.cfg
@@ -16,6 +16,7 @@
     numa_cpus_node0 = 0
     numa_cpus_node1 = 1
     negative_type = fatal
+    test_negative_thread = yes
     variants:
         - threads_test:
             vcpu_sockets = 1


### PR DESCRIPTION
numa_negative.threads_test: includes test_negative_thread cfg param

Include the test_negative_thread configuration param to avoid
setting the number of vcpu_threads to 1 in qemu_vm avocado-vt.

ID: 2217797
Signed-off-by: mcasquer <mcasquer@redhat.com>
