### PR TITLE
uefishell.check_smbios: update expression to match new strings

### DIFF
--- a/qemu/tests/cfg/uefishell.cfg
+++ b/qemu/tests/cfg/uefishell.cfg
@@ -85,8 +85,8 @@
                 - with_entry_point:
                     no Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9.u0 Host_RHEL.m9.u1
                     smbios_output_handler = "handle_smbiosview"
-                    bios_version = "BiosVersion.*:.*edk2-([0-9]{8})"
-                    bios_release_date = "BiosReleaseDate.*:.*(?P<month>[0-9]{2})/(?P<day>[0-9]{2})/(?P<year>[0-9]{4})"
+                    bios_version = "(?:BiosVersion|BIOS\s+Version).*:.*edk2-([0-9]{8})"
+                    bios_release_date = "(?:BiosReleaseDate|BIOS\s+Release\s+Date).*:.*(?P<month>[0-9]{2})/(?P<day>[0-9]{2})/(?P<year>[0-9]{4})"
                     variants:
                         - type_32:
                             machine_type_extra_params = "smbios-entry-point-type=32"
@@ -96,7 +96,7 @@
                             smbios_version = "Version.*:\s+3\.\d+"
                 - updated_type_0:
                     extra_params += "-smbios type=0,vendor=test_redhat,version=test_v1,date=06/01/2018,uefi=on"
-                    check_result_smbios = "Vendor.*:.*test_redhat, BiosVersion.*:.*test_v1, BiosReleaseDate.*:.*06/01/2018"
+                    check_result_smbios = "Vendor.*:.*test_redhat, (?:BiosVersion|BIOS\s+Version).*:.*test_v1, (?:BiosReleaseDate|BIOS\s+Release\s+Date).*:.*06/01/2018"
                 - updated_type_2:
                     extra_params += "-smbios type=2,manufacturer=redhat,product=rhel,version=test_v1,serial=test_123"
                     check_result_smbios = "Manufacturer.*:.*redhat, ProductName.*:.*rhel, Version.*:.*test_v1, SerialNumber.*:.*test_123"


### PR DESCRIPTION
1. bios version need to match BiosVersion or "BIOS Version"
2. bios release date need to match BiosReleaseDate or "BIOS Release Date"

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2219496