### PR TITLE
nmi_bsod_catch: fix a bug on win10.i386

### DIFF
--- a/qemu/tests/cfg/nmi_bsod_catch.cfg
+++ b/qemu/tests/cfg/nmi_bsod_catch.cfg
@@ -14,7 +14,7 @@
     config_cmd3 = reg add HKLM\System\CurrentControlSet\Control\CrashControl /v DumpFile /d C:\Memory.dmp /t REG_EXPAND_SZ /f
     # enable nmi dump
     config_cmd4 = reg add HKLM\System\CurrentControlSet\Control\CrashControl /v NMICrashDump  /d 1 /t REG_DWORD /f
-    config_cmd5 = reg add HKLM\System\CurrentControlSet\Control\CrashControl /v AlwaysKeepMemoryDump /d 1 /t REG_DWORD /f 
+    config_cmd5 = reg add HKLM\System\CurrentControlSet\Control\CrashControl /v AlwaysKeepMemoryDump /d 1 /t REG_DWORD /f
     # disable windows error reporting, it may block our test
     config_cmd6 = reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\Windows Error Reporting" /v Disabled /d 1 /t REG_DWORD /f
     manual_reboot_cmd =
@@ -22,10 +22,11 @@
     i386:
         windbg_path = "x86\windbg.exe"
         devcon_dirname += "x86"
+        chk_windbg_cmd = 'dir "C:\Program Files\Windows Kits\10\Debuggers\%s"'
     x86_64:
         windbg_path = "x64\windbg.exe"
         devcon_dirname += "amd64"
-    chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
+        chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
     devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     feature = "OptionId.WindowsDesktopDebuggers"
     sdk_setup = winsdksetup.exe
@@ -46,7 +47,7 @@
     dump_path = C:\Memory.dmp
     save_path_cmd = "echo ${dump_path} > C:\dump_path.txt"
     chk_dump_cmd = "WIN_UTILS:\AutoIt3\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"
-    check_dump_cmd = dir C:\Memory.dmp 
+    check_dump_cmd = dir C:\Memory.dmp
     del_dump_cmd = del C:\Memory.dmp
     nmi_cmd = inject-nmi
     virtio_blk:


### PR DESCRIPTION
windbg install path is different between x64 and i386, so update the configuration file to fix the error.

ID:2218864