### PR TITLE
block_detect_zeroes:fix case name

### DIFF
--- a/qemu/tests/cfg/block_detect_zeroes.cfg
+++ b/qemu/tests/cfg/block_detect_zeroes.cfg
@@ -19,17 +19,17 @@
     ovmf:
         no i440fx
     variants:
-        - off:
+        - with_off:
             drv_extra_params_stg1 += ",detect-zeroes=off"
-        - on:
+        - with_on:
             drv_extra_params_stg1 += ",detect-zeroes=on"
-        - unmap:
+        - with_unmap:
             drv_extra_params_stg1 += ",detect-zeroes=unmap"
     variants:
-        - boot:
+        - with_boot:
             guest_operation = boot_test
-        - hotplug_unplug:
+        - with_hotplug:
             guest_operation = hotplug_unplug_test
-        - block_resize:
+        - with_resize:
             guest_operation = block_resize_test
             new_image_size_stg1 = 3221225472


### PR DESCRIPTION
Avoid the case name being the same as the top variant.
ID:2219519

Signed-off-by: qingwangrh <qinwang@redhat.com>
