### PR TITLE
device_bit_check:fix pci search pattern

### DIFF
--- a/qemu/tests/cfg/device_bit_check.cfg
+++ b/qemu/tests/cfg/device_bit_check.cfg
@@ -24,18 +24,18 @@
             virtio_blk:
                 dev_param_name = blk_extra_params
                 blk_extra_params = ""
-                pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio block device"
+                pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1001|1042)"
                 dev_type = "virtio-blk-.*"
             virtio_scsi:
                 dev_param_name = bus_extra_params
                 bus_extra_params = ""
-                pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio SCSI"
+                pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1004|1048)"
                 dev_type = "virtio-scsi-.*"
                 s390x:
                     ccw_id_pattern = "\d+\.\d+\."
         - nic_device:
             only virtio_net
             nic_extra_params = ""
-            pci_id_pattern = "(\d+:\d+\.\d+)\s+Ethernet controller:.*?Virtio network device"
+            pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1000|1041)"
             dev_type = "virtio-net-.*"
             dev_param_name = nic_extra_params

--- a/qemu/tests/device_bit_check.py
+++ b/qemu/tests/device_bit_check.py
@@ -83,7 +83,7 @@ def run(test, params, env):
                         test.error("Can't get the ccw id for device")
                     cmd = "cat /sys/bus/ccw/devices/%s/" % ccw_n[0]
                 else:
-                    pci_info = session.cmd_output("lspci")
+                    pci_info = session.cmd_output("lspci -n")
                     pci_n = re.findall(pci_id_pattern, pci_info)
                     if not pci_n:
                         test.error("Can't get the pci id for device")


### PR DESCRIPTION

Updates the case logic using numerical ID as
test point due to name will be changed without
notice. In order to support 0.9 and 1.0 virtio
devices, the pattern now contains both IDs.

The ids of device may refer to
https://github.com/vcrhonek/hwdata/blob/master/pci.ids#L24039-L24058

ID:2217301