### PR TITLE
virtio_port_hotplug.hotplug_port_pci: No free matching bus error

### DIFF
--- a/qemu/tests/virtio_serial_hotplug_port_pci.py
+++ b/qemu/tests/virtio_serial_hotplug_port_pci.py
@@ -150,6 +150,7 @@ def run(test, params, env):
         # for windows guest, disable/uninstall driver to get memory leak based on
         # driver verifier is enabled
         if params.get("os_type") == "windows":
-            vm.devices.simple_hotplug(buses[0], vm.monitor)
-            vm.devices.simple_hotplug(serial_devices[0], vm.monitor)
+            if params.get("unplug_pci") == "yes":
+                vm.devices.simple_hotplug(buses[0], vm.monitor)
+                vm.devices.simple_hotplug(serial_devices[0], vm.monitor)
             win_driver_utils.memory_leak_check(vm, test, params)


### PR DESCRIPTION
Because the hotplug logic did not show up the correct place,
cause this kind of problem. Change the strategy of hotplugging pci

ID: 1114
Signed-off-by: demeng <demeng@redhat.com>