### PR TITLE
qsd_blockdev_check:fix qcow2 format support

### DIFF
--- a/qemu/tests/cfg/qsd_blockdev_check.cfg
+++ b/qemu/tests/cfg/qsd_blockdev_check.cfg
@@ -11,6 +11,8 @@
     image_size_stg1 = 128M
     image_name_stg2 = images/stg2
     image_size_stg2 = 256M
+    image_format_stg1 = qcow2
+    image_format_stg2 = raw
 
     qsd_cmd_lines += " --object iothread,id=iothread1;"
 


### PR DESCRIPTION
Explicitly declare the image format.
Avoid mismatches with default value.

ID:2210617