### PR TITLE
limit test version of check_get_diskstatus

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -567,6 +567,7 @@
             kill_qga_program_cmd = taskkill /im qemu-ga.exe /t /f
         - check_get_diskstats:
             only Linux
+            no  RHEL.7 RHEL.8 RHEL.9.0 RHEL.9.1
             gagent_check_type = get_diskstats
             count_num_arg = head -n 1 /proc/diskstats | awk '{print NF; exit}'
             disk_num_guest = cat /proc/diskstats |wc -l


### PR DESCRIPTION
QGA: limit RHEL and qemu version for check_get_diskstats

ID: 2214946

Signed-off-by: Boqiao Fu <bfu@redhat.com>