### PR TITLE
Update the indirect_image_blacklist dynamically

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -108,6 +108,8 @@
                     force_create_image = no
                     pre_command = "modprobe -r scsi_debug; modprobe sg; modprobe scsi_debug add_host=9 dev_size_mb=50"
                     post_command = "rmmod scsi_debug"
+                    disk_check_cmd = "ls -1d /dev/nvme* || ls -1d /dev/sda*"
+                    image_stg_blacklist = "/dev/sda[\d]* /dev/sg0"
                     stg_params += "image_raw_device:yes "
                     stg_params += "image_format:raw "
                     stg_params += "indirect_image_select:range(-9,0) "


### PR DESCRIPTION
Need to update the indirect_image_blacklist dynamically according to the host environments when create disk by scsi_debug.

ID: 2216399
Signed-off-by: Sibo Wang siwang@redhat.com