### PR TITLE
virtio_mode: updates PCI patterns according to the numerical ID

### DIFF
--- a/qemu/tests/cfg/virtio_mode.cfg
+++ b/qemu/tests/cfg/virtio_mode.cfg
@@ -22,6 +22,9 @@
             virtio_dev_disable_legacy = off
             virtio_mode = legacy
     variants:
+        # Numerical PCI ids have been used as a reference
+        # https://man7.org/linux/man-pages/man5/pci.ids.5.html
+        # https://github.com/pciutils/pciids/blob/master/pci.ids
         - with_netkvm:
             only virtio_net
             driver_name = netkvm
@@ -30,12 +33,12 @@
                 driver_verifier += " ndis"
             device_type = "virtio-net-pci"
             device_name = "Red Hat VirtIO Ethernet Adapter.*"
-            pci_id_pattern = "(\d+:\d+\.\d+)\s+Ethernet controller:.*?Virtio network device"
+            pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1000|1041)"
         - with_viorng:
             driver_name = viorng
             device_type = "virtio-rng-pci"
             device_name = "VirtIO RNG Device"
-            pci_id_pattern = "(\d+:\d+\.\d+)\s+Unclassified device\s.*?Virtio RNG"
+            pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1005|1044)"
             no_virtio_rng:
                 virtio_rngs += " rng0"
             variants:
@@ -56,13 +59,13 @@
             driver_name = viostor
             device_type = "virtio-blk-pci"
             device_name = "Red Hat VirtIO SCSI controller"
-            pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio block device"
+            pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1001|1042)"
         - with_vioscsi:
             only virtio_scsi
             driver_name = vioscsi
             device_type = "virtio-scsi-pci"
             device_name = "Red Hat VirtIO SCSI pass-through controller"
-            pci_id_pattern = "(\d+:\d+\.\d+)\s+SCSI storage controller:.*?Virtio SCSI"
+            pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1004|1048)"
         - with_vioserial:
             only Windows
             driver_name = vioser
@@ -70,7 +73,7 @@
             serial_type_vs = virtserialport
             device_type = "virtio-serial-pci"
             device_name = "VirtIO Serial Driver"
-            pci_id_pattern = "(\d+:\d+\.\d+)\s+Communication controller:.*?Virtio console"
+            pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1003|1043)"
         - with_balloon:
             driver_name = balloon
             balloon = balloon0
@@ -78,4 +81,4 @@
             balloon_dev_add_bus = yes
             device_name = "VirtIO Balloon Driver"
             device_type = "virtio-balloon-pci"
-            pci_id_pattern = "(\d+:\d+\.\d+)\s+Unclassified device\s.*?Virtio memory balloon"
+            pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1002|1045)"

--- a/qemu/tests/virtio_mode.py
+++ b/qemu/tests/virtio_mode.py
@@ -96,7 +96,7 @@ def run(test, params, env):
 
         :param session: shell Object
         """
-        pci_info = session.cmd_output("lspci")
+        pci_info = session.cmd_output("lspci -n")
         pci_id_pattern = params["pci_id_pattern"]
         pci_n = re.findall(pci_id_pattern, pci_info)[0]
         if not pci_n:


### PR DESCRIPTION
virtio_mode: updates PCI patterns according to the numerical ID

Updates the case logic, checking the numerical ID of the PCI devices
instead of the full name, that could be updated without notice.
In order to support 0.9 and 1.0 virtio devices, the pattern now
contains both IDs.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2222179