### PR TITLE
virtio_fs: change the support for extra virtiofsd options

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -106,8 +106,6 @@
         - @default:
         - @extra_parameters:
             variants:
-                - lock_posix_off:
-                    fs_binary_extra_options += " -o no_posix_lock"
                 - lock_posix_on:
                     only Host_RHEL.m8
                     fs_binary_extra_options += " -o posix_lock"
@@ -115,13 +113,9 @@
                 - flock_on:
                     only Host_RHEL.m8
                     fs_binary_extra_options += " -o flock"
-                - flock_off:
-                    fs_binary_extra_options += " -o no_flock"
             variants:
                 - xattr_on:
                     fs_binary_extra_options += " -o xattr"
-                - xattr_off:
-                    fs_binary_extra_options += " -o no_xattr"
         - with_writeback:
             only with_cache
             # Since in writeback-cache mode writes go to the cache only, A large number of dirty pages will be generated.

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -107,8 +107,6 @@
         - @default_extra_parameters:
         - @extra_parameters:
             variants:
-                - lock_posix_off:
-                    fs_binary_extra_options += " -o no_posix_lock"
                 - lock_posix_on:
                     only Host_RHEL.m8
                     fs_binary_extra_options += " -o posix_lock"
@@ -116,13 +114,9 @@
                 - flock_on:
                     only Host_RHEL.m8
                     fs_binary_extra_options += " -o flock"
-                - flock_off:
-                    fs_binary_extra_options += " -o no_flock"
             variants:
                 - xattr_on:
                     fs_binary_extra_options += " -o xattr"
-                - xattr_off:
-                    fs_binary_extra_options += " -o no_xattr"
         - with_writeback:
             # Since in writeback-cache mode writes go to the cache only, A large number of dirty pages will be generated.
             # When the memory is insufficient, the performance will be seriously degraded, so increase the memory to 8G.


### PR DESCRIPTION
ID: 2207877
1. Remove xattr/lock_posix/flock=off variants as they are disabled by default.
2. Remove lock_posix/flock=on support on RHEL9,as they're not supported.