### PR TITLE
multi_disk_random_hotplug:fix scsi bus miss issue

### DIFF
--- a/qemu/tests/cfg/multi_disk_random_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_random_hotplug.cfg
@@ -60,6 +60,8 @@
                 usb_type_ehci = ich9-usb-ehci1
             Linux:
                 dd_timeout = 1800
+            virtio_blk:
+                set_drive_bus = yes
         - single_type:
             no ide, ahci, scsi
             virtio_scsi:


### PR DESCRIPTION
There is no scsi bus when boot OS with virtio_blk. 
It needs to adding scsi bus before hotplug scsi_hd disk.

ID:2203001

