### PR TITLE
qemu_guest_agent: adjust check method for isa-serial situation

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -461,11 +461,12 @@
         - gagent_check_log:
             only isa_serial
             gagent_check_type = log
+            gagent_serial_type = isa
             black_list = "guest-file-[a-zA-Z]*"
-            get_log_cmd = cat /var/log/qemu-ga/qemu-ga.log |grep "read data"
+            get_log_cmd = cat /var/log/qemu-ga/qemu-ga.log |grep "%s"
             tmp_file = "/tmp/qga_test"
             Windows:
-                get_log_cmd = type c:\qga.log |findstr /c:"read data"
+                get_log_cmd = type c:\qga.log |findstr /c:"%s"
                 tmp_file = "C:\qga_test.txt"
         - gagent_query_chardev:
             no isa_serial
@@ -615,13 +616,12 @@
         - isa_serial:
             # isa-serial is only supported on x86
             only i386, x86_64
-            gagent_serial_type = isa
             check_vioser = no
             serials += " org.qemu.guest_agent.0"
-            gagent_start_cmd = "pgrep qemu-ga || qemu-ga -d -m isa-serial -p /dev/ttyS1 -l /var/log/qemu-ga/qemu-ga.log -v"
+            gagent_start_cmd = "pgrep qemu-ga || qemu-ga -d -m isa-serial -p /dev/ttyS1 -l /var/log/qemu-ga/qemu-ga.log"
             gagent_status_cmd = "pgrep qemu-ga"
             gagent_restart_cmd = "pgrep qemu-ga |xargs kill -s 9 &&  ${gagent_start_cmd}"
             Windows:
-                gagent_start_cmd = "cd C:\Program Files\Qemu-ga & start /b qemu-ga.exe -m isa-serial -p COM2 -l c:\qga.log -v"
+                gagent_start_cmd = "cd C:\Program Files\Qemu-ga & start /b qemu-ga.exe -m isa-serial -p COM2 -l c:\qga.log"
                 gagent_status_cmd = "tasklist |findstr /i /r qemu-ga.exe.*Console"
                 gagent_restart_cmd = "taskkill /f /t /im qemu-ga.exe & ${gagent_start_cmd}"

--- a/qemu/tests/live_backup_add_bitmap.py
+++ b/qemu/tests/live_backup_add_bitmap.py
@@ -52,9 +52,9 @@ def run(test, params, env):
     error_context.context("check bitmap existence", test.log.info)
     check_bitmap_existence_as_expected(bitmaps, "existence")
 
-    error_context.context("system powerdown", test.log.info)
-    vm.monitor.system_powerdown()
-    if not vm.wait_for_shutdown(int(params.get("shutdown_timeout", 360))):
+    error_context.context("Shutting down the guest", test.log.info)
+    vm.graceful_shutdown(params.get_numeric("shutdown_timeout", 360))
+    if not vm.wait_for_shutdown():
         test.fail("guest refuses to go down")
 
     error_context.context("start vm", test.log.info)

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -3150,13 +3150,12 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             """
             error_context.context("Check %s cmd in agent log." % qga_cmd,
                                   LOG_JOB.info)
-            log_str = session.cmd_output(get_log_cmd).strip().split('\n')[-1]
-            pattern = r"%s" % qga_cmd
-            if not re.findall(pattern, log_str, re.M | re.I):
+            get_log_cmd = params["get_log_cmd"] % qga_cmd
+            status, log_str = session.cmd_status_output(get_log_cmd).strip().split('\n')[-1]
+            if status or not log_str:
                 test.fail("The %s command is not recorded in agent"
                           " log." % qga_cmd)
 
-        get_log_cmd = params["get_log_cmd"]
         session = self._get_session(self.params, self.vm)
         self._open_session_list.append(session)
         self._change_bl(session)


### PR DESCRIPTION
since there is a minor change for starting qemu-ga.exe, it will display debug info about version of mingw-qemu-ga so that auto program couldn't catch the expected condition to determine cmd run finished. so remove invaluable parameter '-v' after confirm with dev.

ID: 2199116
Signed-off-by: demeng <demeng@redhat.com>