### PR TITLE
boot_from_virtiofs: Update console for different arch

### DIFF
--- a/qemu/tests/cfg/boot_from_virtiofs.cfg
+++ b/qemu/tests/cfg/boot_from_virtiofs.cfg
@@ -27,5 +27,11 @@
     mem-path_mem0 = /dev/shm
     backend_mem_mem0 = memory-backend-file
     share_mem = yes
-    kernel_params = "root=virtiofs:${fs_target} console=ttyS0"
+    x86_64, i386:
+        console_dev = "ttyS0,115200"
+    ppc64le, ppc64:
+        console_dev = "hvc0,38400"
+    aarch64:
+        console_dev = "ttyAMA0,38400"
+    kernel_params = "root=virtiofs:${fs_target} console=${console_dev}"
     shell_prompt = "\[root@.{0,50}][\#\$] "


### PR DESCRIPTION
Different arch use different console, need to update kernel_params on different arch.

ID: 2215182
Signed-off-by: Sibo Wang siwang@redhat.com