### PR TITLE
qga: adjust new sebools to 'gagent_ssh_public_key_injection'

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -539,20 +539,29 @@
             input_dev_type_input3 = tablet
         - gagent_ssh_public_key_injection:
             only Linux
-            guest_user = "fedora"
-            guest_user_passwd = "redhat"
-            guest_homepath = /home/${guest_user}
+            no  RHEL.7 RHEL.8 RHEL.9.0 RHEL.9.1
             gagent_check_type = ssh_public_key_injection
-            cmd_add_user_set_passwd = useradd ${guest_user} && echo ${guest_user_passwd} | passwd --stdin ${guest_user}
-            set_setenforce = "setenforce %s"
-            cmd_remove_user = userdel -rf ${guest_user}
+            set_sebool = "setsebool virt_qemu_ga_read_nonsecurity_files on ; setsebool virt_qemu_ga_manage_ssh on"
             cmd_clean_keys = rm -rf ~/.ssh/*
             ssh_keygen_cmd =  "ssh-keygen -t rsa -P "" -f ~/.ssh/id_rsa"
+            cmd_get_hostkey = "cat ~/.ssh/id_rsa.pub"
+            variants:
+                - root:
+                    guest_user = "root"
+                    guest_homepath = /${guest_user}
+                    test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls ${guest_homepath}
+                    output_check_str = 'anaconda-ks.cfg'
+                - non_root_user:
+                    guest_user = "fedora"
+                    guest_user_passwd = "redhat"
+                    guest_homepath = "/home/${guest_user}"
+                    cmd_add_user_set_passwd = useradd ${guest_user} && echo ${guest_user_passwd} | passwd --stdin ${guest_user}
+                    cmd_remove_user = userdel -rf ${guest_user}
+                    test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls '/home'
+                    output_check_str = '${guest_user}'
             add_line_at_end = "echo >> ${guest_homepath}/.ssh/authorized_keys"
             cmd_get_guestkey = "cat ${guest_homepath}/.ssh/authorized_keys"
-            cmd_get_hostkey = "cat ~/.ssh/id_rsa.pub"
             cmd_del_key_file = "rm -rf ${guest_homepath}/.ssh/authorized_keys"
-            test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls /home
         - check_get_cpustats:
             only Linux
             no  RHEL.7 RHEL.8 RHEL.9.1 RHEL.9.0


### PR DESCRIPTION
1. the latest change is to add two new sebools instead of using `setenforce 0`. those are two specific selinux boolean values.
2. add the checkpoint for checking user root.

ID: 1127
Signed-off-by: demeng <demeng@redhat.com>