### PR TITLE
Stop firewalld on s390x during netperf_stress test

### DIFF
--- a/qemu/tests/cfg/netperf_stress_test.cfg
+++ b/qemu/tests/cfg/netperf_stress_test.cfg
@@ -29,6 +29,8 @@
             netperf_client = ${main_vm}
             netperf_server = vm2
         - host2guest:
+            s390x:
+                pre_command = "service iptables stop; systemctl stop firewalld.service"
             netperf_client = ${vms}
             netperf_server = localhost
     variants:


### PR DESCRIPTION
Virtual_network: stop firewalld on s390x during netperf_stress test

ID: 2178917
    
Signed-off-by: Boqiao Fu <bfu@redhat.com>
