### PR TITLE
dump_guest_core: Update the params name to fix conflict

### DIFF
--- a/qemu/tests/cfg/dump_guest_core.cfg
+++ b/qemu/tests/cfg/dump_guest_core.cfg
@@ -17,7 +17,7 @@
     gdb_command = "gdb --core ${core_file}%s --command=${gdb_command_file}"
     crash_cmd = "crash -i ${crash_script} /usr/lib/debug/lib/modules/%s/vmlinux ${vmcore_file}"
     dump_guest_memory_file = "/usr/share/qemu-kvm/dump-guest-memory.py"
-    check_vmcore_file = 'yes'
+    check_vmcore = 'yes'
     x86_64:
         vmcoreinfo = yes
     ppc64:
@@ -26,7 +26,7 @@
     ppc64le:
         RHEL.9:
             check_env = 'no'
-            check_vmcore_file = 'no'
+            check_vmcore = 'no'
     # When 'dump-guest-core=off' is specified, guest memory is omitted from the core dump.
     variants:
         - on:

--- a/qemu/tests/dump_guest_core.py
+++ b/qemu/tests/dump_guest_core.py
@@ -83,7 +83,7 @@ def run(test, params, env):
     crash_script = params["crash_script"]
     crash_cmd = params["crash_cmd"]
     vmcore_file = params["vmcore_file"]
-    check_vmcore_file = params["check_vmcore_file"]
+    check_vmcore = params["check_vmcore"]
     arch = params["vm_arch_name"]
     host_kernel_version = process.getoutput("uname -r").strip()
     vm = env.get_vm(params["main_vm"])
@@ -100,7 +100,7 @@ def run(test, params, env):
     utils_misc.wait_for(lambda: os.path.exists(core_file), timeout=60)
     if params.get('check_core_file', 'yes') == 'yes':
         check_core_file(arch)
-        if dump_guest_core == 'on' and check_vmcore_file == 'yes':
+        if dump_guest_core == 'on' and check_vmcore == 'yes':
             crash_cmd %= host_kernel_version
             utils_misc.wait_for(lambda: os.path.exists(vmcore_file), timeout=60)
             check_vmcore_file()


### PR DESCRIPTION
As there is a conflict between the param and the function, rename check_vmcore_file to check_vmcore.

ID: 2229116
Signed-off-by: Wenkang Ji <wji@redhat.com>