### PR TITLE
live_backup_add_bitmap: Replace system_shutdown with graceful_shutdown

### DIFF
--- a/qemu/tests/live_backup_add_bitmap.py
+++ b/qemu/tests/live_backup_add_bitmap.py
@@ -52,9 +52,9 @@ def run(test, params, env):
     error_context.context("check bitmap existence", test.log.info)
     check_bitmap_existence_as_expected(bitmaps, "existence")
 
-    error_context.context("system powerdown", test.log.info)
-    vm.monitor.system_powerdown()
-    if not vm.wait_for_shutdown(int(params.get("shutdown_timeout", 360))):
+    error_context.context("Shutting down the guest", test.log.info)
+    vm.graceful_shutdown(params.get_numeric("shutdown_timeout", 360))
+    if not vm.wait_for_shutdown():
         test.fail("guest refuses to go down")
 
     error_context.context("start vm", test.log.info)


### PR DESCRIPTION
`system_shutdown` will use qmp command to shut down the guest, but when guest is still booting, sometimes it may ignore the `POWERDOWN` event, this causes the guest failed to down. To safely shut down the guest, send a shell command by guest itself would be better.

ID: 2229869