### PR TITLE
block_hotplug_check:Update pci search pattern

### DIFF
--- a/qemu/tests/cfg/block_hotplug_check.cfg
+++ b/qemu/tests/cfg/block_hotplug_check.cfg
@@ -32,11 +32,11 @@
     Linux:
         no RHEL.3.9
         offset = 64k
-        match_string = "Virtio block device"
+        pci_id_pattern = "(\d+:\d+\.\d+).*?1af4:(?:1001|1042)"
         guest_check_cmd = cat /proc/partitions |tee /var/tmp/partitions
         pci_test_cmd = "echo %s; yes | mke2fs `fdisk -l 2>&1 | awk '/\/dev\/[sv]d[a-z]* doesn/ {print $2}'` | sort | tail -1"
         reference_cmd = lspci
-        find_pci_cmd = lspci
+        find_pci_cmd = lspci -n
         wait_secs_for_hook_up = 3
         mark_cmd = "echo "%s"| dd of=/dev/%s count=1 bs=%s seek=1"
         confirm_cmd = "dd if=/dev/%s bs=%s count=1 skip=1"

--- a/qemu/tests/pci_hotplug_check.py
+++ b/qemu/tests/pci_hotplug_check.py
@@ -237,7 +237,7 @@ def run(test, params, env):
                 ref = [line.strip() for line in reference.splitlines()]
                 output = [_ for _ in output if _ not in ref]
                 output = "\n".join(output)
-                if re.search(params.get("match_string"), output, re.I):
+                if re.search(params.get("pci_id_pattern"), output, re.I):
                     return True
                 return False
 


### PR DESCRIPTION
Updates the case logic using numerical ID, as test point due to name will be changed without notice. In order to support 0.9 and 1.0 virtio devices, the pattern now contains both IDs.

ID: 2230552
Signed-off-by: Sibo Wang siwang@redhat.com