### PR TITLE
hotplug_mem_repeat:Update size_mem acquisition method

### DIFF
--- a/qemu/tests/cfg/hotplug_memory_repeat.cfg
+++ b/qemu/tests/cfg/hotplug_memory_repeat.cfg
@@ -9,7 +9,7 @@
     no WinXP Win2000 Win2003 WinVista
     slots_mem = 256
     mem_fixed = 4096
-    x86_64:
+    aarch64,x86_64:
         mem_fixed = 8192
     size_mem = 128M
     maxmem_mem = 40G
@@ -24,6 +24,13 @@
         maxmem_mem = 70G
     backend_mem = memory-backend-ram
     repeat_times = 256
+    aarch64:
+        # Section size must be at least 128MB for 4K and 16k base
+        # page size config.
+        # Section size must be at least 512MB for 64K base
+        get_basic_page = "getconf PAGE_SIZE"
+        size_mem_64k = 512M
+        maxmem_mem = 140G
     variants test_type:
         - repeat_256:
             only Linux


### PR DESCRIPTION
For the arm platform, there are two smallest mem block sizes.
Section size must be at least 128MB for 4K and 16k base page size config.
Section size must be at least 512MB for 64K base
Update the block size mem acquisition method by the current
guest base page size.

ID: 2229699
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)