### PR TITLE
win_driver_install_uninstall: update uninstalled check method

### DIFF
--- a/qemu/tests/win_virtio_driver_installer_uninstall.py
+++ b/qemu/tests/win_virtio_driver_installer_uninstall.py
@@ -1,4 +1,5 @@
 import time
+import re
 
 from virttest import error_context
 from virttest import utils_misc
@@ -86,8 +87,9 @@ def run(test, params, env):
     # viostor and vioscsi drivers can not uninstalled by installer
     for device_name in device_name_list:
         chk_cmd = params["vio_driver_chk_cmd"] % device_name[0:30]
-        status = session.cmd_status(chk_cmd)
-        if status == 0:
+        output = session.cmd_output(chk_cmd).strip()
+        inf_name = re.findall(r"\.inf", output, re.I)
+        if inf_name:
             uninstalled_device.append(device_name)
     if uninstalled_device:
         test.fail("%s uninstall failed" % uninstalled_device)


### PR DESCRIPTION
ID: 2233424
Eventhough driver was uninstalled by installer, the return for driverquery cmd still get correct return. Therefore, it's better to check the driver status by checking if it has inf file.