### PR TITLE
Updated virtio-fs test cases on s390x

### DIFF
--- a/qemu/tests/cfg/virtio_fs_readonly.cfg
+++ b/qemu/tests/cfg/virtio_fs_readonly.cfg
@@ -6,12 +6,6 @@
     required_qemu = [4.2.0,)
     s390, s390x:
         required_qemu = [5.2.0,)
-        vm_mem_share = yes
-        pre_command_noncritical = yes
-        pre_command = "echo 3 > /proc/sys/vm/drop_caches"
-        setup_hugepages = yes
-        kvm_module_parameters = 'hpage=1'
-        expected_hugepage_size = 1024
     kill_vm = yes
     start_vm = yes
     filesystems = fs
@@ -23,15 +17,18 @@
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
     fs_dest = '/mnt/${fs_target}'
-    mem_devs = mem1
-    backend_mem_mem1 = memory-backend-file
-    mem-path_mem1 = /dev/shm
-    size_mem1 = ${mem}M
-    use_mem_mem1 = no
+    vm_mem_share = yes
+    vm_mem_backend = memory-backend-file
+    vm_mem_backend_path = /dev/shm
+    cmd_create_file = 'touch ${fs_dest}/fs_file'
+    check_str = 'Read-only file system'
     share_mem = yes
     !s390, s390x:
+        mem_devs = mem1
+        backend_mem_mem1 = memory-backend-file
+        mem-path_mem1 = /dev/shm
+        size_mem1 = ${mem}M
+        use_mem_mem1 = no
         guest_numa_nodes = shm0
         numa_memdev_shm0 = mem-mem1
         numa_nodeid_shm0 = 0
-    cmd_create_file = 'touch ${fs_dest}/fs_file'
-    check_str = 'Read-only file system'

--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -7,12 +7,6 @@
     required_qemu = [4.2.0,)
     s390, s390x:
         required_qemu = [5.2.0,)
-        vm_mem_share = yes
-        pre_command_noncritical = yes
-        pre_command = "echo 3 > /proc/sys/vm/drop_caches"
-        setup_hugepages = yes
-        kvm_module_parameters = 'hpage=1'
-        expected_hugepage_size = 1024
     kill_vm = yes
     start_vm = no
     filesystems = fs
@@ -23,13 +17,16 @@
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
-    mem_devs = mem1
-    backend_mem_mem1 = memory-backend-file
-    mem-path_mem1 = /dev/shm
-    size_mem1 = ${mem}M
-    use_mem_mem1 = no
+    vm_mem_share = yes
+    vm_mem_backend = memory-backend-file
+    vm_mem_backend_path = /dev/shm
     share_mem = yes
     !s390, s390x:
+        mem_devs = mem1
+        backend_mem_mem1 = memory-backend-file
+        mem-path_mem1 = /dev/shm
+        size_mem1 = ${mem}M
+        use_mem_mem1 = no
         guest_numa_nodes = shm0
         numa_memdev_shm0 = mem-mem1
         numa_nodeid_shm0 = 0

--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -5,6 +5,8 @@
     type = virtio_fs_share_data
     virt_test_type = qemu
     required_qemu = [4.2.0,)
+    s390, s390x:
+        required_qemu = [5.2.0,)
     kill_vm = yes
     start_vm = yes
     filesystems = fs
@@ -15,29 +17,24 @@
     remove_fs_source = yes
     fs_target = 'myfs'
     fs_driver_props = {"queue-size": 1024}
-    mem_devs = mem1
-    backend_mem_mem1 = memory-backend-file
-    mem-path_mem1 = /dev/shm
-    size_mem1 = ${mem}M
-    use_mem_mem1 = no
     share_mem = yes
-    s390, s390x:
-        required_qemu = [5.2.0,)
-        vm_mem_share = yes
-        pre_command_noncritical = yes
-        pre_command = "echo 3 > /proc/sys/vm/drop_caches"
-        setup_hugepages = yes
-        kvm_module_parameters = 'hpage=1'
-        expected_hugepage_size = 1024
-    !s390, s390x:
-        guest_numa_nodes = shm0
-        numa_memdev_shm0 = mem-mem1
-        numa_nodeid_shm0 = 0
     io_timeout = 600
     test_file = 'test_file'
     fs_dest = '/mnt/${fs_target}'
+    vm_mem_share = yes
+    vm_mem_backend = memory-backend-file
+    vm_mem_backend_path = /dev/shm
     driver_name = viofs
     fs_binary_extra_options = ''
+    !s390, s390x:
+        mem_devs = mem1
+        backend_mem_mem1 = memory-backend-file
+        mem-path_mem1 = /dev/shm
+        size_mem1 = ${mem}M
+        use_mem_mem1 = no
+        guest_numa_nodes = shm0
+        numa_memdev_shm0 = mem-mem1
+        numa_nodeid_shm0 = 0
     Windows:
         # install winfsp tool
         i386, i686:


### PR DESCRIPTION
Virtio_fs: since we could set up memory-backend without numa/hugepage, remove workaround for virtio_fs ralated test cases on s390x

ID: 2213759

Signed-off-by: Boqiao Fu <bfu@redhat.com>