### PR TITLE
qemu_guest_agent: adjust new output of using isa-serial

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -622,6 +622,6 @@
             gagent_status_cmd = "pgrep qemu-ga"
             gagent_restart_cmd = "pgrep qemu-ga |xargs kill -s 9 &&  ${gagent_start_cmd}"
             Windows:
-                gagent_start_cmd = "cd C:\Program Files\Qemu-ga & start /b qemu-ga.exe -m isa-serial -p COM2 -l c:\qga.log -v"
+                gagent_start_cmd = "cd C:\Program Files\Qemu-ga & start /b qemu-ga.exe -m isa-serial -p COM2 -l c:\qga.log -v > nul"
                 gagent_status_cmd = "tasklist |findstr /i /r qemu-ga.exe.*Console"
                 gagent_restart_cmd = "taskkill /f /t /im qemu-ga.exe & ${gagent_start_cmd}"

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -235,7 +235,7 @@ class QemuGuestAgentTest(BaseVirtTest):
         :param vm: Virtual machine object.
         """
         error_context.context("Try to start qemu-ga service.", LOG_JOB.info)
-        s, o = session.cmd_status_output(self.params["gagent_start_cmd"])
+        s, o = session.cmd_status_output(self.params["gagent_start_cmd"], safe=True)
         # if start a running service, for rhel guest return code is zero,
         # for windows guest,return code is not zero
         if s and "already been started" not in o:


### PR DESCRIPTION
there is debug output of running qemu-ga.exe as isa-serial. have to send a 'ent after start qemu-ga.exe so that program can catch the correct output to determin whether case is well.

ID: 1439	
Signed-off-by: demeng <demeng@redhat.com>
