### PR TITLE
libblkio_release_test: Ignore the case from aarch64 and s390x

### DIFF
--- a/qemu/tests/cfg/block_libblkio_release.cfg
+++ b/qemu/tests/cfg/block_libblkio_release.cfg
@@ -1,5 +1,6 @@
 - block_libblkio_release:
     only Linux
+    no aarch64 s390 s390x
     virt_test_type = qemu
     type = block_libblkio_release
     required_qemu = [8.0.0,)


### PR DESCRIPTION
skip aarch64 and s390x in this case.

ID:2230227