### PR TITLE
numa_prealloc_threads: boot guest with thread-context and cpu-affinity

### DIFF
--- a/qemu/tests/cfg/numa_prealloc_threads.cfg
+++ b/qemu/tests/cfg/numa_prealloc_threads.cfg
@@ -1,0 +1,20 @@
+- numa_prealloc_threads:
+    no RHEL.6 RHEL.7 RHEL.8
+    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+    required_qemu = [7.2,)
+    type = numa_prealloc_threads
+    virt_test_type = qemu
+    login_timeout = 1000
+    qemu_command_prefix = "taskset -c 0 "
+    vm_thread_contexts = "tc1"
+    smp_fixed = 8
+    vcpu_maxcpus = ${smp_fixed}
+    vm_thread_context_cpu-affinity = "1-7"
+    not_preprocess = yes
+    variants:
+        - @default:
+            qemu_sandbox = on
+            qemu_sandbox_resourcecontrol = deny
+            sandbox_error_message = "Setting CPU affinity failed: Operation not permitted"
+        - sandbox_off:
+            qemu_sandbox = off

--- a/qemu/tests/numa_prealloc_threads.py
+++ b/qemu/tests/numa_prealloc_threads.py
@@ -1,0 +1,69 @@
+import re
+
+from avocado.utils import cpu
+from virttest import env_process
+from virttest import error_context
+from virttest.qemu_monitor import QMPCmdError
+from avocado.utils import process
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    numa_prealloc_threads test
+    1) Boot a guest with thread-context and cpu-affinity option
+    2) Obtain the thread-id
+    3) Check the affinity obtained from QEMU is correct
+    4) With sandbox enabled, try to change the cpu-affinity
+       and handle the error
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    test.log.info("Check host CPUs number")
+    host_cpus = int(cpu.online_count())
+    smp_fixed = params.get_numeric("smp_fixed")
+    if host_cpus < smp_fixed:
+        test.cancel("The host only has %d CPUs, it needs at least %d!" % (host_cpus, smp_fixed))
+
+    params['not_preprocess'] = "no"
+    timeout = params.get_numeric("login_timeout", 1000)
+    env_process.preprocess(test, params, env)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    vm.wait_for_login(timeout=timeout)
+
+    thread_context_device = vm.devices.get_by_params({"backend": "thread-context"})[0]
+    thread_context_device_id = thread_context_device.get_param("id")
+    error_msg = params.get("sandbox_error_message", "")
+
+    thread_id = vm.monitor.qom_get(thread_context_device_id, "thread-id")
+    if not thread_id:
+        test.fail("No thread-id setted.")
+
+    expected_cpu_affinity = thread_context_device.get_param("cpu-affinity")
+    cpu_affinity = vm.monitor.qom_get(thread_context_device_id, "cpu-affinity")
+    affinity = str(cpu_affinity[0]) + "-" + str(cpu_affinity[-1])
+    test.log.debug("The affinity: %s and the expected_cpu_affinity: %s"
+                   % (affinity, expected_cpu_affinity))
+    if expected_cpu_affinity != affinity:
+        test.fail("Test and QEMU cpu-affinity does not match!")
+
+    cmd_taskset = "taskset -c -p " + str(thread_id)
+    output = process.getoutput(cmd_taskset)
+    if not re.search(affinity, output):
+        test.fail("The affinities %s and %s do not match!"
+                  % (affinity, str(output)))
+
+    sandbox = params.get("qemu_sandbox", "on")
+    if sandbox == "on":
+        try:
+            # The command is expected to fail
+            vm.monitor.qom_set(thread_context_device_id, "cpu-affinity", cpu_affinity)
+        except QMPCmdError as e:
+            test.log.debug("The expected error message: %s and the output: %s"
+                           % (error_msg, e.data))
+            if not re.search(error_msg, str(e.data)):
+                test.fail("Can not get expected error message: %s" % error_msg)


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3756

numa_prealloc_threads: boot guest with thread-context and cpu-affinity

Creates a new auto case that boots up a guest with a thread-context
object with a cpu-affinity configured. Verify the cpu-affinity is
correct and cannot be changed with sandbox enabled.

ID: 2224513
Signed-off-by: mcasquer <mcasquer@redhat.com>
