### PR TITLE
x86_cpu_model:add new cpu model EPYC-Genoa

### DIFF
--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -21,6 +21,22 @@
             cpu_model = max
             start_vm = yes
             cpu_model_flags += ",check"
+        - EPYC-Genoa:
+            only HostCpuVendor.amd
+            flags = "la57 vnmi avx512f avx512dq avx512ifma avx512cd avx512bw avx512vl avx512vbmi avx512_vbmi2 gfni avx512_vnni avx512_bitalg avx512_vpopcntdq avx512_bf16"
+            model_pattern = "AMD EPYC-Genoa Processor%s"
+            cpu_model_flags += ",svm=on"
+            # support CPU model since RHEL.9.3
+            RHEL.6, RHEL.7, RHEL.8, RHEL.9.1, RHEL.9.2:
+                flags = ""
+        - EPYC-Genoa-v1:
+            only HostCpuVendor.amd
+            flags = "la57 vnmi avx512f avx512dq avx512ifma avx512cd avx512bw avx512vl avx512vbmi avx512_vbmi2 gfni avx512_vnni avx512_bitalg avx512_vpopcntdq avx512_bf16"
+            model_pattern = "AMD EPYC-Genoa Processor%s"
+            cpu_model_flags += ",svm=on"
+            # support CPU model since RHEL.9.3
+            RHEL.6, RHEL.7, RHEL.8, RHEL.9.1, RHEL.9.2:
+                flags = ""
         - EPYC-Milan:
             only HostCpuVendor.amd
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
@@ -32,6 +48,14 @@
             only HostCpuVendor.amd
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
             model_pattern = "AMD EPYC-Milan Processor%s"
+            # support 'pcid' since RHEL.8.3
+            RHEL.6, RHEL.7, RHEL.8.0, RHEL.8.1, RHEL.8.2:
+                flags = ""
+        - EPYC-Milan-v2:
+            only HostCpuVendor.amd
+            required_qemu = [8.0.0,)
+            flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
+            model_pattern = "AMD EPYC-Milan-v2 Processor%s"
             # support 'pcid' since RHEL.8.3
             RHEL.6, RHEL.7, RHEL.8.0, RHEL.8.1, RHEL.8.2:
                 flags = ""
@@ -53,6 +77,13 @@
             model_pattern = "AMD EPYC-Rome Processor%s"
             RHEL.6, RHEL.7:
                 flags = ""
+        - EPYC-Rome-v3:
+            only HostCpuVendor.amd
+            required_qemu = [8.0.0,)
+            flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves"
+            model_pattern = "AMD EPYC-Rome-v3 Processor%s"
+            RHEL.6, RHEL.7:
+                flags = ""
         - EPYC:
             only HostCpuVendor.amd
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c"
@@ -71,6 +102,11 @@
             # support "ibpb"
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c"
             model_pattern = "AMD EPYC Processor%s"
+        - EPYC-v4:
+            only HostCpuVendor.amd
+            required_qemu = [8.0.0,)
+            flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c"
+            model_pattern = "AMD EPYC-v4 Processor%s"
         - Opteron_G5:
             only HostCpuVendor.amd
             flags = "vme sse2 sse fxsr mmx clflush pse36 pat cmov mca pge mtrr sep apic cx8 mce pae msr tsc pse de f16c avx xsave aes popcnt sse4_2 sse4_1 cx16 fma ssse3 pclmulqdq lm pdpe1gb nx syscall tbm fma4 xop 3dnowprefetch misalignsse sse4a abm lahf_lm fpu"


### PR DESCRIPTION
ID: 1224

AMD support one new cpu model EPYC-Genoa now.