### PR TITLE
Disable luks format test for qsd relevant cases

### DIFF
--- a/qemu/tests/cfg/qsd_blockdev_check.cfg
+++ b/qemu/tests/cfg/qsd_blockdev_check.cfg
@@ -1,5 +1,6 @@
 - qsd_blockdev_check:
     type = qsd_blockdev_check
+    no luks
     start_vm = no
     images = ""
     # QSD attributes

--- a/qemu/tests/cfg/qsd_export_vhub_check.cfg
+++ b/qemu/tests/cfg/qsd_export_vhub_check.cfg
@@ -1,5 +1,6 @@
 - qsd_export_vhub_check:
     type = qsd_export_vhub_check
+    no luks
     start_vm = no
     images = ""
     # QSD attributes

--- a/qemu/tests/cfg/qsd_object_check.cfg
+++ b/qemu/tests/cfg/qsd_object_check.cfg
@@ -1,5 +1,6 @@
 - qsd_object_check:
     type = qsd_object_check
+    no luks
     start_vm = no
     images = ""
     # QSD attributes

--- a/qemu/tests/cfg/qsd_pidfile_check.cfg
+++ b/qemu/tests/cfg/qsd_pidfile_check.cfg
@@ -1,5 +1,6 @@
 - qsd_pidfile_check:
     type = qsd_pidfile_check
+    no luks
     start_vm = no
     qsd_enable_pidfile = yes
     qsd_force_create_qsd1 = yes

--- a/qemu/tests/cfg/qsd_qmp_cmd_check.cfg
+++ b/qemu/tests/cfg/qsd_qmp_cmd_check.cfg
@@ -1,5 +1,6 @@
 - qsd_qmp_cmd_check:
     type = qsd_qmp_cmd_check
+    no luks
     start_vm = no
     images = ""
     # QSD attributes


### PR DESCRIPTION
Disable luks format test for qsd cases:
qsd_blockdev_check,qsd_export_vhub_check,
qsd_object_check,qsd_pidfile_check,qsd_qmp_cmd_check

ID:2208501,2208500,2208502,2208503,2208497

Signed-off-by: qingwangrh <qinwang@redhat.com>