### PR TITLE
Set vlan id on Windows guest using powershell

### DIFF
--- a/generic/tests/cfg/vlan.cfg
+++ b/generic/tests/cfg/vlan.cfg
@@ -23,9 +23,8 @@
         vlan_num = 1
         win_vlan_id = 900
         cdroms += " virtio"
-        prepare_netkvmco_cmd = 'xcopy %s c:\\ /y && rundll32 netkvmco.dll,RegisterNetKVMNetShHelper'
-        set_vlan_cmd = 'netsh netkvm setparam 0 param=vlanid value=${win_vlan_id}'
         driver_verifier = netkvm
+        set_vlan_cmd = powershell -command "Set-NetAdapter -Name '%s' -VlanID ${win_vlan_id} -Confirm:$False"
         Win2016, Win2019, Win8..1, Win2012..r2:
                 driver_verifier += " ndis"
     variants:

--- a/generic/tests/vlan.py
+++ b/generic/tests/vlan.py
@@ -192,8 +192,7 @@ def run(test, params, env):
     file_size = params.get("file_size", 4096)
     cmd_type = params.get("cmd_type", "ip")
     login_timeout = int(params.get("login_timeout", 360))
-    prepare_netkvmco_cmd = params.get("prepare_netkvmco_cmd")
-    set_vlan_cmd = params.get("set_vlan_cmd")
+    set_vlan_cmd = params["set_vlan_cmd"]
     driver_verifier = params.get("driver_verifier")
 
     vms.append(env.get_vm(params["main_vm"]))
@@ -207,14 +206,11 @@ def run(test, params, env):
             session = utils_test.qemu.windrv_check_running_verifier(session, vm,
                                                                     test,
                                                                     driver_verifier)
-            netkvmco_path = get_netkvmco_path(session)
-            session.cmd(prepare_netkvmco_cmd % netkvmco_path, timeout=240)
-            session.close()
             session = vm.wait_for_serial_login(timeout=login_timeout)
-            session.cmd(set_vlan_cmd)
             dev_mac = vm.virtnet[0].mac
             connection_id = utils_net.get_windows_nic_attribute(
                 session, "macaddress", dev_mac, "netconnectionid")
+            session.cmd(set_vlan_cmd % connection_id)
             utils_net.restart_windows_guest_network(
                 session, connection_id)
             time.sleep(10)

--- a/qemu/tests/cfg/ctrl_vlan.cfg
+++ b/qemu/tests/cfg/ctrl_vlan.cfg
@@ -12,9 +12,8 @@
         vlan_set_cmd += "ifconfig %s ${vlan_ip}/24 up"
     Windows:
         cdroms += " virtio"
-        prepare_netkvmco_cmd = 'xcopy %s c:\\ /y && rundll32 netkvmco.dll,RegisterNetKVMNetShHelper'
-        vlan_set_cmd = 'netsh netkvm setparam 0 param=vlanid value=${vlan_id}'
         driver_verifier = netkvm
+        vlan_set_cmd = powershell -command "Set-NetAdapter -Name '%s' -VlanID ${vlan_id} -Confirm:$False"
         Win2016, Win2019, Win8..1, Win2012..r2:
             driver_verifier += " ndis"
     variants:

--- a/qemu/tests/ctrl_vlan.py
+++ b/qemu/tests/ctrl_vlan.py
@@ -106,12 +106,8 @@ def run(test, params, env):
                 ifname = utils_net.get_windows_nic_attribute(
                             session=session, key="netenabled", value=True,
                             target="netconnectionID")
-                netkvmco_path = get_netkvmco_path(session)
-                prepare_netkvmco_cmd = params.get("prepare_netkvmco_cmd")
-                session.cmd(prepare_netkvmco_cmd % netkvmco_path, timeout=240)
-                session.close()
                 session = vm.wait_for_serial_login(timeout=login_timeout)
-                status, output = session.cmd_status_output(vlan_set_cmd)
+                status, output = session.cmd_status_output(vlan_set_cmd % ifname)
                 if status:
                     test.error("Error occured when set vlan tag for "
                                "network interface: %s, err info: %s "


### PR DESCRIPTION
As the result of Win10+ guest will not support the netsh netkvm command, so use powershell to replace it.

ID:1231
Signed-off-by: Lei Yang leiyang@redhat.com