### PR TITLE
Add device_cio_free.service check after guest finish upgrading

### DIFF
--- a/qemu/tests/cfg/in_place_upgrade.cfg
+++ b/qemu/tests/cfg/in_place_upgrade.cfg
@@ -31,6 +31,10 @@
     stop_yum_update = "rm -rf /var/run/yum.pid"
     check_repo_list = "yum repolist enabled"
     check_rhel_ver = "cut -f1-2 -d. /etc/redhat-release | sed 's/[^0-9]//g'"
+    s390,s390x:
+        # no need to check in host, and we don't support RHEL.7.9 as the
+        # host on s390x
+        device_cio_free_check_cmd = "systemctl status device_cio_free"
     # com_install = "yes" installing leapp from compose
     # com_install = "no" installing leapp from upstream
     # <repo_leapp> it's leapp tool's repo

--- a/qemu/tests/cfg/in_place_upgrade_legacy.cfg
+++ b/qemu/tests/cfg/in_place_upgrade_legacy.cfg
@@ -23,6 +23,10 @@
     error_info = "No old kernels to remove"
     reboot_cmd = "reboot"
     check_rhel_ver = "cut -f1-2 -d. /etc/redhat-release | sed 's/[^0-9]//g'"
+    s390,s390x:
+        # no need to check in host, and we don't support RHEL.7.9 as the
+        # host on s390x
+        device_cio_free_check_cmd = "systemctl status device_cio_free"
     # <repo_leapp_7> it's leapp tool's repo
     # <ins_leapp_cmd> install leapp tool command
     # <prepare_env>, <get_answer_files_source>, <get_answer_files>

--- a/qemu/tests/in_place_upgrade.py
+++ b/qemu/tests/in_place_upgrade.py
@@ -105,6 +105,11 @@ def run(test, params, env):
         upgrade_test.post_upgrade_check(test, post_release)
         post_rhel_ver = upgrade_test.run_guest_cmd(check_rhel_ver)
         vm.verify_kernel_crash()
+        if params.get("device_cio_free_check_cmd"):
+            cio_status = str(upgrade_test.session.cmd_status_output(
+                params.get("device_cio_free_check_cmd")))
+            if 'inactive' in cio_status:
+                test.fail("device_cio_free is not enabled after upgrading")
     finally:
         vm.graceful_shutdown(timeout=300)
         try:

--- a/qemu/tests/in_place_upgrade_legacy.py
+++ b/qemu/tests/in_place_upgrade_legacy.py
@@ -146,6 +146,11 @@ def run(test, params, env):
         upgrade_test.post_upgrade_check(test, post_release)
         post_rhel_ver = upgrade_test.run_guest_cmd(check_rhel_ver)
         vm.verify_kernel_crash()
+        if params.get("device_cio_free_check_cmd"):
+            cio_status = str(upgrade_test.session.cmd_status_output(
+                params.get("device_cio_free_check_cmd")))
+            if 'inactive' in cio_status:
+                test.fail("device_cio_free is not enabled after upgrading")
     finally:
         vm.graceful_shutdown(timeout=300)
         try:


### PR DESCRIPTION
Leapp: add device_cio_free.service check after guest finish upgrading,
reference to Bug 2032953 - s390x: leapp post-upgrade doesn't enable
"device_cio_free.service" unit, which is required on Z

ID: 2231264

Signed-off-by: Boqiao Fu <bfu@redhat.com>