### PR TITLE
Update generic blacklist format

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -295,7 +295,7 @@
                     # generic/003 120: https://gitlab.com/virtio-fs/qemu/-/issues/8
                     # generic/426 467 477: https://gitlab.com/virtio-fs/qemu/-/issues/10
                     # generic/551: Costs a lot of time
-                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551'
+                    generic_blacklist = 'generic/003\ngeneric/120\ngeneric/426\ngeneric/467\ngeneric/477\ngeneric/551\n'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.
@@ -319,7 +319,7 @@
                     cmd_setenv += 'export SCRATCH_MNT=${fs_dest_fs2} && export FSTYP=virtiofs && export FSX_AVOID="-E" && '
                     cmd_setenv += 'echo -e 'TEST_DEV=${fs_target_fs1}\nTEST_DIR=${fs_dest_fs1}\nSCRATCH_DEV=${fs_target_fs2}\n'
                     cmd_setenv += 'SCRATCH_MNT=${fs_dest_fs2}\nFSTYP=virtiofs\nFSX_AVOID="-E"' > configs/localhost.config'
-                    cmd_setenv += ' && echo "${generic_blacklist}" > blacklist'
+                    cmd_setenv += ' && echo -e "${generic_blacklist}" > blacklist'
                     cmd_xfstest = './check -virtiofs -E blacklist'
                     cmd_useradd = 'useradd fsgqa && useradd 123456-fsgqa && useradd fsgqa2'
                     cmd_get_tmpfs = 'df -h | grep /dev/shm | gawk '{ print $2 }''

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -202,12 +202,12 @@
                     # generic/035 nfs specific: https://gitlab.com/virtio-fs/qemu/-/issues/12
                     # generic/531 nfs specific,id1938936
                     # generic/070 650: due to nfs+virtiofs limitation, skip them if no '--inode_file_handles' specified, id2018072 and id1908490
-                    generic_blacklist = 'generic/003 generic/120 generic/426 generic/467 generic/477 generic/551 generic/035 generic/531'
+                    generic_blacklist = 'generic/003\ngeneric/120\ngeneric/426\ngeneric/467\ngeneric/477\ngeneric/551\ngeneric/035\ngeneric/531\n'
                     with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs:
-                        generic_blacklist += ' generic/070 generic/650'
+                        generic_blacklist += 'generic/070\ngeneric/650\n'
                     aarch64:
                         only with_cache..with_nfs_source
-                        generic_blacklist += ' generic/568'
+                        generic_blacklist += 'generic/568\n'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.
@@ -232,7 +232,7 @@
                     cmd_setenv += 'export SCRATCH_MNT=${fs_dest_fs2} && export FSTYP=virtiofs && export FSX_AVOID="-E" && '
                     cmd_setenv += 'echo -e 'TEST_DEV=${fs_target_fs1}\nTEST_DIR=${fs_dest_fs1}\nSCRATCH_DEV=${fs_target_fs2}\n'
                     cmd_setenv += 'SCRATCH_MNT=${fs_dest_fs2}\nFSTYP=virtiofs\nFSX_AVOID="-E"' > configs/localhost.config'
-                    cmd_setenv += ' && echo "${generic_blacklist}" > blacklist'
+                    cmd_setenv += ' && echo -e "${generic_blacklist}" > blacklist'
                     cmd_xfstest = './check -virtiofs -E blacklist'
                     cmd_useradd = 'useradd fsgqa && useradd 123456-fsgqa && useradd fsgqa2'
                     cmd_get_tmpfs = 'df -h | grep /dev/shm | gawk '{ print $2 }''


### PR DESCRIPTION
Upstream changes the code to match a regular expression,  so we need to update the generic_blacklist format in virtio_fs_share_data and virtio_fs_share_data_multi_backend.
refer to commit: https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/commit/?id=6d63f23987a629b4f7dd6e57e5b67ba37a3b742e

ID：2237222

Signed-off-by: Sibo Wang siwang@redhat.com