### PR TITLE
Add generic/451 to blacklist in cache=always scenario for xfstest

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -295,7 +295,10 @@
                     # generic/003 120: https://gitlab.com/virtio-fs/qemu/-/issues/8
                     # generic/426 467 477: https://gitlab.com/virtio-fs/qemu/-/issues/10
                     # generic/551: Costs a lot of time
+                    # generic/451 : due to generic/451 writes a file directly, add it into blacklist in cache=always scenario, id2231253
                     generic_blacklist = 'generic/003\ngeneric/120\ngeneric/426\ngeneric/467\ngeneric/477\ngeneric/551\n'
+                    with_xfstest..with_cache.always:
+                        generic_blacklist += 'generic/451\n'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -202,9 +202,12 @@
                     # generic/035 nfs specific: https://gitlab.com/virtio-fs/qemu/-/issues/12
                     # generic/531 nfs specific,id1938936
                     # generic/070 650: due to nfs+virtiofs limitation, skip them if no '--inode_file_handles' specified, id2018072 and id1908490
+                    # generic/451 : due to generic/451 writes a file directly, add it into blacklist in cache= always scenario, id2231253
                     generic_blacklist = 'generic/003\ngeneric/120\ngeneric/426\ngeneric/467\ngeneric/477\ngeneric/551\ngeneric/035\ngeneric/531\n'
                     with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs:
                         generic_blacklist += 'generic/070\ngeneric/650\n'
+                    with_cache.always..with_nfs_source.multi_fs:
+                        generic_blacklist += 'generic/451\n'
                     aarch64:
                         only with_cache..with_nfs_source
                         generic_blacklist += 'generic/568\n'


### PR DESCRIPTION
Due to generic/451 writes a file directly, add it into blacklist in cache=always scenario

ID: 2231253
Signed-off-by: Sibo Wang [siwang@redhat.com](mailto:siwang@redhat.com)