### PR TITLE
cdrom:fix tray close behavior

### DIFF
--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -518,12 +518,8 @@ def run(test, params, env):
                 if not is_tray_opened(vm, qemu_cdrom_device):
                     test.fail("Monitor reports tray closed"
                               " when ejecting (round %s)" % i)
-                if params["os_type"] != "windows":
-                    cmd = "dd if=%s of=/dev/null count=1" % guest_cdrom_device
-                else:
-                    # windows guest does not support auto close door when reading
-                    # cdrom, so close it by eject command;
-                    cmd = params["close_cdrom_cmd"] % guest_cdrom_device
+
+                cmd = params["close_cdrom_cmd"] % guest_cdrom_device
                 session.cmd(cmd)
                 if is_tray_opened(vm, qemu_cdrom_device):
                     test.fail("Monitor reports tray opened when close"


### PR DESCRIPTION
Test tray close/open should use tray-relevant
 commands directly instead of
depending on auto auto-close feature. Due to this
feature is not always supported.

ID:2229667

Signed-off-by: qingwangrh <qinwang@redhat.com>