### PR TITLE
Change the command that creates files in Windows guests

### DIFF
--- a/qemu/tests/cfg/virtual_nic.cfg
+++ b/qemu/tests/cfg/virtual_nic.cfg
@@ -22,7 +22,8 @@
                 check_proc_temp = 'tasklist /fi "IMAGENAME eq %s"'
                 clean_cmd = del
                 tmp_dir = C:\
-                dd_cmd = D:\coreutils\DummyCMD.exe %s %s 1
+                filesize = 104857600
+                dd_cmd = fsutil file createNew %s %s
                 tcpdump_check_cmd = tasklist | findstr /I wireshark
                 tcpdump_kill_cmd = taskkill /T /F /IM ${wireshark_name}
                 copy_cmd = C:\tools\rss_client.py -u %s %s %s %s


### PR DESCRIPTION
According the test result, DummyCMD.exe command has no longer support on the windows guest, so use the tools fsutil that come with Windows

ID:1322
Signed-off-by: Lei Yang leiyang@redhat.com