### PR TITLE
PXE booting test with vDPA nic

### DIFF
--- a/qemu/tests/cfg/vdpa_pxe_boot.cfg
+++ b/qemu/tests/cfg/vdpa_pxe_boot.cfg
@@ -1,0 +1,16 @@
+- vdpa_pxe_boot:
+    type = vdpa_pxe_boot
+    images = pxe
+    image_boot_pxe = no
+    image_name_pxe = images/pxe-test
+    image_size_pxe = 1G
+    force_create_image_pxe = yes
+    remove_image_pxe = yes
+    pxe_timeout = 60
+    kill_vm = yes
+    bootindex_nic1 = 1
+    boot_menu = on
+    machine_type_extra_params = "graphics=off"
+    match_string = "iPXE initialising devices..."
+    ovmf:
+        match_string = "start pxe over ipv4"

--- a/qemu/tests/vdpa_pxe_boot.py
+++ b/qemu/tests/vdpa_pxe_boot.py
@@ -1,0 +1,29 @@
+import re
+import time
+
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    vdpa nic PXE test:
+
+    1) Boot up guest from vdpa NIC
+    2) Check guest if works well after sleep 240s
+
+    :param test: QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+    error_context.context("Try to boot from vdpa NIC", test.log.info)
+    vm = env.get_vm(params["main_vm"])
+    timeout = params.get_numeric("pxe_timeout")
+    test.log.info("Waiting %ss" % timeout)
+    time.sleep(timeout)
+    vm.verify_status("running")
+    match_str = params["match_string"]
+    output = vm.serial_console.get_output()
+    if not re.search(match_str, output, re.M | re.I):
+        test.fail("Guest can not boot up from pxe boot")
+    test.log.info("Guest works well")


### PR DESCRIPTION
This scenario from a product bug, we only need to check the guest if can works well when pxe booting with vDPA nic.

ID:1342
Signed-off-by: Lei Yang leiyang@redhat.com