### PR TITLE
vDPA IPv6 connect testing

### DIFF
--- a/qemu/tests/cfg/vdpa_ipv6_connect_testing.cfg
+++ b/qemu/tests/cfg/vdpa_ipv6_connect_testing.cfg
@@ -1,0 +1,13 @@
+- vdpa_ipv6_connect_testing:
+    virt_test_type = qemu
+    only Linux
+    type = transfer_file_over_ipv6
+    vms = "vm1 vm2"
+    image_snapshot = yes
+    filesize = 4096
+    file_trans_timeout = 2400
+    file_md5_check_timeout = 600
+    dd_cmd = "dd if=/dev/zero of=%s bs=1M count=%d"
+    netid = "2620:2023:09:12"
+    tmp_dir = "/var/tmp/"
+    link_local_ipv6_addr = false


### PR DESCRIPTION
Add a new case to support vdpa ipv6 connect testing,since the vdpa nic can not got an available ipv6 address at the current stage.Therefore I used the stable net id and random guest it to consist of a ipv6 address.

ID:1347
Signed-off-by: Lei Yang leiyang@redhat.com