### PR TITLE
netperf_stress: limit this test to smp <= 32

### DIFF
--- a/qemu/tests/cfg/netperf_stress_test.cfg
+++ b/qemu/tests/cfg/netperf_stress_test.cfg
@@ -28,6 +28,8 @@
             vms += " vm2"
             netperf_client = ${main_vm}
             netperf_server = vm2
+            Windows:
+                start_vm_vm2 = no
         - host2guest:
             netperf_client = ${vms}
             netperf_server = localhost

--- a/qemu/tests/netperf_stress.py
+++ b/qemu/tests/netperf_stress.py
@@ -6,6 +6,7 @@ from virttest import utils_net
 from virttest import utils_netperf
 from virttest import utils_misc
 from virttest import data_dir
+from virttest import env_process
 
 
 @error_context.context_aware
@@ -67,6 +68,11 @@ def run(test, params, env):
     for server in netperf_server:
         s_info = {}
         if server in vms:
+            if params.get("os_type") == "windows":
+                if params.get_numeric("smp") > 32 or params.get_numeric("vcpu_maxcpus") > 32:
+                    params["smp"] = params["vcpu_maxcpus"] = 32
+                params["start_vm"] = "yes"
+                env_process.preprocess_vm(test, params, env, server)
             server_vm = env.get_vm(server)
             server_vm.verify_alive()
             session = server_vm.wait_for_login(timeout=login_timeout)


### PR DESCRIPTION
netperf_stress: limit this test to smp <= 32 
reset to 32 when the netperf server's smp is larger than 32.
(guest will get half of the total number of vcpus of the host)

ID: 1377
Signed-off-by: Wenkang Ji wji@redhat.com