### PR TITLE
dump_guest_core: Handle timeout condition in wait_for function

### DIFF
--- a/qemu/tests/cfg/dump_guest_core.cfg
+++ b/qemu/tests/cfg/dump_guest_core.cfg
@@ -1,6 +1,6 @@
 - dump_guest_core:
     type = dump_guest_core
-    only x86_64 ppc64 ppc64le
+    only x86_64 ppc64 ppc64le s390x
     virt_test_type = qemu
     limits_path = "/etc/security/limits.conf"
     limits_backup_path = "/tmp/limits.conf"

--- a/qemu/tests/dump_guest_core.py
+++ b/qemu/tests/dump_guest_core.py
@@ -97,7 +97,7 @@ def run(test, params, env):
     trigger_core_dump_command %= str(qemu_id)
     test.log.info("trigger core dump command: %s", trigger_core_dump_command)
     process.run(trigger_core_dump_command)
-    utils_misc.wait_for(lambda: os.path.exists(core_file), timeout=60)
+    utils_misc.wait_for(lambda: os.path.exists(core_file), timeout=120)
     if params.get('check_core_file', 'yes') == 'yes':
         check_core_file(arch)
         if dump_guest_core == 'on' and check_vmcore == 'yes':


### PR DESCRIPTION
Increase timeout duration to prevent issues when the desired condition
is not fulfilled within the given time frame.

ID: 1343
Signed-off-by: Wenkang Ji [wji@redhat.com](mailto:wji@redhat.com)