### PR TITLE
Add some tests to blacklist in cache=none scenario for xfstest

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -296,6 +296,13 @@
                     generic_blacklist = 'generic/003\ngeneric/120\ngeneric/426\ngeneric/467\ngeneric/477\ngeneric/551\n'
                     with_xfstest..with_cache.always:
                         generic_blacklist += 'generic/451\n'
+                    # These tests not support mmap with cache=none
+                    with_xfstest..with_cache.none:
+                        generic_blacklist += 'generic/029\ngeneric/030\ngeneric/074\ngeneric/080\ngeneric/127\ngeneric/141\n'
+                        generic_blacklist += 'generic/198\ngeneric/215\ngeneric/240\ngeneric/246\ngeneric/247\ngeneric/248\n'
+                        generic_blacklist += 'generic/340\ngeneric/344\ngeneric/345\ngeneric/346\ngeneric/354\ngeneric/428\n'
+                        generic_blacklist += 'generic/437\ngeneric/438\ngeneric/446\ngeneric/469\ngeneric/567\ngeneric/638\n'
+                        generic_blacklist += 'generic/647\ngeneric/729\n'
                     io_timeout = 14400
                     take_regular_screendumps = no
                     # Because screendump uses '/dev/shm' by default, it is shared with memory-backend-file.

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -202,7 +202,7 @@
                     # generic/035 nfs specific: https://gitlab.com/virtio-fs/qemu/-/issues/12
                     # generic/531 nfs specific,id1938936
                     # generic/070 650: due to nfs+virtiofs limitation, skip them if no '--inode_file_handles' specified, id2018072 and id1908490
-                    # generic/451 : due to generic/451 writes a file directly, add it into blacklist in cache= always scenario, id2231253
+                    # generic/451 : due to generic/451 writes a file directly, add it into blacklist in cache=always scenario
                     generic_blacklist = 'generic/003\ngeneric/120\ngeneric/426\ngeneric/467\ngeneric/477\ngeneric/551\ngeneric/035\ngeneric/531\n'
                     with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs:
                         generic_blacklist += 'generic/070\ngeneric/650\n'

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -208,6 +208,13 @@
                         generic_blacklist += 'generic/070\ngeneric/650\n'
                     with_cache.always..with_nfs_source.multi_fs:
                         generic_blacklist += 'generic/451\n'
+                    # These tests not support mmap with cache=none
+                    with_xfstest..with_cache.none:
+                        generic_blacklist += 'generic/029\ngeneric/030\ngeneric/074\ngeneric/080\ngeneric/127\ngeneric/141\n'
+                        generic_blacklist += 'generic/198\ngeneric/215\ngeneric/240\ngeneric/246\ngeneric/247\ngeneric/248\n'
+                        generic_blacklist += 'generic/340\ngeneric/344\ngeneric/345\ngeneric/346\ngeneric/354\ngeneric/428\n'
+                        generic_blacklist += 'generic/437\ngeneric/438\ngeneric/446\ngeneric/469\ngeneric/567\ngeneric/638\n'
+                        generic_blacklist += 'generic/647\ngeneric/729\n'
                     aarch64:
                         only with_cache..with_nfs_source
                         generic_blacklist += 'generic/568\n'

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -206,7 +206,7 @@
                     generic_blacklist = 'generic/003\ngeneric/120\ngeneric/426\ngeneric/467\ngeneric/477\ngeneric/551\ngeneric/035\ngeneric/531\n'
                     with_cache.auto.default_extra_parameters.default.with_nfs_source.multi_fs:
                         generic_blacklist += 'generic/070\ngeneric/650\n'
-                    with_cache.always..with_nfs_source.multi_fs:
+                    with_xfstest..with_cache.always:
                         generic_blacklist += 'generic/451\n'
                     # These tests not support mmap with cache=none
                     with_xfstest..with_cache.none:


### PR DESCRIPTION
Some tests of xfstest not support mmap with cache=none.

ID: 1443