### PR TITLE
numa_consistency: updates case to numa node memory binding

### DIFF
--- a/qemu/tests/cfg/numa.cfg
+++ b/qemu/tests/cfg/numa.cfg
@@ -3,6 +3,10 @@
     kill_vm_on_error = yes
     login_timeout = 240
     numa_hardware_cmd = "numactl --hardware"
+    mem_ratio = 0.6
+    mem_map_tool = "mem_mapping.tar.gz"
+    stress_cmds_mem_mapping = "./mem_mapping"
+    make_cmds_mem_mapping = "gcc mem_mapping.c -o ${stress_cmds_mem_mapping}"
     variants:
         - numa_basic:
             vms = ""
@@ -11,22 +15,19 @@
             only Linux
             type = numa_consistency
             start_vm = no
-            threshold = 0.05
-            ppc64,ppc64le:
-                threshold = 0.15
+            mem_fixed = 4096
+            vm_mem_backend = "memory-backend-ram"
+            mem_ratio = 0.3
+            guest_stress_args = "-a -p -l %sM"
+            vm_mem_policy = bind
         - numa_stress:
             only Linux
             no ppc64 ppc64le
             type = numa_stress
             del stress_args
             mem = 8192
-            mem_ratio = 0.6
-            cmd_cp_mmap_tool = "/bin/cp -rf %s /var/tmp/ && cd /var/tmp/ && tar zxvf mem_mapping.tar.gz"
-            make_cmds_mem_mapping = "gcc mem_mapping.c -o mem_mapping"
-            cmd_mmap = "cd /var/tmp/mem_mapping && ${make_cmds_mem_mapping} && numactl -m %s ./mem_mapping -a -p -l %dK &"
-            cmd_mmap_cleanup = "rm -rf /var/tmp/mem_mapping*"
+            cmd_cp_mmap_tool = "/bin/cp -rf %s %s && cd %s && tar zxvf ${mem_map_tool}"
+            cmd_mmap = "cd %s/mem_mapping && ${make_cmds_mem_mapping} && numactl -m %s ${stress_cmds_mem_mapping} -a -p -l %dK &"
+            cmd_mmap_cleanup = "rm -rf %s/mem_mapping*"
             cmd_mmap_stop = "pkill -9 mem_mapping"
             cmd_migrate_pages = "migratepages %s %s %s"
-            mem_map_tool = "mem_mapping.tar.gz"
-            stress_cmds_mem_mapping = "./mem_mapping"
-            uninstall_cmds_mem_mapping = "rm -rf /home/mem_mapping*"

--- a/qemu/tests/numa_stress.py
+++ b/qemu/tests/numa_stress.py
@@ -51,9 +51,10 @@ def run(test, params, env):
     if len(host_numa_node.online_nodes) < 2:
         test.cancel("Host only has one NUMA node, skipping test...")
 
+    tmp_directory = "/var/tmp"
     mem_map_tool = params.get("mem_map_tool")
     cmd_cp_mmap_tool = params.get("cmd_cp_mmap_tool")
-    cmd_mmap_cleanup = params.get("cmd_mmap_cleanup")
+    cmd_mmap_cleanup = params.get("cmd_mmap_cleanup") % tmp_directory
     cmd_mmap_stop = params.get("cmd_mmap_stop")
     cmd_migrate_pages = params.get("cmd_migrate_pages")
     mem_ratio = params.get_numeric("mem_ratio", 0.6, float)
@@ -73,7 +74,7 @@ def run(test, params, env):
         guest_stress_args = "-a -p -l %sM" % int(test_mem)
         stress_path = os.path.join(data_dir.get_deps_dir('mem_mapping'), mem_map_tool)
         test.log.info("Compile the mem_mapping tool")
-        cmd_cp_mmap_tool = cmd_cp_mmap_tool % stress_path
+        cmd_cp_mmap_tool = cmd_cp_mmap_tool % (stress_path, tmp_directory, tmp_directory)
         process.run(cmd_cp_mmap_tool, shell=True)
         utils_memory.drop_caches()
         for test_round in range(test_count):
@@ -84,7 +85,7 @@ def run(test, params, env):
                 most_used_node, memory_used = max_mem_map_node(host_numa_node, qemu_pid)
                 numa_node_malloc = most_used_node
                 mmap_size = math.floor(float(node_meminfo(numa_node_malloc, 'MemTotal')) * mem_ratio)
-                cmd_mmap = cmd_mmap % (numa_node_malloc, mmap_size)
+                cmd_mmap = cmd_mmap % (tmp_directory, numa_node_malloc, mmap_size)
                 error_context.context("Run mem_mapping on host node "
                                       "%s." % numa_node_malloc, test.log.info)
                 process.system(cmd_mmap, shell=True, ignore_bg_processes=True)


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3792

numa_consistency: updates case to numa node memory binding

In order to do a proper memory allocation, this case is updated,
to bind the qemu-kvm process to the NUMA node with more free
memory. After that, a memory allocation process is started for
every node inside the vm and it's checked the memory has increased
in the binded host NUMA node.

ID: 1398
Signed-off-by: mcasquer <mcasquer@redhat.com>