### PR TITLE
virtio_port_hotplug: Update filesize for max_chardevs and unplug_chardev

### DIFF
--- a/qemu/tests/cfg/virtio_port_hotplug.cfg
+++ b/qemu/tests/cfg/virtio_port_hotplug.cfg
@@ -31,9 +31,10 @@
             serial_type_vc2 = virtconsole
             file_transfer_serial_port = vc1
             unplug_device = vc1 vc2
-            filesize = 100
+            filesize = 200
             unplug_chardev_vc1 = yes
             unplug_chardev_vc2 = yes
+            check_module = no
         - @unplug_port:
             serials += " vs1 vs2"
             serial_type_vs1 = virtserialport
@@ -113,6 +114,7 @@
                     #Port number 0 on virtio-serial devices reserved for
                     #virtconsole devices for backward compatibility
                     virtio_serial_ports = 30
+                    filesize = 200
         - remove_pending_watches:
             type = chardev_remove_pending_watches
             serials += " vs1"


### PR DESCRIPTION
Due to small filesize, the transfer process is too fast to catch python process. Enlarge the size of 'dd'.

id: 1415
Signed-off-by: meinli [meinli@redhat.com](url)