### PR TITLE
Fix the hv_tlbflush_ext dependency hv_tlbflush issue

### DIFF
--- a/qemu/tests/cfg/hv_tlbflush.cfg
+++ b/qemu/tests/cfg/hv_tlbflush.cfg
@@ -5,7 +5,7 @@
     required_qemu = [3.1.0,)
 
     cpu_model_flags += hv_crash,hv_reset
-    hv_flags_to_ignore = hv_tlbflush hv_vpindex hv_reset hv_ipi hv_synic hv_stimer hv_stimer_direct
+    hv_flags_to_ignore = hv_tlbflush hv_vpindex hv_reset hv_ipi hv_synic hv_stimer hv_stimer_direct hv_tlbflush_ext
 
     copy_tlbflush_cmd = "copy /y WIN_UTILS:\hv_tools\%%PROCESSOR_ARCHITECTURE%%\%s c:\"
     delete_tlbflush_cmd = "del /f c:\%s"


### PR DESCRIPTION
When detach hv_tlbflush, also need detach hv_tlbflush_ext as well.
Since hv_tlbflush_ext depends on hv_tlflush.

ID: 1397
Signed-off-by: Peixiu <phou@redhat.com>