### PR TITLE
qemu-guest-agent: Add new test case for checking VSS DLL

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -619,6 +619,17 @@
                 devcon_dirname += "amd64"
                 qemu_ga_pkg = qemu-ga-x64.msi
             devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        - gagent_debugview_VSS_DLL:
+            only Windows
+            no isa_serial
+            gagent_check_type = debugview_VSS_DLL
+            virtio_win_media_type = iso
+            cdroms += " virtio"
+            clone_master = yes
+            master_images_clone = image1
+            remove_image_image1 = yes
+            cmd_run_debugview = 'start WIN_UTILS:\Debugviewconsole.exe -d C:\deb.dbglog'
+            cmd_check_string_VSS = 'type C:\debug.dbglog | findstr /i "QEMU Guest Agent VSS Provider\[[0-9]*\]"'
     variants:
         - virtio_serial:
             gagent_serial_type = virtio

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -4424,6 +4424,34 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
 
         session.close()
 
+    @error_context.context_aware
+    def gagent_check_debugview_VSS_DLL(self, test, params, env):
+        """
+        :param test: QEMU test object
+        :param params: Dictionary with the test parameters
+        :param env: Dictionary with test environment
+        """
+
+        vm = env.get_vm(params["main_vm"])
+        session = vm.wait_for_login()
+        gagent = self.gagent
+
+        cmd_run_debugview = utils_misc.set_winutils_letter(session,
+                                                           params["cmd_run_debugview"])
+        cmd_check_string_VSS = params["cmd_check_string_VSS"]
+
+        error_context.context("Check if debugview can capture log info", test.log.info)
+        s, o = session.cmd_status_output(cmd_run_debugview)
+        if s:
+            test.error("Debugviewconsole.exe run failed, "
+                       "Please check the output is: %s" % o)
+        gagent.fsfreeze()
+        gagent.fsthaw()
+        s, o = session.cmd_status_output(cmd_check_string_VSS)
+        if s:
+            test.fail("debugview can't capture expected log info,  "
+                      "the actual output is %s" % o)
+
 
 def run(test, params, env):
     """


### PR DESCRIPTION
Currently, VSS DLL can only report an error as a response to the VSS commands. 
This is significantly limiting the ability to debug the VSS DLL.

So this case involved exe program 'Deviewconsole.exe' to check the log info.

ID: 1240
Signed-off-by: demeng <demeng@redhat.com>