### PR TITLE
Adding discard=ignore in block_detect_zeroes testing

### DIFF
--- a/qemu/tests/cfg/block_detect_zeroes.cfg
+++ b/qemu/tests/cfg/block_detect_zeroes.cfg
@@ -2,7 +2,6 @@
     type = block_detect_zeroes
     data_image="stg1"
     images += " ${data_image}"
-    drv_extra_params_stg1 += "discard=unmap"
     blk_extra_params_stg1 += ",serial=stg1"
     image_name_stg1 = images/stg1
     image_size_stg1 = 2G
@@ -25,6 +24,12 @@
             drv_extra_params_stg1 += ",detect-zeroes=on"
         - with_unmap:
             drv_extra_params_stg1 += ",detect-zeroes=unmap"
+    variants:
+        - with_discard_ignore:
+            only with_off with_on
+            drv_extra_params_stg1 += ",discard=ignore"
+        - with_discard_unmap:
+            drv_extra_params_stg1 += ",discard=unmap"
     variants:
         - with_boot:
             guest_operation = boot_test


### PR DESCRIPTION
It only uses discard=unmap in current testing.
Adding discard=ignore to expand the test scope.

ID:1331