### PR TITLE
hotplug_memory_repeat:Update arm hotplug mem block size

### DIFF
--- a/qemu/tests/cfg/hotplug_memory_repeat.cfg
+++ b/qemu/tests/cfg/hotplug_memory_repeat.cfg
@@ -31,6 +31,10 @@
         get_basic_page = "getconf PAGE_SIZE"
         size_mem_64k = 512M
         maxmem_mem = 140G
+        # On rhel8 section size must be at least 1024MB for 64K base
+        RHEL.8:
+            size_mem_64k = 1024M
+            repeat_times = 128
     variants test_type:
         - repeat_256:
             only Linux


### PR DESCRIPTION
We hit unaligned hotplug range issue, on rhel8.
In older versions of the kernel it requires a larger address space. 
So update arm hotplug mem block size.

ID: 1454