### PR TITLE
boot_from_virtiofs: add a disk to workaround ovmf fd generation defect

### DIFF
--- a/qemu/tests/cfg/boot_from_virtiofs.cfg
+++ b/qemu/tests/cfg/boot_from_virtiofs.cfg
@@ -11,6 +11,13 @@
     fs_passwd = virtiofs
     set_passwd_cmd = "echo ${fs_passwd} | passwd --stdin root ; exit"
     images = ""
+    # Workaround for no ovmf related qemu command line
+    ovmf:
+        images += "stg"
+        image_size_stg = 1G
+        image_name_stg = images/stg
+        remove_image_stg = yes
+        force_create_image_stg = yes
     cdroms = ""
     nics = ""
     filesystems = fs


### PR DESCRIPTION
Currently, in avocado-vt, it will check parameter
firmware_path and images, if these 2 paremeters are not none, then add firmware related qemu command line.

So add a disk to fix current bug in tp-qemu

ID:1450

Signed-off-by: Leidong Wang <leidwang@redhat.com>