### PR TITLE
vlan: moving functionality of netkvmco.dll to netkvco.exe

### DIFF
--- a/generic/tests/cfg/vlan.cfg
+++ b/generic/tests/cfg/vlan.cfg
@@ -24,7 +24,7 @@
         win_vlan_id = 900
         cdroms += " virtio"
         driver_verifier = netkvm
-        set_vlan_cmd = powershell -command "Set-NetAdapter -Name '%s' -VlanID ${win_vlan_id} -Confirm:$False"
+        set_vlan_cmd = "%s setparam 0 param=vlanid value=${win_vlan_id}"
         Win2016, Win2019, Win8..1, Win2012..r2:
                 driver_verifier += " ndis"
     variants:


### PR DESCRIPTION
Use netkvco.exe to replace the netsh netkvm command.
netkvmco.dll is removed from the release and converted
to an executable, and netkvmco.exe is added which
terminates all the calls that
previously were terminated by netshell.

ID: 1449
Signed-off-by: Wenkang Ji <wji@redhat.com>