### PR TITLE
Installer test: add network static configuration test

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
@@ -249,4 +249,10 @@
             variants:
                 - from_old_installer:
                     update_from_previous_installer = yes
+                    static_ip = 192.168.0.11
+                    static_mask = 255.255.255.0
+                    static_gateway = 192.168.0.5
+                    static_dns = 192.168.0.1
+                    setup_ip_cmd = 'netsh interface ip set address "%s" static ${static_ip} ${static_mask} ${static_gateway}'
+                    setup_dns_cmd = 'netsh interface ip add dns "%s" ${static_dns} validate=no'
                 - from_old_virtio_win_iso:


### PR DESCRIPTION
Driver installer support restore network configuration after upgrade driver, so add a check point for it.

ID: 1386

Signed-off-by: Leidong Wang <leidwang@redhat.com>