### PR TITLE
fix(virtual-network): Use bootindex instead of boot order

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -9,7 +9,6 @@
     image_size_pxe = 1G
     force_create_image_pxe = yes
     remove_image_pxe = yes
-    boot_once = n
     kill_vm_on_error = yes
     network = bridge
     restart_vm = yes
@@ -17,9 +16,14 @@
     image_verify_bootable = no
     kill_vm = yes
     kill_vm_gracefully = no
+    del boot_order
+    del boot_once
+    del boot_reboot_timeout
+    del boot_splash_time
+    nics = nic1
+    bootindex_nic1 = 0
     s390x:
         extra_params += " -no-shutdown"
-        bootindex_nic1 = 0
     # pxe_boot does not work for macvtap backend, as pxe can't
     # capture the packet from the macvtap tap port, disable it
     # for macvtap temporarily, will fix it in the furture.


### PR DESCRIPTION
Without bootindex in the nic command line, the bios will use the default boot entries for pxe booting, but if the pxe entry is not the first entry, then the guest will directly boot into the OS.

ID: 1475