### PR TITLE
hotplug_mem_migration:enable dirty ring test

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_migration.cfg
+++ b/qemu/tests/cfg/hotplug_mem_migration.cfg
@@ -32,6 +32,17 @@
     numa_test = 'numactl -m %s dd if=/dev/urandom of=/tmp/numa_test/test '
     numa_test += 'bs=1k count=%d && rm -rf /tmp/numa_test/'
     stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 4096M'
+    variants with_cache:
+        - @default:
+        - enable_dirty_ring:
+            only i386, x86_64, aarch64
+            required_qemu = [6.3.0,)
+            aarch64:
+                required_qemu = [8.1.0,)
+            only with_multi_numa_nodes
+            extra_params += "-accel kvm,dirty-ring-size=65536"
+            disable_kvm = yes
+            enable_kvm = no
     variants numa_nodes:
         - with_single_numa_node:
             guest_numa_nodes = "node0"


### PR DESCRIPTION
Enable dirty ring test on x86_64 and aarch64

ID: 1474
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>
