### PR TITLE
numa_prealloc_handling: Basic preallocation handling

### DIFF
--- a/qemu/tests/cfg/numa_prealloc_handling.cfg
+++ b/qemu/tests/cfg/numa_prealloc_handling.cfg
@@ -1,0 +1,12 @@
+- numa_prealloc_handling:
+    no RHEL.6 RHEL.7 RHEL.8
+    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+    required_qemu = [7.2,)
+    type = numa_prealloc_handling
+    virt_test_type = qemu
+    vms = ""
+    cmd_time_taskset =  "/usr/bin/time -f %%e taskset -c 0"
+    cmd_qemu_options = "-nographic -sandbox on,resourcecontrol=deny -monitor stdio -cpu host -object memory-backend-ram,id=mem0,size=20G,prealloc=on,prealloc-threads=4"
+    cmd_option_tc = ",prealloc-context=tc1 -object thread-context,id=tc1,cpu-affinity=1-7"
+    cmd_without_tc = "${cmd_time_taskset} %s ${cmd_qemu_options} 2>&1 | tail -1"
+    cmd_with_tc = "${cmd_time_taskset} %s ${cmd_qemu_options}${cmd_option_tc} 2>&1 | tail -1"

--- a/qemu/tests/numa_prealloc_handling.py
+++ b/qemu/tests/numa_prealloc_handling.py
@@ -1,0 +1,35 @@
+from avocado.utils import process
+
+from virttest import utils_misc
+from virttest import utils_package
+
+
+def run(test, params, env):
+    """
+    numa_prealloc_handling test
+    1) Measures the time takes QEMU to preallocate the memory
+    2) Checks the timing is shorter when thread-context is used
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    if not utils_package.package_install("time"):
+        test.cancel("time package is not installed!")
+
+    qemu_path = utils_misc.get_qemu_binary(params)
+
+    cmd_without_tc = params.get("cmd_without_tc") % qemu_path
+    cmd_with_tc = params.get("cmd_with_tc") % qemu_path
+
+    execution_time = float(process.getoutput(cmd_without_tc,
+                                             ignore_status=True,
+                                             shell=True))
+    test.log.debug("Execution time without thread_context: %f" % execution_time)
+
+    execution_time_tc = float(process.getoutput(cmd_with_tc,
+                                                ignore_status=True,
+                                                shell=True))
+    test.log.debug("Execution time with thread_context: %f" % execution_time_tc)
+
+    if execution_time <= execution_time_tc:
+        test.fail("There is no boot time speedup when using thread-context!")


### PR DESCRIPTION
numa_prealloc_handling: Basic preallocation handling

Creates a new case that measures the time that needs QEMU
to preallocate the memory with and without thread-context.

ID: 1502
Signed-off-by: mcasquer <mcasquer@redhat.com>
