### PR TITLE
block_with_share_rw:fix vm creation command failed

### DIFF
--- a/qemu/tests/cfg/block_with_share_rw.cfg
+++ b/qemu/tests/cfg/block_with_share_rw.cfg
@@ -53,7 +53,8 @@
                     drive_format_stg = scsi-generic
                     drive_cache_stg = writethrough
                     image_aio_stg = threads
-                    image_name_stg = /dev/sg*
+                    image_name_stg = /dev/sg[0-9]*
+                    disk_check_cmd = "ls -1d /dev/sg*|grep -E '/dev/sg[0-9]{1,3}'"
     variants:
         - turn_on:
             share_rw = on


### PR DESCRIPTION
THe /dev/sg* not only sg devices but also other devices in host. e.g. /dev/sg0  /dev/sgx_enclave  /dev/sgx_provision  /dev/sgx_vepc It should filter out sg devices only.

ID:1484