### PR TITLE
Change the ipv6 link local syntax for rhel9

### DIFF
--- a/qemu/tests/cfg/bigfile_transfer_over_ipv6.cfg
+++ b/qemu/tests/cfg/bigfile_transfer_over_ipv6.cfg
@@ -13,6 +13,8 @@
         tmp_dir = "C:\\"
     variants:
         - remote_addr:
-             link_local_ipv6_addr = false
+            link_local_ipv6_addr = false
         - link_local_addr:
-             link_local_ipv6_addr = true
+            link_local_ipv6_addr = true
+            Host_RHEL.m5, Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8:
+                using_guest_interface = true

--- a/qemu/tests/transfer_file_over_ipv6.py
+++ b/qemu/tests/transfer_file_over_ipv6.py
@@ -134,6 +134,10 @@ def run(test, params, env):
                         error_context.context("Transferring data from %s to %s" %
                                               (vm_src.name, vm_dst.name),
                                               test.log.info)
+                        if params.get_boolean("using_guest_interface"):
+                            dst_interface = inet_name[vm_src]
+                        else:
+                            dst_interface = host_ifname
                         remote.scp_between_remotes(addresses[vm_src],
                                                    addresses[vm_dst],
                                                    port, password, password,
@@ -141,7 +145,7 @@ def run(test, params, env):
                                                    guest_path, dest_path,
                                                    timeout=file_trans_timeout,
                                                    src_inter=host_ifname,
-                                                   dst_inter=inet_name[vm_src])
+                                                   dst_inter=dst_interface)
                         dst_md5 = get_file_md5sum(dest_path, sessions[vm_dst],
                                                   timeout=file_md5_check_timeout)
                         error_context.context("md5 value of data in %s: %s" % (vm.name, dst_md5),


### PR DESCRIPTION
Since from rhel9,ipv6 link local's scp syntax has been changed. So QE sent a MR to fix this problem.

ID: 1530
Signed-off-by: Lei Yang leiyang@redhat.com