### PR TITLE
multi_disk:fix vm creation command failed

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -121,7 +121,7 @@
                         - generic:
                             stg_params += "image_aio:threads "
                             stg_params += "drive_format:scsi-generic "
-                            stg_params += "image_name:/dev/sg* "
+                            stg_params += "image_name:/dev/sg[0-9]* "
                             variants:
                                 - with_cache_writethrough:
                                     stg_params += "drive_cache:writethrough "


### PR DESCRIPTION
THe /dev/sg* not only sg devices but also other devices in host. e.g. /dev/sg0  /dev/sgx_enclave  /dev/sgx_provision  /dev/sgx_vepc It should filter out sg devices only.

ID：1483