### PR TITLE
unplug_block_during_io_reboot: Shrink the waiting time when stress test

### DIFF
--- a/qemu/tests/cfg/unplug_block_during_io_reboot.cfg
+++ b/qemu/tests/cfg/unplug_block_during_io_reboot.cfg
@@ -9,7 +9,7 @@
     remove_image_stg0 = yes
     force_create_image_stg0 = yes
     kill_vm_on_error = yes
-    sleep_time = 30
+    sleep_time = 10
     Linux:
         stress_args = 'dd if=/dev/zero of={0} bs=1M count=40000 oflag=direct'
     Windows:


### PR DESCRIPTION
During IO stress test (dd cmd), the waiting time is too long to check the status of stress, so shrink the waiting time from 30s to 10s.

ID:1531
Signed-off-by: Sibo Wang [siwang@redhat.com](mailto:siwang@redhat.com)