### PR TITLE
block_performance_test:fix resource usage

### DIFF
--- a/qemu/tests/cfg/block_performance_test.cfg
+++ b/qemu/tests/cfg/block_performance_test.cfg
@@ -19,11 +19,11 @@
     image_name_stg2 = stg2
     kill_vm = yes
     dd_cmd_timeout = 180
+    vcpu_maxcpus = 8
+    mem = 4096
     Linux:
-        mem = 2048
         dd_cmd = "time dd if=/dev/zero of=/dev/%s bs=256k count=10240 oflag=direct"
     Windows:
-        mem = 4096
         dd_cmd = 'WIN_UTILS:\coreutils\DummyCMD.exe %s 1536000000 1'
     variants:
         - with_queue_size:
@@ -36,7 +36,6 @@
                 bus_extra_params_stg0 = "virtqueue_size=128"
                 bus_extra_params_stg1 = "virtqueue_size=1024"
         - with_multi_queue:
-            vcpu_maxcpus = 8
             Linux:
                 check_default_mp = 'yes'
                 check_default_mp_cmd = "ls /sys/block/%s/mq/"


### PR DESCRIPTION
It consumes too much memory resulting in VM boot
failing if there are too many CPUs in the VM.
The test point of this case is irrelevant to the CPU. limit the CPU number and increase memory usage
avoid to VM boot failing out of memory.

ID:1518