### PR TITLE
Add analyzing conditions before remove disk in image_black_list

### DIFF
--- a/qemu/tests/multi_disk.py
+++ b/qemu/tests/multi_disk.py
@@ -258,7 +258,8 @@ def run(test, params, env):
         matching_images = process.run(disk_check_cmd, ignore_status=True,
                                       shell=True).stdout_text
         for disk in image_stg_blacklist:
-            if not re.search(disk, matching_images):
+            if not re.search(disk, matching_images) and disk in \
+                    indirect_image_blacklist:
                 indirect_image_blacklist.remove(disk)
         params["indirect_image_blacklist"] = " ".join(indirect_image_blacklist)
 


### PR DESCRIPTION
Multi_disk: add analyzing conditions before remove disk in image_black_
list. Otherwise there would be an error when disk is not in the list.
like this: list.remove(x): x not in list

ID: KVMAUTOMA-1361

Signed-off-by: Boqiao Fu <bfu@redhat.com>