### PR TITLE
Forbidden pxe_boot test for igb nic

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -28,6 +28,7 @@
     # capture the packet from the macvtap tap port, disable it
     # for macvtap temporarily, will fix it in the furture.
     no macvtap
+    no igb
     variants:
         - @default:
         - gpxe:


### PR DESCRIPTION
Based on the developer comment forbidden PXE tests, since igb is not supported yet in BIOS.

ID: 1544
Signed-off-by: Lei Yang leiyang@redhat.com
