### PR TITLE
Configure outer VLAN MTU to 1504 for e1000e device on qemu-8.1

### DIFF
--- a/qemu/tests/bridge_qinq.py
+++ b/qemu/tests/bridge_qinq.py
@@ -11,6 +11,8 @@ from virttest import data_dir
 from virttest import utils_test
 from virttest import remote
 
+from virttest.utils_version import VersionInterval
+
 
 @error_context.context_aware
 def run(test, params, env):
@@ -288,6 +290,11 @@ def run(test, params, env):
                              ethertype2="ethertype 802.1Q",
                              vlan_tag="vlan 10,",
                              vlan_tag2="vlan 20,")
+
+        # configure the outer VLAN MTU to 1504 on qemu-8.1
+        if vm.devices.qemu_version in VersionInterval('[8.1.0,)') and \
+                params.get("nic_model") == "e1000e":
+            session.cmd("ip link set %s mtu 1504" % nic_name)
 
         # scp file to guest with L2 vlan tag
         cmd = "dd if=/dev/zero of=%s bs=1M count=%d" % (host_path, file_size)


### PR DESCRIPTION
Since there is commit fixed the packet size check and made it more strict about the packet size,based on this commit QEMU handled the ethernet FCS packets which is 4-byte long, so the maximum size should be subtracted 4.This surfaced a problem in the test case that the guest sends a packet larger than 1522 bytes without setting the LPE flag.A QinQ packet has a 22-byte header, the default MTU in VLAN is 1500, and an ethernet FCS is 4-byte long as I described earlier so the maximum packet size will be 22 + 1500 + 4 = 1526, which is 4-byte larger than 1522 bytes.So the fix is make the outer VLAN MTU greater to let the driver set the LPE flag.

ID: 1556
Signed-off-by: Lei Yang leiyang@redhat.com