### PR TITLE
virtio_fs: stress test add different bs size

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -245,24 +245,25 @@
                     viofs_case_insense_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v CaseInsensitive /d 1 /t REG_DWORD'
         - run_stress:
             no extra_parameters socket_group
+            stress_bs = 4K 16K 64K
             variants:
                 - with_fio:
                     smp = 8
                     vcpu_maxcpus = 8
                     io_timeout = 2000
                     fio_options = '--name=stress --filename=%s --ioengine=libaio --rw=write --direct=1 '
-                    fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800'
+                    fio_options += '--bs=%s --size=1G --iodepth=256 --numjobs=128 --runtime=1800'
                     Windows:
                         fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
-                        fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800 --thread'
+                        fio_options += '--bs=%s --size=1G --iodepth=256 --numjobs=128 --runtime=1800 --thread'
                 - with_iozone:
                     smp = 8
                     vcpu_maxcpus = 8
                     io_timeout = 1800
-                    iozone_options = " -azR -r 64k -n 1G -g 4G -I -i 0 -i 1 -f %s"
+                    iozone_options = " -azR -r %s -n 1G -g 4G -I -i 0 -i 1 -f %s"
                     Windows:
                         iozone_path = "WIN_UTILS:\Iozone\iozone.exe"
-                        iozone_options = " -azR -r 64k -n 1G -g 4G -M -I -i 0 -i 1 -b iozone.xls -f %s"
+                        iozone_options = " -azR -r %s -n 1G -g 4G -M -I -i 0 -i 1 -b iozone.xls -f %s"
                 - with_pjdfstest:
                     no s390 s390x ppc64 ppc64le
                     no Windows

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -541,7 +541,8 @@ def run(test, params, env):
                     error_context.context("Run fio on %s." % fs_dest, test.log.info)
                     fio = generate_instance(params, vm, 'fio')
                     try:
-                        fio.run(fio_options % guest_file, io_timeout)
+                        for bs in params.get_list("stress_bs"):
+                            fio.run(fio_options % (guest_file, bs), io_timeout)
                     finally:
                         fio.clean()
                     vm.verify_dmesg()
@@ -550,7 +551,8 @@ def run(test, params, env):
                     error_context.context("Run iozone test on %s." % fs_dest, test.log.info)
                     io_test = generate_instance(params, vm, 'iozone')
                     try:
-                        io_test.run(iozone_options % guest_file, io_timeout)
+                        for bs in params.get_list("stress_bs"):
+                            io_test.run(iozone_options % (bs, guest_file), io_timeout)
                     finally:
                         io_test.clean()
 


### PR DESCRIPTION
Simulate the scenario where direct IO and buffered IO are interleaved. 
When the buffered IO and direct IO sizes are different, 
product issues are more likely to occur.

ID: 1560