### PR TITLE
qemu_guest_agent: adjust '--allow-rpcs' as new default option

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -15,13 +15,12 @@
     setsebool_cmd = "setsebool virt_qemu_ga_read_nonsecurity_files %s"
     getsebool_cmd = "getsebool -a | grep virt_qemu_ga_read_nonsecurity_files |awk '{print$3}'"
     backup_file = /etc/sysconfig/qemu-ga-bk
-    black_list_backup = /bin/cp -f /etc/sysconfig/qemu-ga ${backup_file}
+    black_file_backup = /bin/cp -f /etc/sysconfig/qemu-ga ${backup_file}
     recovery_black_list = mv -f ${backup_file} /etc/sysconfig/qemu-ga
+    black_list_spec = "BLACKLIST_RPC"
+    black_list_check_cmd = "grep -nr '%s=%s' /etc/sysconfig/qemu-ga"
     black_list_change_cmd = "sed -i 's/%s//g' /etc/sysconfig/qemu-ga"
-    black_list_spec = BLOCK_RPCS
-    Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1:
-        black_list_spec = BLACKLIST_RPC
-    black_list_check_cmd = "grep -nr '${black_list_spec}=.*%s' /etc/sysconfig/qemu-ga"
+    black_list_new = "guest-file-open,guest-file-close,guest-file-read,guest-file-write,guest-file-seek,guest-file-flush"
     # /qga_setup_fail.log is saved during guest preinstall phase, if you don't have this file, please skip this parameter.
     cmd_check_qga_installlog = "ls /qga_setup_fail.log"
     # please fill the 'qga_rpm_path' if want to install specified version, form like "qga_rpm_path = ' '"
@@ -308,12 +307,12 @@
                     gagent_check_type = file_read
                 - with_fsfreeze:
                     gagent_check_type = with_fsfreeze
-                - with_selinux:
-                    no Windows
-                    gagent_check_type = with_selinux
+                    allow_list = ",guest-fsfreeze-freeze,guest-fsfreeze-status,guest-fsfreeze-thaw"
+                    black_list_new = ${black_list_new}${allow_list}
         - check_guest_exec:
             gagent_check_type = guest_exec
             black_list = "guest-exec guest-exec-status"
+            black_list_new = "guest-exec,guest-exec-status"
             guest_cmd = "echo"
             guest_cmd_args = "This is a test."
             guest_cmd_timeout = 60
@@ -464,10 +463,6 @@
         - gagent_check_blacklist:
             only Linux
             gagent_check_type = blacklist
-            black_list_spec = BLOCK_RPCS
-            Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1:
-                black_list_spec = BLACKLIST_RPC
-            black_list_change_cmd = "sed -i 's/${black_list_spec}.*/${black_list_spec}=guest-info/g' /etc/sysconfig/qemu-ga"
         - gagent_check_log:
             only isa_serial
             gagent_check_type = log

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -9,6 +9,7 @@ import json
 
 import aexpect
 
+from packaging import version
 from avocado.utils import genio
 from avocado.utils import path as avo_path
 from avocado.utils import process
@@ -167,18 +168,24 @@ class QemuGuestAgentTest(BaseVirtTest):
         s, o = session.cmd_status_output(cmd_check_status)
         return s == 0
 
-    def _get_main_qga_version(self, session, vm):
+    def _get_qga_version(self, session, vm, main_ver=True):
         """
-        Get qemu-guest-agent version in guest
+        Get qemu-guest-agent version or
+        main version in guest
         :param session: use for sending cmd
         :param vm: guest object.
         :return: main qga version
         """
         LOG_JOB.info("Get guest agent's main version for linux guest.")
         qga_ver = session.cmd_output(self.params["gagent_pkg_check_cmd"])
-        pattern = r"guest-agent-(\d+).\d+.\d+-\d+"
-        ver_main = int(re.findall(pattern, qga_ver)[0])
-        return ver_main
+        if main_ver:
+            pattern = r"guest-agent-(\d+).\d+.\d+-\d+"
+            ver_main = int(re.findall(pattern, qga_ver)[0])
+            return ver_main
+        else:
+            match = re.search(r'qemu-guest(-(agent))?-(\d+\.\d+\.\d+-\d+)', qga_ver)
+            full_ver = match.group(3)
+            return full_ver
 
     def gagent_install(self, session, vm):
         """
@@ -1729,16 +1736,29 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         Now only linux guest has this behavior,but still leave interface
         for windows guest.
         """
+
         if self.params.get("os_type") == "linux":
-            cmd_black_list = self.params["black_list"]
-            cmd_blacklist_backup = self.params["black_list_backup"]
+            cmd_blacklist_backup = self.params["black_file_backup"]
             session.cmd(cmd_blacklist_backup)
+            full_qga_ver = self._get_qga_version(session, self.vm, main_ver=False)
+            full_qga_ver = version.parse(full_qga_ver)
+            value_full_qga_ver = (full_qga_ver >= version.parse("8.1.0-5"))
+            black_list_spec = self.params["black_list_spec"]
+            cmd_black_list = self.params["black_list"]
+            black_list_change_cmd = self.params["black_list_change_cmd"]
+            if full_qga_ver >= version.parse("8.1.0-5"):
+                black_list_spec = "allow-rpcs"
+                cmd_black_list = self.params["black_list_new"]
+                black_list_change_cmd = "sed -i 's/allow-rpcs.*/allow-rpcs=%s\"/g' /etc/sysconfig/qemu-ga"
+            elif full_qga_ver >= version.parse("7.2.0-4"):
+                black_list_spec = "BLOCK_RPCS"
             for black_cmd in cmd_black_list.split():
-                bl_check_cmd = self.params["black_list_check_cmd"] % black_cmd
-                bl_change_cmd = self.params["black_list_change_cmd"] % black_cmd
+                bl_check_cmd = self.params["black_list_check_cmd"] % (black_list_spec, black_cmd)
+                bl_change_cmd = black_list_change_cmd % black_cmd
                 session.cmd(bl_change_cmd)
                 output = session.cmd_output(bl_check_cmd)
-                if not output == "":
+                if (output == "" and value_full_qga_ver or
+                        (not output == "" and not value_full_qga_ver)):
                     self.test.fail("Failed to change the cmd to "
                                    "white list, the output is %s" % output)
 
@@ -1957,7 +1977,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         error_context.context("Read the big file with an invalid count number",
                               LOG_JOB.info)
         if params.get("os_type") == "linux":
-            main_qga_ver = self._get_main_qga_version(session, self.vm)
+            main_qga_ver = self._get_qga_version(session, self.vm)
         if params.get("os_type") == "linux" and main_qga_ver <= 2:
             # if resource is sufficient can read file,
             # else file handle will not be found.
@@ -3419,8 +3439,19 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         error_context.context("Change command in blacklist and restart"
                               " agent service.", LOG_JOB.info)
         session.cmd("cp /etc/sysconfig/qemu-ga /etc/sysconfig/qemu-ga-bk")
+        full_qga_ver = self._get_qga_version(session, self.vm, main_ver=False)
+        full_qga_ver = version.parse(full_qga_ver)
+        black_list_spec = "BLACKLIST_RPC"
+        if full_qga_ver >= version.parse("8.1.0-5"):
+            black_list_spec, black_list_spec_replace = "allow-rpcs", "block-rpcs"
+        elif full_qga_ver >= version.parse("7.2.0-4"):
+            black_list_spec = "BLOCK_RPCS"
+        if black_list_spec == "allow-rpcs":
+            black_list_change_cmd = "sed -i 's/%s.*/%s=guest-info\"/g' /etc/sysconfig/qemu-ga" % (black_list_spec, black_list_spec_replace)
+        else:
+            black_list_change_cmd = "sed -i 's/%s.*/%s=guest-info/g' /etc/sysconfig/qemu-ga" % (black_list_spec, black_list_spec)
         try:
-            session.cmd(params["black_list_change_cmd"])
+            session.cmd(black_list_change_cmd)
             session.cmd(params["gagent_restart_cmd"])
 
             error_context.context("Try to execute guest-file-open and "


### PR DESCRIPTION
We add this for security reasons.  From QEMU 8.1, the guest agent supports the allow rpcs list. Maybe will be better to start using it.

ID: 1442
Signed-off-by: demeng [demeng@redhat.com](mailto:demeng@redhat.com)