### PR TITLE
Update nested_hyperv_on_kvm.cfg for cpu flags

### DIFF
--- a/qemu/tests/cfg/nested_hyperv_on_kvm.cfg
+++ b/qemu/tests/cfg/nested_hyperv_on_kvm.cfg
@@ -8,7 +8,7 @@
     nested_dest = "C:\\nested-hyperv-on-kvm"
     cpu_model_flags += ",hv_reset,hv_crash,hv-no-nonarch-coresharing=auto"
     Host_RHEL.m9:
-        cpu_model_flags += ",hv_emsr_bitmap"
+        cpu_model_flags += ",hv_emsr_bitmap,hv_tlbflush_ext,hv_tlbflush_direct"
 
     HostCpuVendor.intel:
         cpu_model_flags += ",hv_evmcs,+vmx"


### PR DESCRIPTION
Add cpu flags hv_tlbflush_ext,hv_tlbflush_direct for rhel 9 
ID: 2219365
Signed-off-by: xuemin <xuli@redhat.com>