### PR TITLE
multi_disk.virtio_scsi.passthrough: Dynamically update blacklist

### DIFF
--- a/qemu/tests/cfg/multi_disk.cfg
+++ b/qemu/tests/cfg/multi_disk.cfg
@@ -106,10 +106,14 @@
                     stg_params = "drive_format:scsi-block "
                     kill_vm = yes
                     force_create_image = no
-                    pre_command = "modprobe -r scsi_debug; modprobe sg; modprobe scsi_debug add_host=9 dev_size_mb=50"
-                    post_command = "rmmod scsi_debug"
-                    disk_check_cmd = "ls -1d /dev/nvme* || ls -1d /dev/sda*"
-                    image_stg_blacklist = "/dev/sda[\d]* /dev/sg0"
+                    disk_check_cmd = "ls /dev/s[dg]* -1A"
+                    get_new_disks_cmd = "cat /tmp/add_disks"
+                    pre_command = "${disk_check_cmd} > /tmp/old_disks &&"
+                    pre_command += "modprobe -r scsi_debug; modprobe sg; modprobe scsi_debug add_host=9 dev_size_mb=50 &&"
+                    pre_command += "${disk_check_cmd} > /tmp/new_disks && comm -3 /tmp/old_disks /tmp/new_disks > /tmp/add_disks"
+                    post_command = "rmmod scsi_debug &&"
+                    post_command += "rm -rf /tmp/old_disks /tmp/new_disks /tmp/add_disks"
+                    post_command_noncritical = yes
                     stg_params += "image_raw_device:yes "
                     stg_params += "image_format:raw "
                     stg_params += "indirect_image_select:range(-9,0) "

--- a/qemu/tests/multi_disk.py
+++ b/qemu/tests/multi_disk.py
@@ -252,14 +252,14 @@ def run(test, params, env):
 
     disk_check_cmd = params.get('disk_check_cmd')
     indirect_image_blacklist = params.get('indirect_image_blacklist').split()
+    get_new_disks_cmd = params.get("get_new_disks_cmd")
 
     if disk_check_cmd:
-        image_stg_blacklist = params.get('image_stg_blacklist').split()
-        matching_images = process.run(disk_check_cmd, ignore_status=True,
-                                      shell=True).stdout_text
-        for disk in image_stg_blacklist:
-            if not re.search(disk, matching_images):
-                indirect_image_blacklist.remove(disk)
+        new_images = process.run(get_new_disks_cmd, ignore_status=True,
+                                 shell=True).stdout_text
+        for black_disk in indirect_image_blacklist[:]:
+            if re.search(black_disk, new_images):
+                indirect_image_blacklist.remove(black_disk)
         params["indirect_image_blacklist"] = " ".join(indirect_image_blacklist)
 
     # Always recreate VMs and disks


### PR DESCRIPTION
Because the names of disks in different host environments are different, we need to dynamically modify the 'indirect_image_blacklist'. Check disks before and after scsi_debug is created, and update the 'indirect_image_blacklist' based on newly added disks.

ID: 1361
Signed-off-by: Sibo Wang [siwang@redhat.com](mailto:siwang@redhat.com)