### PR TITLE
pxe_boot: disable cdroms in the test

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -29,6 +29,7 @@
     # for macvtap temporarily, will fix it in the furture.
     no macvtap
     no igb
+    cdroms = ""
     variants:
         - @default:
         - gpxe:


### PR DESCRIPTION
No need cdroms in the case, so set cdroms to null string.

ID: 1570
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
