### PR TITLE
numa_opts: increase memory size for 128 nodes variant

### DIFF
--- a/qemu/tests/cfg/numa_opts.cfg
+++ b/qemu/tests/cfg/numa_opts.cfg
@@ -101,11 +101,14 @@
             numa_expected = "0-63"
         - nodes.128:
             no aarch64
+            x86_64:
+                # Disabled for RHEL 9.2, check 1589
+                no RHEL.9.2
             type = numa_maxnodes
             numa_nodes = 128
-            mem_fixed = 4G
-            vm_mem_minimum = 4G
-            node_size = 32M
+            mem_fixed = 16G
+            vm_mem_minimum = 16G
+            node_size = 128M
             start_vm = no
             ppc64,ppc64le:
                 mem_fixed = 32G


### PR DESCRIPTION
numa_opts: increase memory size for 128 nodes variant

When booting a VM with 128 NUMA nodes, ensure this one
has at least 128M per node for the all RHEL versions.
Also disables this case for RHEL 9.2

ID: 1589
Signed-off-by: mcasquer <mcasquer@redhat.com>