### PR TITLE
Change the way of backup image

### DIFF
--- a/qemu/tests/cfg/nic_acpi_index.cfg
+++ b/qemu/tests/cfg/nic_acpi_index.cfg
@@ -3,9 +3,8 @@
     type = nic_acpi_index
     only Linux
     only x86_64
-    clone_master = yes
-    master_images_clone = image1
-    remove_image_image1 = yes
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
     nic_hotplug_count=1
     nic_name_number = 2
     nic_model = virtio-net-pci

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -2,9 +2,8 @@
     no RHEL.3
     pci_type = nic
     type = nic_hotplug
-    clone_master = yes
-    master_images_clone = image1
-    remove_image_image1 = yes
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
     repeat_times = 1
     nic_hotplug_count=1
     RHEL.7:


### PR DESCRIPTION
Based on the current framework, the guest source image will be removed if continue to used the old way to backup image when the test case be cancel due to the qemu version. Therefore changed to the current way.

ID:1696
Signed-off-by: Lei Yang leiyang@redhat.com