### PR TITLE
virtio_fs: Modify the level of verify_dmesg

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -252,6 +252,7 @@
                     smp = 8
                     vcpu_maxcpus = 8
                     io_timeout = 2000
+                    guest_dmesg_level = 2
                     fio_options = '--name=stress --filename=%s --ioengine=libaio --rw=write --direct=1 '
                     fio_options += '--bs=4K --size=1G --iodepth=256 --numjobs=128 --runtime=1800'
                     Windows:


### PR DESCRIPTION
The case will verify the guest dmesg after stress test with fio, and the default level will throw exception if checked warning info, so we need to change the level of verify_dmesg.

ID:1698
Signed-off-by: Sibo Wang [siwang@redhat.com](mailto:siwang@redhat.com)