### PR TITLE
cpu_utils: adjust thread count for Windows guests

### DIFF
--- a/qemu/tests/cpu_device_hotplug_maximum.py
+++ b/qemu/tests/cpu_device_hotplug_maximum.py
@@ -96,11 +96,13 @@ def run(test, params, env):
     if params.get_boolean("check_cpu_topology", True):
         error_context.context("Check CPU topology of guest", test.log.info)
         if not cpu_utils.check_if_vm_vcpu_topology_match(session, os_type,
-                                                         cpuinfo):
+                                                         cpuinfo, test,
+                                                         vm.devices):
             test.fail("CPU topology of guest is not as expected.")
         session = vm.reboot(session, timeout=reboot_timeout)
         if not cpu_utils.check_if_vm_vcpu_topology_match(session, os_type,
-                                                         cpuinfo):
+                                                         cpuinfo, test,
+                                                         vm.devices):
             test.fail("CPU topology of guest is not as expected after reboot.")
 
     if os_type == "linux":

--- a/qemu/tests/cpu_device_hotpluggable.py
+++ b/qemu/tests/cpu_device_hotpluggable.py
@@ -178,7 +178,9 @@ def run(test, params, env):
         check_guest_cpu_count()
         if vm.get_cpu_count() == maxcpus and check_cpu_topology:
             if not cpu_utils.check_if_vm_vcpu_topology_match(session, os_type,
-                                                             vm.cpuinfo):
+                                                             vm.cpuinfo,
+                                                             test,
+                                                             vm.devices):
                 session.close()
                 test.fail("CPU topology of guest is inconsistent with "
                           "expectations.")

--- a/qemu/tests/cpu_topology_test.py
+++ b/qemu/tests/cpu_topology_test.py
@@ -71,7 +71,8 @@ def run(test, params, env):
                 raise
         vm = env.get_vm(vm_name)
         session = vm.wait_for_login()
-        if not check_if_vm_vcpu_topology_match(session, os_type, vm.cpuinfo):
+        if not check_if_vm_vcpu_topology_match(session, os_type, vm.cpuinfo,
+                                               test, vm.devices):
             test.fail('CPU topology of guest is incorrect.')
         if params.get('check_siblings_cmd'):
             check('sibling', vcpu_threads * vcpu_cores, params['check_siblings_cmd'])


### PR DESCRIPTION
Until QEMU 8.1 there was a different behaviour for thread count in case of Windows guests. It represented number of threads per single core, not the total number of threads available for all cores in socket. Therefore we disable check for older QEMU versions and adjust for newer versions.

ID: 1539