### PR TITLE
virt_firmware_check_phys_bits: get memory encryption bits dynamically

### DIFF
--- a/qemu/tests/cfg/virt_firmware_check_phys_bits.cfg
+++ b/qemu/tests/cfg/virt_firmware_check_phys_bits.cfg
@@ -26,7 +26,7 @@
                     variants:
                         - _36:
                             host_phys_bits_limit = 36
-                            ignored_err_msg = "Address space limit 0xfffffffff < (?:0x17bfffffff|0x273fffffff) phys-bits too low \(36\)"
+                            ignored_err_msg = "Address space limit 0xfffffffff < 0x\w+ phys-bits too low \(36\)"
                         - _39:
                             host_phys_bits_limit = 39
                         - _46:
@@ -38,7 +38,7 @@
                     variants:
                         - _36:
                             host_phys_bits_limit = 36
-                            ignored_err_msg = "Address space limit 0xfffffffff < (?:0x17bfffffff|0x273fffffff) phys-bits too low \(36\)"
+                            ignored_err_msg = "Address space limit 0xfffffffff < 0x\w+ phys-bits too low \(36\)"
                         - _40:
                             host_phys_bits_limit = 40
                         - _43:
@@ -48,10 +48,10 @@
                             check_sev_cmd = "cat /sys/module/kvm_amd/parameters/sev"
                             check_sev_es_cmd = "cat /sys/module/kvm_amd/parameters/sev_es"
                             enabled_status = "Y,YES,1"
-                            host_memory_encryption_bits = 5
+                            encryption_bits_grep_cmd = "sevctl ok es| grep -m1 'Physical address bit reduction:'| awk '{split($0, arr, " "); print arr[9]}'"
                         - _52:
                             host_phys_bits_limit = 52
                             check_sev_cmd = "cat /sys/module/kvm_amd/parameters/sev"
                             check_sev_es_cmd = "cat /sys/module/kvm_amd/parameters/sev_es"
                             enabled_status = "Y,YES,1"
-                            host_memory_encryption_bits = 5
+                            encryption_bits_grep_cmd = "sevctl ok es| grep -m1 'Physical address bit reduction:'| awk '{split($0, arr, " "); print arr[9]}'"


### PR DESCRIPTION
The memory encryption bit is 5 on Milan and it's 6 on Genoa, so get it dynamically instead of hard-coding.

ID: 1722
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>