### PR TITLE
fix(sve): get-reg-list test is move to parent directory

### DIFF
--- a/qemu/tests/cfg/sve_suite.cfg
+++ b/qemu/tests/cfg/sve_suite.cfg
@@ -1,4 +1,5 @@
 - sve_suite:
+    only RHEL
     type = sve_guest_suite
     only aarch64
     image_snapshot = yes
@@ -21,8 +22,10 @@
             type = sve_host_suite
             vms = ''
             start_vm = no
-            suite_dir = ${dst_dir}/tools/testing/selftests/kvm/
-            execute_suite_cmd = '${suite_dir}/aarch64/get-reg-list'
+            suite_dir = ${dst_dir}/tools/testing/selftests/kvm
+            execute_suite_cmd = '${suite_dir}/get-reg-list'
+            RHEL.8, RHEL9.0, RHEL.9.1, RHEL.9.2, RHEL.9.3:
+                execute_suite_cmd = '${suite_dir}/aarch64/get-reg-list'
             compile_cmd = 'make -C ${suite_dir}'
         - sve_stress:
             suite_dir = ${dst_dir}/tools/testing/selftests/arm64/fp


### PR DESCRIPTION
from kernel commit 17da79e009c376523ab977a351a2a69bad8e847b, the get-reg-list self test is moved from 'aarch64' to parent directory, so fix the issue to execute it.

ID: 1729