### PR TITLE
win_virtio_driver_installer: update balloon test

### DIFF
--- a/provider/win_driver_installer_test.py
+++ b/provider/win_driver_installer_test.py
@@ -20,15 +20,15 @@ from provider.vioinput_basic import key_tap_test as vioinput_test  # pylint: dis
 LOG_JOB = logging.getLogger('avocado.test')
 
 
-driver_name_list = ['viorng', 'viostor', 'vioscsi',
-                    'balloon', 'viofs', 'vioser',
+driver_name_list = ['balloon', 'viostor', 'vioscsi',
+                    'viorng', 'viofs', 'vioser',
                     'pvpanic', 'netkvm', 'vioinput',
                     'fwcfg']
 
-device_hwid_list = ['"PCI\\VEN_1AF4&DEV_1005" "PCI\\VEN_1AF4&DEV_1044"',
+device_hwid_list = ['"PCI\\VEN_1AF4&DEV_1002" "PCI\\VEN_1AF4&DEV_1045"',
                     '"PCI\\VEN_1AF4&DEV_1001" "PCI\\VEN_1AF4&DEV_1042"',
                     '"PCI\\VEN_1AF4&DEV_1004" "PCI\\VEN_1AF4&DEV_1048"',
-                    '"PCI\\VEN_1AF4&DEV_1002" "PCI\\VEN_1AF4&DEV_1045"',
+                    '"PCI\\VEN_1AF4&DEV_1005" "PCI\\VEN_1AF4&DEV_1044"',
                     '"PCI\\VEN_1AF4&DEV_105A"',
                     '"PCI\\VEN_1AF4&DEV_1003" "PCI\\VEN_1AF4&DEV_1043"',
                     '"ACPI\\QEMU0001"',
@@ -36,9 +36,9 @@ device_hwid_list = ['"PCI\\VEN_1AF4&DEV_1005" "PCI\\VEN_1AF4&DEV_1044"',
                     '"PCI\\VEN_1AF4&DEV_1052"',
                     '"ACPI\\VEN_QEMU&DEV_0002"']
 
-device_name_list = ["VirtIO RNG Device", "Red Hat VirtIO SCSI controller",
+device_name_list = ["VirtIO Balloon Driver", "Red Hat VirtIO SCSI controller",
                     "Red Hat VirtIO SCSI pass-through controller",
-                    "VirtIO Balloon Driver", "VirtIO FS Device",
+                    "VirtIO RNG Device", "VirtIO FS Device",
                     "VirtIO Serial Driver", "QEMU PVPanic Device",
                     "Red Hat VirtIO Ethernet Adapter", "VirtIO Input Driver",
                     "QEMU FwCfg Device"]

--- a/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
@@ -98,7 +98,7 @@
             numa_memdev_shm0 = mem-mem1
             numa_nodeid_shm0 = 0
             fs_binary_extra_options = " -o cache=auto"
-            test_drivers = 'viorng viostor vioscsi viofs balloon'
+            test_drivers = 'balloon viostor vioscsi viorng viofs'
             driver_test_name_viorng = 'rng'
             driver_test_name_viostor = 'iozone'
             driver_test_params_viostor = {'images': 'stg0'}

--- a/qemu/tests/win_virtio_driver_update_by_installer.py
+++ b/qemu/tests/win_virtio_driver_update_by_installer.py
@@ -142,8 +142,6 @@ def run(test, params, env):
                                                    expected_gagent_version)
     win_driver_installer_test.driver_check(session, test, params)
 
-    balloon_test_win = BallooningTestWin(test, params, env)
-
     error_context.context("Run driver function test after update",
                           test.log.info)
     fail_tests = []
@@ -157,6 +155,7 @@ def run(test, params, env):
         driver_test_params = params.get('driver_test_params_%s'
                                         % driver_name, '{}')
         if driver_name == "balloon":
+            balloon_test_win = BallooningTestWin(test, params, env)
             driver_test_params = {"balloon_test_win": balloon_test_win}
         else:
             driver_test_params = ast.literal_eval(driver_test_params)


### PR DESCRIPTION
Define balloon test object together with execution. And in the driver
     function loop, move balloon test to the top to avoid possible conflicts.

ID: 1727