### PR TITLE
virtio_fs: extend fio test time when cache is set to None

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -253,6 +253,8 @@
                     smp = 8
                     vcpu_maxcpus = 8
                     io_timeout = 2000
+                    with_fio..with_cache.none:
+                        io_timeout = 7200
                     fio_options = '--name=stress --filename=%s --ioengine=libaio --rw=write --direct=1 '
                     fio_options += '--bs=%s --size=1G --iodepth=256 --numjobs=128 --runtime=1800'
                     Windows:


### PR DESCRIPTION
When cache=None condition, fio test takes more time.
ID: 1751