### PR TITLE
virtio_fs: use dd cmd to create file

### DIFF
--- a/qemu/tests/cfg/virtio_fs_host_owner_win.cfg
+++ b/qemu/tests/cfg/virtio_fs_host_owner_win.cfg
@@ -43,7 +43,8 @@
     virtio_win_media_type = iso
     cdroms += " virtio"
     devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
-    create_file_cmd = 'echo test > %s'
+    # workaround to create a file instead of 'echo' cmd
+    create_file_cmd = 'dd if=/dev/random of=%s bs=1M count=20'
     change_source_owner = chown test:test %s
     change_source_perm = chmod o+w %s
     variants:


### PR DESCRIPTION
Echo cmd sometimes cause timeout issue in automation, and the main test point isn't create files in this case, so using dd cmd to instead of echo cmd.
ID: 1752