### PR TITLE
virt_firmware_check_phys_bits: add support for seabios

### DIFF
--- a/qemu/tests/cfg/virt_firmware_check_phys_bits.cfg
+++ b/qemu/tests/cfg/virt_firmware_check_phys_bits.cfg
@@ -1,15 +1,20 @@
 - virt_firmware_check_phys_bits:
-    only q35
-    only ovmf
+    only x86_64
     type = virt_firmware_check_phys_bits
     not_preprocess = yes
     start_vm = yes
     only Linux
     cpu_model_flags += ",host-phys-bits=on,host-phys-bits-limit=%s"
     phys_bits_grep_cmd = "cat /proc/cpuinfo | grep -m1 'address sizes' | awk '{split($0, arr, " "); print arr[4]}'"
-    limitation_from_ovmf = 46
-    limitation_msg = "limit PhysBits to ${limitation_from_ovmf} \(avoid 5-level paging\)"
     no Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9.u0 Host_RHEL.m9.u1 Host_RHEL.m9.u2
+    ovmf:
+        only q35
+        limitation_from_ovmf = 46
+        limitation_msg = "limit PhysBits to ${limitation_from_ovmf} \(avoid 5-level paging\)"
+        phys_bits_msg = "PhysBits: %d"
+    default_bios:
+        no Host_RHEL.m9.u3
+        phys_bits_msg = "phys-bits=%d"
     variants:
         - with_invalid_value:
             variants:


### PR DESCRIPTION
enable dynamic mmio window on seabios from rhel9.4, so add support for seabios.

ID: 1755
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>