### PR TITLE
hugepage_mem_stress: includes verify_guest_dmesg

### DIFF
--- a/qemu/tests/cfg/hugepage_mem_stress.cfg
+++ b/qemu/tests/cfg/hugepage_mem_stress.cfg
@@ -6,6 +6,7 @@
     Linux:
         del stress_args
         stress_custom_args = "--vm %d --vm-bytes 256M --timeout 30s"
+        verify_guest_dmesg = yes
     Windows:
         x86_64:
             install_path = "C:\Program Files (x86)\JAM Software\HeavyLoad"

--- a/qemu/tests/hugepage_mem_stress.py
+++ b/qemu/tests/hugepage_mem_stress.py
@@ -47,7 +47,6 @@ def run(test, params, env):
                 stress_test.load_stress_tool()
                 utils_misc.wait_for(lambda: (stress_test.app_running is False), 30)
                 stress_test.unload_stress()
-                utils_misc.verify_dmesg(session=session)
             finally:
                 stress_test.clean()
         else:


### PR DESCRIPTION
hugepage_mem_stress: includes verify_guest_dmesg

This commit includes verify_guest_dmesg
as cfg param to avoid any possible failure.

ID: 1760
Signed-off-by: mcasquer <mcasquer@redhat.com>
