### PR TITLE
trans_hugepage.base: enable transparent_hugepages before test

### DIFF
--- a/generic/tests/cfg/trans_hugepage.cfg
+++ b/generic/tests/cfg/trans_hugepage.cfg
@@ -6,6 +6,7 @@
     kill_vm = yes
     login_timeout = 360
     setup_thp = yes
+    test_config = "/sys/kernel/mm/transparent_hugepage/enabled:always"
     variants:
         - base:
             no aarch64 s390x


### PR DESCRIPTION
trans_hugepage.base: enable transparent_hugepages before test

Enables THPs before starting the test to avoid any possible
failure in case it had been disabled before.

ID: 1757
Signed-off-by: mcasquer <mcasquer@redhat.com>