### PR TITLE
numa_node_affinity: creates new node-affinity test case

### DIFF
--- a/qemu/tests/cfg/numa_node_affinity.cfg
+++ b/qemu/tests/cfg/numa_node_affinity.cfg
@@ -1,0 +1,9 @@
+- numa_node_affinity:
+    no RHEL.6 RHEL.7 RHEL.8
+    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+    required_qemu = [7.2,)
+    type = numa_node_affinity
+    virt_test_type = qemu
+    not_preprocess = yes
+    vm_thread_contexts = "tc1"
+    error_msg = "Property 'thread-context.node-affinity' is not readable"

--- a/qemu/tests/numa_node_affinity.py
+++ b/qemu/tests/numa_node_affinity.py
@@ -1,0 +1,62 @@
+import re
+
+from virttest import env_process
+from virttest import error_context
+from virttest import utils_misc
+
+from virttest.qemu_monitor import QMPCmdError
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    numa_node_affinity test
+    1) Check the NUMA topology, cancel if there is a single node.
+    2) Boot up a guest with node-affinity selecting the first valid node.
+    3) Check the cpu-affinity obtained from QEMU is correct.
+    4) Check the node-affinity property is not readable.
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    host_numa_node = utils_misc.NumaInfo()
+    node_list = host_numa_node.online_nodes_withcpu
+    if len(node_list) < 2:
+        test.cancel("Host only has one NUMA node, skipping test...")
+
+    error_msg = params.get("error_msg",
+                           "Property 'thread-context.node-affinity' is not readable")
+    node_affinity = node_list[0]
+    node = utils_misc.NumaNode(node_affinity)
+    params["vm_thread_context_node-affinity"] = str(node_affinity)
+    vm_name = params['main_vm']
+    env_process.preprocess_vm(test, params, env, vm_name)
+    vm = env.get_vm(vm_name)
+    vm.verify_alive()
+
+    thread_context_device = vm.devices.get_by_params({"backend": "thread-context"})[0]
+    thread_context_device_id = thread_context_device.get_param("id")
+
+    error_context.base_context("Get the CPU affinity", test.log.info)
+    cpu_affinity = vm.monitor.qom_get(thread_context_device_id, "cpu-affinity")
+    cpu_affinity = list(map(str, cpu_affinity))
+    error_context.base_context("Get the host node cpus", test.log.info)
+    host_node_cpus = node.get_node_cpus(node_affinity).split()
+
+    if cpu_affinity != host_node_cpus:
+        test.fail("The cpu-affinity does not match with the node topology!")
+
+    try:
+        error_context.base_context("Trying to read node-affinity",
+                                   test.log.info)
+        node_affinity = vm.monitor.qom_get(thread_context_device_id,
+                                           "node-affinity")
+    except QMPCmdError as e:
+        if not re.search(error_msg, str(e.data)):
+            test.fail("Cannot get expected error message: %s" % error_msg)
+        test.log.debug("Get the expected error message: %s" % error_msg)
+    else:
+        test.fail("Got the node-affinity: %s however it is expected to be a non-readable property"
+                  % str(node_affinity))


### PR DESCRIPTION
numa_node_affinity: creates new node-affinity test case

Creates a new case that tests the node-affinity property.
For it, boots up a guest with a valid node set, checks
the cpu-affinity status and finally verifies that the
property is not readable.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 1789