### PR TITLE
trans_hugepage.defrag: re-design test case

### DIFF
--- a/generic/tests/cfg/trans_hugepage.cfg
+++ b/generic/tests/cfg/trans_hugepage.cfg
@@ -15,7 +15,14 @@
             #The file is different for different product, different arch, check in py
             largepages_files = 'pages_2m pages_1g num_2M_pages num_1G_pages lpages largepages'
         - defrag:
+            no s390x
             type = trans_hugepage_defrag
+            dst_dir = "/var/tmp"
+            pre_command = "rm -rf ${dst_dir}/thp_fragment*"
+            post_command = "rm -rf ${dst_dir}/thp_fragment*"
+            test_bin = "${dst_dir}/thp_fragment"
+            source_file = "thp_fragment.c"
+            source_package = "thp_fragment.tar.gz"
         - swapping:
             type = trans_hugepage_swapping
             dd_timeout = 900

--- a/generic/tests/trans_hugepage_defrag.py
+++ b/generic/tests/trans_hugepage_defrag.py
@@ -1,80 +1,50 @@
 import time
 import os
-import re
 
 from avocado.utils import process
+
+from virttest import data_dir
 from virttest import test_setup
 from virttest import error_context
+from virttest import kernel_interface
+from virttest import utils_misc
 
 
 @error_context.context_aware
 def run(test, params, env):
     """
-    KVM khugepage userspace side test:
-    1) Verify that the host supports kernel hugepages.
-        If it does proceed with the test.
-    2) Verify that the kernel hugepages can be used in host.
-    3) Verify that the kernel hugepages can be used in guest.
-    4) Use dd and tmpfs to make fragement in memory
-    5) Use libhugetlbfs to allocated huge page before start defrag
-    6) Set the khugepaged do defrag
-    7) Use libhugetlbfs to allocated huge page compare the value
+    Transparent hugepage defrag test:
+    1) Copy and compile the THP defrag tool.
+    2) Turn off the defrag value.
+    3) Get the number of THPs allocated using the tool.
+    4) Turn on the defrag in THP.
+    5) Get again the number of THPs allocated using the tool, this one
+       should be higher than previous one.
 
     :param test: QEMU test object.
     :param params: Dictionary with test parameters.
     :param env: Dictionary with the test environment.
     """
-    def get_mem_stat(param):
-        """
-        Get the memory size for a given memory param.
-
-        :param param: Memory parameter.
-        """
-        with open('/proc/meminfo', 'r') as f:
-            for line in f.readlines():
-                if line.startswith("%s" % param):
-                    output = re.split(r'\s+', line)[1]
-            return int(output)
-
-    def set_libhugetlbfs(number):
-        """
-        Set the number of hugepages on the system.
-
-        :param number: Number of pages (either string or numeric).
-        """
-        test.log.info("Trying to setup %d hugepages on host", number)
-        with open("/proc/sys/vm/nr_hugepages", "w+") as f:
-            pre_ret = f.read()
-            test.log.debug("Number of huge pages on libhugetlbfs"
-                           " (pre-write): %s", pre_ret.strip())
-            f.write(str(number))
-            f.seek(0)
-            ret = f.read()
-            test.log.debug("Number of huge pages on libhugetlbfs:"
-                           " (post-write): %s", ret.strip())
-            return int(ret)
-
-    def change_feature_status(test, status, feature_path, test_config):
+    def change_feature_status(status, feature_path, test_config):
         """
         Turn on/off feature functionality.
 
         :param status: String representing status, may be 'on' or 'off'.
-        :param relative_path: Path of the feature relative to THP config base.
+        :param feature_path: Path of the feature relative to THP config base.
         :param test_config: Object that keeps track of THP config state.
 
         :raise: error.TestFail, if can't change feature status
         """
-        feature_path = os.path.join(test_config.thp_path, feature_path)
-        feature_file = open(feature_path, 'r')
-        feature_file_contents = feature_file.read()
-        feature_file.close()
-        possible_values = test_config.value_listed(feature_file_contents)
+
+        thp = kernel_interface.SysFS(os.path.join(test_config.thp_path, feature_path),
+                                     session=None)
+        possible_values = [each.strip("[]") for each in thp.fs_value.split()]
 
         if 'yes' in possible_values:
             on_action = 'yes'
             off_action = 'no'
-        elif 'always' in possible_values:
-            on_action = 'always'
+        elif 'madvise' in possible_values:
+            on_action = 'madvise'
             off_action = 'never'
         elif '1' in possible_values or '0' in possible_values:
             on_action = '1'
@@ -88,74 +58,49 @@ def run(test, params, env):
         elif status == 'off':
             action = off_action
 
-        try:
-            feature_file = open(feature_path, 'w')
-            feature_file.write(action)
-            feature_file.close()
-        except IOError as e:
-            test.fail("Error writing %s to %s: %s" % (action, feature_path, e))
+        thp.sys_fs_value = action
         time.sleep(1)
 
-    def fragment_host_memory(mem_path):
-        """
-        Attempt to fragment host memory.
-
-        It accomplishes that goal by spawning a large number of dd processes
-        on a tmpfs mount.
-
-        :param mem_path: tmpfs mount point.
-        """
-        error_context.context("Fragmenting host memory")
-        try:
-            test.log.info("Prepare tmpfs in host")
-            if not os.path.isdir(mem_path):
-                os.makedirs(mem_path)
-            process.run("mount -t tmpfs none %s" % mem_path, shell=True)
-            test.log.info("Start using dd to fragment memory in guest")
-            cmd = ("for i in `seq 262144`; do dd if=/dev/urandom of=%s/$i "
-                   "bs=4K count=1 & done" % mem_path)
-            process.run(cmd, shell=True)
-        finally:
-            process.run("umount %s" % mem_path, shell=True)
-
-    test_config = test_setup.TransparentHugePageConfig(test, params)
+    dst_dir = params.get("dst_dir", "/var/tmp")
+    test_bin = params.get("test_bin", "/var/tmp/thp_fragment")
+    source_file = params.get("source_file", "thp_fragment.c")
+    source_package = params.get("source_package", "thp_fragment.tar.gz")
+    host_path = utils_misc.get_path(data_dir.get_deps_dir('thp_defrag_tool'),
+                                    source_package)
+    copy_cmd = "cp -rf %s %s" % (host_path, dst_dir)
+    if process.system(copy_cmd, ignore_status=True, shell=True) != 0:
+        test.fail("Failed on copying the tool package!")
+    extract_cmd = "cd %s; tar xzvf %s" % (dst_dir, source_package)
+    if process.system(extract_cmd, ignore_status=True, shell=True) != 0:
+        test.fail("Failed extracting the tool package: %s" % source_package)
+    build_cmd = "cd %s; gcc -lrt %s -o %s" % (dst_dir,
+                                              source_file,
+                                              test_bin)
+    error_context.context("Build binary file '%s'" % test_bin, test.log.info)
+    if process.run(build_cmd, ignore_status=True, shell=True).exit_status != 0:
+        test.fail("Failed building the the tool binary: %s" % test_bin)
+    test_config = test_setup.TransparentHugePageConfig(test, params, env)
     test.log.info("Defrag test start")
-    login_timeout = float(params.get("login_timeout", 360))
-    mem_path = os.path.join("/tmp", "thp_space")
 
-    try:
-        error_context.context("deactivating khugepaged defrag functionality")
-        change_feature_status(test, "off", "khugepaged/defrag", test_config)
-        change_feature_status(test, "off", "defrag", test_config)
+    error_context.context("deactivating khugepaged defrag functionality",
+                          test.log.info)
+    change_feature_status("off", "khugepaged/defrag", test_config)
+    change_feature_status("off", "defrag", test_config)
 
-        vm = env.get_vm(params.get("main_vm"))
-        session = vm.wait_for_login(timeout=login_timeout)
+    thps_defrag_off = int(process.getoutput(test_bin, shell=True).split()[1])
+    test.log.debug("THPs allocated with defrag off: %d" % thps_defrag_off)
 
-        fragment_host_memory(mem_path)
+    error_context.context("activating khugepaged defrag functionality",
+                          test.log.info)
+    change_feature_status("on", "khugepaged/defrag", test_config)
+    change_feature_status("on", "defrag", test_config)
 
-        total = get_mem_stat('MemTotal')
-        hugepagesize = get_mem_stat('Hugepagesize')
-        nr_full = int(0.8 * (total / hugepagesize))
+    thps_defrag_on = int(process.getoutput(test_bin, shell=True).split()[1])
+    test.log.debug("THPs allocated with defrag on: %d" % thps_defrag_on)
 
-        nr_hp_before = set_libhugetlbfs(nr_full)
-
-        error_context.context("activating khugepaged defrag functionality")
-        change_feature_status(test, "on", "khugepaged/defrag", test_config)
-        change_feature_status(test, "on", "defrag", test_config)
-
-        sleep_time = 10
-        test.log.debug("Sleeping %s s to settle things out", sleep_time)
-        time.sleep(sleep_time)
-
-        nr_hp_after = set_libhugetlbfs(nr_full)
-
-        if nr_hp_before >= nr_hp_after:
-            test.fail("No memory defragmentation on host: "
-                      "%s huge pages before turning "
-                      "khugepaged defrag on, %s after it" %
-                      (nr_hp_before, nr_hp_after))
-        test.log.info("Defrag test succeeded")
-        session.close()
-    finally:
-        test.log.debug("Cleaning up libhugetlbfs on host")
-        set_libhugetlbfs(0)
+    if thps_defrag_off >= thps_defrag_on:
+        test.fail("No memory defragmentation on host: "
+                  "%s THPs before turning "
+                  "khugepaged defrag on, %s after it" %
+                  (thps_defrag_off, thps_defrag_on))
+    test.log.info("Defrag test succeeded")


### PR DESCRIPTION
Depends on https://github.com/autotest/tp-qemu/pull/3933

trans_hugepage.defrag: re-design test case

Changes test case functionality in order to make use
of the thp_fragment tool, this way the defragmentation
could be properly tested. Keeps the original comparison
of THPs allocated w/wo defrag enabled.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 1419