### PR TITLE
uefishell.check_smbios: update the default version of smbios

### DIFF
--- a/qemu/tests/cfg/uefishell.cfg
+++ b/qemu/tests/cfg/uefishell.cfg
@@ -81,7 +81,9 @@
             command_smbios = "smbiosview"
             variants:
                 - @default:
-                    check_result_smbios = "Version.*:\s+2\.\d+"
+                    check_result_smbios = "Version.*:\s+3\.\d+"
+                    Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3:
+                        check_result_smbios = "Version.*:\s+2\.\d+"
                 - with_entry_point:
                     no Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9.u0 Host_RHEL.m9.u1
                     smbios_output_handler = "handle_smbiosview"


### PR DESCRIPTION
The default version of smbios is 3.0 from RHEL-9.4, so update it.

ID: 1862
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>