### PR TITLE
Do not backup and remove test image after test finish

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -1,7 +1,8 @@
 - unattended_install:
     virt_test_type = qemu libvirt
     type = unattended_install
-    backup_image_after_testing_passed = yes
+    images = image1
+    backup_image_after_testing_passed_image1 = yes
     start_vm = no
     kill_vm = yes
     kill_vm_gracefully = yes
@@ -44,7 +45,7 @@
     # random time in the range random.randint(0, install_trigger_time)
     random_trigger = "no"
     ovmf:
-      only q35
+        only q35
     variants:
         - aio_native:
             image_aio = native

--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -3,7 +3,8 @@
     cd_format_fixed = ide
     q35:
         cd_format_fixed = ahci
-    clone_master = yes
+    images = image1
+    clone_master_image1 = yes
     master_images_clone = image1
     remove_image_image1 = yes
     only Windows


### PR DESCRIPTION
1.unattended_install..multi_disk_install: don't backup the test disk
2.single_dirver_install: for viostor and vioscsi, remove the test image stg1 with name 'storage' after test finish

ID: 1852, 1854

Signed-off-by: Yanan Fu <yfu@redhat.com>
