### PR TITLE
rng_bat.cfg: fix Mandatory parameter missing issue

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -17,7 +17,7 @@
             devcon_dirname = "x86"
         x86_64:
             devcon_dirname = "amd64"
-    	devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
+        devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
         need_memory_leak_check = yes
     Linux:
         session_cmd_timeout = 360
@@ -35,7 +35,7 @@
         s390x:
             RHEL.9:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
-   variants:
+    variants:
         - @default:
         - iommu_enabled:
             only q35


### PR DESCRIPTION
fix Mandatory parameter 'devcon_path'
is missing, the root cause is that
Mix spaces and tabs before 'devcon_path'.

ID: 1860
Signed-off-by: menli <menli@redhat.com>