### PR TITLE
migration_virtio_mem_ignore_shared: creates new test case

### DIFF
--- a/qemu/tests/cfg/migration_virtio_mem_ignore_shared.cfg
+++ b/qemu/tests/cfg/migration_virtio_mem_ignore_shared.cfg
@@ -1,0 +1,35 @@
+- migration_virtio_mem_ignore_shared:
+    only Linux
+    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+    no RHEL.6 RHEL.7 RHEL.8
+    no s390x
+    required_qemu = [8.1.0,)
+    type = migration_virtio_mem_ignore_shared
+    virt_test_type = qemu
+    threshold = 0.025
+    mem_threshold = 0.01
+    aarch64:
+        mem_threshold = 0.1
+    smp = 8
+    vcpu_maxcpus = ${smp}
+    slots_mem = 20
+    maxmem_mem = 80G
+    mem = 4096
+    share_mem = yes
+    vm_mem_share = yes
+    mem_devs = 'mem0'
+    backend_mem = memory-backend-file
+    vm_mem_backend = memory-backend-file
+    mem-path = "/dev/shm/mem0"
+    vm_mem_backend_path = "/dev/shm/machine_mem"
+    vm_memdev_model_mem0 = "virtio-mem"
+    size_mem_mem0 = 8G
+    use_mem_mem0 = yes
+    requested-size_memory_mem0 = 8G
+    memdev_memory_mem0 = "mem-mem0"
+    kernel_extra_params_add = "memhp_default_state=online_movable"
+    pcie_extra_root_port = 0
+    requested-size_test_vmem0 = "4G 0 8G"
+    mig_timeout = 1200
+    migration_protocol = "tcp"
+    migrate_capabilities = "{'x-ignore-shared': 'on'}"

--- a/qemu/tests/migration_virtio_mem_ignore_shared.py
+++ b/qemu/tests/migration_virtio_mem_ignore_shared.py
@@ -1,0 +1,108 @@
+import ast
+import time
+
+from virttest import error_context
+from virttest import utils_test
+
+from virttest.utils_misc import normalize_data_size
+
+from provider import virtio_mem_utils
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Migrates a guest with virtio-mem device and x-ignore-shared enabled
+    1) Boot source and destination VMs with a virtio-mem device
+       and shared memory.
+    2) Enable x-ignore-shared capability in both hosts.
+    3) Check the capability is enabled.
+    4) Start stress tool in source VM.
+    5) Migrate VM.
+    6) Memory tool stress is stopped and migration completed.
+    7) Prove the total ram migrated is a little amount.
+    8) Resize the virtio-mem device in destination a couple of times.
+    9) Ascertain the virtio-mem device work properly.
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    threshold = params.get_numeric("threshold", target_type=float)
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    # Stress in source VM
+    error_context.base_context("Install and compile stress tool",
+                               test.log.info)
+    test_mem = params.get_numeric("mem", target_type=float)
+    params["stress_args"] = '--cpu 4 --io 4 --vm 2 --vm-bytes %fM' % float(test_mem * 0.8)
+    clone = None
+    try:
+        stress_test = utils_test.VMStress(vm, "stress", params)
+        error_context.context("Stress test start", test.log.info)
+        try:
+            stress_test.load_stress_tool()
+            # Migration
+            error_context.base_context("Set migrate capabilities and do migration",
+                                       test.log.info)
+            capabilities = ast.literal_eval(params.get("migrate_capabilities",
+                                                       "{'x-ignore-shared': 'on'}"))
+            mig_timeout = params.get_numeric("mig_timeout", 1200, float)
+            mig_protocol = params.get("migration_protocol", "tcp")
+            clone = vm.migrate(mig_timeout,
+                               mig_protocol,
+                               env=env,
+                               migrate_capabilities=capabilities,
+                               not_wait_for_migration=True)
+
+            vm.wait_for_migration(mig_timeout)
+
+            clone.resume()
+            error_context.context("Check the total ram migrated", test.log.info)
+            total_mem_migrated = str(vm.monitor.info("migrate")['ram']['total'])
+            total_mem_migrated = float(normalize_data_size(total_mem_migrated, 'M'))
+            test.log.debug("Total memory migrated: %f" % total_mem_migrated)
+
+            mem_threshold = params.get_numeric("mem_threshold", target_type=float)
+            if total_mem_migrated > test_mem * mem_threshold:
+                test.error("Error, more memory than expected has been migrated!")
+
+            test.log.debug("Stress tool running status: %s" % stress_test.app_running())
+            if not stress_test.app_running():
+                test.fail("Stress tool must be running at this point!")
+
+        except utils_test.StressError as guest_info:
+            test.error(guest_info)
+
+        finally:
+            stress_test.unload_stress()
+            stress_test.clean()
+
+        error_context.base_context("Test virtio-mem device on destination VM",
+                                   test.log.info)
+        virtio_mem_model = 'virtio-mem-pci'
+        if '-mmio:' in params.get("machine_type"):
+            virtio_mem_model = 'virtio-mem-device'
+        vmem_dev = clone.devices.get_by_params({'driver': virtio_mem_model})[0]
+        device_id = vmem_dev.get_qid()
+        requested_size_vmem = params.get("requested-size_test_vmem0")
+        for requested_size in requested_size_vmem.split():
+            req_size_normalized = int(float(normalize_data_size(requested_size,
+                                                                'B')))
+            clone.monitor.qom_set(device_id, "requested-size", req_size_normalized)
+            time.sleep(45)
+            virtio_mem_utils.check_memory_devices(device_id,
+                                                  requested_size,
+                                                  threshold,
+                                                  clone,
+                                                  test)
+            virtio_mem_utils.check_numa_plugged_mem(0,
+                                                    requested_size,
+                                                    threshold,
+                                                    clone,
+                                                    test)
+    finally:
+        if clone:
+            clone.destroy(gracefully=False)
+            env.unregister_vm("%s_clone" % vm.name)


### PR DESCRIPTION
migration_virtio_mem_ignore_shared: creates new test case

Creates new case to test virtio-mem device migration with
x-ignore-shared capability enabled. It starts both guests,
source and destination ones, then puts some stress in the
first one during the migration process. Finally, does the
migration and checks that, only a little amount of memory
has been migrated because of the capability and the virtio-mem
device works as expected.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 1334