### PR TITLE
balloon_in_use: extend balloon memory timeout

### DIFF
--- a/qemu/tests/cfg/balloon_in_use.cfg
+++ b/qemu/tests/cfg/balloon_in_use.cfg
@@ -11,7 +11,7 @@
     bg_stress_run_flag = balloon_test
     set_bg_stress_flag = yes
     session_cmd_timeout = 240
-    balloon_timeout = 240
+    balloon_timeout = 480
     check_setup_events = balloon_test_setup_ready
     Windows:
         stress_test = win_video_play


### PR DESCRIPTION
Sometimes, balloon memory from a little value to a large one, it will take a bit longer time.
ID: 1885