### PR TITLE
vdpa_sim_utils.py: add module for VDPA net device interface.

### DIFF
--- a/qemu/tests/block_vhost_vdpa_test.py
+++ b/qemu/tests/block_vhost_vdpa_test.py
@@ -3,7 +3,7 @@ from avocado.core import exceptions
 from avocado.utils import process
 
 from provider.block_devices_plug import BlockDevicesPlug
-from provider.vdpa_sim_blk_utils import VhostVdpaSimulatorTest
+from provider.vdpa_sim_utils import VhostVdpaBlkSimulatorTest
 from virttest import env_process, utils_disk, utils_misc, virt_vm
 from virttest.utils_misc import get_linux_drive_path
 from virttest.utils_windows.drive import get_disk_props_by_serial_number
@@ -40,12 +40,12 @@ def run(test, params, env):
 
     def _setup_vdpa_disks():
         for img in vdpa_blk_images:
-            dev = vdpa_blk_test.add_vdpa_blk_dev(img)
+            dev = vdpa_blk_test.add_dev(img)
             logger.debug("Add vhost device %s %s" % (img, dev))
 
     def _cleanup_vdpa_disks():
         for img in vdpa_blk_images:
-            vdpa_blk_test.remove_vdpa_blk_dev(img)
+            vdpa_blk_test.remove_dev(img)
 
     def _get_window_disk_index_by_serial(serial):
         idx_info = get_disk_props_by_serial_number(session, serial, ["Index"])
@@ -108,7 +108,7 @@ def run(test, params, env):
         test_vm = params.get("test_vm", "no")
 
         logger.debug("Deploy VDPA blk env on host...")
-        vdpa_blk_test = VhostVdpaSimulatorTest()
+        vdpa_blk_test = VhostVdpaBlkSimulatorTest()
         vdpa_blk_test.setup()
 
         logger.debug("Add VDPA blk disk on host...")

--- a/qemu/tests/vdpa_sim_blk_test.py
+++ b/qemu/tests/vdpa_sim_blk_test.py
@@ -3,7 +3,7 @@
 from avocado.utils import process
 
 from provider.block_devices_plug import BlockDevicesPlug
-from provider.vdpa_sim_blk_utils import VirtioVdpaSimulatorTest
+from provider.vdpa_sim_utils import VirtioVdpaBlkSimulatorTest
 from virttest import env_process, utils_disk, utils_misc
 from virttest.utils_misc import get_linux_drive_path
 from virttest.utils_windows.drive import get_disk_props_by_serial_number
@@ -41,7 +41,7 @@ def run(test, params, env):
 
     def _setup_vdpa_disks():
         for img in vdpa_blk_images:
-            dev = vdpa_blk_test.add_vdpa_blk_dev(img)
+            dev = vdpa_blk_test.add_dev(img)
             vdpa_blk_info[img] = "/dev/%s" % dev
             params["image_name_%s" % img] = vdpa_blk_info[img]
             cmd = host_cmd.format(dev)
@@ -49,7 +49,7 @@ def run(test, params, env):
 
     def _cleanup_vdpa_disks():
         for img in vdpa_blk_images:
-            vdpa_blk_test.remove_vdpa_blk_dev(img)
+            vdpa_blk_test.remove_dev(img)
 
     def _get_window_disk_index_by_serial(serial):
         idx_info = get_disk_props_by_serial_number(session, serial, ["Index"])
@@ -108,7 +108,7 @@ def run(test, params, env):
         test_vm = params.get("test_vm", "no")
 
         logger.debug("Deploy VDPA blk env on host...")
-        vdpa_blk_test = VirtioVdpaSimulatorTest()
+        vdpa_blk_test = VirtioVdpaBlkSimulatorTest()
         vdpa_blk_test.setup()
 
         logger.debug("Add VDPA blk disk on host...")


### PR DESCRIPTION
    vdpa_sim_utils.py: add module for VDPA net device interface

    vdpa_sim_utils.py:
      1. repalce filename from vdpa_sim_blk_utils to vdpa_sim_utils
      2. update the VDPA block interfaces
      3. add Class VhostVdpaNetSimulator
    block_vhost_vdpa_test.py: point to new VhostVdpaBlkSimulatorTest
    vdpa_sim_blk_test.py: point to new VhostVdpaBlkSimulatorTest

ID:1929
Signed-off-by: Wenli Quan <wquan@redhat.com>