### PR TITLE
Deprecate methods from threading module

### DIFF
--- a/generic/tests/iozone_windows.py
+++ b/generic/tests/iozone_windows.py
@@ -65,7 +65,7 @@ def run(test, params, env):
             args = (iozone_cmd.format(disk_letter), iozone_timeout)
             thread_maps[disk_letter] = (iozone_session.cmd, args)
             iozone_thread = utils_misc.InterruptedThread(iozone_session.cmd, args)
-            iozone_thread.setName(disk_letter)
+            iozone_thread.name = disk_letter
             iozone_threads.append(iozone_thread)
             iozone_thread.start()
 
@@ -75,12 +75,12 @@ def run(test, params, env):
                 if iozone_thread.is_alive():
                     continue
                 else:
-                    thread_name = iozone_thread.getName()
+                    thread_name = iozone_thread.name
                     iozone_threads.remove(iozone_thread)
                     iozone_threads.append(
                         utils_misc.InterruptedThread(thread_maps[thread_name][0],
                                                      thread_maps[thread_name][1]))
-                    iozone_threads[-1].setName(thread_name)
+                    iozone_threads[-1].name = thread_name
                     iozone_threads[-1].start()
 
         for iozone_thread in iozone_threads:

--- a/multi_host_migration/tests/migration_multi_host_with_file_transfer.py
+++ b/multi_host_migration/tests/migration_multi_host_with_file_transfer.py
@@ -137,7 +137,7 @@ def run(test, params, env):
 
         def _copy_until_end(self, end_event):
             # Copy until migration not end.
-            while not end_event.isSet():
+            while not end_event.is_set():
                 logging.info("Copy file to guest %s.", self.vm_addr)
                 remote.copy_files_to(self.vm_addr, "scp", guest_root,
                                      guest_pass, 22, host_path,

--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -1368,7 +1368,7 @@ def run(test, params, env):
                 i += 1
                 time.sleep(2)
             if not threads[0].is_alive():
-                if EXIT_EVENT.isSet():
+                if EXIT_EVENT.is_set():
                     test.fail("Exit event emitted, check the log "
                               "for send/recv thread failure.")
                 else:


### PR DESCRIPTION
There are a few threading methods been deprecated since Python3.10, let's replace them according to the guide.

Reference: https://docs.python.org/3/whatsnew/3.10.html#deprecated

ID: 1791