### PR TITLE
Updated dumped image info since it changed start from qemu.8.2.0

### DIFF
--- a/qemu/tests/thin_write_in_qemu_img_commit.py
+++ b/qemu/tests/thin_write_in_qemu_img_commit.py
@@ -51,17 +51,14 @@ def run(test, params, env):
         qemu_version = env_process._get_qemu_version(qemu_path)
         match = re.search(r'[0-9]+\.[0-9]+\.[0-9]+(\-[0-9]+)?', qemu_version)
         host_qemu = match.group(0)
+        expected = {
+            "length": int(utils_numeric.normalize_data_size(
+                params["write_size"], "B")),
+            "start": 0, "depth": 0, "zero": True, "data": False}
         if host_qemu in VersionInterval('[6.1.0,)'):
-            expected = {
-                "length": int(utils_numeric.normalize_data_size(
-                    params["write_size"], "B")),
-                "start": 0, "depth": 0, "present": True, "zero": True,
-                "data": False}
-        else:
-            expected = {
-                "length": int(utils_numeric.normalize_data_size(
-                    params["write_size"], "B")),
-                "start": 0, "depth": 0, "zero": True, "data": False}
+            expected["present"] = True
+        if host_qemu in VersionInterval('[8.2.0,)'):
+            expected["compressed"] = False
         if expected not in json.loads(output.stdout_text):
             test.fail("Commit failed, data from 0 to %s are not zero" %
                       params["write_size"])


### PR DESCRIPTION
disk_format: Add '"compressed": False' since the behavior has been
changed start from qemu.8.2.0

ID: 1950

Signed-off-by: Boqiao Fu <bfu@redhat.com>