### PR TITLE
balloon_check: extent vm login timeout after evict memory

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -92,6 +92,9 @@
         - balloon_evict:
             # Disable balloon_base case as it not run any sub test
             no balloon_base
+            Windows:
+                balloon-reboot:
+                    login_timeout = 600
             run_sub_test_after_balloon = yes
             test_tags = "evict"
             balloon_type = evict


### PR DESCRIPTION
As guest memory was ballooned to a very small value, it leads to the guest couldn't boot up in a short period.
Therefore, it's better to extend the timeout of os booting up.
ID: 1975