### PR TITLE
single_driver_install: install viomem driver

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -155,3 +155,17 @@
             device_name = "QEMU FwCfg Device"
             device_hwid = '"ACPI\VEN_QEMU&DEV_0002"'
             vmcoreinfo = yes
+        - with_viomem:
+            no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+            required_virtio_win_prewhql = [0.1.251, )
+            required_virtio_win = [1.9.40.0, )
+            maxmem_mem = 80G
+            mem_fixed = 4096
+            mem_devs = 'vmem0'
+            vm_memdev_model_vmem0 = "virtio-mem"
+            size_mem_vmem0 = 8G
+            requested-size_memory_vmem0 = 1G
+            memdev_memory_vmem0 = "mem-vmem0"
+            driver_name = "viomem"
+            device_name = "VirtIO Viomem Driver"
+            device_hwid = '"PCI\VEN_1AF4&DEV_1002" "PCI\VEN_1AF4&DEV_1058"'


### PR DESCRIPTION
Install viomem driver in a preinstalled windows guest.
ID: 1974

Signed-off-by: menli <menli@redhat.com>