### PR TITLE
viomem: support viomem driver for win driver case

### DIFF
--- a/qemu/tests/cfg/virtio_driver_sign_check.cfg
+++ b/qemu/tests/cfg/virtio_driver_sign_check.cfg
@@ -66,3 +66,7 @@
             tested_driver = viofs
         - with_fwcfg:
             tested_driver = fwcfg
+        - with_viomem:
+            required_virtio_win_prewhql = [0.1.251, )
+            required_virtio_win = [1.9.40.0, )
+            tested_driver = viomem

--- a/qemu/tests/cfg/win_sigverif.cfg
+++ b/qemu/tests/cfg/win_sigverif.cfg
@@ -94,3 +94,16 @@
             numa_nodeid_shm0 = 0
             driver_name = viofs
             device_name = "VirtIO FS Device"
+        - with_viomem:
+            no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+            required_virtio_win_prewhql = [0.1.251, )
+            required_virtio_win = [1.9.40.0, )
+            maxmem_mem = 80G
+            mem_fixed = 4096
+            mem_devs = 'vmem0'
+            vm_memdev_model_vmem0 = "virtio-mem"
+            size_mem_vmem0 = 8G
+            requested-size_memory_vmem0 = 1G
+            memdev_memory_vmem0 = "mem-vmem0"
+            driver_name = "viomem"
+            device_name = "VirtIO Viomem Driver"


### PR DESCRIPTION
Support viomem driver in win_sigverify and virtio_driver_sign_check test cases.

ID: 1984, 1985

Signed-off-by: menli <menli@redhat.com>