### PR TITLE
pvpanic_event_check: add time to prevent failure

### DIFF
--- a/qemu/tests/cfg/pvpanic_event_check.cfg
+++ b/qemu/tests/cfg/pvpanic_event_check.cfg
@@ -3,8 +3,8 @@
     virt_test_type = qemu
     only Linux
     only x86_64
-    check_kdump_service = "service kdump status"
-    kdump_expect_status = "Active: active"
+    check_kdump_service = "systemctl is-active kdump.service"
+    kdump_expect_status = "active"
     setup_guest_cmd = "grubby --update-kernel=ALL --args="crash_kexec_post_notifiers=1""
     check_kexec_cmd = "dmesg | grep crash_kexec_post_notifiers=1"
     expect_event = "GUEST_CRASHLOADED"


### PR DESCRIPTION
This patch is primarily needed to add time for waiting until the service has finished. In addition, it replaces a simpler command for checking the service's status.

ID: 1341

Signed-off-by: wji <wji@redhat.com>
