### PR TITLE
multi_disk_wild_hotplug:specify the boot index explicitly

### DIFF
--- a/qemu/tests/cfg/multi_disk_wild_hotplug.cfg
+++ b/qemu/tests/cfg/multi_disk_wild_hotplug.cfg
@@ -11,6 +11,7 @@
     stg_image_name = "images/stg%s"
     stg_image_size = 256M
     vt_ulimit_nofile = 65536
+    bootindex_image1 = 0
     variants:
         - without_delay:
             stg_image_num = 3


### PR DESCRIPTION
It can not find boot disk if exist multiple scsi disks. It need to specify the boot index explicitly.

ID:2006