### PR TITLE
virtio_win_installer: update installer repair function

### DIFF
--- a/provider/win_driver_utils.py
+++ b/provider/win_driver_utils.py
@@ -215,6 +215,27 @@ def run_installer(vm, session, test, params, run_installer_cmd):
     return session
 
 
+def remove_driver_by_msi(session, vm, params):
+    """
+    Remove virtio_win drivers by msi.
+
+    :param session: The guest session object
+    :param vm:
+    :param params: the dict used for parameters
+    :return: a new session after restart os
+    """
+    media_type = params.get("virtio_win_media_type", "iso")
+    get_drive_letter = getattr(virtio_win, "drive_letter_%s" % media_type)
+    drive_letter = get_drive_letter(session)
+    msi_path = drive_letter + "\\" + params["msi_name"]
+    msi_uninstall_cmd = params["msi_uninstall_cmd"] % msi_path
+    vm.send_key('meta_l-d')
+    # msi uninstall cmd will restart os.
+    session.cmd(msi_uninstall_cmd)
+    time.sleep(15)
+    return vm.wait_for_login(timeout=360)
+
+
 def copy_file_to_samepath(session, test, params):
     """
     Copy autoit scripts and installer tool to the same path.

--- a/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
@@ -243,6 +243,7 @@
         - driver_repair:
             only all_drivers
             type = win_virtio_driver_installer_repair
+            msi_uninstall_cmd = "msiexec.exe /q /passive /x %s"
         - driver_uninstall:
             only all_drivers
             driver_test_names = ''

--- a/qemu/tests/win_virtio_driver_installer_repair.py
+++ b/qemu/tests/win_virtio_driver_installer_repair.py
@@ -1,8 +1,6 @@
 import ast
-import time
 
 from virttest import error_context
-from virttest import utils_misc
 
 from provider import win_driver_utils
 from provider import win_driver_installer_test
@@ -19,106 +17,72 @@ def run(test, params, env):
     1) Create shared directories on the host.
     2) Run virtiofsd daemons on the host.
     3) Boot guest with all virtio device.
-    4) Install driver via virtio-win-guest-tools.exe.
-    5) Run virtio-win-guest-tools.exe signature check command in guest.
-    6) Verify the qemu-ga version match expected version.
-    7) Run driver signature check command in guest.
+    4) Run driver signature check command in guest.
        Verify target driver.
-    8) Run virtio-win-guest-tools.exe repair test by uninstall
-       the target driver.
-    9) Run the driver function test after virtio-win-guest-tools.exe repair.
-    10) Repeat step 9 and 10 for other drivers.
+    5) Uninstall dirvers by msi uninstall.
+    6) Run virtio-win-guest-tools.exe repair test.
+    7) Run the driver function test after repair.
 
     :param test: QEMU test object
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment
     """
-    devcon_path = params["devcon_path"]
     run_install_cmd = params["run_install_cmd"]
-    installer_pkg_check_cmd = params["installer_pkg_check_cmd"]
-
-    # gagent version check test config
-    qemu_ga_pkg = params["qemu_ga_pkg"]
-    gagent_pkg_info_cmd = params["gagent_pkg_info_cmd"]
-    gagent_install_cmd = params["gagent_install_cmd"]
-    gagent_uninstall_cmd = params["gagent_uninstall_cmd"]
+    run_repair_cmd = params["run_repair_cmd"]
 
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login()
 
-    expected_gagent_version = win_driver_installer_test.install_gagent(
-        session, test,
-        qemu_ga_pkg,
-        gagent_install_cmd,
-        gagent_pkg_info_cmd)
-    win_driver_installer_test.uninstall_gagent(session, test,
-                                               gagent_uninstall_cmd)
     win_driver_installer_test.win_uninstall_all_drivers(session,
                                                         test, params)
     session = vm.reboot(session)
-    win_driver_installer_test.install_test_with_screen_on_desktop(
-        vm, session, test,
+
+    test.log.info("Install virtio-win driver by installer.")
+    session = win_driver_installer_test.run_installer_with_interaction(
+        vm, session, test, params,
         run_install_cmd,
-        installer_pkg_check_cmd,
         copy_files_params=params)
-    win_driver_installer_test.win_installer_test(session, test, params)
-    win_driver_installer_test.check_gagent_version(session, test,
-                                                   gagent_pkg_info_cmd,
-                                                   expected_gagent_version)
+
     win_driver_installer_test.driver_check(session, test, params)
 
     error_context.context("Run virtio-win-guest-tools.exe repair test",
                           test.log.info)
-    unrepaired_driver = []
+    test.log.info("Remove virtio-win driver by msi.")
+    session = win_driver_utils.remove_driver_by_msi(session, vm, params)
+
+    test.log.info("Repair virtio-win driver by installer.")
+    session = win_driver_installer_test.run_installer_with_interaction(
+        vm, session, test, params,
+        run_repair_cmd)
+
+    # driver check after repair
+    win_driver_installer_test.driver_check(session, test, params)
+
+    error_context.context("Run driver function test after repair",
+                          test.log.info)
     fail_tests = []
-    for driver_name, device_name, device_hwid in zip(
-            win_driver_installer_test.driver_name_list,
-            win_driver_installer_test.device_name_list,
-            win_driver_installer_test.device_hwid_list):
-        error_context.context("Uninstall %s driver"
-                              % driver_name, test.log.info)
-        win_driver_utils.uninstall_driver(session, test, devcon_path,
-                                          driver_name, device_name,
-                                          device_hwid)
-        session = vm.reboot(session)
-        vm.send_key('meta_l-d')
-        time.sleep(30)
-        run_repair_cmd = utils_misc.set_winutils_letter(
-            session, params["run_repair_cmd"])
-        session = win_driver_installer_test.run_installer_with_interaction(
-            vm, session, test, params,
-            run_repair_cmd,
-            copy_files_params=params)
-
-        error_context.context("Check if %s driver is repaired"
-                              % driver_name, test.log.info)
-        chk_cmd = params["vio_driver_chk_cmd"] % device_name[0:30]
-        status = session.cmd_status(chk_cmd)
-        if status != 0:
-            test.log.info("%s driver repair failed" % driver_name)
-            unrepaired_driver.append(driver_name)
+    test_drivers = params.get('test_drivers',
+                              win_driver_installer_test.driver_name_list)
+    if params.get('test_drivers'):
+        test_drivers = params["test_drivers"].split()
+    for driver_name in test_drivers:
+        test_name = params.get('driver_test_name_%s' % driver_name)
+        test_func = "win_driver_installer_test.%s_test" % test_name
+        driver_test_params = params.get('driver_test_params_%s'
+                                        % driver_name, '{}')
+        if driver_name == "balloon":
+            balloon_test_win = BallooningTestWin(test, params, env)
+            driver_test_params = {"balloon_test_win": balloon_test_win}
+        elif driver_name == "viofs":
+            virtio_fs_utils.run_viofs_service(test, params, session)
         else:
-            error_context.context("Run %s driver function test after repair"
-                                  % driver_name, test.log.info)
-            test_name = params.get('driver_test_name_%s' % driver_name)
-            test_func = "win_driver_installer_test.%s_test" % test_name
-            driver_test_params = params.get('driver_test_params_%s'
-                                            % driver_name, '{}')
-            if driver_name == "viofs":
-                virtio_fs_utils.run_viofs_service(test, params, session)
-            if driver_name != "balloon":
-                driver_test_params = ast.literal_eval(driver_test_params)
-            else:
-                balloon_test_win = BallooningTestWin(test, params, env)
-                driver_test_params = {"balloon_test_win": balloon_test_win}
-            try:
-                eval("%s(test, params, vm, **driver_test_params)" % test_func)
-            except Exception as e:
-                fail_tests.append('%s:\n%s' % (test_name, str(e)))
+            driver_test_params = ast.literal_eval(driver_test_params)
 
-    if unrepaired_driver or fail_tests:
-        test.fail("Repaired failed driver list is %s, repair success but "
-                  "function test failed list is %s"
-                  % (unrepaired_driver, fail_tests))
-
+        try:
+            eval("%s(test, params, vm, **driver_test_params)" % test_func)
+        except Exception as e:
+            fail_tests.append('%s:\n%s' % (test_name, str(e)))
+    if fail_tests:
+        test.fail("Function test failed list is %s after repair."
+                  % fail_tests)
     session.close()


### PR DESCRIPTION
It's not a valid case to uninstall some drivers and then repair them by installer.
The correct way is removeing virtio-win msi and then repair it by installer.
ID: 2024