### PR TITLE
pktgen: add support for two vdpa test cases in pktgen

### DIFF
--- a/generic/tests/cfg/pktgen_perf.cfg
+++ b/generic/tests/cfg/pktgen_perf.cfg
@@ -2,7 +2,6 @@
     no JeOS
     no Windows
     no Host_RHEL.m5, Host_RHEL.m6
-    only bridge
     virt_test_type = qemu
     type = pktgen_perf
     kill_vm = yes
@@ -15,7 +14,29 @@
     guest_ver_cmd = "uname -r"
     record_list = "pkt_size run_threads burst mpps"
     pkt_size = 64
-    numa_node = 1
     burst = 1
     pktgen_script = "pktgen_perf pktgen_sample01_simple pktgen_sample03_burst_single_flow pktgen_sample05_flow_per_thread"
     disable_iptables_rules_cmd = "iptables -F || nft flush ruleset"
+    start_vm = no
+    variants:
+        - @default:
+            only bridge
+            test_vm = yes
+        - vdpa_enabled:
+            vdpa_test = yes
+            vt_ulimit_memlock = ulimited
+            pktgen_script = "pktgen_sample03_burst_single_flow"
+            category = "loopback"
+            vhost_fixed =
+            variants:
+                - vhost_sim_test_vm:
+                    test_vm = yes
+                    nics = 'nic1  nic2'
+                    netdst_nic2 = vdpa0
+                    nettype_nic2 = vdpa
+                    mac_nic2 =  00:11:22:33:44:00
+                - virtio_sim_test_host:
+                    test_vm = no
+                    nettype_fixed = vdpa
+                    netdst = vdpa0
+                    mac = 00:11:22:33:44:00

--- a/generic/tests/pktgen_perf.py
+++ b/generic/tests/pktgen_perf.py
@@ -1,48 +1,38 @@
 import logging
 import os
-import six
-import aexpect
-import functools
-import re
+import time
 
 from avocado.utils import process
 
-from virttest import data_dir
-from virttest import utils_net
+from provider import pktgen_utils
+from provider.vdpa_sim_utils import VhostVdpaNetSimulatorTest, VirtioVdpaNetSimulatorTest
+
+from virttest import env_process
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import error_context
 
 LOG_JOB = logging.getLogger('avocado.test')
 
-_system_output = functools.partial(process.system_output, shell=True)
-
-
-def format_result(result, base, fbase):
-    """
-    Format the result to a fixed length string.
-
-    :param result: result need to convert
-    :param base: the length of converted string
-    :param fbase: the decimal digit for float
-    """
-    if isinstance(result, six.string_types):
-        value = "%" + base + "s"
-    elif isinstance(result, int):
-        value = "%" + base + "d"
-    elif isinstance(result, float):
-        value = "%" + base + "." + fbase + "f"
-    return value % result
-
 
 @error_context.context_aware
 def run(test, params, env):
     """
-    Run Pktgen test between host/guest
-
-    1) Boot the main vm, or just grab it if it's already booted.
-    2) Configure pktgen on guest or host
-    3) Run pktgen test, finish when timeout
+    Pktgen tests multiple scenarios:
+    default test steps:
+        Run Pktgen test between host/guest
+        1) Boot the main vm, or just grab it if it's already booted.
+        2) Configure pktgen on guest or host
+        3) Run tx/rx test on the VM
+        4) Finish when timeout
+    vhost_sim_test_vm test steps:
+        1) Setup vdpa simulator ENV and create vhost-vdpa devices.
+        2) Boot vm and run pktgen test on VM
+        3) Destroy vm, vhost-vdpa devices and vdpa simulator ENV
+    virtio_sim_test_host test steps:
+        1) Setup vdpa simulator env and create virtio vdpa devices
+        2) run pktgen test on host
+        3) Destroy virtio vdpa devices and vdpa simulator env
 
     :param test: QEMU test object.
     :param params: Dictionary with the test parameters.
@@ -60,193 +50,77 @@ def run(test, params, env):
                 node = utils_misc.NumaNode(int(node))
             utils_test.qemu.pin_vm_threads(vm, node)
 
-    timeout = float(params.get("pktgen_test_timeout", "240"))
-    error_context.context("Init the VM, and try to login", test.log.info)
-    vm = env.get_vm(params["main_vm"])
-    vm.verify_alive()
-    session_serial = vm.wait_for_serial_login(restart_network=True)
-    session = vm.wait_for_login()
-
-    # print numa information on host and pinning vhost and vcpus to cpus
-    process.system_output("numactl --hardware")
-    process.system_output("numactl --show")
-    _pin_vm_threads(params.get("numa_node"))
+    def init_vm_and_login(test, params, env, result_file, pktgen_runner):
+        error_context.context("Init the VM, and try to login", test.log.info)
+        params["start_vm"] = 'yes'
+        env_process.preprocess_vm(test, params, env, params.get("main_vm"))
+        vm = env.get_vm(params["main_vm"])
+        vm.verify_alive()
+        session_serial = vm.wait_for_serial_login(restart_network=True)
+        # print numa information on host and pinning vhost and vcpus to cpus
+        process.system_output("numactl --hardware")
+        process.system_output("numactl --show")
+        _pin_vm_threads(params.get("numa_node"))
+        guest_ver = session_serial.cmd_output(guest_ver_cmd)
+        result_file.write("### guest-kernel-ver :%s" % guest_ver)
+        if pktgen_runner.is_version_lt_rhel7(session_serial.cmd('uname -r')):
+            pktgen_runner.install_package(guest_ver.strip(), vm=vm, session_serial=session_serial)
+        return vm, session_serial
 
     # get parameter from dictionary
-    category = params.get("category")
-    pkt_size = params.get("pkt_size")
-    run_threads = params.get("pktgen_threads")
-    burst = params.get("burst")
-    record_list = params.get("record_list")
-    pktgen_script = params.get('pktgen_script')
     kvm_ver_chk_cmd = params.get("kvm_ver_chk_cmd")
     guest_ver_cmd = params["guest_ver_cmd"]
-    base = params.get("format_base", "12")
-    fbase = params.get("format_fbase", "2")
     disable_iptables_rules_cmd = params.get("disable_iptables_rules_cmd")
+    test_vm = params.get_boolean("test_vm")
+    vdpa_test = params.get_boolean("vdpa_test")
 
-    # get qemu, guest kernel and kvm version info and write them into result
+    # get qemu, kvm version info and write them into result
     result_path = utils_misc.get_path(test.resultsdir, "pktgen_perf.RHS")
     result_file = open(result_path, "w")
     kvm_ver = process.system_output(kvm_ver_chk_cmd, shell=True).decode()
     host_ver = os.uname()[2]
-    guest_ver = session.cmd_output(guest_ver_cmd, timeout)
     result_file.write("### kvm-userspace-ver : %s\n" % kvm_ver)
     result_file.write("### kvm_version : %s\n" % host_ver)
-    result_file.write("### guest-kernel-ver :%s" % guest_ver)
-
-    # get record_list
-    record_line = ""
-    for record in record_list.split():
-        record_line += "%s|" % format_result(record, base, fbase)
 
     if disable_iptables_rules_cmd:
         error_context.context("disable iptables rules on host")
         process.system(disable_iptables_rules_cmd, shell=True)
 
-    def install_package(ver, session=None):
-        """ check module pktgen, install kernel-modules-internal package """
+    pktgen_runner = pktgen_utils.PktgenRunner()
+    if pktgen_runner.is_version_lt_rhel7(process.getoutput('uname -r')):
+        pktgen_runner.install_package(host_ver)
 
-        output_cmd = _system_output
-        kernel_ver = "kernel-modules-internal-%s" % ver
-        cmd_download = "cd /tmp && brew download-build %s --rpm" % kernel_ver
-        cmd_install = "cd /tmp && rpm -ivh  %s.rpm --force --nodeps" % kernel_ver
-        output_cmd(cmd_download).decode()
-        cmd_clean = "rm -rf /tmp/%s.rpm" % kernel_ver
-        if session:
-            output_cmd = session.cmd_output
-            local_path = "/tmp/%s.rpm" % kernel_ver
-            remote_path = "/tmp/"
-            vm.copy_files_to(local_path, remote_path)
-        output_cmd(cmd_install)
-        output_cmd(cmd_clean)
-
-    def is_version_lt_rhel7(uname_str):
-        ver = re.findall('el(\\d)', uname_str)
-        if ver:
-            return int(ver[0]) > 7
-        return False
-
-    if is_version_lt_rhel7(process.getoutput('uname -r')):
-        install_package(host_ver)
-    if is_version_lt_rhel7(session.cmd('uname -r')):
-        install_package(guest_ver.strip(), session=session)
-
-    # get result tested by each scenario
-    pktgen_script = params.get('pktgen_script')
-    for pktgen_script in pktgen_script.split():
-
-        # copy pktgen_test script to test server
-        local_path = os.path.join(data_dir.get_shared_dir(),
-                                  "scripts/pktgen_perf")
-        remote_path = "/tmp/"
-        for pkt_cate in category.split():
-            result_file.write("Script:%s " % pktgen_script)
-            result_file.write("Category:%s\n" % pkt_cate)
-            result_file.write("%s\n" % record_line.rstrip("|"))
-
-            if pkt_cate == "tx":
-                vm.copy_files_to(local_path, remote_path)
-            elif pkt_cate == "rx":
-                process.run("cp -r %s %s" % (local_path, remote_path))
-
-            for size in pkt_size.split():
-                for threads in run_threads.split():
-                    for burst in burst.split():
-                        if pkt_cate == "tx":
-                            error_context.context("test guest tx pps"
-                                                  " performance",
-                                                  test.log.info)
-                            guest_mac = vm.get_mac_address(0)
-                            pktgen_interface = utils_net.get_linux_ifname(
-                                               session, guest_mac)
-                            dsc_dev = utils_net.Interface(vm.get_ifname(0))
-                            dsc = dsc_dev.get_mac()
-                            runner = session.cmd
-                            pktgen_ip = vm.wait_for_get_address(0, timeout=5)
-                        elif pkt_cate == "rx":
-                            error_context.context("test guest rx pps"
-                                                  " performance",
-                                                  test.log.info)
-                            host_bridge = params.get("netdst", "switch")
-                            host_nic = utils_net.Interface(host_bridge)
-                            pktgen_ip = host_nic.get_ip()
-                            if pktgen_script == "pktgen_perf":
-                                dsc = vm.wait_for_get_address(0, timeout=5)
-                            else:
-                                dsc = vm.get_mac_address(0)
-                            pktgen_interface = vm.get_ifname(0)
-                            runner = _system_output
-                        pkt_cate_r = run_test(session_serial, runner,
-                                              pktgen_script, pkt_cate,
-                                              pktgen_ip, pktgen_interface,
-                                              dsc, threads, size, burst,
-                                              timeout)
-                        line = "%s|" % format_result(size, base, fbase)
-                        line += "%s|" % format_result(threads, base, fbase)
-                        line += "%s|" % format_result(burst, base, fbase)
-                        line += "%s" % format_result(pkt_cate_r, base, fbase)
-                        result_file.write(("%s\n" % line))
-
-    error_context.context("Verify Host and guest kernel no error\
-                           and call trace", test.log.info)
-    vm.verify_kernel_crash()
-    utils_misc.verify_dmesg()
-    result_file.close()
-    session_serial.close()
-    session.close()
-
-
-def run_test(session_serial, runner, pktgen_script, pkt_rate, pktgen_ip,
-             interface, dsc, threads, size, burst, timeout):
-    """
-    Run pktgen_perf script on remote and gather packet numbers/time and
-    calculate mpps.
-
-    :param session_serial: session serial for vm.
-    :param runner: connection for vm or host.
-    :param pktgen_script: pktgen script name.
-    :param pkt_rate: tx or rx category.
-    :param pktgen_ip: ip address which pktgen script was running.
-    :param interface: device name pass to pktgen_perf script.
-    :param dsc: dsc mac or dsc ip pass to pktgen_perf script.
-    :param threads: the numbers pktgen threads.
-    :param size: packet size pass to pktgen_perf script.
-    :param burst: HW level bursting of SKBs.
-    :param timeout: test run time.
-    """
-
-    pktgen_script_path = "/tmp/pktgen_perf/%s.sh" % pktgen_script
-    if pktgen_script in "pktgen_perf":
-        dsc_option = '-m' if pkt_rate == 'tx' else '-d'
-        exec_cmd = "%s -i %s %s %s -t %s -s %s" % (
-                pktgen_script_path, interface, dsc_option, dsc, threads, size)
-    else:
-        exec_cmd = "%s -i %s -m %s -n 0 -t %s -s %s -b %s -c 0" % (
-                pktgen_script_path, interface, dsc, threads, size, burst)
-    packets = "cat /sys/class/net/%s/statistics/tx_packets" % interface
-    LOG_JOB.info("Start pktgen test by cmd '%s'", exec_cmd)
+    vdpa_net_test = None
+    vm = None
     try:
-        packet_b = runner(packets)
-        runner(exec_cmd, timeout)
-    except aexpect.ShellTimeoutError:
-        # when pktgen script is running on guest, it's damaged,
-        # guest could not response by ssh, so uses serial instead.
-        packet_a = session_serial.cmd(packets, timeout)
-        kill_cmd = "kill -9 `ps -ef | grep %s --color | grep -v grep | "\
-                   "awk '{print $2}'`" % pktgen_script
-        session_serial.cmd(kill_cmd)
-        session_serial.cmd("ping %s -c 5" % pktgen_ip, ignore_all_errors=True)
-    except process.CmdError:
-        # when pktgen script is running on host, the pktgen process
-        # will be quit when timeout trigger, so no need to kill it.
-        packet_a = runner(packets)
-        runner("ping %s -c 5" % pktgen_ip)
-    count = int(packet_a) - int(packet_b)
-    pps_results = count / timeout
-
-    # conver pps to mpps
-    power = 10**6
-    mpps_results = float(pps_results) / float(power)
-    mpps_results = "%.2f" % mpps_results
-    return mpps_results
+        if vdpa_test and not test_vm:
+            vdpa_net_test = VirtioVdpaNetSimulatorTest()
+            vdpa_net_test.setup()
+            interface = vdpa_net_test.add_dev(params.get("netdst"), params.get("mac"))
+            LOG_JOB.info("The virtio_vdpa device name is: '%s'", interface)
+            LOG_JOB.info("Test virtio_vdpa with the simulator on the host")
+            pktgen_utils.run_tests_for_category(params, result_file,  test_vm, interface=interface)
+        elif vdpa_test and test_vm:
+            vdpa_net_test = VhostVdpaNetSimulatorTest()
+            vdpa_net_test.setup()
+            dev = vdpa_net_test.add_dev(params.get("netdst_nic2"), params.get("mac_nic2"))
+            LOG_JOB.info("The vhost_vdpa device name is: '%s'", dev)
+            LOG_JOB.info("Test vhost_vdpa with the simulator on the vm")
+            vm, session_serial = init_vm_and_login(test, params, env, result_file, pktgen_runner)
+            pktgen_utils.run_tests_for_category(params, result_file, test_vm, vm, session_serial)
+        elif not vdpa_test:
+            vm, session_serial = init_vm_and_login(test, params, env, result_file, pktgen_runner)
+            pktgen_utils.run_tests_for_category(params, result_file, test_vm, vm, session_serial)
+    finally:
+        if test_vm:
+            vm.verify_kernel_crash()
+            session_serial.close()
+            utils_misc.verify_dmesg()
+            vm.destroy()
+        result_file.close()
+        if vdpa_net_test:
+            time.sleep(5)
+            vdpa_net_test.remove_dev(params.get("netdst_nic2"))
+            vdpa_net_test.cleanup()
+        error_context.context("Verify Host and guest kernel no error"
+                              "and call trace", test.log.info)

--- a/provider/pktgen_utils.py
+++ b/provider/pktgen_utils.py
@@ -1,0 +1,229 @@
+import logging
+import os
+import re
+import six
+import aexpect
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import utils_net
+
+LOG_JOB = logging.getLogger('avocado.test')
+
+
+class PktgenConfig:
+    def __init__(self, interface=None, dsc=None, runner=None):
+        self.interface = interface
+        self.dsc = dsc
+        self.runner = runner
+
+    def configure_pktgen(self, params, script, pkt_cate, test_vm,
+                         vm=None, session_serial=None, interface=None):
+        local_path = os.path.join(data_dir.get_shared_dir(),
+                                  "scripts/pktgen_perf")
+        remote_path = "/tmp/"
+
+        if pkt_cate == "tx":
+            LOG_JOB.info("test guest tx pps performance")
+            vm.copy_files_to(local_path, remote_path)
+            guest_mac = vm.get_mac_address(0)
+            self.interface = utils_net.get_linux_ifname(session_serial, guest_mac)
+            dsc_dev = utils_net.Interface(vm.get_ifname(0))
+            self.dsc = dsc_dev.get_mac()
+            self.runner = session_serial.cmd
+        elif pkt_cate == "rx":
+            LOG_JOB.info("test guest rx pps performance")
+            process.run("cp -r %s %s" % (local_path, remote_path))
+            host_bridge = params.get("netdst", "switch")
+            host_nic = utils_net.Interface(host_bridge)
+            if script == "pktgen_perf":
+                self.dsc = vm.wait_for_get_address(0, timeout=5)
+            else:
+                self.dsc = vm.get_mac_address(0)
+            self.interface = vm.get_ifname(0)
+            self.runner = process.getoutput
+        elif pkt_cate == "loopback":
+            if test_vm:
+                LOG_JOB.info("test guest loopback pps performance")
+                vm.copy_files_to(local_path, remote_path)
+                guest_mac = vm.get_mac_address(1)
+                self.interface = utils_net.get_linux_ifname(session_serial, guest_mac)
+                self.dsc = vm.get_mac_address(1)
+                self.runner = session_serial.cmd
+            elif not test_vm:
+                LOG_JOB.info("test loopback pps performance on host")
+                process.run("cp -r %s %s" % (local_path, remote_path))
+                self.interface = interface
+                self.dsc = params.get("mac")
+                self.runner = process.getoutput
+        return self
+
+    def generate_pktgen_cmd(self, script, pkt_cate, interface, dsc,
+                            threads, size, burst, session_serial=None):
+        script_path = "/tmp/pktgen_perf/%s.sh" % script
+        if script in "pktgen_perf":
+            dsc_option = '-m' if pkt_cate == 'tx' else '-d'
+            cmd = "%s -i %s %s %s -t %s -s %s" % (
+                script_path, interface, dsc_option, dsc, threads, size)
+        else:
+            cmd = "%s -i %s -m %s -n 0 -t %s -s %s -b %s -c 0" % (
+                script_path, interface, dsc, threads, size, burst)
+
+        if session_serial and \
+           hasattr(self.runner, '__name__') and \
+           self.runner.__name__ == session_serial.cmd.__name__:
+            cmd += " &"
+
+        return cmd
+
+
+class PktgenRunner:
+    def run_test(self, script, cmd, runner, interface, timeout):
+        """
+        Run pktgen  script on remote and gather packet numbers/time and
+        calculate mpps.
+        :param script: pktgen script name.
+        :param cmd: The command to execute the pktgen script
+        :param runner: The command runner function
+        :param interface: The network interface used by pktgen.
+        :param timeout: The maximum time allowed for the test to run
+        :return: The calculated MPPS (Million Packets Per Second)
+        """
+
+        packets = "cat /sys/class/net/%s/statistics/tx_packets" % interface
+        LOG_JOB.info("Start pktgen test by cmd '%s'", cmd)
+        try:
+            packet_b = runner(packets)
+            packet_a = None
+            runner(cmd, timeout)
+        except aexpect.ShellTimeoutError:
+            # when pktgen script is running on guest, the pktgen process
+            # need to be killed.
+            kill_cmd = "kill -9 `ps -ef | grep %s --color | grep -v grep | "\
+                       "awk '{print $2}'`" % script
+            runner(kill_cmd)
+            packet_a = runner(packets)
+        except process.CmdError:
+            # when pktgen script is running on host, the pktgen process
+            # will be quit when timeout triggers, so no need to kill it.
+            packet_a = runner(packets)
+        count = int(packet_a) - int(packet_b)
+        pps_results = count / timeout
+
+        # convert pps to mpps
+        power = 10**6
+        mpps_results = float(pps_results) / float(power)
+        mpps_results = "%.2f" % mpps_results
+        return mpps_results
+
+    def install_package(self, ver, vm=None, session_serial=None):
+        """Check module pktgen, install kernel-modules-internal package"""
+
+        output_cmd = process.getoutput
+        kernel_ver = "kernel-modules-internal-%s" % ver
+        cmd_download = "cd /tmp && brew download-build %s --rpm" % kernel_ver
+        cmd_install = "cd /tmp && rpm -ivh  %s.rpm --force --nodeps" % kernel_ver
+        output_cmd(cmd_download).decode()
+        cmd_clean = "rm -rf /tmp/%s.rpm" % kernel_ver
+        if session_serial:
+            output_cmd = session_serial.cmd_output
+            local_path = "/tmp/%s.rpm" % kernel_ver
+            remote_path = "/tmp/"
+            vm.copy_files_to(local_path, remote_path)
+        output_cmd(cmd_install)
+        output_cmd(cmd_clean)
+
+    def is_version_lt_rhel7(self, uname_str):
+        ver = re.findall('el(\\d)', uname_str)
+        if ver:
+            return int(ver[0]) > 7
+        return False
+
+
+def format_result(result, base, fbase):
+    """
+    Format the result to a fixed length string.
+
+    :param result: result need to convert
+    :param base: the length of converted string
+    :param fbase: the decimal digit for float
+    """
+    if isinstance(result, six.string_types):
+        value = "%" + base + "s"
+    elif isinstance(result, int):
+        value = "%" + base + "d"
+    elif isinstance(result, float):
+        value = "%" + base + "." + fbase + "f"
+    return value % result
+
+
+def run_tests_for_category(params, result_file, test_vm, vm=None, session_serial=None, interface=None):
+    """
+    Run Pktgen tests for a specific category.
+    :param params: Dictionary with the test parameters
+    :param result_file: File to write the test results.
+    :param test_vm: Flag indicating whether the test is running on a VM
+    :param vm: VM instance
+    :param session_serial: Session serial for VM
+    :param interface: Network interface for the test
+    """
+
+    timeout = float(params.get("pktgen_test_timeout", "240"))
+    category = params.get("category")
+    pkt_size = params.get("pkt_size")
+    run_threads = params.get("pktgen_threads")
+    burst = params.get("burst")
+    record_list = params.get("record_list")
+    pktgen_script = params.get('pktgen_script')
+    base = params.get("format_base", "12")
+    fbase = params.get("format_fbase", "2")
+
+    # get record_list
+    record_line = ""
+    for record in record_list.split():
+        record_line += "%s|" % format_result(record, base, fbase)
+
+    pktgen_config = PktgenConfig()
+    pktgen_runner = PktgenRunner()
+
+    for script in pktgen_script.split():
+        for pkt_cate in category.split():
+            result_file.write("Script:%s " % script)
+            result_file.write("Category:%s\n" % pkt_cate)
+            result_file.write("%s\n" % record_line.rstrip("|"))
+
+            for size in params.get("pkt_size", "").split():
+                for threads in params.get("pktgen_threads", "").split():
+                    for burst in params.get("burst", "").split():
+                        if pkt_cate != "loopback":
+                            pktgen_config = pktgen_config.configure_pktgen(
+                                params, script, pkt_cate, test_vm, vm, session_serial)
+                            exec_cmd = pktgen_config.generate_pktgen_cmd(
+                                script, pkt_cate, pktgen_config.interface, pktgen_config.dsc,
+                                threads, size, burst, session_serial)
+                        else:
+                            if not test_vm:
+                                pktgen_config = pktgen_config.configure_pktgen(
+                                    params, script, pkt_cate, test_vm, interface=interface)
+                                exec_cmd = pktgen_config.generate_pktgen_cmd(
+                                    script, pkt_cate, pktgen_config.interface, pktgen_config.dsc,
+                                    threads, size, burst)
+                            elif test_vm:
+                                pktgen_config = pktgen_config.configure_pktgen(
+                                    params, script, pkt_cate, test_vm, vm, session_serial)
+                                exec_cmd = pktgen_config.generate_pktgen_cmd(
+                                    script, pkt_cate, pktgen_config.interface, pktgen_config.dsc,
+                                    threads, size, burst, session_serial)
+                        pkt_cate_r = pktgen_runner.run_test(
+                                script, exec_cmd, pktgen_config.runner, pktgen_config.interface, timeout)
+
+                        line = "%s|" % format_result(
+                            size, params.get("format_base", "12"), params.get("format_fbase", "2"))
+                        line += "%s|" % format_result(
+                            threads, params.get("format_base", "12"), params.get("format_fbase", "2"))
+                        line += "%s|" % format_result(
+                            burst, params.get("format_base", "12"), params.get("format_fbase", "2"))
+                        line += "%s" % format_result(
+                            pkt_cate_r, params.get("format_base", "12"), params.get("format_fbase", "2"))
+                        result_file.write(("%s\n" % line))


### PR DESCRIPTION
    pktgen: add support for two vdpa test cases in pktgen

     1. Test pktgen on a VM with vdpa simulator and vhost-vdpa as the backend
     2. Test pktgen on a host with vdpa simulator and virtio-vdpa as the backend

    vdpa_sim_utils.py: add Class VirtioVdpaNetSimulatorTest

     1. correct cmd in the add_dev function of VhostVdpaNetSimulatorTest
     2. add Class VirtioVdpaNetSimulatorTest

ID: 2040, 2047
Signed-off-by: Wenli Quan [wquan@redhat.com]