### PR TITLE
trans_hugepage.relocated: fix existing issues

### DIFF
--- a/generic/tests/cfg/trans_hugepage.cfg
+++ b/generic/tests/cfg/trans_hugepage.cfg
@@ -29,7 +29,7 @@
             check_cmd_timeout = 900
         - relocated:
             type = trans_hugepage_relocated
-            thp_test_config = "/sys/kernel/mm/redhat_transparent_hugepage/khugepaged/pages_to_scan:4096;/sys/kernel/mm/redhat_transparent_hugepage/khugepaged/scan_sleep_millisecs:10000;/sys/kernel/mm/redhat_transparent_hugepage/khugepaged/alloc_sleep_millisecs:60000"
+            thp_test_config = "/sys/kernel/mm/transparent_hugepage/khugepaged/pages_to_scan:4096;/sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs:10000;/sys/kernel/mm/transparent_hugepage/khugepaged/alloc_sleep_millisecs:60000"
         - migration:
             type = migration
             migration_test_command = help


### PR DESCRIPTION
Depends on https://github.com/autotest/tp-qemu/pull/3987, https://github.com/autotest/tp-qemu/pull/3988

trans_hugepage.relocated: fix existing issues

Fixes existing issues with the params and variables casting.
Removes the redhat prefix from cfg values. For memory
fragmentation, uses the thp_fragment tool, now invoked
from an external provider.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2037