### PR TITLE
storage_benchmark:fix windows default fio to latest

### DIFF
--- a/provider/storage_benchmark.py
+++ b/provider/storage_benchmark.py
@@ -372,7 +372,7 @@ class FioWinCfg(object):
         label = params.get('win_utils_label', 'WIN_UTILS')
         utils_letter = utils_misc.get_winutils_vol(session, label)
         arch = params.get('vm_arch_name', 'x84_64')
-        fio_ver = params.get('fio_ver', 'fio-3.1')
+        fio_ver = params.get('fio_ver', 'fio-latest')
         self.fio_inst = {'x86_64': r'C:\Program Files (x86)\fio',
                          'i686': r'C:\Program Files\fio'}
         self.fio_msi = {'x86_64': r'%s:\%s-x64.msi' % (utils_letter, fio_ver),


### PR DESCRIPTION
The old default fio point to fixed 3.1 , it is too old result in output has gap with linux fio.

ID:2042