### PR TITLE
virtio-win-installer: some update of installer tests

### DIFF
--- a/provider/win_driver_installer_test.py
+++ b/provider/win_driver_installer_test.py
@@ -100,29 +100,32 @@ def win_uninstall_all_drivers(session, test, params):
 
 
 @error_context.context_aware
-def install_test_with_screen_on_desktop(vm, session, test, run_install_cmd,
-                                        installer_pkg_check_cmd,
-                                        copy_files_params=None):
+def run_installer_with_interaction(vm, session, test, params,
+                                   run_installer_cmd,
+                                   copy_files_params=None):
     """
-    Install test when guest screen on desktop.
+    Install/uninstall/repair virtio-win drivers and qxl,spice and
+    qemu-ga-win by installer.
 
     :param vm: vm object
     :param session: The guest session object.
     :param test: kvm test object.
-    :param run_install_cmd: install cmd.
-    :param installer_pkg_check_cmd: installer pkg check cmd.
+    :param params: the dict used for parameters
+    :param run_installer_cmd: install/uninstall/repair cmd cmd.
     :param copy_files_params: copy files params.
+    :return session: a new session after restart of installer
     """
-    error_context.context("Install virtio-win drivers via "
-                          "virtio-win-guest-tools.exe.", LOG_JOB.info)
+    error_context.context("Run virtio-win-guest-tools.exe by %s."
+                          % run_installer_cmd, LOG_JOB.info)
     vm.send_key('meta_l-d')
     time.sleep(30)
     if copy_files_params:
         win_driver_utils.copy_file_to_samepath(session, test,
                                                copy_files_params)
-    win_driver_utils.install_driver_by_installer(session, test,
-                                                 run_install_cmd,
-                                                 installer_pkg_check_cmd)
+    session = win_driver_utils.run_installer(vm, session,
+                                             test, params,
+                                             run_installer_cmd)
+    return session
 
 
 @error_context.context_aware

--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -610,7 +610,6 @@
             run_install_cmd = 'WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe C:\install.au3'
             run_repair_cmd = 'WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe C:\repair.au3'
             run_uninstall_cmd = 'WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe C:\uninstall.au3'
-            installer_pkg_check_cmd = 'wmic product get name |findstr "Virtio-win-driver-installer"'
             signed_check_cmd = 'wmic product where name="Virtio-win-driver-installer" | findstr "Red Hat, Inc."'
             gagent_uninstall_cmd = "wmic product where name='Qemu guest agent' call uninstall"
             devcon_dirname = "win7_"

--- a/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
@@ -19,8 +19,9 @@
     run_install_cmd = 'WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe C:\install.au3'
     run_repair_cmd = 'WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe C:\repair.au3'
     run_uninstall_cmd = 'WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe C:\uninstall.au3'
-    installer_pkg_check_cmd = 'wmic product get name |findstr "Virtio-win-driver-installer"'
     signed_check_cmd = 'wmic product where name="Virtio-win-driver-installer" | findstr "Red Hat, Inc."'
+    # set virtio_win version range to determine the diff behavior of installer
+    installer_restart_version = [1.9.37.0,)
     monitor_type = qmp
     monitors = qmp1
     mem_stat_check_list = 'stat-free-memory'
@@ -44,8 +45,6 @@
     gagent_install_cmd = "start /wait %s /quiet"
     gagent_pkg_info_cmd = 'wmic product where name="Qemu guest agent"'
     gagent_uninstall_cmd = "wmic product where name='Qemu guest agent' call uninstall"
-    Win8, Win2012, Win2012..r2:
-        need_reboot = yes
     nic_model_nic1 = rtl8139
     q35:
         nic_model_nic1 = e1000e
@@ -248,6 +247,7 @@
             only all_drivers
             driver_test_names = ''
             type = win_virtio_driver_installer_uninstall
+            installer_pkg_check_cmd = 'wmic product get name |findstr "Virtio-win-driver-installer"'
             variants:
                 - by_installer:
                 - by_msi:

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -27,7 +27,7 @@ from virttest import qemu_migration
 
 from virttest.utils_windows import virtio_win
 from provider.win_driver_installer_test import (uninstall_gagent,
-                                                install_test_with_screen_on_desktop)
+                                                run_installer_with_interaction)
 
 LOG_JOB = logging.getLogger('avocado.test')
 
@@ -4412,7 +4412,6 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
         """
 
         run_install_cmd = params["run_install_cmd"]
-        installer_pkg_check_cmd = params["installer_pkg_check_cmd"]
         gagent_uninstall_cmd = params["gagent_uninstall_cmd"]
 
         vm = env.get_vm(params["main_vm"])
@@ -4421,9 +4420,9 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
         qga_ver_pkg = str(self.gagent.guest_info()["version"])
         uninstall_gagent(session, test, gagent_uninstall_cmd)
         session = vm.reboot(session)
-        install_test_with_screen_on_desktop(vm, session, test, run_install_cmd,
-                                            installer_pkg_check_cmd,
-                                            copy_files_params=params)
+        session = run_installer_with_interaction(vm, session, test, params,
+                                                 run_install_cmd,
+                                                 copy_files_params=params)
         qga_ver_installer = str(self.gagent.guest_info()["version"])
 
         error_context.context("Check if qga version is corresponding between"

--- a/qemu/tests/win_virtio_driver_install_by_installer.py
+++ b/qemu/tests/win_virtio_driver_install_by_installer.py
@@ -38,7 +38,6 @@ def run(test, params, env):
     gagent_uninstall_cmd = params["gagent_uninstall_cmd"]
 
     run_install_cmd = params["run_install_cmd"]
-    installer_pkg_check_cmd = params["installer_pkg_check_cmd"]
     driver_test_params = params.get("driver_test_params", "{}")
     driver_test_params = ast.literal_eval(driver_test_params)
 
@@ -58,11 +57,12 @@ def run(test, params, env):
                                       driver_name,
                                       device_name,
                                       device_hwid)
-
     session = vm.reboot(session)
-    win_driver_installer_test.install_test_with_screen_on_desktop(
-            vm, session, test, run_install_cmd, installer_pkg_check_cmd,
-            copy_files_params=params)
+
+    session = win_driver_installer_test.run_installer_with_interaction(
+        vm, session, test, params,
+        run_install_cmd,
+        copy_files_params=params)
     win_driver_installer_test.win_installer_test(session, test, params)
     win_driver_installer_test.check_gagent_version(session, test,
                                                    gagent_pkg_info_cmd,

--- a/qemu/tests/win_virtio_driver_installer_repair.py
+++ b/qemu/tests/win_virtio_driver_installer_repair.py
@@ -47,20 +47,20 @@ def run(test, params, env):
     session = vm.wait_for_login()
 
     expected_gagent_version = win_driver_installer_test.install_gagent(
-                                             session, test,
-                                             qemu_ga_pkg,
-                                             gagent_install_cmd,
-                                             gagent_pkg_info_cmd)
+        session, test,
+        qemu_ga_pkg,
+        gagent_install_cmd,
+        gagent_pkg_info_cmd)
     win_driver_installer_test.uninstall_gagent(session, test,
                                                gagent_uninstall_cmd)
     win_driver_installer_test.win_uninstall_all_drivers(session,
                                                         test, params)
     session = vm.reboot(session)
     win_driver_installer_test.install_test_with_screen_on_desktop(
-                                        vm, session, test,
-                                        run_install_cmd,
-                                        installer_pkg_check_cmd,
-                                        copy_files_params=params)
+        vm, session, test,
+        run_install_cmd,
+        installer_pkg_check_cmd,
+        copy_files_params=params)
     win_driver_installer_test.win_installer_test(session, test, params)
     win_driver_installer_test.check_gagent_version(session, test,
                                                    gagent_pkg_info_cmd,
@@ -72,9 +72,9 @@ def run(test, params, env):
     unrepaired_driver = []
     fail_tests = []
     for driver_name, device_name, device_hwid in zip(
-                win_driver_installer_test.driver_name_list,
-                win_driver_installer_test.device_name_list,
-                win_driver_installer_test.device_hwid_list):
+            win_driver_installer_test.driver_name_list,
+            win_driver_installer_test.device_name_list,
+            win_driver_installer_test.device_hwid_list):
         error_context.context("Uninstall %s driver"
                               % driver_name, test.log.info)
         win_driver_utils.uninstall_driver(session, test, devcon_path,
@@ -85,8 +85,11 @@ def run(test, params, env):
         time.sleep(30)
         run_repair_cmd = utils_misc.set_winutils_letter(
             session, params["run_repair_cmd"])
-        session.cmd(run_repair_cmd)
-        time.sleep(30)
+        session = win_driver_installer_test.run_installer_with_interaction(
+            vm, session, test, params,
+            run_repair_cmd,
+            copy_files_params=params)
+
         error_context.context("Check if %s driver is repaired"
                               % driver_name, test.log.info)
         chk_cmd = params["vio_driver_chk_cmd"] % device_name[0:30]


### PR DESCRIPTION
From virtio-win-1.9.37 later, installer work behavior has some change, it will pop up restart button at the end.
So there are following task list.

update autoit script for install/uninstall/update/repair in WIN-UTIL. update tp-qemu to remove restart action after use installer.
ID: 2031