### PR TITLE
nvdimm_nvml: adds environment variable to guest

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -135,6 +135,7 @@
             depends_pkgs += ndctl-devel daxctl-devel pandoc cmake
             nvml_test = yes
             nvml_dir = /tmp/nvml
+            export_pmem_conf = 'export PMEMOBJ_CONF="sds.at_create=0"'
             get_nvml = "[ -d ${nvml_dir} ] && rm -rf ${nvml_dir}"
             get_nvml += ";git clone --depth=1 https://github.com/pmem/nvml.git ${nvml_dir}"
             compile_nvml = "cd ${nvml_dir}; make"

--- a/qemu/tests/nvdimm.py
+++ b/qemu/tests/nvdimm.py
@@ -166,6 +166,7 @@ def run(test, params, env):
         error_context.context("Format and mount nvdimm in guest", test.log.info)
         nvdimm_test.mount_nvdimm()
         if params.get("nvml_test", "no") == "yes":
+            nvdimm_test.run_guest_cmd(params["export_pmem_conf"])
             nvdimm_test.run_guest_cmd(params["get_nvml"])
             nvdimm_test.run_guest_cmd(params["compile_nvml"])
             nvdimm_test.run_guest_cmd(params["config_nvml"])


### PR DESCRIPTION
nvdimm_nvml: adds environment variable to guest

For the success of the integration tests from of the PMDK
project, is it needed to export the PMEMOBJ_CONF variable
following the suggestion of the repository maintainers.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2051