### PR TITLE
ci: Add check to avoid using blacklisted authors

### DIFF
--- a/.ci/commit-author-check.sh
+++ b/.ci/commit-author-check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+echo "** Running author-check..."
+COMMIT_COUNT="${COMMIT_COUNT:-1}"
+
+exit_code=0
+blacklist=("root")
+
+readarray -t commits <<< $(git log --no-merges -n "${COMMIT_COUNT}" --format='%H')
+for commit in "${commits[@]}"; do
+  AUTHOR=$(git show --format='%aN' --no-patch "${commit}")
+  echo "Checking commit: ${commit}"
+  # shellcheck disable=SC2076
+  if [[ " ${blacklist[*]} " =~ ${AUTHOR} ]]; then
+    echo -e "The commit author should not be ${AUTHOR}\n"
+    exit_code=1
+  else
+    echo -e "The commit author is not in the blacklist\n"
+  fi
+done
+
+if [ "${exit_code}" -ne 0 ]; then
+  guide="https://avocado-framework.readthedocs.io/en/latest/guides/contributor/chapters/how.html#git-workflow"
+  echo "Please refer to ${guide} to correct your commit(s)"
+fi
+exit ${exit_code}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,23 @@ jobs:
         run: inspekt checkall --disable-style E501,E265,W601,E402,E722,E741 --disable-lint=W,R,C,E0601,E1002,E1101,E1103,E1120,F0401,I0011,I1101 --enable-lint W0611,W1201 --no-license-check
       - run: echo "This job's status is ${{ job.status }}."
 
+  author-blacklist:
+
+    name: Author blacklist
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Check commits author
+        env:
+          COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          ./.ci/commit-author-check.sh
+
   commitlint:
 
     name: Commit lint


### PR DESCRIPTION
In order to avoid contributors using the wrong author name to push commits, add a github action to check if the author name is in the blacklist.