### PR TITLE
multi_vms_with_stress: Add max vcpu scenario

### DIFF
--- a/qemu/tests/cfg/multi_vms_with_stress.cfg
+++ b/qemu/tests/cfg/multi_vms_with_stress.cfg
@@ -4,7 +4,7 @@
     kill_vm = yes
     start_vm = no
     not_preprocess = yes
-    vms += " vm2 vm3 vm4 vm5"
+    vms += " vm2 vm3"
     mem = 4G
     vm_mem_minimum = ${mem}
     stress_inst_dir = /tmp/stress
@@ -14,10 +14,10 @@
     stress_cmd = ${stress_bin} --cpu 4 --io 4 --vm 2 --vm-bytes 128M &
     pre_command = "mkdir -p ${stress_inst_dir}"
     post_command = "killall -9 stress; rm -rf ${stress_inst_dir}"
-    ovmf:
-        smp = 1
-        vcpu_maxcpus = 1
-        vcpu_sockets = 1
-        vcpu_dies = 1
-        vcpu_cores = 1
-        vcpu_threads = 1
+    variants:
+        - with_default_cpu:
+        - with_maxcpus:
+            set_maxcpus = yes
+            # Due to known product issue, switch to new testing method after fix
+            required_qemu = [8.2.0-7,)
+            vcpu_sockets = 1

--- a/qemu/tests/multi_vms_with_stress.py
+++ b/qemu/tests/multi_vms_with_stress.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 
+from avocado.utils import cpu
 from avocado.utils import process
 
 from virttest import data_dir
@@ -94,6 +95,14 @@ def run(test, params, env):
     install_stress_pkg()
     run_stress_background()
     is_stress_alive()
+
+    if params.get_boolean('set_maxcpus'):
+        num_vms = int(len(params.objects('vms')))
+        online_cpu = cpu.online_count() * 2 // num_vms
+        if (online_cpu % 2) != 0:
+            online_cpu += 1
+        params['smp'] = online_cpu
+        params['vcpu_maxcpus'] = params['smp']
 
     params['start_vm'] = 'yes'
     env_process.process(test, params, env,


### PR DESCRIPTION
For max vCPU, 8 pCPUs allows 2 VMs with 8vCPUs
but not 1 VM with 16vCPUs

ID: 2062