### PR TITLE
virtio_fs: limit memory size for some Windows guest

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -156,6 +156,8 @@
         - with_viofs:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
             no Win2008 Win7
+            Win10.i386:
+                mem = 4096
             virt_test_type = qemu
             required_qemu = [4.2.0,)
             filesystems = fs

--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -125,6 +125,8 @@
         - with_viofs:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
             no Win2008 Win7
+            Win10.i386:
+                mem = 4096
             virt_test_type = qemu
             required_qemu = [4.2.0,)
             filesystems = fs

--- a/qemu/tests/cfg/virtio_driver_sign_check.cfg
+++ b/qemu/tests/cfg/virtio_driver_sign_check.cfg
@@ -44,6 +44,8 @@
         - with_viofs:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
             no Win2008 Win7
+            Win10.i386:
+                mem = 4096
             virt_test_type = qemu
             required_qemu = [4.2.0,)
             filesystems = fs

--- a/qemu/tests/cfg/virtio_fs_group_permission_access.cfg
+++ b/qemu/tests/cfg/virtio_fs_group_permission_access.cfg
@@ -11,6 +11,8 @@
         setup_hugepages = yes
         kvm_module_parameters = 'hpage=1'
         expected_hugepage_size = 1024
+    Win10.i386:
+        mem = 4096
     kill_vm = yes
     start_vm = no
     filesystems = fs

--- a/qemu/tests/cfg/virtio_fs_hotplug.cfg
+++ b/qemu/tests/cfg/virtio_fs_hotplug.cfg
@@ -10,6 +10,8 @@
     remove_image_image1 = yes
     kill_vm = yes
     start_vm = yes
+    Win10.i386:
+        mem = 4096
     extra_filesystems = fs
     fs_target = 'myfs'
     fs_source_dir = virtio_fs_test/

--- a/qemu/tests/cfg/virtio_fs_memory_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_memory_backend.cfg
@@ -7,6 +7,8 @@
     required_qemu = [4.2.0,)
     s390, s390x:
         required_qemu = [5.2.0,)
+    Win10.i386:
+        mem = 4096
     kill_vm = yes
     start_vm = yes
     filesystems = fs

--- a/qemu/tests/cfg/virtio_fs_multi_users_access.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_users_access.cfg
@@ -6,6 +6,8 @@
     clone_master = yes
     master_images_clone = image1
     remove_image_image1 = yes
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_type = mount

--- a/qemu/tests/cfg/virtio_fs_multi_vms.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_vms.cfg
@@ -9,6 +9,8 @@
     clone_master = yes
     master_images_clone = image1
     remove_image_image1 = yes
+    Win10.i386:
+        mem = 4096
     mem_devs = mem1
     backend_mem_mem1 = memory-backend-file
     size_mem1 = ${mem}M

--- a/qemu/tests/cfg/virtio_fs_readonly.cfg
+++ b/qemu/tests/cfg/virtio_fs_readonly.cfg
@@ -8,6 +8,8 @@
         required_qemu = [5.2.0,)
     kill_vm = yes
     start_vm = yes
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_type = mount

--- a/qemu/tests/cfg/virtio_fs_sandbox.cfg
+++ b/qemu/tests/cfg/virtio_fs_sandbox.cfg
@@ -15,6 +15,8 @@
         expected_hugepage_size = 1024
     kill_vm = yes
     start_vm = no
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     force_create_fs_source = no

--- a/qemu/tests/cfg/virtio_fs_security_label.cfg
+++ b/qemu/tests/cfg/virtio_fs_security_label.cfg
@@ -10,6 +10,8 @@
     required_qemu = [4.2.0,)
     kill_vm = yes
     start_vm = no
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_type = mount

--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -9,6 +9,8 @@
         required_qemu = [5.2.0,)
     kill_vm = yes
     start_vm = no
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_dir = virtio_fs_test/

--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -26,6 +26,8 @@
     vm_mem_backend_path = /dev/shm
     driver_name = viofs
     fs_binary_extra_options = ''
+    Win10.i386:
+        mem = 4096
     !s390, s390x:
         mem_devs = mem1
         backend_mem_mem1 = memory-backend-file
@@ -122,8 +124,11 @@
             only with_cache.auto with_cache.always
             # Since in writeback-cache mode writes go to the cache only, A large number of dirty pages will be generated.
             # When the memory is insufficient, the performance will be seriously degraded, so increase the memory to 8G.
+            # For win10 32bit, the supported maximum memory size is 4G, so let's ignore the performance thing for win10 32bit.
             mem = 8192
-            size_mem1 = 8G
+            Win10.i386:
+                mem = 4096
+            size_mem1 = ${mem}M
             fs_binary_extra_options += " -o writeback"
         - sandbox:
             variants:

--- a/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
@@ -7,6 +7,8 @@
     required_qemu = [4.2.0,)
     kill_vm = yes
     start_vm = no
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_type = mount

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -7,6 +7,8 @@
     required_qemu = [4.2.0,)
     start_vm = no
     kill_vm = yes
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_type = mount
@@ -127,7 +129,9 @@
             # Since in writeback-cache mode writes go to the cache only, A large number of dirty pages will be generated.
             # When the memory is insufficient, the performance will be seriously degraded, so increase the memory to 8G.
             mem = 8192
-            size_mem1 = 8G
+            Win10.i386:
+                mem = 4096
+            size_mem1 = ${mem}M
             fs_binary_extra_options += " -o writeback"
         - sandbox:
             variants:

--- a/qemu/tests/cfg/virtio_fs_supp_group_transfer.cfg
+++ b/qemu/tests/cfg/virtio_fs_supp_group_transfer.cfg
@@ -15,6 +15,8 @@
         expected_hugepage_size = 1024
     kill_vm = yes
     start_vm = no
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     force_create_fs_source = yes

--- a/qemu/tests/cfg/virtio_fs_support_win_fs.cfg
+++ b/qemu/tests/cfg/virtio_fs_support_win_fs.cfg
@@ -6,6 +6,8 @@
     backup_image_before_testing = yes
     restore_image_after_testing = yes
     kill_vm = yes
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     force_create_fs_source = yes

--- a/qemu/tests/cfg/virtio_fs_winfsp_test.cfg
+++ b/qemu/tests/cfg/virtio_fs_winfsp_test.cfg
@@ -7,6 +7,8 @@
     required_qemu = [4.2.0,)
     kill_vm = yes
     start_vm = yes
+    Win10.i386:
+        mem = 4096
     filesystems = fs
     fs_driver = virtio-fs
     fs_source_type = mount

--- a/qemu/tests/cfg/win_sigverif.cfg
+++ b/qemu/tests/cfg/win_sigverif.cfg
@@ -73,6 +73,8 @@
         - with_viofs:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
             no Win2008 Win7
+            Win10.i386:
+                mem = 4096
             virt_test_type = qemu
             required_qemu = [4.2.0,)
             filesystems = fs

--- a/qemu/tests/cfg/win_virtio_driver_install_from_update.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_from_update.cfg
@@ -102,6 +102,8 @@
         - with_viofs:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
             no Win2008 Win7
+            Win10.i386:
+                mem = 4096
             virt_test_type = qemu
             required_qemu = [4.2.0,)
             filesystems = fs

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -226,6 +226,8 @@
         - with_viofs:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
             no Win2008 Win7
+            Win10.i386:
+                mem = 4096
             virt_test_type = qemu
             required_qemu = [4.2.0,)
             filesystems = fs


### PR DESCRIPTION
For Win10 i386 guest, the max memory size is 4G, so set it in the specific cases which use memory backend way to start VM.
ID: 1915