### PR TITLE
nmi_bsod_catch: change win2025 min memory to 4096

### DIFF
--- a/qemu/tests/cfg/nmi_bsod_catch.cfg
+++ b/qemu/tests/cfg/nmi_bsod_catch.cfg
@@ -2,7 +2,7 @@
     type = nmi_bsod_catch
     only Windows
     mem_fixed = 2048
-    Win2016, Win2019, Win2022:
+    Win2016, Win2019, Win2022, Win2025:
         mem_fixed = 4096
     enable_pvpanic = no
     config_cmds = config_cmd1, config_cmd2, config_cmd3, config_cmd4, config_cmd5, config_cmd6


### PR DESCRIPTION
Guest min memory has to be 4096.0 for win2025.

ID: 2113
Signed-off-by: menli <menli@redhat.com>