### PR TITLE
virtio_win_driver: update pnputil cmd to remove drivers

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -87,6 +87,9 @@
             cdrom_virtio_downgrade = isos/windows/virtio-win-downgrade.iso
             qga_url = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga"
             qga_pattern = "qemu-ga-win-\d\.\d\.\d-\d.el\dev"
+            Win2016:
+                # win2016 os build 14393 doesn't support uninstall parameter
+                uninst_store_cmd = "pnputil /delete-driver %s /force"
             variants:
                 - @default:
                 - without_driver:

--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -24,6 +24,9 @@
     devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     del devcon_dirname
     vio_driver_chk_cmd = 'driverquery /si | find /i "%s"'
+    Win2016:
+        # win2016 os build 14393 doesn't support uninstall parameter
+        uninst_store_cmd = "pnputil /delete-driver %s /force"
     key_to_install_driver = "tab;kp_enter"
     need_uninstall = yes
     need_destroy = yes

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -18,6 +18,9 @@
     sub_test = win_virtio_driver_update_test
     devcon_dirname = "win7_"
     vio_driver_chk_cmd = 'driverquery /si | find /i "%s"'
+    Win2016:
+        # win2016 os build 14393 doesn't support uninstall parameter
+        uninst_store_cmd = "pnputil /delete-driver %s /force"
     key_to_install_driver = "tab;kp_enter"
     Win2008..sp2:
         devcon_dirname = "wlh_"

--- a/qemu/tests/qemu_guest_agent_update.py
+++ b/qemu/tests/qemu_guest_agent_update.py
@@ -121,7 +121,9 @@ class QemuGuestAgentUpdateTest(QemuGuestAgentBasicCheckWin):
             inf_names = wmic.parse_list(session.cmd(inf_names_get_cmd,
                                                     timeout=360))
             for inf_name in inf_names:
-                uninst_store_cmd = "pnputil /f /d %s" % inf_name
+                pnp_cmd = "pnputil /delete-driver %s /uninstall /force"
+                uninst_store_cmd = params.get("uninst_store_cmd",
+                                              pnp_cmd) % inf_name
                 s, o = session.cmd_status_output(uninst_store_cmd, 360)
                 if s:
                     test.error("Failed to uninstall driver '%s' from store, "

--- a/qemu/tests/single_driver_install.py
+++ b/qemu/tests/single_driver_install.py
@@ -122,7 +122,9 @@ def run(test, params, env):
         error_context.context("Uninstalling previous installed driver",
                               test.log.info)
         for inf_name in _pnpdrv_info(session, device_name, ["InfName"]):
-            uninst_store_cmd = "pnputil /f /d %s" % inf_name
+            pnp_cmd = "pnputil /delete-driver %s /uninstall /force"
+            uninst_store_cmd = params.get("uninst_store_cmd",
+                                          pnp_cmd) % inf_name
             status, output = session.cmd_status_output(uninst_store_cmd,
                                                        inst_timeout)
             if status:


### PR DESCRIPTION
Virtio-win drivers behavior are changed because of INF isolation, So change the pnputil cmd to deletes a driver package from the
 driver store.
ID: 2219