### PR TITLE
bypass cache cases: the system call remains as openat in rhel10

### DIFF
--- a/qemu/tests/cfg/image_commit_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_commit_bypass_host_cache.cfg
@@ -13,9 +13,9 @@
     guest_tmp_filename = "/var/tmp/sn1"
     backup_image_before_testing = yes
     restore_image_after_testing = yes
-    trace_events = open
-    Host_RHEL.m8, Host_RHEL.m9:
-        trace_events = openat
+    trace_events = openat
+    Host_RHEL.m6, Host_RHEL.m7:
+        trace_events = open
     Windows:
         guest_tmp_filename = "C:\\sn1"
         x86_64:

--- a/qemu/tests/cfg/image_compare_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_compare_bypass_host_cache.cfg
@@ -8,6 +8,6 @@
     image_size_source = "10M"
     image_name_target = "images/target"
     convert_target = "target"
-    strace_event = open
-    Host_RHEL.m8, Host_RHEL.m9:
-        strace_event = openat
+    strace_event = openat
+    Host_RHEL.m6, Host_RHEL.m7:
+        strace_event = open

--- a/qemu/tests/cfg/image_convert_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_convert_bypass_host_cache.cfg
@@ -10,9 +10,9 @@
     image_name_target0 = "images/target0"
     image_name_target1 = "images/target1"
     convert_target = " target0 target1"
-    strace_event = open
-    Host_RHEL.m8, Host_RHEL.m9:
-        strace_event = openat
+    strace_event = openat
+    Host_RHEL.m6, Host_RHEL.m7:
+        strace_event = open
     variants:
         - luks_to_luks:
             image_format = luks

--- a/qemu/tests/cfg/image_rebase_bypass_host_cache.cfg
+++ b/qemu/tests/cfg/image_rebase_bypass_host_cache.cfg
@@ -13,13 +13,13 @@
     image_name_sn2 = "images/sn2"
     image_format_sn2 = qcow2
     image_size_sn2 = ""
-    trace_event = open
+    trace_event = openat
     guest_tmp_filename = "/var/tmp/%s"
     # only backup system disk
     backup_image_before_testing_image1 = yes
     restore_image_after_testing_image1 = yes
-    Host_RHEL.m8, Host_RHEL.m9:
-        trace_event = openat
+    Host_RHEL.m6, Host_RHEL.m7:
+        trace_event = open
     Windows:
         guest_tmp_filename = "C:\\%s"
         x86_64:


### PR DESCRIPTION
Add rhel10 host in the conf files for openat system call

ID: 2221