### PR TITLE
jumbo:extend the time to wait for the MTU to be ok after MTU changed

### DIFF
--- a/generic/tests/jumbo.py
+++ b/generic/tests/jumbo.py
@@ -190,7 +190,7 @@ def run(test, params, env):
                                   "than 50% for size %s" % size)
 
         test.log.info("Waiting for the MTU to be OK")
-        wait_mtu_ok = 10
+        wait_mtu_ok = 20
         if not utils_misc.wait_for(is_mtu_ok, wait_mtu_ok, 0, 1):
             test.log.debug(process.getoutput("ifconfig -a",
                                              verbose=False,


### PR DESCRIPTION
After QE debugging found the Windows 2025 needs to re-identify the nic configuration after changing the MTU, so the original waiting time is a bit short to cause testing errors, so it was extended.

ID:2222
Signed-off-by: Lei Yang leiyang@redhat.com