### PR TITLE
fwcfg: add the 'dmp file removed' step at the test case end

### DIFF
--- a/provider/win_driver_installer_test.py
+++ b/provider/win_driver_installer_test.py
@@ -396,5 +396,6 @@ def fwcfg_test(test, params, vm):
     else:
         cmd = "ls -l %s | awk '{print $5}'" % dump_file
         dump_size = int(process.getoutput(cmd))
+        process.system("rm -rf %s" % dump_file, shell=True)
         if dump_size == 0:
             test.fail("The dump file is empty")


### PR DESCRIPTION
This patch primarily adds a 'dmp file removed' step in the fwcfg part. We need it because it will completely fill the disk during the acceptance test.

ID: 2084

Signed-off-by: wji <wji@redhat.com>