### PR TITLE
virtio_fs: add user to the group when it exists

### DIFF
--- a/qemu/tests/virtio_fs_group_permission_access.py
+++ b/qemu/tests/virtio_fs_group_permission_access.py
@@ -51,6 +51,7 @@ def run(test, params, env):
 
     try:
         for _username in username:
+            add_cmd = add_user_cmd % _username
             if process.system("id %s" % _username, shell=True,
                               ignore_status=True) == 0:
                 s, o = process.getstatusoutput(del_user_cmd % _username)
@@ -61,7 +62,10 @@ def run(test, params, env):
                     else:
                         test.fail("Unknown error when deleting the "
                                   "user: %s" % o)
-            process.run(add_user_cmd % _username)
+            if process.system("grep %s /etc/group" % _username, shell=True,
+                              ignore_status=True) == 0:
+                add_cmd = "useradd -g %s %s" % (_username, _username)
+            process.run(add_cmd)
         user_one, user_two = username[0], username[-1]
         # create the folder before daemon running
         shared_dir = os.path.join("/home/" + user_one, fs_source)

--- a/qemu/tests/virtio_fs_host_owner_win.py
+++ b/qemu/tests/virtio_fs_host_owner_win.py
@@ -105,10 +105,23 @@ def run(test, params, env):
     if params.get("privileged", ""):
         # start virtiofsd with user config
         user_name = params["new_user"]
+        add_user_cmd = params["add_user_cmd"]
+        del_user_cmd = params["del_user_cmd"]
         if process.system("id %s" % user_name, shell=True,
                           ignore_status=True) == 0:
-            process.run(params["del_user_cmd"])
-        process.run(params["add_user_cmd"])
+            s, o = process.getstatusoutput(del_user_cmd)
+            if s:
+                if "is currently used by process" in o:
+                    test.error("The common user is used by other process,"
+                               " pls check on your host.")
+                else:
+                    test.fail("Unknown error when deleting the "
+                              "user: %s" % o)
+        if process.system("grep %s /etc/group" % user_name, shell=True,
+                          ignore_status=True) == 0:
+            add_user_cmd = "useradd -g %s %s" % (user_name, user_name)
+        process.run(add_user_cmd)
+
         # config socket
         sock_path = os.path.join("/home/" + user_name,
                                  '-'.join(('avocado-vt-vm1', 'viofs',


### PR DESCRIPTION
Sometimes when add a new user, it failed when the group
    existed. In this situation, add the new user to the group.

ID: 2224