### PR TITLE
ppc64le:compatible mode is not supported for rhel9 guest

### DIFF
--- a/qemu/tests/cfg/mmu_basic.cfg
+++ b/qemu/tests/cfg/mmu_basic.cfg
@@ -12,6 +12,7 @@
         - @default:
             only RHEL.8
         - hpt:
+            no RHEL.9
             machine_type_extra_params = "max-cpu-compat=power8"
             RHEL.7:
                 mmu_option = no


### PR DESCRIPTION
ppc64le:compatible mode is not supported for rhel9 guest

ID: 2269

Signed-off-by: Miriam Deng mdeng@redhat.com