### PR TITLE
 Limit virtio_fsd_check_info test scenario

### DIFF
--- a/qemu/tests/cfg/virtio_fsd_check_info.cfg
+++ b/qemu/tests/cfg/virtio_fsd_check_info.cfg
@@ -1,5 +1,6 @@
 - virtio_fsd_check_info:
-    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8.u0 Host_RHEL.m8.u1
+    no Host_RHEL.m8.u0 Host_RHEL.m8.u1
+    only Host_RHEL.m8
     type = virtio_fsd_check_info
     virt_test_type = qemu
     required_qemu = [4.2.0,)


### PR DESCRIPTION
Virtio_fs: Limit virtio_fsd_check_info only run on RHEL8, cause start
from virtiofsd version info not include qemu version anymore

ID: 1501

Signed-off-by: Boqiao Fu <bfu@redhat.com>