### PR TITLE
hv_avic: Add timeout=300 for "yum -y install cpuid"

### DIFF
--- a/qemu/tests/hv_avic.py
+++ b/qemu/tests/hv_avic.py
@@ -46,7 +46,7 @@ def run(test, params, env):
     status = session.cmd_status(cpuid_chk_cmd)
     if status:
         install_epel_repo()
-        status = session.cmd_status("yum -y install %s" % cpuid_pkg)
+        status = session.cmd_status("yum -y install %s" % cpuid_pkg, timeout=300)
         if status:
             test.error("Fail to install target cpuid")
     error_context.context("Check the corresponding CPUID entries with "


### PR DESCRIPTION
Original timeout is 60, it isn't enough for yum install cpuid. There are many files extract, enlarge it to 300.

ID: 2343
Signed-off-by: Peixiu Hou <phou@redhat.com>