### PR TITLE
Forbidden ovs tests in nic_teaming case

### DIFF
--- a/qemu/tests/nic_teaming.py
+++ b/qemu/tests/nic_teaming.py
@@ -80,6 +80,9 @@ def run(test, params, env):
         team_exists_cmd = params.get("team_if_exists_cmd")
         return session_serial.cmd_status(team_exists_cmd, safe=True) == 0
 
+    if params["netdst"] not in utils_net.Bridge().list_br():
+        test.cancel("Host does not use Linux Bridge")
+
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     timeout = int(params.get("login_timeout", 1200))


### PR DESCRIPTION
After discussion with developer who think in this case the lost ratio from 0% ~ 100% are all correct, so QE decided to remove ovs test case.

ID:2351
Signed-off-by: Lei Yang leiyang@redhat.com