### PR TITLE
qemu_guest_agent_update: system reboot needed after remove drivers

### DIFF
--- a/qemu/tests/qemu_guest_agent_update.py
+++ b/qemu/tests/qemu_guest_agent_update.py
@@ -125,7 +125,9 @@ class QemuGuestAgentUpdateTest(QemuGuestAgentBasicCheckWin):
                 uninst_store_cmd = params.get("uninst_store_cmd",
                                               pnp_cmd) % inf_name
                 s, o = session.cmd_status_output(uninst_store_cmd, 360)
-                if s:
+                if s not in (0, 3010):
+                    # for vioser, they need system reboot
+                    # acceptable status: OK(0), REBOOT(3010)
                     test.error("Failed to uninstall driver '%s' from store, "
                                "details:\n%s" % (driver_name, o))
 


### PR DESCRIPTION
For vioser, they need system reboot after
removing drivers with new pnputil cmd
"pnputil /delete-driver %s /uninstall /force"

ID: 2353
Signed-off-by: Dehan Meng <demeng@redhat.com>