### PR TITLE
qemu_guest_agent: Add absolute path to 'python' for windows guest

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -160,7 +160,7 @@
             gagent_check_type = get_time
             get_guest_time_cmd = `command -v python python3 | head -1` -c "import time; print(int(time.time()))"
             Windows:
-                get_guest_time_cmd = python -c "import time; print(int(time.time()))"
+                get_guest_time_cmd = C:\python312\python -c "import time; print(int(time.time()))"
         - check_memory_leak:
             only Windows
             gagent_check_type = memory_leak
@@ -174,7 +174,7 @@
             gagent_check_type = set_time
             get_guest_time_cmd = `command -v python python3 | head -1` -c "import time; print(int(time.time()))"
             Windows:
-                get_guest_time_cmd = python -c "import time; print(int(time.time()))"
+                get_guest_time_cmd = C:\python312\python -c "import time; print(int(time.time()))"
             move_time_cmd = "date --rfc-3339=seconds --utc; date --set='now - 1 week' > /dev/null; date --rfc-3339=seconds --utc"
             variants:
                 - @default:
@@ -185,7 +185,7 @@
             gagent_check_type = time_sync
             image_snapshot = yes
             rtc_drift = none
-            get_guest_time_cmd = python -c "import time; print(int(time.time()))"
+            get_guest_time_cmd = C:\python312\python -c "import time; print(int(time.time()))"
             time_service_config = w32tm /config /manualpeerlist:"clock.redhat.com" /syncfromflags:manual /reliable:yes /update
             time_service_status_cmd = sc query w32time |findstr "RUNNING"
             time_service_stop_cmd = net stop w32time
@@ -449,7 +449,7 @@
                 cmd_get_user_domain = wmic useraccount where name='%s' get domain |findstr /vi domain
                 # 3/3/2020 9:35 AM
                 time_pattern = " (\d+/\d+/\d+ \d+:\d+ [APap][Mm])"
-                cmd_time_trans = python -c "import time; dt='%s'; t=time.mktime(time.strptime(dt, '%%m/%%d/%%Y %%I:%%M %%p')); print(t)"
+                cmd_time_trans = C:\python312\python -c "import time; dt='%s'; t=time.mktime(time.strptime(dt, '%%m/%%d/%%Y %%I:%%M %%p')); print(t)"
         - check_os_info:
             no RHEL.6
             gagent_check_type = os_info


### PR DESCRIPTION
Python does not add environment variables, so we need to complete the absolute path before it can be used.

ID: 2356
Signed-off-by: Dehan Meng <demeng@redhat.com>