### PR TITLE
virtio_fs: disable debug log for stress test

### DIFF
--- a/qemu/tests/cfg/driver_load_stress.cfg
+++ b/qemu/tests/cfg/driver_load_stress.cfg
@@ -199,6 +199,10 @@
             viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
             viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
             viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
+            debug_log_operation = 'disable'
+            viofs_debug_delete_cmd = 'reg delete HKLM\Software\VirtIO-FS /v DebugFlags /f'
+            viofs_log_delete_cmd = 'reg delete HKLM\Software\VirtIO-FS /v DebugLogFile /f'
+            viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'
             stress_bs = 4K
             fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
             fio_options += '--bs=%s --size=1G --iodepth=16 --numjobs=8 --runtime=600 --thread'

--- a/qemu/tests/cfg/virtio_fs_memory_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_memory_backend.cfg
@@ -42,6 +42,7 @@
         viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
         viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
         viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
+        debug_log_operation = 'enable'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -56,8 +56,11 @@
         viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
         viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
         viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
+        debug_log_operation = 'enable'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
+        viofs_debug_delete_cmd = 'reg delete HKLM\Software\VirtIO-FS /v DebugFlags /f'
+        viofs_log_delete_cmd = 'reg delete HKLM\Software\VirtIO-FS /v DebugLogFile /f'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'
         virtio_win_media_type = iso
         cdroms += " virtio"
@@ -253,6 +256,8 @@
                     viofs_case_insense_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v CaseInsensitive /d 1 /t REG_DWORD'
         - run_stress:
             no extra_parameters socket_group
+            Windows:
+                debug_log_operation = "disable"
             stress_bs = 4K 16K 64K
             variants:
                 - with_fio:

--- a/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
@@ -46,6 +46,7 @@
         viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
         viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
         viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
+        debug_log_operation = 'enable'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -59,6 +59,7 @@
         viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
         viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
         viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
+        debug_log_operation = 'enable'
         viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
         viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
         viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/virtio_fs_winfsp_test.cfg
+++ b/qemu/tests/cfg/virtio_fs_winfsp_test.cfg
@@ -51,6 +51,7 @@
     viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
     viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
     viofs_sc_delete_cmd = 'sc delete ${viofs_svc_name}'
+    debug_log_operation = 'enable'
     viofs_debug_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugFlags /d 0xFFFFFFFF /t REG_DWORD'
     viofs_log_enable_cmd = 'reg add HKLM\Software\VirtIO-FS /v DebugLogFile /d ${viofs_log_file} /t REG_SZ'
     viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -269,6 +269,10 @@
             viofs_sc_create_cmd += ' depend="WinFsp.Launcher/VirtioFsDrv" DisplayName="Virtio FS Service"'
             viofs_sc_start_cmd = 'sc start ${viofs_svc_name}'
             viofs_sc_query_cmd = 'sc query ${viofs_svc_name}'
+            debug_log_operation = 'disable'
+            viofs_debug_delete_cmd = 'reg delete HKLM\Software\VirtIO-FS /v DebugFlags /f'
+            viofs_log_delete_cmd = 'reg delete HKLM\Software\VirtIO-FS /v DebugLogFile /f'
+            viofs_reg_query_cmd = 'reg query HKLM\Software\VirtIO-FS'
             stress_bs = 4K
             fio_options = '--name=stress --filename=%s --ioengine=windowsaio --rw=write --direct=1 '
             fio_options += '--bs=%s --size=1G --iodepth=16 --numjobs=8 --runtime=1800 --thread'


### PR DESCRIPTION
When running stress test on windows vm, there'll
be a large debug log created which will occupy the whole c: volume.
Therefore, disable it before starting stress test.

ID: 1837