### PR TITLE
blockdev_mirror_forbidden_actions:error msg update

### DIFF
--- a/qemu/tests/cfg/blockdev_mirror_forbidden_actions.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_forbidden_actions.cfg
@@ -2,7 +2,6 @@
 #   mirror/commit/resize/live snapshot/stream action should be forbidden during mirror
 #     The mirror image is a local image(filesystem)
 
-
 - blockdev_mirror_forbidden_actions:
     only Linux
     start_vm = no
@@ -25,7 +24,9 @@
     error_msg_stream = Node '${top_device_node}' is busy: block device is in use by block job: mirror
     error_msg_mirror = Need a root block node
     error_msg_commit = Need a root block node
-    error_msg_resize = Device '(null)' is in use
+    error_msg_resize = Node 'drive_${target_images}' is busy: block device is in use by block job: mirror
+    Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3, Host_RHEL.m9.u4:
+        error_msg_resize = Device '(null)' is in use
 
     image_size_data1 = 2G
     image_size_mirror1 = ${image_size_data1}


### PR DESCRIPTION
Error msg for resizing disks during mirror changed since qemu9.0, update the error msg to compate with both old and new qemu version
id:2293

Signed-off-by: Aihua Liang <aliang@redhat.com>