### PR TITLE
blockdev_stream_forbidden_actions:update resize err msg

### DIFF
--- a/qemu/tests/cfg/blockdev_stream_forbidden_actions.cfg
+++ b/qemu/tests/cfg/blockdev_stream_forbidden_actions.cfg
@@ -2,7 +2,6 @@
 #   mirror/commit/resize/live snapshot/stream action should be forbidden during stream
 #     The snapshot images are local fs images
 
-
 - blockdev_stream_forbidden_actions:
     only Linux
     qemu_force_use_drive_expression = no
@@ -29,7 +28,9 @@
     error_msg_stream = "Node '${top_device_node}' is busy: block device is in use by block job: stream"
     error_msg_mirror = "Need a root block node"
     error_msg_commit = "Need a root block node"
-    error_msg_resize = "Device '(null)' is in use"
+    error_msg_resize = Node '${top_device_node}' is busy: block device is in use by block job: stream
+    Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3, Host_RHEL.m9.u4:
+        error_msg_resize = "Device '(null)' is in use"
 
     image_size_data = 2G
     image_size_datasn1 = ${image_size_data}
@@ -48,7 +49,7 @@
     iscsi_direct:
         lun_data = 1
     ceph:
-       image_format_data = raw
+        image_format_data = raw
 
     # For the local snapshot images
     enable_iscsi_datasn2 = no


### PR DESCRIPTION
Error msg for resizing disks during mirror changed since qemu9.0, update it to compatible with both old and new qemu versions.

id: 2292

Signed-off-by: Aihua Liang <aliang@redhat.com>