### PR TITLE
blockdev_commit_forbidden_actions:update resize err msg

### DIFF
--- a/qemu/tests/cfg/blockdev_commit_forbidden_actions.cfg
+++ b/qemu/tests/cfg/blockdev_commit_forbidden_actions.cfg
@@ -31,7 +31,9 @@
     error_msg_stream = "Node '${top_device_node}' is busy: block device is in use by block job: commit"
     error_msg_mirror = "Need a root block node"
     error_msg_commit = "Need a root block node"
-    error_msg_resize = "Device '(null)' is in use"
+    error_msg_resize = Node '${top_device_node}' is busy: block device is in use by block job: commit
+    Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3, Host_RHEL.m9.u4:
+        error_msg_resize = "Device '(null)' is in use"
     iscsi_direct:
         lun_data = 1
         enable_iscsi_sn1 = no


### PR DESCRIPTION
Error msg for resizing during commit changed since qemu9.0, update the error msg to compatible with both old and new qemu version

id: 2295

Signed-off-by: Aihua Liang <aliang@redhat.com>