### PR TITLE
edk2_stability_test:Add edk2 stability test

### DIFF
--- a/qemu/tests/cfg/edk2_stability_test.cfg
+++ b/qemu/tests/cfg/edk2_stability_test.cfg
@@ -1,0 +1,9 @@
+- edk2_stability_test:
+    virt_test_type = qemu
+    only Linux
+    type = edk2_stability_test
+    start_vm = no
+    login_timeout = 120
+    reboot_count = 20
+    skip_image_processing = yes
+    check_messgae = "enter to boot the selected OS"

--- a/qemu/tests/edk2_stability_test.py
+++ b/qemu/tests/edk2_stability_test.py
@@ -1,0 +1,30 @@
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Qemu edk2 stability test:
+    1) Try to log into a guest
+    2) Check serial log information
+    3) Cycle the above process
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    check_messgae = params.get("check_messgae")
+    timeout = params.get_numeric("login_timeout", 120)
+    vm = env.get_vm(params["main_vm"])
+
+    for i in range(params.get_numeric("reboot_count", 1)):
+        vm.create()
+        error_context.context("Check serial log result", test.log.info)
+        try:
+            vm.serial_console.read_until_output_matches([check_messgae],
+                                                        timeout=timeout)
+        except Exception as msg:
+            test.log.error(msg)
+            test.fail("No highlighted entry was detected "
+                      "the boot was abnormal.")
+        vm.destroy(gracefully=False)


### PR DESCRIPTION
Sometimes stability issue occurs when edk2 is loading, 
but this has nothing to do with loading the kernel. 
Design a new test scenario only to check the process from edk2 to the boot kernel.
Skip the subsequent processes of kernel startup.

ID: 2378