### PR TITLE
virtio_mem_dynamic_memslots_with_migration: creates new test case

### DIFF
--- a/qemu/tests/cfg/virtio_mem_dynamic_memslots_with_migration.cfg
+++ b/qemu/tests/cfg/virtio_mem_dynamic_memslots_with_migration.cfg
@@ -1,0 +1,23 @@
+- virtio_mem_dynamic_memslots_with_migration:
+    only Linux
+    no RHEL.6 RHEL.7 RHEL.8
+    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+    no s390x
+    required_qemu = [8.2.0,)
+    type = virtio_mem_dynamic_memslots_with_migration
+    virt_test_type = qemu
+    timeout = 10
+    maxmem_mem = 24G
+    mem = 4096
+    mem_devs = 'vmem0'
+    vm_memdev_model_vmem0 = "virtio-mem"
+    size_mem_vmem0 = 4G
+    use_mem_vmem0 = yes
+    memdev_memory_vmem0 = "mem-vmem0"
+    kernel_extra_params_add = "memhp_default_state=online_movable"
+    pcie_extra_root_port = 1
+    requested-size_test_vmem0 = "4G"
+    total_memslots = 4
+    kill_vm_on_error = yes
+    mig_timeout = 1200
+    migration_protocol = "tcp"

--- a/qemu/tests/virtio_mem_dynamic_memslots_with_migration.py
+++ b/qemu/tests/virtio_mem_dynamic_memslots_with_migration.py
@@ -1,0 +1,50 @@
+import time
+
+from virttest import error_context
+
+from virttest.utils_misc import normalize_data_size
+from provider import virtio_mem_utils
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Virtio-mem dynamic memslots with migration test
+    1) Boot VM
+    2) Resize virtio-mem device
+    3) Do migration
+    4) Check virtio-mem size in dst host
+    5) Validate the virtio-mem device now has the correct number of memslots
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    requested_size_vmem_test = params.get("requested-size_test_vmem0")
+    total_memslots = params.get_numeric("total_memslots", 4)
+    mem_object_id = params["mem_devs"]
+    timeout = params.get_numeric("timeout", 10)
+
+    device_id = "virtio_mem-%s" % mem_object_id
+
+    req_size_normalized = int(float(normalize_data_size(requested_size_vmem_test, "B")))
+    vm.monitor.qom_set(device_id, "requested-size", req_size_normalized)
+
+    time.sleep(10)
+    virtio_mem_utils.check_memory_devices(
+        device_id, requested_size_vmem_test, 0, vm, test
+    )
+
+    mig_timeout = params.get_numeric("mig_timeout", 1200, float)
+    mig_protocol = params.get("migration_protocol", "tcp")
+    vm.migrate(mig_timeout, mig_protocol, env=env)
+
+    virtio_mem_utils.check_memory_devices(
+        device_id, requested_size_vmem_test, 0, vm, test
+    )
+
+    virtio_mem_utils.validate_memslots(total_memslots, test, vm, mem_object_id, timeout)


### PR DESCRIPTION
Depends on: https://github.com/autotest/tp-qemu/pull/4034

virtio_mem_dynamic_memslots_with_migration: creates new test case

Creates new test case that boots up a VM including a virtio-mem device,
then resizes it and then performs live migration. Finally, checks the
virtio-mem size remains the same as before migration and validates
the number of memslots is the expected one.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2370