### PR TITLE
virtio_win_installer: update warining check case via msi

### DIFF
--- a/qemu/tests/win_virtio_driver_installer_repair.py
+++ b/qemu/tests/win_virtio_driver_installer_repair.py
@@ -70,11 +70,12 @@ def run(test, params, env):
         test_func = "win_driver_installer_test.%s_test" % test_name
         driver_test_params = params.get('driver_test_params_%s'
                                         % driver_name, '{}')
+        if driver_name == "viofs":
+            virtio_fs_utils.run_viofs_service(test, params, session)
+
         if driver_name == "balloon":
             balloon_test_win = BallooningTestWin(test, params, env)
             driver_test_params = {"balloon_test_win": balloon_test_win}
-        elif driver_name == "viofs":
-            virtio_fs_utils.run_viofs_service(test, params, session)
         else:
             driver_test_params = ast.literal_eval(driver_test_params)
 

--- a/qemu/tests/win_virtio_driver_installer_uninstall.py
+++ b/qemu/tests/win_virtio_driver_installer_uninstall.py
@@ -36,6 +36,7 @@ def run(test, params, env):
     :param env: Dictionary with test environment
     """
     run_install_cmd = params["run_install_cmd"]
+    run_uninstall_cmd = params["run_uninstall_cmd"]
     installer_pkg_check_cmd = params["installer_pkg_check_cmd"]
 
     # gagent version check test config
@@ -70,18 +71,21 @@ def run(test, params, env):
                           test.log.info)
     vm.send_key('meta_l-d')
     time.sleep(30)
-    run_uninstall_cmd = utils_misc.set_winutils_letter(session,
-                                                       params["run_uninstall_cmd"])
-
-    session = run_installer_with_interaction(vm, session, test, params,
-                                             run_uninstall_cmd)
 
     if uninstall_method == "msi":
+        run_uninstall_cmd = utils_misc.set_winutils_letter(
+            session, run_uninstall_cmd
+        )
+        session.cmd(run_uninstall_cmd)
+        time.sleep(30)
         check_warning_file = params["check_warning_file"]
         output = session.cmd_output(check_warning_file)
         if params["warning_message"] not in output:
             test.fail("Not found expected warning message, the output is %s" % output)
     else:
+        session = run_installer_with_interaction(vm, session,
+                                                 test, params,
+                                                 run_uninstall_cmd)
         s_check, o_check = session.cmd_status_output(installer_pkg_check_cmd)
         if s_check == 0:
             test.fail("Could not uninstall Virtio-win-guest-tools package "


### PR DESCRIPTION
As the installer behavior was changed from 1.9.38, while warning check case just require to check warning status during install all drivers by msi and it doesn't mean to finish the whole installation action.
So, it's better to seperate the two uninstall ways in the script.
fix viofs_basic_io_test argument error

ID: 2385, 2407