### PR TITLE
ci: bypass pylint issue

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,3 @@
-pylint
+pylint<3.2.0
 inspektor==0.5.3
 autopep8


### PR DESCRIPTION
We are no ready for enabling this new check [1] since we have seen hundreds of errors been detected. So let us firstly restrict pylint to an old version and make a regular fix via another patch.

Reference:
[1] https://pylint.readthedocs.io/en/v3.2.0/whatsnew/3/3.2/index.html#new-checks

ID: 2387