### PR TITLE
Fix the wrong bus usage and remove multi mem-backend on s390x

### DIFF
--- a/qemu/tests/cfg/virtio_fs_hotplug.cfg
+++ b/qemu/tests/cfg/virtio_fs_hotplug.cfg
@@ -23,13 +23,7 @@
     force_create_fs_source = no
     remove_fs_source = yes
     fs_driver_props = {"queue-size": 1024}
-    mem_devs = mem1
-    backend_mem_mem1 = memory-backend-file
-    mem-path_mem1 = /dev/shm
-    size_mem1 = ${mem}M
-    use_mem_mem1 = no
     share_mem = yes
-    cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'
     cmd_md5 = 'md5sum %s'
     io_timeout = 120
     s390, s390x:
@@ -45,6 +39,12 @@
         guest_numa_nodes = shm0
         numa_memdev_shm0 = mem-mem1
         numa_nodeid_shm0 = 0
+        cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'
+        mem_devs = mem1
+        backend_mem_mem1 = memory-backend-file
+        mem-path_mem1 = /dev/shm
+        size_mem1 = ${mem}M
+        use_mem_mem1 = no
     Windows:
         # install winfsp tool
         i386, i686:

--- a/qemu/tests/virtio_fs_hotplug.py
+++ b/qemu/tests/virtio_fs_hotplug.py
@@ -240,7 +240,13 @@ def run(test, params, env):
             if isinstance(dev, qdevices.CharDevice):
                 dev.set_param("server", "off")
             if isinstance(dev, qdevices.QDevice) and action == "hotplug":
-                parent_bus = 'pcie_extra_root_port_%s' % index if params['machine_type'] == 'q35' else 'pci.0'
+                if "q35" in params['machine_type'] or "arm64-pci" in params[
+                        'machine_type']:
+                    parent_bus = 'pcie_extra_root_port_%s' % index
+                elif 's390' in params['machine_type']:
+                    parent_bus = 'virtual-css'
+                else:
+                    parent_bus = 'pci.0'
                 parent_bus_obj = vm.devices.get_buses({'aobject': parent_bus})[0]
                 ret = getattr(vm.devices, 'simple_%s' % action)(dev, vm.monitor, bus=parent_bus_obj)
                 if not ret[1]:


### PR DESCRIPTION
virtio_fs: update bus to 'virtual-css' and remove mutl memory backend
on s390x

ID: 2382

Signed-off-by: Boqiao Fu <bfu@redhat.com>