### PR TITLE
pktgen_burst_test: only test virtio_net

### DIFF
--- a/qemu/tests/cfg/pktgen_burst_test.cfg
+++ b/qemu/tests/cfg/pktgen_burst_test.cfg
@@ -3,6 +3,7 @@
     no Host_RHEL.m5, Host_RHEL.m6
     virt_test_type = qemu
     type = pktgen_perf
+    only virtio_net
     kill_vm = yes
     pktgen_test_timeout = 30
     #set pktgen threads


### PR DESCRIPTION
For this case we only test it with multi queues, so limit it on the virtio_net.

ID:2399
Signed-off-by: Lei Yang leiyang@redhat.com