### PR TITLE
emulate_vf_shutdown: only test on igb

### DIFF
--- a/qemu/tests/cfg/emulate_vf_shutdown.cfg
+++ b/qemu/tests/cfg/emulate_vf_shutdown.cfg
@@ -1,6 +1,7 @@
 - emulate_vf_shutdown:
     virt_test_type = qemu
     type = emulate_vf_shutdown
+    only igb
     shutdown_command = shutdown -h now
     login_timeout = 240
     get_pci_id = lspci -D |grep -i Eth |awk '{print $1}'


### PR DESCRIPTION
Due to the emulate sriov function only support on igb device, so let's limit it on igb, it will be update when there is another nic type can support emulate sriov function.

ID:2400
Signed-off-by: Lei Yang leiyang@redhat.com