### PR TITLE
nic_teaming: Limit only run on RHEL7 and RHEL8

### DIFF
--- a/qemu/tests/cfg/nic_teaming.cfg
+++ b/qemu/tests/cfg/nic_teaming.cfg
@@ -1,7 +1,7 @@
-- nic_teaming: 
+- nic_teaming:
     virt_test_type = qemu
     only Linux
-    no RHEL.6
+    only Host_RHEL.m7, Host_RHEL.m8
     type = nic_teaming
     nics += ' nic2 nic3 nic4'
     image_snapshot = yes
@@ -12,7 +12,7 @@
     failed_ratio = 5
     route_cmd = route -n
     team_if = team0
-    nm_stop_cmd = pidof NetworkManager && service NetworkManager stop; true    
+    nm_stop_cmd = pidof NetworkManager && service NetworkManager stop; true
     killteam_cmd = teamd -t ${team_if} -k
     clearip_cmd = ip addr flush %s
     setdown_cmd = ip link set %s down


### PR DESCRIPTION
This module has been deprecated start rhel.9.0,it is supported since rhel7.So limit it only run on RHEL7 and RHEL8.

ID:2431
Signed-off-by: Lei Yang leiyang@redhat.com