### PR TITLE
blockdev_snapshot_install: install tag for RHEL1O

### DIFF
--- a/qemu/tests/cfg/blockdev_snapshot_install.cfg
+++ b/qemu/tests/cfg/blockdev_snapshot_install.cfg
@@ -19,6 +19,7 @@
     tag_for_install_start += "|Mounted Temporary Directory"
     tag_for_install_start += "|NetworkManager autoconnections configuration for Anaconda installation environment"
     tag_for_install_start += "|Anaconda NetworkManager configuration"
+    tag_for_install_start += "|Starting installer, one moment"
     storage_type_default = "directory"
     storage_pool = default
     snapshot_tag = sn1
@@ -48,15 +49,15 @@
         enable_iscsi_image1 = yes
         image_raw_device_sn1 = no
     ceph:
-       enable_ceph_cd1 = no
-       enable_ceph_unattended = no
-       enable_ceph_sn1 = no
-       enable_ceph_image1 = yes
+        enable_ceph_cd1 = no
+        enable_ceph_unattended = no
+        enable_ceph_sn1 = no
+        enable_ceph_image1 = yes
     nbd:
-       enable_nbd_cd1 = no
-       enable_nbd_unattended = no
-       enable_nbd_sn1 = no
-       enable_nbd_image1 = yes
-       nbd_port_image1 = 10830
-       force_create_image_image1 = no
-       remove_image_image1 = no
+        enable_nbd_cd1 = no
+        enable_nbd_unattended = no
+        enable_nbd_sn1 = no
+        enable_nbd_image1 = yes
+        nbd_port_image1 = 10830
+        force_create_image_image1 = no
+        remove_image_image1 = no


### PR DESCRIPTION
Installer tag changed in RHEL10, so need to define the new installer tag for RHEL10
Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2439