### PR TITLE
blockdev_stream_install: install tag for RHEL10

### DIFF
--- a/qemu/tests/cfg/blockdev_stream_install.cfg
+++ b/qemu/tests/cfg/blockdev_stream_install.cfg
@@ -37,6 +37,7 @@
     tag_for_install_start += "|Mounted Temporary Directory"
     tag_for_install_start += "|NetworkManager autoconnections configuration for Anaconda installation environment"
     tag_for_install_start += "|Anaconda NetworkManager configuration"
+    tag_for_install_start += "|Starting installer, one moment"
     rebase_mode = unsafe
 
     # Always access cd1 and unattended as local storage


### PR DESCRIPTION
blockdev_stream_install: install tag for RHEL10
    
    Install tag changed in RHEL1O, so re-set an installer
    tag for RHEL10
    
    Signed-off-by: Aihua Liang <aliang@redhat.com>

id:2440

