### PR TITLE
blockdev_commit_install:install tag for RHEL10

### DIFF
--- a/qemu/tests/cfg/blockdev_commit_install.cfg
+++ b/qemu/tests/cfg/blockdev_commit_install.cfg
@@ -45,6 +45,7 @@
     tag_for_install_start += "|Mounted Temporary Directory"
     tag_for_install_start += "|NetworkManager autoconnections configuration for Anaconda installation environment"
     tag_for_install_start += "|Anaconda NetworkManager configuration"
+    tag_for_install_start += "|Starting installer, one moment"
 
     virtio_scsi:
         # disable iothread
@@ -64,17 +65,17 @@
         enable_iscsi_sn4 = no
         image_raw_device_sn4 = no
     ceph:
-       enable_ceph_cd1 = no
-       enable_ceph_unattended = no
-       enable_ceph_sn1 = no
-       enable_ceph_sn2 = no
-       enable_ceph_sn3 = no
-       enable_ceph_sn4 = no
+        enable_ceph_cd1 = no
+        enable_ceph_unattended = no
+        enable_ceph_sn1 = no
+        enable_ceph_sn2 = no
+        enable_ceph_sn3 = no
+        enable_ceph_sn4 = no
     nbd:
-       enable_nbd_cd1 = no
-       enable_nbd_unattended = no
-       enable_nbd_sn1 = no
-       enable_nbd_sn2 = no
-       enable_nbd_sn3 = no
-       enable_nbd_sn4 = no
-       nbd_port_image1 = 10830
+        enable_nbd_cd1 = no
+        enable_nbd_unattended = no
+        enable_nbd_sn1 = no
+        enable_nbd_sn2 = no
+        enable_nbd_sn3 = no
+        enable_nbd_sn4 = no
+        nbd_port_image1 = 10830


### PR DESCRIPTION
    blockdev_commit_install:install tag for RHEL10
    
    Install tag changed in RHEL10, re-set it.
    
    Signed-off-by: Aihua Liang <aliang@redhat.com>
  id: 2441