### PR TITLE
uefi_check_resolution: set the timeout parameter for reboot method

### DIFF
--- a/qemu/tests/uefi_check_resolution.py
+++ b/qemu/tests/uefi_check_resolution.py
@@ -74,7 +74,7 @@ def run(test, params, env):
     key += save_change_key
     key += esc_boot_menu_key
     list(map(vm.send_key, key))
-    vm.reboot()
+    vm.reboot(timeout=timeout)
 
     if not boot_check(check_info):
         test.fail("Change to resolution {'%s'} fail" % resolution)


### PR DESCRIPTION
because sometimes the vm may login time out with the default value, set the timeout parameter for reboot method

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2486