### PR TITLE
Switch to create keyfile instead of configure file since rhel9

### DIFF
--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -1,10 +1,14 @@
 - multi_nics_verify: guest_test.arp_set
     virt_test_type = qemu
     type = multi_nics_verify
+    image_snapshot = yes
     no RHEL.3.9
     start_vm = no
     login_timeout = 3600
     flexible_nic_index = yes
+    network_manager = yes
+    RHEL.7, RHEL.8:
+        network_manager = no
     variants:
         - nic_virtio:
             only virtio_net


### PR DESCRIPTION
The keyfile format will be the default usage since rhel9,and rhel10 has not support configure file, so sent a patch to resolve this problem.

ID:2497
Signed-off-by: Lei Yang leiyang@redhat.com