### PR TITLE
Update the usage of virtio_fs on s390x

### DIFF
--- a/qemu/tests/cfg/virtio_fs_multi_users_access.cfg
+++ b/qemu/tests/cfg/virtio_fs_multi_users_access.cfg
@@ -18,16 +18,24 @@
     fs_target = 'myfs'
     fs_dest = "/mnt/${fs_target}"
     fs_driver_props = {"queue-size": 1024}
-    mem_devs = mem1
-    backend_mem_mem1 = memory-backend-file
-    mem-path_mem1 = /dev/shm
-    size_mem1 = ${mem}M
-    use_mem_mem1 = no
     share_mem = yes
+    s390, s390x:
+        required_qemu = [5.2.0,)
+        vm_mem_share = yes
+        pre_command_noncritical = yes
+        pre_command = "echo 3 > /proc/sys/vm/drop_caches"
+        setup_hugepages = yes
+        kvm_module_parameters = 'hpage=1'
+        expected_hugepage_size = 1024
     !s390, s390x:
         guest_numa_nodes = shm0
         numa_memdev_shm0 = mem-mem1
         numa_nodeid_shm0 = 0
+        mem_devs = mem1
+        backend_mem_mem1 = memory-backend-file
+        mem-path_mem1 = /dev/shm
+        size_mem1 = ${mem}M
+        use_mem_mem1 = no
     # install winfsp tool
     i386, i686:
         install_winfsp_path = 'C:\Program Files'
@@ -35,8 +43,6 @@
         install_winfsp_path = 'C:\Program Files (x86)'
     virtio_win_media_type = iso
     cdroms += " virtio"
-    Windows:
-        cmd_dd = 'dd if=/dev/random of=%s bs=1M count=100'
     variants:
         - localgroup_users:
             new_user = "user1 user2"


### PR DESCRIPTION
virtio_fs: correct the usage of virtio_fs to only use memory-backend-file
on s390x

ID: 1503

Signed-off-by: Boqiao Fu <bfu@redhat.com>