### PR TITLE
Switch to dhcpcd command for the newer guest

### DIFF
--- a/qemu/tests/cfg/hotplug_unplug_nic_with_viommu.cfg
+++ b/qemu/tests/cfg/hotplug_unplug_nic_with_viommu.cfg
@@ -15,3 +15,6 @@
     netdev_extra_params_hotplug_nic1 = ",vhost=on"
     nic_extra_params_hotplug_nic1 = ",iommu_platform=on"
     virtio_iommu_direct_plug = yes
+    dhcp_cmd = "dhcpcd -n %s"
+    RHEL.7, RHEL.8, RHEL.9:
+        dhcp_cmd = "dhclient -r && dhclient %s"

--- a/qemu/tests/cfg/multi_nics_hotplug.cfg
+++ b/qemu/tests/cfg/multi_nics_hotplug.cfg
@@ -15,6 +15,9 @@
         additional_operation = yes
     RHEL.7:
         make_change = yes
+    dhcp_cmd = "dhcpcd -n %s"
+    RHEL.7, RHEL.8, RHEL.9:
+        dhcp_cmd = "dhclient -r && dhclient %s"
     variants:
         - nic_8139:
             only i386, x86_64

--- a/qemu/tests/cfg/multi_nics_stress.cfg
+++ b/qemu/tests/cfg/multi_nics_stress.cfg
@@ -30,5 +30,7 @@
         disable_firewall = "netsh firewall set opmode mode=disable"
         login_timeout = 600
     Linux:
-        dhcp_cmd = "for nic in `ls /sys/class/net|grep -v lo`;do arp -a|grep -v $nic && dhclient -r $nic && dhclient -v $nic;done"
+        dhcp_cmd = "for nic in `ls /sys/class/net|grep -v lo`;do arp -a|grep -v $nic && dhcpcd -n $nic;done"
+        RHEL.7, RHEL.8, RHEL.9:
+            dhcp_cmd = "for nic in `ls /sys/class/net|grep -v lo`;do arp -a|grep -v $nic && dhclient -r $nic && dhclient -v $nic;done"
         disable_firewall = "service iptables stop; systemctl stop firewalld.service"

--- a/qemu/tests/cfg/nic_acpi_index.cfg
+++ b/qemu/tests/cfg/nic_acpi_index.cfg
@@ -14,6 +14,9 @@
         required_qemu = [8.0.0,)
     kernel_extra_params_remove = biosdevname=0 net.ifnames=0
     kernel_extra_params_serial_login = yes
+    dhcp_cmd = "dhcpcd -n %s"
+    RHEL.7, RHEL.8, RHEL.9:
+        dhcp_cmd = "dhclient -r && dhclient %s"
     variants:
         - boot_with_acpi:
             vhost = on

--- a/qemu/tests/cfg/nic_bonding.cfg
+++ b/qemu/tests/cfg/nic_bonding.cfg
@@ -15,3 +15,6 @@
     bonding_params = 'max_bonds=1'
     dd_cmd = "dd if=/dev/zero of=%s bs=1M count=${filesize}"
     tmp_dir = "/var/tmp/"
+    dhcp_cmd = "dhcpcd -n bond0"
+    RHEL.7, RHEL.8, RHEL.9:
+        dhcp_cmd = "dhclient -r bond0 && dhclient bond0"

--- a/qemu/tests/cfg/nic_hotplug.cfg
+++ b/qemu/tests/cfg/nic_hotplug.cfg
@@ -6,6 +6,9 @@
     restore_image_after_testing = yes
     repeat_times = 1
     nic_hotplug_count=1
+    dhcp_cmd = "dhcpcd -n %s"
+    RHEL.7, RHEL.8, RHEL.9:
+        dhcp_cmd = "dhclient -r && dhclient %s"
     RHEL.7:
         make_change = yes
     variants:

--- a/qemu/tests/nic_acpi_index.py
+++ b/qemu/tests/nic_acpi_index.py
@@ -34,8 +34,8 @@ def run(test, params, env):
         arp_clean = "arp -n|awk '/^[1-9]/{print \"arp -d \" $1}'|sh"
         session.cmd_output_safe(make_conf)
         session.cmd_output_safe("ip link set dev %s up" % ifname)
-        session.cmd_output_safe("dhclient -r", timeout=240)
-        session.cmd_output_safe("dhclient %s" % ifname, timeout=240)
+        dhcp_cmd = params.get("dhcp_cmd")
+        session.cmd_output_safe(dhcp_cmd % ifname, timeout=240)
         session.cmd_output_safe(arp_clean)
 
     def verified_nic_name():

--- a/qemu/tests/nic_bonding.py
+++ b/qemu/tests/nic_bonding.py
@@ -50,19 +50,8 @@ def run(test, params, env):
     session_serial.cmd_output_safe("ip link set dev bond0 addr %s up" % mac)
     setup_cmd = "ifenslave bond0 " + " ".join(ifnames)
     session_serial.cmd_output_safe(setup_cmd)
-    # do a pgrep to check if dhclient has already been running
-    pgrep_cmd = "pgrep dhclient"
-    try:
-        session_serial.cmd_output_safe(pgrep_cmd)
-    # if dhclient is there, killl it
-    except aexpect.ShellCmdError:
-        test.log.info("it's safe to run dhclient now")
-    else:
-        test.log.info("dhclient is already running, kill it")
-        session_serial.cmd_output_safe("killall -9 dhclient")
-        time.sleep(1)
-
-    session_serial.cmd_output_safe("dhclient bond0")
+    dhcp_cmd = params.get("dhcp_cmd")
+    session_serial.cmd_output_safe(dhcp_cmd, timeout=240)
     # prepare test data
     guest_path = os.path.join(tmp_dir + "dst-%s" %
                               utils_misc.generate_random_string(8))

--- a/qemu/tests/nic_hotplug.py
+++ b/qemu/tests/nic_hotplug.py
@@ -56,8 +56,8 @@ def run(test, params, env):
         arp_clean = "arp -n|awk '/^[1-9]/{print \"arp -d \" $1}'|sh"
         session.cmd_output_safe(make_conf)
         session.cmd_output_safe("ip link set dev %s up" % ifname)
-        session.cmd_output_safe("dhclient -r", timeout=240)
-        session.cmd_output_safe("dhclient %s" % ifname, timeout=240)
+        dhcp_cmd = params.get("dhcp_cmd")
+        session.cmd_output_safe(dhcp_cmd % ifname, timeout=240)
         session.cmd_output_safe(arp_clean)
         return None
 


### PR DESCRIPTION
Due to dhcp-client has been replaced with dhcpcd in the future, so modified these cases to switch to dhcpcd command for the newer guest.

ID:2528
Signed-off-by: Lei Yang leiyang@redhat.com