### PR TITLE
qemu_nobody: set 'elevateprivileges=allow' 

### DIFF
--- a/qemu/tests/cfg/qemu_nobody.cfg
+++ b/qemu/tests/cfg/qemu_nobody.cfg
@@ -3,3 +3,4 @@
     user_runas = nobody
     type = qemu_nobody
     requires_root = yes
+    qemu_sandbox_elevateprivileges = allow


### PR DESCRIPTION
Since 'elevateprivileges=deny' in the sandbox conflicts with runas,
set the value of this parameter to allow from the perspective of qemu-kvm

ID: 2494

Signed-off-by: Yiqian Wei <yiwei@redhat.com>
