### PR TITLE
seabios_strict: disable sga device from rhel8.6 and the later version

### DIFF
--- a/qemu/tests/cfg/seabios_strict.cfg
+++ b/qemu/tests/cfg/seabios_strict.cfg
@@ -5,10 +5,11 @@
     only default_bios
     image_boot = no
     boot_menu = on
-    enable_sga = yes
-    Host_RHEL.m9:
-        enable_sga = no
-        machine_type_extra_params = "graphics=off"
+    enable_sga = no
+    machine_type_extra_params = "graphics=off"
+    Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8.u0, Host_RHEL.m8.u1, Host_RHEL.m8.u2, Host_RHEL.m8.u3, Host_RHEL.m8.u4, Host_RHEL.m8.u5:
+        enable_sga = yes
+        machine_type_extra_params = ""
     images = 'stg'
     bootindex_stg = 1
     image_name_stg = 'images/stg'


### PR DESCRIPTION
1. since sga device has been removed in rhel9, disable it
2. using "-machine graphics=off" instead of "-device sga"
3. rhel8 will continue to support sgabios, but starting with 8.6 libvirt uses "-machine graphics=off" so rhel-8 testing should be switched over too.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2566