### PR TITLE
bitmaps_merge_with_nospace: limit the qemu version

### DIFF
--- a/qemu/tests/cfg/bitmaps_merge_with_nospace.cfg
+++ b/qemu/tests/cfg/bitmaps_merge_with_nospace.cfg
@@ -1,5 +1,6 @@
 - bitmaps_merge_with_nospace:
     type = bitmaps_merge_with_nospace
+    required_qemu= [7.2.0-8,)
     only filesystem
     start_vm = no
     virt_test_type = qemu

--- a/qemu/tests/cfg/commit_with_bitmaps_nospace.cfg
+++ b/qemu/tests/cfg/commit_with_bitmaps_nospace.cfg
@@ -1,5 +1,6 @@
 - commit_with_bitmaps_nospace:
     type = commit_with_bitmaps_nospace
+    required_qemu= [7.2.0-8,)
     only filesystem
     start_vm = no
     virt_test_type = qemu


### PR DESCRIPTION
commit_with_bitmaps_nospace: limit the qemu version

Limit the qemu version higher than 7.2.0-8 according to the production bug

ID: 2570