### PR TITLE
nvdimm: disable pmem=on test cases

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -58,6 +58,7 @@
             variants:
                 - @pmem_default:
                 - pmem_on:
+                    only Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9
                     pmem_mem = on
         - nvdimm_dax:
             start_vm = "no"
@@ -71,7 +72,7 @@
             del_dax_cmd = "ndctl create-namespace -m memory -e namespace0.0 -f -v -a 4096"
         - nvdimm_mapsync:
             type = nvdimm_mapsync
-            no Host_RHEL.m7
+            only Host_RHEL.m8 Host_RHEL.m9
             pmem_mem = on
             nv_backend = nvdimm0
             mount_dir = "/mnt/pmem"


### PR DESCRIPTION
nvdimm: disable pmem=on test cases

Following the deprecation of the pmem feature in the incoming
release, exclude the hosts on the respective test cases.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2580