### PR TITLE
qemu_guest_agent: optimize the matching conditions

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -104,7 +104,7 @@
             gagent_check_type = powerdown
             journal_file = /var/log/journal
             cmd_prepared_and_restart_journald = "mkdir -p ${journal_file} && chgrp systemd-journal ${journal_file} && chmod g+s ${journal_file} && systemctl restart systemd-journald"
-            cmd_query_log = "journalctl -e | grep -6 -i 'core-dump'"
+            cmd_query_log = "journalctl -e | grep -i 'core-dump' | grep -A 6 -i 'qemu-guest-agent.service'"
         - check_reboot:
             gagent_check_type = reboot
             # This config would be overriden in guest-os.cfg.


### PR DESCRIPTION
optimize the matching conditions for case
'qemu_guest_agent.virtio_serial.check_powerdown'.
To prevent the test from being interrupted by
filtering out error messages that are not
qga services.

ID: 2594
Signed-off-by: Dehan Meng <demeng@redhat.com>