### PR TITLE
nvdimm: removes epel dependecies and use DOC=n flag with make

### DIFF
--- a/qemu/tests/cfg/nvdimm.cfg
+++ b/qemu/tests/cfg/nvdimm.cfg
@@ -39,12 +39,6 @@
     share_mem = yes
     nv_file = "${mount_dir}/nv0"
     depends_pkgs = "ndctl "
-    RHEL.9:
-        repo_install_cmd = "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-    RHEL.8:
-        repo_install_cmd = "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-    RHEL.7:
-        repo_install_cmd = "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
     variants:
         - nvdimm_basic:
         - nvdimm_emulate:
@@ -134,30 +128,28 @@
                     unarmed_dimm_mem1 = on
         - nvdimm_nvml:
             no ppc64, ppc64le
-            depends_pkgs += ndctl-devel daxctl-devel pandoc cmake
+            depends_pkgs += ndctl-devel daxctl-devel cmake
             nvml_test = yes
             nvml_dir = /tmp/nvml
+            tests_dir = ${nvml_dir}/src/test
             export_pmem_conf = 'export PMEMOBJ_CONF="sds.at_create=0"'
             get_nvml = "[ -d ${nvml_dir} ] && rm -rf ${nvml_dir}"
             get_nvml += ";git clone --depth=1 https://github.com/pmem/nvml.git ${nvml_dir}"
-            compile_nvml = "cd ${nvml_dir}; make"
-            ppc64le:
-                compile_nvml = "cd ${nvml_dir}; make EXTRA_CFLAGS='-USDS_ENABLED'"
+            compile_nvml = "cd ${nvml_dir}; make DOC=n"
             config_nvml = "cd ${nvml_dir}; cp src/test/testconfig.sh.example src/test/testconfig.sh"
             config_nvml += ";echo 'PMEM_FS_DIR_FORCE_PMEM=1' >> src/test/testconfig.sh"
             config_nvml += ";echo 'PMEM_FS_DIR=${mount_dir}' >> src/test/testconfig.sh"
-            run_test = "cd ${nvml_dir}; make check"
-            ppc64le:
-                run_test += " TEST_BUILD=debug"
+            build_tests = "cd ${tests_dir}; make test"
+            run_test = "cd ${tests_dir}; ./RUNTESTS.sh"
         - nvdimm_redis:
             no ppc64, ppc64le
             type = nvdimm_redis
-            depends_pkgs += ndctl-devel daxctl-devel pandoc tcl
+            depends_pkgs += ndctl-devel daxctl-devel tcl
             redis_dir = /tmp/redis
             get_redis = "[ -d ${redis_dir} ] && rm -rf ${redis_dir}"
             get_redis += "; git clone --depth=1 https://github.com/pmem/redis.git ${redis_dir}"
             nvml_dir = ${redis_dir}/deps/nvml
             get_nvml = "git clone --depth=1 https://github.com/pmem/nvml.git ${nvml_dir}"
-            compile_nvml = "cd ${nvml_dir}; make"
+            compile_nvml = "cd ${nvml_dir}; make DOC=n"
             compile_redis = "cd ${redis_dir}; make USE_NVML=yes STD=-std=gnu99"
             run_test = "cd ${redis_dir}; make test"

--- a/qemu/tests/nvdimm.py
+++ b/qemu/tests/nvdimm.py
@@ -154,7 +154,6 @@ def run(test, params, env):
                 hotplug_test.hotplug_memory(vm, mem)
             time.sleep(10)
             mems += target_mems
-        nvdimm_test.run_guest_cmd(params["repo_install_cmd"])
         error_context.context("Verify nvdimm in monitor and guest", test.log.info)
         pkgs = params.objects("depends_pkgs")
         if not utils_package.package_install(pkgs, nvdimm_test.session):
@@ -170,6 +169,7 @@ def run(test, params, env):
             nvdimm_test.run_guest_cmd(params["get_nvml"])
             nvdimm_test.run_guest_cmd(params["compile_nvml"])
             nvdimm_test.run_guest_cmd(params["config_nvml"])
+            nvdimm_test.run_guest_cmd(params["build_tests"])
             nvdimm_test.run_guest_cmd(params["run_test"], timeout=3600)
             return
         nv_file = params.get("nv_file", "/mnt/nv")


### PR DESCRIPTION
nvdimm: removes epel dependecies and use DOC=n flag with make

As the documents compilation can be skipped using 'DOC=n' flag,
the pandoc package is no longer needed and in the same way is
the EPEL repository. Changes the approach to first call make
with the DOC=n flag, then build the tests with make test and
run the RUNTESTS.sh script to execute the tests.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2569