### PR TITLE
netperf_udp_perf: Update CFLAGS in netperf setup command

### DIFF
--- a/qemu/tests/cfg/netperf_udp_perf.cfg
+++ b/qemu/tests/cfg/netperf_udp_perf.cfg
@@ -26,7 +26,7 @@
     test_duration = 20
     netperf_version = 2.7.1
     netperf_pkg = netperf/netperf-2.7.1.tar.bz2
-    setup_cmd = "cd /tmp && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && ./configure --enable-burst --enable-demo=yes --enable-intervals=yes && make CFLAGS=-fcommon"
+    setup_cmd = "cd /tmp && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && ./configure --enable-burst --enable-demo=yes --enable-intervals=yes && make CFLAGS='-fcommon -Wno-implicit-function-declaration'"
     log_hostinfo_script = scripts/rh_perf_log_hostinfo_script.sh
     host_tuned_profile = "tuned-adm profile virtual-host"
     client_tuned_profile = "tuned-adm profile virtual-host"


### PR DESCRIPTION
bypass compilation with -Wno-implicit-function-declaration
More information reference [1]

[1] avocado-framework/avocado-vt#3930

Signed-off-by: Wenli Quan <wquan@redhat.com>

id: 2633