### PR TITLE
Netkvm: Add a case for iperf with very short packets length

### DIFF
--- a/qemu/tests/cfg/iperf_test.cfg
+++ b/qemu/tests/cfg/iperf_test.cfg
@@ -43,3 +43,12 @@
                 - host2guest:
                 - guest2host:
                     iperf_server = ${main_vm}
+        - with_short_packets:
+            iperf_version = iperf-2.1.9
+            host_iperf_file = ${iperf_version}.tar.gz
+            Windows:
+                guest_iperf_file = ${iperf_version}.exe
+            catch_data = '%s port 5001 connected with %s'
+            iperf_test_duration = 60
+            iperf_server_options = ' -s -i 0 -t 10'
+            iperf_client_options = ' -c %s -B %s -l 2 -t %s'


### PR DESCRIPTION
Netkvm: Add a case for iperf with very short packets length
                                                       
ID: 2403                                                                       
Signed-off-by: wji <wji@redhat.com>  