### PR TITLE
rh_kselftests_vm: kernel selftests execution in guest

### DIFF
--- a/qemu/tests/cfg/rh_kselftests_vm.cfg
+++ b/qemu/tests/cfg/rh_kselftests_vm.cfg
@@ -1,0 +1,13 @@
+- rh_kselftests_vm:
+    only RHEL
+    type = rh_kselftests_vm
+    virt_test_type = qemu
+    kernel_path = "/tmp/kernel"
+    kselftests_path = "/usr/libexec/kselftests"
+    variants:
+        - mm:
+            s390x:
+                kvm_module_parameters = 'hpage=1'
+                whitelist = "hugetlb_fault_after_madv"
+            setup_hugepages = yes
+            tests_execution_cmd = "cd ${kselftests_path}/mm && sh run_vmtests.sh -t hugetlb"

--- a/qemu/tests/rh_kselftests_vm.py
+++ b/qemu/tests/rh_kselftests_vm.py
@@ -1,0 +1,69 @@
+import re
+
+from avocado.core import exceptions
+
+from virttest import error_context
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    rh_kselftests_vm test
+    1) Download the current kernel selftests RPM
+    2) Install the RPM
+    3) Execute the kernel selftests
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    session = vm.wait_for_login()
+    kernel_path = params.get("kernel_path", "/tmp/kernel")
+    tests_execution_cmd = params.get("tests_execution_cmd")
+    whitelist = params.get("whitelist", "").split()
+
+    session.cmd("mkdir -p %s" % kernel_path)
+    kernel_version = session.cmd_output("uname -r").strip().split("+")[0]
+    error_context.base_context("The kernel version: %s" % kernel_version, test.log.info)
+
+    error_context.context("Download the kernel selftests RPM", test.log.debug)
+    session.cmd("cd %s" % kernel_path)
+    session.cmd(
+        "brew download-build --rpm kernel-selftests-internal-%s.rpm" % kernel_version,
+        180,
+    )
+
+    error_context.context("Install the RPM", test.log.debug)
+    session.cmd("dnf install -y ./kernel-*")
+
+    try:
+        error_context.base_context("Execute the selftests", test.log.info)
+        s, o = session.cmd_status_output(tests_execution_cmd, 180)
+        test.log.info("The selftests results: %s" % o)
+
+        summary = re.findall(r"\# SUMMARY.+", o)
+        num_failed_tests = int(re.findall(r"FAIL\=\d+", str(summary))[0].split('=')[1])
+        test.log.debug("Number of failed tests: %d", num_failed_tests)
+
+        if num_failed_tests != 0:
+            test.fail("Failed selftests found in the execution")
+
+        num_skipped_tests = int(re.findall(r"SKIP\=\d+", str(summary))[0].split('=')[1])
+        test.log.debug("Number of skipped tests: %d", num_skipped_tests)
+
+        skipped_list = []
+        for test_name in whitelist:
+            skipped_list.append(
+                re.findall(r"\#.(\[SKIP\])\s.+(%s).\#.(SKIP)" % test_name, o)
+            )
+
+        if len(skipped_list) == num_skipped_tests:
+            return True
+        elif len(skipped_list) < num_skipped_tests:
+            raise exceptions.TestWarn("Some skipped test(s) are not in the whitelist")
+
+    finally:
+        error_context.context("Cleaning kernel files", test.log.debug)
+        session.cmd("rm -rf %s" % kernel_path)
+        session.cmd("dnf remove -y $(rpm -q kernel-selftests-internal)")


### PR DESCRIPTION
rh_kselftests_vm: kernel selftests execution in guest

Creates a new test case that executes the kernel selftests
inside the VM through the RPM that has been previously downloaded
and installed. Could be expanded with more tests in the future.


Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2637