### PR TITLE
pktgen_perf: add 'vm_mem_share = yes' for case vhost_sim_test_vm

### DIFF
--- a/generic/tests/cfg/pktgen_perf.cfg
+++ b/generic/tests/cfg/pktgen_perf.cfg
@@ -39,6 +39,7 @@
                     netdst_nic2 = vdpa0
                     nettype_nic2 = vdpa
                     mac_nic2 =  00:11:22:33:44:00
+                    vm_mem_share = yes
                 - virtio_sim_test_host:
                     test_vm = no
                     nettype_fixed = vdpa

--- a/generic/tests/pktgen_perf.py
+++ b/generic/tests/pktgen_perf.py
@@ -114,6 +114,7 @@ def run(test, params, env):
             dev = vdpa_net_test.add_dev(params.get("netdst_nic2"), params.get("mac_nic2"))
             LOG_JOB.info("The vhost_vdpa device name is: '%s'", dev)
             LOG_JOB.info("Test vhost_vdpa with the simulator on the vm")
+            process.system_output("cat /sys/module/vdpa_sim/parameters/use_va")
             vm, session_serial = init_vm_and_login(test, params, env, result_file, pktgen_runner)
             pktgen_utils.run_tests_for_category(params, result_file, test_vm, vm, session_serial)
         elif not vdpa_test:


### PR DESCRIPTION
The default parameter 'use_va' of module 'vdpa_sim' was changed from False to True. When 'use_va' is True, it only works with shared memory enabled

More information : RHEL-12125

Signed-off-by: Wenli Quan <wquan@redhat.com>

id: 2640