### PR TITLE
chardev: set "spawn=allow" for specific case

### DIFF
--- a/qemu/tests/cfg/virtio_console.cfg
+++ b/qemu/tests/cfg/virtio_console.cfg
@@ -32,7 +32,7 @@
                 - virtio_console_smoke:
                     variants:
                         - open:
-                           virtio_console_test = open
+                            virtio_console_test = open
                         - multi_open:
                             virtio_console_test = multi_open
                         - close:
@@ -77,7 +77,7 @@
                     # Works with virtconsole, but is not the comon usage, don't test by default
                     no virtconsole_test
                     variants:
-                       # Destructive tests
+                        # Destructive tests
                         - rmmod:
                             only Linux
                             virtio_console_test = rmmod
@@ -92,6 +92,7 @@
                                     virtio_console_test = migrate_offline
                                 - online:
                                     virtio_console_test = migrate_online
+                                    qemu_sandbox_spawn = allow
                         - restart:
                             virtio_console_method = shell
                             variants:


### PR DESCRIPTION
ID: 2495

VM won't boot up with error "Operation not permitted" with "spawn=deny".