### PR TITLE
Fix ping timeout short and netperf compile issue

### DIFF
--- a/qemu/tests/cfg/ovs_host_vlan.cfg
+++ b/qemu/tests/cfg/ovs_host_vlan.cfg
@@ -24,7 +24,7 @@
     ovs_port_vlan_vm4 = 20
     shutdown_firewall = "systemctl stop firewalld.service || service iptables stop"
     stop_network_manager = "systemctl stop NetworkManager || service NetworkManager stop"
-    setup_cmd = cd %s && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && ./configure --enable-burst --enable-demo=yes && make && make install
+    setup_cmd = cd %s && rm -rf netperf-2.7.1 && tar xvfj netperf-2.7.1.tar.bz2 && cd netperf-2.7.1 && sh autogen.sh && CFLAGS=-Wno-implicit-function-declaration ./configure --enable-burst --enable-demo=yes && make && make install
     netperf_link = netperf-2.7.1.tar.bz2
     netserver_cmd = netperf-2.7.1/src/netserver
     netperf_cmd = netperf-2.7.1/src/netperf -l %s -H %s

--- a/qemu/tests/ovs_host_vlan.py
+++ b/qemu/tests/ovs_host_vlan.py
@@ -69,7 +69,7 @@ def ping(test, os_type, match_error, dest, count, session, same_vlan):
     """
     if os_type == "linux":
         status, output = utils_test.ping(dest, count,
-                                         timeout=int(count) * 1.50,
+                                         timeout=60,
                                          session=session)
         loss_ratio = utils_test.get_loss_ratio(output)
         ping_result_check(test, loss_ratio, same_vlan)


### PR DESCRIPTION
1.Extend the ping timeout due to sometimes it will take more time when sometimes host has low machine resource.
2.Add a workaround to bypass the netperf compile issues, the root cause is gcc's implicit function declarations are treated as errors from 14.0.

ID:2642
Signed-off-by: Lei Yang leiyang@redhat.com