### PR TITLE
rss_iperf_test: limited guest version more than RHEL9.4

### DIFF
--- a/qemu/tests/cfg/rss_iperf_test.cfg
+++ b/qemu/tests/cfg/rss_iperf_test.cfg
@@ -3,6 +3,7 @@
     image_snapshot = yes
     firewalld_service = disable
     type = iperf_test
+    no RHEL.6 RHEL.7 RHEL.8 RHEL.9.0 RHEL.9.1 RHEL.9.2 RHEL.9.3 RHEL.9.4
     required_qemu = [9.0.0-1,)
     fw_stop_cmd = systemctl stop firewalld || service iptables stop
     linux_compile_cmd = tar zxf %s -C %s > /dev/null ; cd %s ; ./configure > /dev/null; make > /dev/null


### PR DESCRIPTION
Since this feature support start from rhel.9.5's kernel, so add a condition to limited it executed by old guest

ID:2655
Signed-off-by: Lei Yang leiyang@redhat.com