### PR TITLE
block_hotplug_with_cpu_hotplug: remove WinNext

### DIFF
--- a/qemu/tests/cfg/block_hotplug_with_cpu_hotplug.cfg
+++ b/qemu/tests/cfg/block_hotplug_with_cpu_hotplug.cfg
@@ -2,7 +2,7 @@
     type = block_hotplug_with_cpu_hotplug
     virt_test_type = qemu
     only x86_64 i386
-    no Win10 Win11
+    no Win10 Win11 WinNext
     bootindex_image1 = 0
     images += " stg0 stg1"
     boot_drive_stg0 = no


### PR DESCRIPTION
WinNext means inside preview version of Win11.
This case not support it as well.

ID: 2657
Signed-off-by: menli menli@redhat.com