### PR TITLE
virtio_mem_hugetlb_migration: adds new test case

### DIFF
--- a/qemu/tests/cfg/virtio_mem_hugetlb_migration.cfg
+++ b/qemu/tests/cfg/virtio_mem_hugetlb_migration.cfg
@@ -1,0 +1,39 @@
+- virtio_mem_hugetlb_migration:
+    only Linux
+    no Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9.u0 Host_RHEL.m9.u1 Host_RHEL.m9.u2 Host_RHEL.m9.u3
+    no RHEL.7 RHEL.8
+    no s390x
+    type = virtio_mem_hugetlb_migration
+    virt_test_type = qemu
+    smp = 8
+    vcpu_maxcpus = ${smp}
+    threshold = 0.025
+    slots_mem = 20
+    maxmem_mem = 80G
+    mem = 8192
+    size_mem_mem0 = 8G
+    # This is a workaround to use the hugepages based on the size of mem.
+    size_mem_vmem0 = ${size_mem_mem0}
+    setup_hugepages = yes
+    mem_devs = 'mem0 vmem0'
+    backend_mem_vmem0 = memory-backend-file
+    mem-path_vmem0 = /mnt/kvm_hugepage
+    vm_memdev_model_vmem0 = "virtio-mem"
+    reserve_vmem0 = no
+    guest_numa_nodes = 'node0'
+    numa_memdev_node0 = mem-mem0
+    numa_cpus_node0 = "0-7"
+    use_mem_mem0 = no
+    use_mem_vmem0 = yes
+    requested-size_memory_vmem0 = 1G
+    node_memory_vmem0 = "0"
+    memdev_memory_vmem0 = "mem-vmem0"
+    prealloc_memory_vmem0 = yes
+    kernel_extra_params_add = "memhp_default_state=online_movable"
+    pcie_extra_root_port = 0
+    requested-size_test_vmem0 = "4G"
+    kill_vm_on_error = yes
+    mig_timeout = 1200
+    migration_protocol = "tcp"
+    error_msg = "'requested-size' cannot exceed the memory backend size"
+    requested-size_fail_vmem0 = "9G"

--- a/qemu/tests/virtio_mem_hugetlb_migration.py
+++ b/qemu/tests/virtio_mem_hugetlb_migration.py
@@ -1,0 +1,73 @@
+import re
+import time
+
+from virttest import error_context
+
+from virttest.qemu_monitor import QMPCmdError
+from virttest.utils_misc import normalize_data_size
+from provider import virtio_mem_utils
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Do migration of a virtio-mem device consuming hugepages
+    1) Setup hugepages in source and destination hosts
+    2) Boot VMs in source and destination hosts
+    3) Do migration
+    4) Check virtio-mem device
+    5) Resize virtio-mem devices to a different value
+    6) Check virtio-mem device
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    error_msg = params.get(
+        "error_msg", "Error: 'requested-size' cannot exceed the memory backend size"
+    )
+
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    vm.wait_for_login()
+    threshold = params.get_numeric("threshold", target_type=float)
+    mem_object_id = params["mem_devs"].split().pop()
+    initial_req_size = params.get("requested-size_memory_%s" % mem_object_id)
+    requested_size_vmem = params.get("requested-size_test_%s" % mem_object_id)
+    requested_size_vmem_fail = params.get("requested-size_fail_%s" % mem_object_id)
+    device_id = "virtio_mem-%s" % mem_object_id
+    node_id = params.get_numeric("node_memory_%s" % mem_object_id)
+
+    mig_timeout = params.get_numeric("mig_timeout", 1200, float)
+    mig_protocol = params.get("migration_protocol", "tcp")
+    vm.migrate(mig_timeout, mig_protocol, env=env)
+
+    virtio_mem_utils.check_memory_devices(
+        device_id, initial_req_size, threshold, vm, test
+    )
+    virtio_mem_utils.check_numa_plugged_mem(
+        node_id, initial_req_size, threshold, vm, test
+    )
+
+    try:
+        error_context.base_context(
+            "Setting 'requested-size' to a higher value", test.log.info
+        )
+        req_size_normalized = int(
+            float(normalize_data_size(requested_size_vmem_fail, "B"))
+        )
+        vm.monitor.qom_set(device_id, "requested-size", req_size_normalized)
+    except QMPCmdError as e:
+        if not re.search(error_msg, str(e.data)):
+            test.fail("Cannot get expected error message: %s" % error_msg)
+
+    req_size_normalized = int(float(normalize_data_size(requested_size_vmem, "B")))
+    vm.monitor.qom_set(device_id, "requested-size", req_size_normalized)
+    time.sleep(10)
+    virtio_mem_utils.check_memory_devices(
+        device_id, requested_size_vmem, threshold, vm, test
+    )
+    virtio_mem_utils.check_numa_plugged_mem(
+        node_id, requested_size_vmem, threshold, vm, test
+    )


### PR DESCRIPTION
virtio_mem_hugetlb_migration: adds new test case

Creates a new test case for performing a live migration
of a VM with a virtio-mem device that consumes hugepages

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2653