### PR TITLE
qemu_guest_agent: Add ssh-key injection support for windows

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -549,30 +549,52 @@
             input_dev_type_input2 = mouse
             input_dev_type_input3 = tablet
         - gagent_ssh_public_key_injection:
-            only Linux
             no  RHEL.7 RHEL.8 RHEL.9.0 RHEL.9.1
             gagent_check_type = ssh_public_key_injection
             set_sebool = "setsebool virt_qemu_ga_read_nonsecurity_files on ; setsebool virt_qemu_ga_manage_ssh on"
             cmd_clean_keys = rm -rf ~/.ssh/*
             ssh_keygen_cmd =  "ssh-keygen -t rsa -P "" -f ~/.ssh/id_rsa"
             cmd_get_hostkey = "cat ~/.ssh/id_rsa.pub"
-            variants:
-                - root:
-                    guest_user = "root"
-                    guest_homepath = /${guest_user}
-                    test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls ${guest_homepath}
-                    output_check_str = 'anaconda-ks.cfg'
-                - non_root_user:
-                    guest_user = "fedora"
-                    guest_user_passwd = "redhat"
-                    guest_homepath = "/home/${guest_user}"
-                    cmd_add_user_set_passwd = useradd ${guest_user} && echo ${guest_user_passwd} | passwd --stdin ${guest_user}
-                    cmd_remove_user = userdel -rf ${guest_user}
-                    test_login_guest = ssh ${guest_user}@%s -o stricthostkeychecking=no ls '/home'
-                    output_check_str = '${guest_user}'
             add_line_at_end = "echo >> ${guest_homepath}/.ssh/authorized_keys"
             cmd_get_guestkey = "cat ${guest_homepath}/.ssh/authorized_keys"
             cmd_del_key_file = "rm -rf ${guest_homepath}/.ssh/authorized_keys"
+            cmd_install_sshpass = "dnf -y install sshpass"
+            # Please set user password
+            # guest_user_passwd =
+            variants:
+                - root:
+                    only Linux
+                    guest_user = "root"
+                    guest_homepath = /${guest_user}
+                    test_login_guest = ssh ${guest_user}@%s -o StrictHostKeyChecking=no ls ${guest_homepath}
+                    output_check_str = 'anaconda-ks.cfg'
+                - non_root_user:
+                    only Linux
+                    guest_user = "fedora"
+                    guest_homepath = "/home/${guest_user}"
+                    cmd_add_user_set_passwd = "useradd ${guest_user} && echo %s | passwd --stdin ${guest_user}"
+                    cmd_remove_user = userdel -rf ${guest_user}
+                    test_login_guest = ssh ${guest_user}@%s -o StrictHostKeyChecking=no ls '/home'
+                    output_check_str = '${guest_user}'
+                - administrator:
+                    only Windows
+                    guest_user = "Administrator"
+                    guest_homepath = "C:\Users\${guest_user}"
+                    cmd_get_guestkey = "powershell.exe Get-Content C:\ProgramData\ssh\administrators_authorized_keys"
+                - non_admin_user:
+                    only Windows
+                    guest_user = "nonadminuser"
+                    guest_homepath = "C:\Users\${guest_user}"
+                    guest_sshdir = "${guest_homepath}\.ssh"
+                    cmd_add_user_set_passwd = "powershell.exe $securePassword = ConvertTo-SecureString -String %s -AsPlainText -Force;New-LocalUser -Name ${guest_user} -Password $securePassword -FullName 'New User' -Description 'Standard non-admin user';Add-LocalGroupMember -Group 'Users' -Member ${guest_user}"
+                    cmd_remove_user = "powershell.exe Remove-LocalUser -Name ${guest_user}"
+                    cmd_get_guestkey = "powershell.exe Get-Content ${guest_homepath}\.ssh\authorized_keys"
+            Windows:
+                install_config_openssh = "powershell.exe Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process -Force; WIN_UTILS:\Install_config_OpenSSH.ps1"
+                # Please fill out guest_user_passwd before running test
+                cmd_sshpass = 'sshpass -p %s ssh ${guest_user}@%s -o StrictHostKeyChecking=no dir "${guest_homepath}"'
+                test_login_guest = ssh ${guest_user}@%s -o StrictHostKeyChecking=no dir "${guest_homepath}"
+                output_check_str = "Downloads"
         - check_get_cpustats:
             only Linux
             no  RHEL.7 RHEL.8 RHEL.9.1 RHEL.9.0


### PR DESCRIPTION
Add public ssh-key injection support for windows. Linux had been supported already.

ID: 2587
Signed-off-by: Dehan Meng [demeng@redhat.com](mailto:demeng@redhat.com)