### PR TITLE
blockdev_mirror_stress:not run stress test as a thread

### DIFF
--- a/qemu/tests/blockdev_mirror_stress.py
+++ b/qemu/tests/blockdev_mirror_stress.py
@@ -2,8 +2,6 @@ import six
 import time
 import random
 
-from virttest import utils_test
-
 from provider.storage_benchmark import generate_instance
 from provider.blockdev_mirror_wait import BlockdevMirrorWaitTest
 
@@ -11,7 +9,7 @@ from provider.blockdev_mirror_wait import BlockdevMirrorWaitTest
 class BlockdevMirrorStressTest(BlockdevMirrorWaitTest):
     """Do block-mirror with fio test as background test"""
 
-    def fio_thread(self):
+    def fio_run_bg(self):
         fio_options = self.params.get("fio_options")
         if fio_options:
             self.test.log.info("Start to run fio")
@@ -38,9 +36,7 @@ class BlockdevMirrorStressTest(BlockdevMirrorWaitTest):
                 session.close()
 
     def do_test(self):
-        bg_test = utils_test.BackgroundTest(self.fio_thread, "")
-        bg_test.thread.daemon = True
-        bg_test.start()
+        self.fio_run_bg()
         self.test.log.info("sleep random time before mirror during fio")
         mint = self.params.get_numeric("sleep_min")
         maxt = self.params.get_numeric("sleep_max")

--- a/qemu/tests/cfg/blockdev_mirror_stress.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_stress.cfg
@@ -18,6 +18,7 @@
     fio_timeout = 300
     fio_options = '--name=stress --filename=${mnt_on_sys_dsk}/${file_fio} --ioengine=libaio --rw=write --direct=1 '
     fio_options += '--bs=4K --size=2G --iodepth=256 --numjobs=256 --runtime=${fio_timeout} --time_based'
+    fio_options += ' --output=/tmp/fio_report.txt &'
     sync = full
     storage_pools = default
     storage_pool = default


### PR DESCRIPTION
When running stress test as a thread, we usually hit resource lock issue, so some processes hang there even though test has finished and vm quit successfully,this will block all the tests in a loop.

id:2784