### PR TITLE
virtio_win_installer: update the installer script

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
@@ -21,7 +21,7 @@
     run_uninstall_cmd = 'WIN_UTILS:\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe C:\uninstall.au3'
     signed_check_cmd = 'wmic product where name="Virtio-win-driver-installer" | findstr "Red Hat, Inc."'
     # set virtio_win version range to determine the diff behavior of installer
-    installer_restart_version = [1.9.37.0,)
+    installer_restart_version = [1.9.37.0, 1.9.40.0]
     monitor_type = qmp
     monitors = qmp1
     mem_stat_check_list = 'stat-free-memory'


### PR DESCRIPTION
Since virtio-win 1.9.41 version, there is no restart requirement when install and uninstall the installer, while repair still has.
ID: 2785