### PR TITLE
blockdev_stream_backing_mask_on: backing_mask_protocol on

### DIFF
--- a/qemu/tests/blockdev_stream_backing_mask_on.py
+++ b/qemu/tests/blockdev_stream_backing_mask_on.py
@@ -1,0 +1,94 @@
+import logging
+
+from virttest import data_dir
+
+from provider import backup_utils
+from provider.blockdev_stream_base import BlockDevStreamTest
+from provider.virt_storage.storage_admin import sp_admin
+
+LOG_JOB = logging.getLogger('avocado.test')
+
+
+class BlockdevStreamBackingMaskOnTest(BlockDevStreamTest):
+    """Do block-stream based on an existed snapshot in snapshot chain"""
+
+    def __init__(self, test, params, env):
+        super(BlockdevStreamBackingMaskOnTest, self).__init__(test, params, env)
+        self._snapshot_images = self.params.objects("snapshot_images")
+        self._trash = []
+
+    def snapshot_test(self):
+        """create one snapshot, create one new file"""
+        self.generate_tempfile(self.disks_info[self.base_tag][1],
+                               filename="base",
+                               size=self.params["tempfile_size"])
+
+        # data->sn1->sn2->sn3->sn4
+        chain = [self.base_tag] + self._snapshot_images
+        for idx in range(1, len(chain)):
+            backup_utils.blockdev_snapshot(
+                self.main_vm,
+                "drive_%s" % chain[idx-1],
+                "drive_%s" % chain[idx]
+            )
+
+            self.generate_tempfile(self.disks_info[self.base_tag][1],
+                                   filename=chain[idx],
+                                   size=self.params["tempfile_size"])
+
+    def _disk_define_by_params(self, tag):
+        params = self.params.copy()
+        params.setdefault("target_path", data_dir.get_data_dir())
+        return sp_admin.volume_define_by_params(tag, params)
+
+    def prepare_snapshot_file(self):
+        """hotplug all snapshot images"""
+        for tag in self._snapshot_images:
+            disk = self._disk_define_by_params(tag)
+            disk.hotplug(self.main_vm)
+            self._trash.append(disk)
+
+    def _remove_images(self):
+        for img in self._trash:
+            sp_admin.remove_volume(img)
+
+    def post_test(self):
+        try:
+            if self.main_vm.is_alive():
+                self.main_vm.destroy()
+            self._remove_images()
+        except Exception as e:
+            LOG_JOB.warning(str(e))
+
+    def check_backing_format(self):
+        base_format = self.base_image.get_format()
+        output = self.snapshot_image.info(force_share=True).split("\n")
+        for item in output:
+            if "backing file format" in item:
+                if base_format not in item:
+                    self.test.fail("Expected format: %s, current format: %s"
+                                   % (item.split(":")[1], base_format))
+
+    def do_test(self):
+        self.snapshot_test()
+        self.blockdev_stream()
+        self.check_backing_format()
+
+
+def run(test, params, env):
+    """
+    Basic block stream test with stress
+    test steps:
+        1. boot VM with a data image
+        2. add snapshot images
+        3. create a file(base) on data image
+        4. take snapshots(data->sn1->sn2->sn3i->sn4),
+           take one snapshot, create one new file(snx, x=1,2,3,4)
+        5. do block-stream (base-node:sn1, device: sn4)
+        6. check backing format of the top node(data->sn4)
+    :param test: test object
+    :param params: test configuration dict
+    :param env: env object
+    """
+    stream_test = BlockdevStreamBackingMaskOnTest(test, params, env)
+    stream_test.run_test()

--- a/qemu/tests/cfg/blockdev_stream_backing_mask_on.cfg
+++ b/qemu/tests/cfg/blockdev_stream_backing_mask_on.cfg
@@ -1,0 +1,61 @@
+# The following testing scenario is covered:
+#   Basic block stream test based on an existed snapshot
+#     data -> sn1 -> sn2 -> sn3 -> sn4
+#     The snapshot images are local fs images
+#     block-strem: {device: sn4, base-node: data}
+
+- blockdev_stream_backing_mask_on:
+    only Linux
+    qemu_force_use_drive_expression = no
+    type = blockdev_stream_backing_mask_on
+    virt_test_type = qemu
+    start_vm = yes
+    kill_vm = yes
+    images += " data"
+    base_tag = data
+    node = drive_data
+    remove_image_data = yes
+    force_create_image_data = yes
+    snapshot_images = "sn1 sn2 sn3 sn4"
+    snapshot_tag = sn4
+    base_node = drive_data
+    tempfile_size = 200M
+    storage_pools = default
+    storage_pool = default
+    rebase_mode = unsafe
+    required_qemu = [9.0.0,)
+
+    image_size_data = 2G
+    image_size_sn1 = ${image_size_data}
+    image_size_sn2 = ${image_size_data}
+    image_size_sn3 = ${image_size_data}
+    image_size_sn4 = ${image_size_data}
+    image_name_data = data
+    image_name_sn1 = sn1
+    image_name_sn2 = sn2
+    image_name_sn3 = sn3
+    image_name_sn4 = sn4
+    image_format_data = raw
+    image_format_sn1 = qcow2
+    image_format_sn2 = qcow2
+    image_format_sn3 = qcow2
+    image_format_sn4 = qcow2
+    ceph:
+        enable_ceph_data = yes
+    nbd:
+        enable_nbd_data = yes
+        nbd_port_data = 10831
+        image_format_data = raw
+        remove_image_data = no
+        force_create_image_data = no
+    iscsi_direct:
+        lun_data = 1
+        enable_iscsi_data = yes
+        image_raw_device_data = yes
+
+    # For the local snapshot images
+    storage_type_default = directory
+    enable_iscsi_sn4 = no
+    enable_ceph_sn4 = no
+    enable_nbd_sn4 = no
+    image_raw_device_sn4 = no


### PR DESCRIPTION
When doing stream with backing_mask_protocol on,
    the backing raw image format can be identified
    correctly as "raw" for "raw format blockdev
    elimination".
    
    Signed-off-by: Aihua Liang <aliang@redhat.com>

id:2806