### PR TITLE
blockdev_commit_backing_mask_on:test backing_mask on

### DIFF
--- a/qemu/tests/blockdev_commit_backing_mask_on.py
+++ b/qemu/tests/blockdev_commit_backing_mask_on.py
@@ -1,0 +1,51 @@
+from provider.blockdev_commit_base import BlockDevCommitTest
+from provider import backup_utils
+
+
+class BlockDevCommitBackingMaskOn(BlockDevCommitTest):
+
+    def commit_snapshots(self):
+        self.base_device = self.params["device_tag"].split()[0]
+        device_params = self.params.object_params(self.base_device)
+        snapshot_tags = device_params["snapshot_tags"].split()
+        self.device_node = self.get_node_name(self.base_device)
+        options = ["base-node", "top-node", "backing-mask-protocol"]
+        arguments = self.params.copy_from_keys(options)
+        arguments["base-node"] = self.device_node
+        arguments["top-node"] = self.get_node_name(snapshot_tags[-2])
+        arguments["backing-mask-protocol"] = self.params.get("backing_mask_protocol")
+        device = self.get_node_name(snapshot_tags[-1])
+        backup_utils.block_commit(self.main_vm, device, **arguments)
+
+    def check_backing_format(self):
+        base_image = self.get_image_by_tag(self.base_device)
+        base_format = base_image.get_format()
+        output = self.snapshot_images[-1].info(force_share=True).split("\n")
+        for item in output:
+            if "backing file format" in item:
+                if base_format not in item:
+                    self.test.fail("Expected format: %s, current format: %s"
+                                   % (item.split(":")[1], base_format))
+
+    def run_test(self):
+        self.pre_test()
+        try:
+            self.commit_snapshots()
+            self.verify_data_file()
+            self.check_backing_format()
+        finally:
+            self.post_test()
+
+
+def run(test, params, env):
+    """
+    Block commit base Test
+
+    1. boot guest with data disk
+    2. create 4 snapshots and save file in each snapshot
+    3. commit snapshot 3 to snapshot 4
+    6. verify files's md5
+    """
+
+    block_test = BlockDevCommitBackingMaskOn(test, params, env)
+    block_test.run_test()

--- a/qemu/tests/cfg/blockdev_commit_backing_mask_on.cfg
+++ b/qemu/tests/cfg/blockdev_commit_backing_mask_on.cfg
@@ -1,0 +1,68 @@
+- blockdev_commit_backing_mask_on:
+    type = blockdev_commit_backing_mask_on
+    virt_test_type = qemu
+    only Linux
+    images += " data"
+    force_create_image = yes
+    force_remove_image = yes
+    force_create_image_image1 = no
+    force_remove_image_image1 = no
+    start_vm = yes
+    kill_vm = yes
+    storage_pools = default
+    storage_type_default = "directory"
+    storage_pool = default
+    image_size_data = 2G
+    image_name_data = data
+    image_format_data = raw
+    snapshot_tags = sn1 sn2 sn3 sn4
+
+    image_name_sn1 = sn1
+    image_format_sn1 = qcow2
+
+    image_name_sn2 = sn2
+    image_format_sn2 = qcow2
+
+    image_name_sn3 = sn3
+    image_format_sn3 = qcow2
+
+    image_name_sn4 = sn4
+    image_format_sn4 = qcow2
+
+    device_tag = "data"
+    format = qcow2
+    rebase_mode = unsafe
+    node = ${device}
+    qemu_force_use_drive_expression = no
+    required_qemu = [9.0.0,)
+    backing_mask_protocol = yes
+    iscsi_direct:
+        lun_data = 1
+        enable_iscsi_sn1 = no
+        image_raw_device_sn1 = no
+        enable_iscsi_sn2 = no
+        image_raw_device_sn2 = no
+        enable_iscsi_sn3 = no
+        image_raw_device_sn3 = no
+        enable_iscsi_sn4 = no
+        image_raw_device_sn4 = no
+    ceph:
+        image_format_data = raw
+        enable_ceph_sn1 = no
+        enable_ceph_sn2 = no
+        enable_ceph_sn3 = no
+        enable_ceph_sn4 = no
+    nbd:
+        image_format_data = raw
+        image_size_data = 2G
+        nbd_port_data = 10831
+        enable_nbd_sn1 = no
+        enable_nbd_sn2 = no
+        enable_nbd_sn3 = no
+        enable_nbd_sn4 = no
+        force_create_image_data = no
+        remove_image_data = no
+    image_size_sn1 = ${image_size_data}
+    image_size_sn2 = ${image_size_data}
+    image_size_sn3 = ${image_size_data}
+    image_size_sn4 = ${image_size_data}


### PR DESCRIPTION
When doing commit with backing_mask_protocol on,
the backing raw image format can be identified
correctly as "raw" for "raw format blockdev
elimination".

id:2808