### PR TITLE
blockdev_commit_firewall:update the expected host dmsg

### DIFF
--- a/qemu/tests/cfg/blockdev_commit_firewall.cfg
+++ b/qemu/tests/cfg/blockdev_commit_firewall.cfg
@@ -14,6 +14,7 @@
     qemu_force_use_drive_expression = no
     #Fixme if no driver deprecated warning in host_dmesg.log
     expected_host_dmesg = Warning: Deprecated Driver is detected
+    expected_host_dmesg += |Warning: Unmaintained driver is detected
 
     # Settings for a local fs image 'nbddata',
     # which will be exported by qemu-nbd


### PR DESCRIPTION
Expected host dmesg changed for nft_compat,
so update it.

id: 1917