### PR TITLE
Fix disk serial issue for throttle relevant test

### DIFF
--- a/qemu/tests/cfg/throttle_operation_test.cfg
+++ b/qemu/tests/cfg/throttle_operation_test.cfg
@@ -2,6 +2,7 @@
     type = throttle_operation_test
     virt_test_type = qemu
     qemu_force_use_drive_expression = no
+    no aarch64
     images += "  stg1 stg2"
     remove_image = yes
     force_create_image_image1 = no

--- a/qemu/tests/cfg/throttle_parameter_test.cfg
+++ b/qemu/tests/cfg/throttle_parameter_test.cfg
@@ -1,6 +1,7 @@
 - throttle_parameter_test:
     type = throttle_parameter_test
     qemu_force_use_drive_expression = no
+    no aarch64
     images += "  stg1 stg2 stg3 stg4"
     remove_image = yes
     force_create_image_image1 = no

--- a/qemu/tests/throttle_operation_test.py
+++ b/qemu/tests/throttle_operation_test.py
@@ -1,5 +1,6 @@
 """IO-Throttling group and other operation relevant testing"""
 import json
+import time
 
 from virttest import error_context
 from virttest.qemu_monitor import QMPCmdError
@@ -97,6 +98,7 @@ def run(test, params, env):
     vm.verify_alive()
 
     session = vm.wait_for_login(timeout=360)
+    time.sleep(20)
 
     error_context.context("Deploy fio", test.log.info)
     fio = generate_instance(params, vm, 'fio')

--- a/qemu/tests/throttle_parameter_test.py
+++ b/qemu/tests/throttle_parameter_test.py
@@ -1,3 +1,5 @@
+import time
+
 from virttest import error_context
 
 from provider.storage_benchmark import generate_instance
@@ -23,6 +25,7 @@ def run(test, params, env):
     vm.verify_alive()
 
     session = vm.wait_for_login(timeout=360)
+    time.sleep(20)
 
     error_context.context("Deploy fio", test.log.info)
     fio = generate_instance(params, vm, 'fio')


### PR DESCRIPTION
The disk serial number in the latest Linux guest can 
not be displayed in time. Adding some time delay
after booting.

ID:2793