### PR TITLE
installer_uninstall: wait a moment to check drivers

### DIFF
--- a/qemu/tests/win_virtio_driver_installer_uninstall.py
+++ b/qemu/tests/win_virtio_driver_installer_uninstall.py
@@ -80,6 +80,8 @@ def run(test, params, env):
             "Could not uninstall Virtio-win-guest-tools package "
             "in guest, detail: '%s'" % o_check)
     error_context.context("Check if all drivers are uninstalled.", test.log.info)
+    # Wait a moment to check if drivers were uninstalled totally
+    time.sleep(5)
     uninstalled_device = []
     device_name_list = [
         "VirtIO RNG Device",


### PR DESCRIPTION
After run the installer uninstallation function, better to wait a moment to check whether drivers were totally uninstalled,because it would take some time to clear the drivers info in some os.
ID: 2855