### PR TITLE
qemu_guest_agent: fix installer installation failed issue

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -602,6 +602,7 @@
             remove_image_image1 = yes
             cd_format_fixed = ahci
             drive_format_image1 = ahci
+            nic_model_nic1 = rtl8139
             install_script_path = "WIN_UTILS:\install.au3"
             repair_script_path = "WIN_UTILS:\repair.au3"
             uninstall_script_path = "WIN_UTILS:\uninstall.au3"


### PR DESCRIPTION
Installation of installer would quit because virtio-net was uninstalled and re-installed in the process which cause the session was lost, and then autoit process would quit. Then using other network type instead of virtio-net would work.

ID: 2811