### PR TITLE
Netkvm: Fix session handling issue during netkvm driver installation

### DIFF
--- a/qemu/tests/single_driver_install.py
+++ b/qemu/tests/single_driver_install.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from aexpect import ShellTimeoutError
-from virttest import error_context, utils_misc
+from virttest import error_context, utils_misc, utils_net
 from virttest.utils_test.qemu import windrv_verify_running
 from virttest.utils_windows import virtio_win, wmic
 
@@ -147,7 +147,8 @@ def run(test, params, env):
             vm.destroy()
             vm.create()
             vm = env.get_vm(params["main_vm"])
-            session = vm.wait_for_login()
+            # This is a workaround for session logout issue
+            session = vm.wait_for_serial_login()
         else:
             session = vm.reboot(session)
 
@@ -175,6 +176,18 @@ def run(test, params, env):
             lambda: not session.cmd_status(chk_cmd), 600, 60, 10
         ):
             test.fail("Failed to install driver '%s'" % driver_name)
+        if "Red Hat VirtIO Ethernet Adapter" in device_name:
+            ext_host = utils_net.get_ip_address_by_interface(
+                ifname="%s" % params.get("netdst")
+            )
+            test.log.info("ext_host of netkvm adapter is %s", ext_host)
+            guest_ip = vm.get_address("nic2")
+            test.log.info("guest_ip of netkvm adapter is %s", guest_ip)
+            status, output = utils_net.ping(
+                ext_host, interface=guest_ip, count=10, timeout=60, session=session
+            )
+            if status:
+                test.fail("Ping %s failed, output=%s" % (ext_host, output))
 
         installed_any |= True
     if not installed_any:


### PR DESCRIPTION
Installing the netkvm driver on an existing network interface caused session handling issues, leading to test failures. This patch changes the session handling from SSH to the serial session by replacing vm.wait_for_login() with vm.wait_for_serial_login(). It also adds a ping test to verify network connectivity after the driver installation.

ID: 1382
Signed-off-by: wji <wji@redhat.com>