### PR TITLE
ovmf_check_efi: change sgdisk to parted

### DIFF
--- a/qemu/tests/cfg/ovmf_check_efi.cfg
+++ b/qemu/tests/cfg/ovmf_check_efi.cfg
@@ -2,7 +2,7 @@
     only q35
     only ovmf
     type = ovmf_check_efi
-    check_cmd = "gdisk -l /dev/[vs]da"
+    check_cmd = "parted -l"
     efi_info = "EFI System Partition"
     dmesg_cmd = "dmesg | grep EFI"
     Windows:


### PR DESCRIPTION
Due to the deletion of sgdisk in the latest linux, change sgdisk to parted in this case

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2880