### PR TITLE
uefi_boot_from_device: add support for network boot

### DIFF
--- a/qemu/tests/cfg/uefi_boot_from_device.cfg
+++ b/qemu/tests/cfg/uefi_boot_from_device.cfg
@@ -58,6 +58,38 @@
                     bootindex_stg = 0
                 - with_specific_device:
                     boot_dev = "UEFI QEMU QEMU HARDDISK"
+        - UEFI_PXEv4:
+            dev_name = "UEFI PXEv4"
+            boot_entry_info = "Booting UEFI PXEv4"
+            variants:
+                - with_bootindex:
+                    bootindex_nic1 = 1
+                - with_specific_device:
+                    boot_dev = "UEFI PXEv4"
+        - UEFI_PXEv6:
+            dev_name = "UEFI PXEv6"
+            boot_entry_info = "Booting UEFI PXEv6"
+            variants:
+                - with_bootindex:
+                    bootindex_nic1 = 1
+                - with_specific_device:
+                    boot_dev = "UEFI PXEv6"
+        - UEFI_HTTPv4:
+            dev_name = "UEFI HTTPv4"
+            boot_entry_info = "Booting UEFI HTTPv4"
+            variants:
+                - with_bootindex:
+                    bootindex_nic1 = 1
+                - with_specific_device:
+                    boot_dev = "UEFI HTTPv4"
+        - UEFI_HTTPv6:
+            dev_name = "UEFI HTTPv6"
+            boot_entry_info = "Booting UEFI HTTPv6"
+            variants:
+                - with_bootindex:
+                    bootindex_nic1 = 1
+                - with_specific_device:
+                    boot_dev = "UEFI HTTPv6"
         - usb_storage_disk:
             dev_name = usb_storage
             usb_devices = ""


### PR DESCRIPTION
include the following 4 cases:
uefi_boot_from_device.UEFI_PXEv4
uefi_boot_from_device.UEFI_PXEv6
uefi_boot_from_device.UEFI_HTTPv4
uefi_boot_from_device.UEFI_HTTPv6

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 2883