### PR TITLE
Add iommufd case for vfio_net_boot

### DIFF
--- a/qemu/tests/cfg/vfio_net_boot.cfg
+++ b/qemu/tests/cfg/vfio_net_boot.cfg
@@ -30,6 +30,15 @@
         - ipv6:
     variants:
         - @default:
+        # multi hostdev will be bound to the same iommufd
+        - iommufd:
+            vm_hostdev_iommufd = iommufd0
+        # multi hostdev will be bound to different iommufd
+        - multi_iommufd:
+            vm_hostdev_iommufd_hostdev1 = iommufd0
+            vm_hostdev_iommufd_hostdev2 = iommufd1
+    variants:
+        - @default:
         - virtio_iommu:
             required_qemu= [7.0.0,)
             only x86_64, aarch64


### PR DESCRIPTION
iommufd-backed VFIO, for example:
-object iommufd,id=iommufd0
-device vfio-pci,host=01:00.0,iommufd=iommufd0
Multiple pcie device can use the same iommufd.

