### PR TITLE
dump: add 7("111") when reading pvpanic device capability

### DIFF
--- a/qemu/tests/cfg/pvpanic_event_check.cfg
+++ b/qemu/tests/cfg/pvpanic_event_check.cfg
@@ -14,4 +14,6 @@
     i440fx:
         expected_cap = 1
     q35:
-        expected_cap = 3
+        expected_cap = 7
+        RHEL.7, RHEL.8, RHEL.9:
+            expected_cap = 3

--- a/qemu/tests/pvpanic_event_check.py
+++ b/qemu/tests/pvpanic_event_check.py
@@ -1,7 +1,5 @@
 import aexpect
-
-from virttest import error_context
-from virttest import utils_misc
+from virttest import error_context, utils_misc
 
 
 @error_context.context_aware
@@ -33,9 +31,7 @@ def run(test, params, env):
     check_ISA_cmd = params["check_ISA_cmd"]
     device_cmd = params["device_cmd"]
 
-    error_context.context(
-        "Setup crash_kexec_post_notifiers=1 in guest", test.log.info
-    )
+    error_context.context("Setup crash_kexec_post_notifiers=1 in guest", test.log.info)
     session.cmd(setup_guest_cmd)
     session = vm.reboot(session)
     s, o = session.cmd_status_output(check_kexec_cmd)
@@ -44,9 +40,10 @@ def run(test, params, env):
 
     error_context.context("Check kdump server status in guest", test.log.info)
     if not utils_misc.wait_for(
-        lambda: session.cmd_output(check_kdump_service).startswith(
-            kdump_expect_status
-        ), timeout=20, first=0.0, step=5.0
+        lambda: session.cmd_output(check_kdump_service).startswith(kdump_expect_status),
+        timeout=20,
+        first=0.0,
+        step=5.0,
     ):
         test.fail(
             "Kdump service did not reach %s status "
@@ -60,13 +57,11 @@ def run(test, params, env):
     o = session.cmd_output(device_cmd)
     if o.strip() != params["expected_cap"]:
         test.fail(
-            "The capability value of the Pvpanic device is %s, " % o +
-            "while %s is expected" % params["expected_cap"]
+            "The capability value of the Pvpanic device is %s, " % o
+            + "while %s is expected" % params["expected_cap"]
         )
 
-    error_context.context(
-        "Trigger a crash in guest and check qmp event", test.log.info
-    )
+    error_context.context("Trigger a crash in guest and check qmp event", test.log.info)
     try:
         session.cmd(trigger_crash_cmd, timeout=5)
     except aexpect.ShellTimeoutError:


### PR DESCRIPTION
We have a new capability: normal shutdown requests through pvpanic. See https://gitlab.com/qemu-project/qemu/-/blob/master/docs/specs/pvpanic.rst?ref_type=heads and the patchset https://lore.kernel.org/qemu-devel/202 40208-pvpanic-shutdown-v6-0-965580ac057b@t-8ch.de/

ID: 2898

Signed-off-by: wji <wji@redhat.com>