### PR TITLE
IPU:rmmod unsupported modules before doing in place upgrade

### DIFF
--- a/provider/in_place_upgrade_base.py
+++ b/provider/in_place_upgrade_base.py
@@ -127,6 +127,8 @@ class IpuTest(object):
             error_info = self.params.get("error_info")
             if re.search(error_info, output):
                 pass
+            if self.params.get("rmmod_module"):
+                self.session.cmd(self.params.get("rmmod_module"))
         except Exception as error:
             test.fail("Failed to fix issues in advance: %s" % str(error))
 

--- a/qemu/tests/cfg/in_place_upgrade.cfg
+++ b/qemu/tests/cfg/in_place_upgrade.cfg
@@ -31,9 +31,13 @@
     stop_yum_update = "rm -rf /var/run/yum.pid"
     check_repo_list = "yum repolist enabled"
     check_rhel_ver = "cut -f1-2 -d. /etc/redhat-release | sed 's/[^0-9]//g'"
+    RHEL.8:
+        rmmod_module = "rmmod ip_set;rmmod nft_compat"
     s390,s390x:
         # no need to check in host, and we don't support RHEL.7.9 as the
         # host on s390x
+        RHEL.8:
+            rmmod_module = "rmmod ip_set"
         device_cio_free_check_cmd = "systemctl status device_cio_free"
     # com_install = "yes" installing leapp from compose
     # com_install = "no" installing leapp from upstream


### PR DESCRIPTION
ID:2901
IPU:rmmod unsupported modules before doing in place upgrade from RHEL8 to RHEL9