### PR TITLE
Netkvm: Fix multi_nics_verify test by adding NIC initialization check

### DIFF
--- a/qemu/tests/cfg/multi_nics_verify.cfg
+++ b/qemu/tests/cfg/multi_nics_verify.cfg
@@ -9,6 +9,9 @@
     network_manager = yes
     RHEL.7, RHEL.8:
         network_manager = no
+    slow_nics = 2
+    total_timeout = 600
+    single_timeouT = 30
     variants:
         - nic_virtio:
             only virtio_net


### PR DESCRIPTION
The test failed because Windows didn't assign IPs to all NICs immediately after boot. A loop was added to check the NIC count until all are initialized, ensuring the test waits for all NICs to get their IP addresses before proceeding.

ID: 2393
Signed-off-by: wji <wji@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable per-NIC and overall timeouts plus a slow-NIC allowance to control NIC initialization behavior.

- **Tests**
  - Per-NIC polling with retry and aggregate timeout logic for IP detection.
  - Switched to serial-based login with a pre-login VM liveliness check.
  - Improved per-NIC progress logging and final outcome messages.

- **Bug Fixes**
  - Reduced flakiness in multi‑NIC verification by tolerating slower NIC initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->