### PR TITLE
qemu_guest_agent: Add logic to get specific rpm from url

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -27,6 +27,8 @@
     qga_rpm_path = "/qemu-guest-agent"
     # Please update your file share web server url before test
     download_root_url = <your_server_url>
+    gagentrpm_tem_path = "/var/tmp/"
+    gagentrpm_guest_dir = "/var/"
     Windows:
         check_vioser = yes
         gagent_src_type = url


### PR DESCRIPTION
I have to run qga test frequently, so it's necessary to add a piece of logic to install the specific package of qga from url.

ID: 1847
Signed-off-by: demeng [demeng@redhat.com](mailto:demeng@redhat.com)