### PR TITLE
vm_poisoned_migration_prevention: adds new test case

### DIFF
--- a/qemu/tests/cfg/vm_poisoned_migration_prevention.cfg
+++ b/qemu/tests/cfg/vm_poisoned_migration_prevention.cfg
@@ -1,0 +1,16 @@
+- vm_poisoned_migration_prevention:
+    only Linux
+    required_qemu = [9.0.0,)
+    type = vm_poisoned_migration_prevention
+    virt_test_type = qemu
+    smp = 8
+    vcpu_maxcpus = ${smp}
+    slots_mem = 4
+    maxmem_mem = 32G
+    mem = 4096
+    kill_vm_on_error = yes
+    mig_timeout = 1200
+    migration_protocol = "tcp"
+    # The user needs to provide here a valid path to a file that creates HWPoison in the host
+    hwpoison_file = ""
+    target_path = "/var/tmp/hwpoison"

--- a/qemu/tests/vm_poisoned_migration_prevention.py
+++ b/qemu/tests/vm_poisoned_migration_prevention.py
@@ -1,0 +1,55 @@
+import re
+import sys
+from shutil import rmtree
+
+from avocado.utils import process
+from virttest import error_context, qemu_monitor
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Handle migration prevention after VM memory poisoning
+    1) Boot VMs in source and destination hosts
+    2) Download the (internal) hwpoison tool
+    3) Executes the tool to poison some memory
+    4) Checks in the host dmesg the failure traces
+    5) Do migration and check the error message is correct
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    hwpoison_file = params.get("hwpoison_file", "")
+    target_path = params.get("target_path")
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    vm.wait_for_login()
+
+    process.system(f"mkdir -p {target_path}", shell=True)
+    qemu_pid = vm.get_pid()
+
+    # This tool is only for internal use, replace the values if needed
+    error_context.base_context("Download the hwpoison tool", test.log.info)
+    process.system(f"wget {hwpoison_file} -P {target_path} ", shell=True)
+
+    error_context.context("Execute the hwpoison tool", test.log.info)
+    process.system(
+        f"{sys.executable} {target_path}/hwpoison.py -p {qemu_pid}", shell=True
+    )
+
+    error_context.context("Check the memory failure in dmesg log", test.log.debug)
+    trace_found = re.search("Memory failure", str(process.system_output("dmesg")))
+
+    if not trace_found:
+        test.fail("No memory failure traces found in dmesg")
+
+    mig_timeout = params.get_numeric("mig_timeout", 1200, float)
+    mig_protocol = params.get("migration_protocol", "tcp")
+    try:
+        vm.migrate(mig_timeout, mig_protocol, env=env, not_wait_for_migration=True)
+    except qemu_monitor.MonitorError as e:
+        error_context.context(f"The monitor error: {e}", test.log.info)
+
+    test.log.debug("Cleaning the tool file")
+    rmtree(target_path, ignore_errors=True)


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/4022

vm_poisoned_migration_prevention: adds new test case

Creates a new test case that checks the migration prevention
when there's poisoned memory.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2982