### PR TITLE
Use dhcpcd command on rhel 10

### DIFF
--- a/generic/tests/cfg/emulate_vf_jumbo.cfg
+++ b/generic/tests/cfg/emulate_vf_jumbo.cfg
@@ -9,3 +9,6 @@
     get_pci_id = lspci -D |grep -i Eth |awk '{print $1}'
     get_vf_num = cat /sys/bus/pci/devices/%s/sriov_totalvfs
     set_vf_mtu = ip link set dev %s mtu %s
+    dhcp_cmd = "dhcpcd -n %s"
+    RHEL.7, RHEL.8, RHEL.9:
+        dhcp_cmd = "dhclient -r && dhclient %s"

--- a/generic/tests/cfg/mac_change.cfg
+++ b/generic/tests/cfg/mac_change.cfg
@@ -4,6 +4,9 @@
     kill_vm = yes
     no RHEL.4
     image_snapshot = yes
+    dhcp_cmd = "dhcpcd -n %s"
+    RHEL.7, RHEL.8, RHEL.9:
+        dhcp_cmd = "dhclient -r && dhclient %s"
     variants:
         - down_change:
             only Linux

--- a/generic/tests/jumbo.py
+++ b/generic/tests/jumbo.py
@@ -227,8 +227,8 @@ def run(test, params, env):
             ifname = ifnames[1]
             vf_mac = utils_net.get_linux_mac(session, ifname)
             session.cmd_output_safe("ip link set dev %s up" % ifname)
-            session.cmd_output_safe("dhclient -r")
-            session.cmd_output_safe("dhclient %s" % ifname)
+            dhcp_cmd = params.get("dhcp_cmd")
+            session.cmd_output_safe(dhcp_cmd % ifname)
             guest_ip = utils_net.get_guest_ip_addr(session, vf_mac)
             if guest_ip is None:
                 test.error("VF can no got ip address")

--- a/generic/tests/mac_change.py
+++ b/generic/tests/mac_change.py
@@ -104,8 +104,8 @@ def run(test, params, env):
                 session_serial.cmd_output_safe(int_activate_cmd % interface)
             session_serial.cmd_output_safe("ifconfig | grep -i %s" % new_mac)
             test.log.info("Mac address change successfully, net restart...")
-            dhclient_cmd = "dhclient -r && dhclient %s" % interface
-            session_serial.sendline(dhclient_cmd)
+            dhcp_cmd = params.get("dhcp_cmd")
+            session_serial.sendline(dhcp_cmd % interface)
         else:
             mode = "netsh"
             if os_variant == "winxp":


### PR DESCRIPTION
Due to dhclient command has been deleted on rhel 10, so using dhcpcd command to replace it