### PR TITLE
fwcfg: fix wmic query to ensure windbg installation for fwcfg cases

### DIFF
--- a/provider/win_dump_utils.py
+++ b/provider/win_dump_utils.py
@@ -98,8 +98,8 @@ def check_windbg_installed(params, session):
     :param params: the dict used for parameters.
     :param session: The guest session object.
     """
-    check_cmd = params["chk_windbg_cmd"] % params["windbg_path"]
-    status, _ = session.cmd_status_output(check_cmd)
+    chk_windbg_cmd = params["chk_windbg_cmd"]
+    status, _ = session.cmd_status_output(chk_windbg_cmd)
     return False if status else True
 
 

--- a/qemu/tests/cfg/fwcfg.cfg
+++ b/qemu/tests/cfg/fwcfg.cfg
@@ -19,21 +19,17 @@
     image_name_stg = "images/storage"
     remove_image_stg = yes
     no ppc64 ppc64le aarch64
+    chk_windbg_cmd = 'powershell -Command "Get-WmiObject Win32_Product | Where-Object Name -like '*SDK Debuggers*' | Select Name, Version"'
     i386:
-        windbg_path = "x86\windbg.exe"
         devcon_dirname += "x86"
-        chk_windbg_cmd = 'dir "C:\Program Files\Windows Kits\10\Debuggers\%s"'
     x86_64:
-        windbg_path = "x64\windbg.exe"
         devcon_dirname += "amd64"
-        chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
     devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     feature = "OptionId.WindowsDesktopDebuggers"
     sdk_setup = winsdksetup.exe
     Win8..1, Win2012..r1, Win2012..r2:
         sdk_setup = sdksetup_81.exe
         unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
-        chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\8.1\Debuggers\%s"'
     Win2016:
         sdk_setup = sdksetup_1607.exe
     Win2019:

--- a/qemu/tests/cfg/fwcfg_enable.cfg
+++ b/qemu/tests/cfg/fwcfg_enable.cfg
@@ -23,21 +23,17 @@
     remove_image_stg = yes
     memory_leak_check = yes
     no ppc64 ppc64le aarch64
+    chk_windbg_cmd = 'powershell -Command "Get-WmiObject Win32_Product | Where-Object Name -like '*SDK Debuggers*' | Select Name, Version"'
     i386:
-        windbg_path = "x86\windbg.exe"
         devcon_dirname += "x86"
-        chk_windbg_cmd = 'dir "C:\Program Files\Windows Kits\10\Debuggers\%s"'
     x86_64:
-        windbg_path = "x64\windbg.exe"
         devcon_dirname += "amd64"
-        chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
     devcon_path = "WIN_UTILS:\devcon\${devcon_dirname}\devcon.exe"
     feature = "OptionId.WindowsDesktopDebuggers"
     sdk_setup = winsdksetup.exe
     Win8..1, Win2012..r1, Win2012..r2:
         sdk_setup = sdksetup_81.exe
         unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
-        chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\8.1\Debuggers\%s"'
     Win2016:
         sdk_setup = sdksetup_1607.exe
     Win2019:

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -278,6 +278,7 @@
             fio_options += '--bs=%s --size=1G --iodepth=16 --numjobs=8 --runtime=1800 --thread'
             io_timeout = 2000
         - with_fwcfg:
+            no ppc64 ppc64le aarch64
             driver_name = "fwcfg"
             required_qemu = [6.0.0, )
             vmcoreinfo = yes
@@ -298,19 +299,12 @@
             images += " stg"
             image_name_stg = "images/storage"
             remove_image_stg = yes
-            no ppc64 ppc64le aarch64
-            i386:
-                windbg_path = "x86\windbg.exe"
-                chk_windbg_cmd = 'dir "C:\Program Files\Windows Kits\10\Debuggers\%s"'
-            x86_64:
-                windbg_path = "x64\windbg.exe"
-                chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\10\Debuggers\%s"'
+            chk_windbg_cmd = 'powershell -Command "Get-WmiObject Win32_Product | Where-Object Name -like '*SDK Debuggers*' | Select Name, Version"'
             feature = "OptionId.WindowsDesktopDebuggers"
             sdk_setup = winsdksetup.exe
             Win8..1, Win2012..r1, Win2012..r2:
                 sdk_setup = sdksetup_81.exe
                 unzip_cmd = powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s:\Memory.dmp.zip', '%s:'); }"
-                chk_windbg_cmd = 'dir "C:\Program Files (x86)\Windows Kits\8.1\Debuggers\%s"'
             Win2016:
                 sdk_setup = sdksetup_1607.exe
             Win2019:


### PR DESCRIPTION
The issue with WinDbg not being found was caused by incorrect WMIC queries.

ID: 1770
Signed-off-by: wji <wji@redhat.com>
