### PR TITLE
numa_prealloc_threads: sets smp to 1, avoiding boot up timeouts

### DIFF
--- a/qemu/tests/cfg/numa_prealloc_threads.cfg
+++ b/qemu/tests/cfg/numa_prealloc_threads.cfg
@@ -7,8 +7,8 @@
     login_timeout = 1000
     qemu_command_prefix = "taskset -c 0 "
     vm_thread_contexts = "tc1"
-    smp_fixed = 8
-    vcpu_maxcpus = ${smp_fixed}
+    smp_fixed = 1
+    vcpu_maxcpus = 2
     not_preprocess = yes
     first_cpu-affinity = "1-7"
     variants:


### PR DESCRIPTION
numa_prealloc_threads: sets smp to 1, avoiding boot up timeouts

Sets smp to 1 and vcpu_max to 2 (not needed to change the vcpu_sockets)
this way the VM can boot up in a feasible time, four times faster than
before facing the timeout issues.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2978