### PR TITLE
numa_opts: increase the mem required for 128 nodes

### DIFF
--- a/qemu/tests/cfg/numa_opts.cfg
+++ b/qemu/tests/cfg/numa_opts.cfg
@@ -106,9 +106,9 @@
                 no RHEL.9.2
             type = numa_maxnodes
             numa_nodes = 128
-            mem_fixed = 16G
-            vm_mem_minimum = 16G
-            node_size = 128M
+            mem_fixed = 64G
+            vm_mem_minimum = 64G
+            node_size = 512M
             start_vm = no
             ppc64,ppc64le:
                 mem_fixed = 32G


### PR DESCRIPTION
numa_opts: increase the mem required for 128 nodes

The current 16G of memory assigned to this case are not enough,
increasing the memory to 64G, even this will limit the testing
possibilities, it's not realistic testing son many nodes with
so few memory.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2974