### PR TITLE
block_with_iommu: expands the test case functionality

### DIFF
--- a/qemu/tests/block_with_iommu.py
+++ b/qemu/tests/block_with_iommu.py
@@ -12,7 +12,8 @@ def run(test, params, env):
         1. Add "intel_iommu=on" to kernel line of q35 guest.
         2. Boot a guest with virtio-scsi with iommu_platform=on.
         3. Verify IOMMU enabled in the guest.
-        4. Reload kernel then reboot guest.
+        4. Execute a simple I/O in the disk
+        5. Reload kernel then reboot guest.
 
     :param test: QEMU test object.
     :param params: Dictionary with the test parameters.
@@ -60,6 +61,10 @@ def run(test, params, env):
     session = vm.wait_for_login(timeout=360)
     verify_iommu_enabled()
 
+    session.cmd(params.get("dd_cmd"))
+
     if params.get("reload_kernel_cmd"):
         reload_kernel(session)
-        vm.reboot(session)
+
+    session = vm.reboot(session, timeout=360)
+    session.cmd(params.get("dd_cmd"))

--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -18,6 +18,7 @@
             virtio_dev_disable_modern = off
             check_key_words = "DMAR: IOMMU enabled;"
             check_key_words += "DMAR: Intel(R) Virtualization Technology for Directed I/O"
+            dd_cmd = "dd if=/dev/urandom of=/home/dd_test oflag=direct bs=1M count=10"
             variants:
                 - @default:
                 - reload_kernel:


### PR DESCRIPTION
block_with_iommu: expands the test case functionality

Expands the test case functionality, doing a simple i/o
operation after checking the guest has boot up
successfully and finally reboot the VM in all the cases.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2991