### PR TITLE
virtio_fs_share_data_hugepage: correct the argument

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
@@ -65,11 +65,11 @@
         - with_cache:
             variants:
                 - auto:
-                    fs_binary_extra_options += ",cache=auto"
+                    fs_binary_extra_options += " --cache=auto"
                 - always:
-                    fs_binary_extra_options += ",cache=always"
+                    fs_binary_extra_options += " --cache=always"
                 - none:
-                    fs_binary_extra_options += ",cache=none"
+                    fs_binary_extra_options += " --cache=never"
     variants:
         - basic_test:
             cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'


### PR DESCRIPTION
[KVMAUTOMA-2917](https://issues.redhat.com/browse/KVMAUTOMA-2917)-[KVM_AUTOTEST]virtio_fs_share_data_hugepage.*.with_cache.* cases failed because of our new avocado fix

[stdlog] 2024-10-11 04:33:28,979 avocado.virttest.qemu_devices.qdevices qdevices         L2150 INFO | Running virtiofs daemon command /usr/libexec/virtiofsd --socket-path=/var/tmp/avocado_l679k6k3/avocado-vt-vm1-fs-virtiofsd.sock --shared-dir /root/avocado/data/avocado-vt/virtio_fs_test/,cache=auto.

should be "--cache=auto" other than ",cache=auto"