### PR TITLE
Use fs_log_level to set log levels in test cases

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -93,7 +93,7 @@
             only Windows
             only default.default.with_cache.auto.default
             no Host_RHEL.m8
-            fs_binary_extra_options += " --log-level debug"
+            fs_log_level = debug
             winapi_dir_name = test_winapi
             create_dir_winapi_cmd = python -c "import ctypes; kernel32 = ctypes.WinDLL('kernel32', use_last_error=True); kernel32.CreateDirectoryW('%s\\${winapi_dir_name}', 0)"
             check_winapi_dir_cmd = "dir %s\${winapi_dir_name}"

--- a/qemu/tests/cfg/virtio_fs_supp_group_transfer.cfg
+++ b/qemu/tests/cfg/virtio_fs_supp_group_transfer.cfg
@@ -38,7 +38,7 @@
     new_guest_user = "user00001"
     add_user_cmd = "useradd %s"
     del_user_cmd = "userdel -r -f %s"
-    fs_enable_debug_mode = yes
+    fs_log_level = debug
     fs_source_dir = virtio_fs_test/
     variants:
         - @default:


### PR DESCRIPTION
Use the new variable `fs_log_level` to set log levels in test cases. 

ID: 2796

