### PR TITLE
RNG: guest report driver updates for RHEL.7,RHEL.8

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -33,6 +33,8 @@
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
         s390x:
+            no RHEL.7,RHEL.8:
+                update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
             RHEL.9:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:

--- a/qemu/tests/cfg/rng_host_guest_read.cfg
+++ b/qemu/tests/cfg/rng_host_guest_read.cfg
@@ -34,5 +34,7 @@
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
         s390x:
+            no RHEL.7,RHEL.8:
+                update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
             RHEL.9:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"

--- a/qemu/tests/cfg/rng_hotplug.cfg
+++ b/qemu/tests/cfg/rng_hotplug.cfg
@@ -47,6 +47,8 @@
             start_rngd_service = "service rngd start"
         s390x:
             rng_driver = "virtio-rng-ccw"
+            no RHEL.7,RHEL.8:
+                update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
             RHEL.9:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:

--- a/qemu/tests/cfg/rng_maxbytes_period.cfg
+++ b/qemu/tests/cfg/rng_maxbytes_period.cfg
@@ -12,6 +12,8 @@
         check_rngd_service = "service rngd status"
         start_rngd_service = "service rngd start"
     s390x:
+        no RHEL.7,RHEL.8:
+            update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
         RHEL.9:
             update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:

--- a/qemu/tests/cfg/rng_read_longtime.cfg
+++ b/qemu/tests/cfg/rng_read_longtime.cfg
@@ -39,5 +39,7 @@
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
         s390x:
+            no RHEL.7,RHEL.8:
+                update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
             RHEL.9:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"

--- a/qemu/tests/cfg/rng_stress.cfg
+++ b/qemu/tests/cfg/rng_stress.cfg
@@ -35,6 +35,8 @@
             start_rngd_service = "service rngd start"
         s390x:
             rng_driver = "virtio-rng-ccw"
+            no RHEL.7,RHEL.8:
+                update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
             RHEL.9:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:

--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -43,6 +43,8 @@
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
         s390x:
+            no RHEL.7,RHEL.8:
+                update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
             RHEL.9:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:


### PR DESCRIPTION
ID: 2669

Updates for s390x platform fixed 'expect driver error' in cases
"rng_bat", "rng_stress", "rng_hotplug", "viorng_in_use", "rng_host_guest_read", "rng_read_longtime" and "rng_maxbytes_period" for RHEL.7 and RHEL.8