### PR TITLE
storage_volume: set direct=on for image_aio=native

### DIFF
--- a/provider/virt_storage/storage_volume.py
+++ b/provider/virt_storage/storage_volume.py
@@ -191,6 +191,10 @@ class StorageVolume(object):
         discard = params.get("image_discard_request", "unmap")
         self.protocol.set_param("auto-read-only", auto_readonly)
         self.protocol.set_param("discard", discard)
+        # image_aio:native requires cache.direct:on
+        if params.get("image_aio") == "native":
+            self.protocol.set_param("cache.direct", "on")
+            self.protocol.set_param("cache.no-flush", "off")
 
     def info(self):
         out = dict()


### PR DESCRIPTION
When setting image_aio to native, cache.direct:on
is required.

id: 2919