### PR TITLE
RNG: guest report driver add exception for RHEL.7,RHEL.8

### DIFF
--- a/qemu/tests/cfg/rng_bat.cfg
+++ b/qemu/tests/cfg/rng_bat.cfg
@@ -33,7 +33,7 @@
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
         s390x:
-            RHEL.9:
+            !RHEL.7,RHEL.8:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:
         - @default:

--- a/qemu/tests/cfg/rng_host_guest_read.cfg
+++ b/qemu/tests/cfg/rng_host_guest_read.cfg
@@ -34,5 +34,5 @@
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
         s390x:
-            RHEL.9:
+            !RHEL.7,RHEL.8:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"

--- a/qemu/tests/cfg/rng_hotplug.cfg
+++ b/qemu/tests/cfg/rng_hotplug.cfg
@@ -47,7 +47,7 @@
             start_rngd_service = "service rngd start"
         s390x:
             rng_driver = "virtio-rng-ccw"
-            RHEL.9:
+            !RHEL.7,RHEL.8:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:
         - multi_rngs:

--- a/qemu/tests/cfg/rng_maxbytes_period.cfg
+++ b/qemu/tests/cfg/rng_maxbytes_period.cfg
@@ -12,7 +12,7 @@
         check_rngd_service = "service rngd status"
         start_rngd_service = "service rngd start"
     s390x:
-        RHEL.9:
+        !RHEL.7,RHEL.8:
             update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:
         - positive_test:

--- a/qemu/tests/cfg/rng_read_longtime.cfg
+++ b/qemu/tests/cfg/rng_read_longtime.cfg
@@ -39,5 +39,5 @@
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
         s390x:
-            RHEL.9:
+            !RHEL.7,RHEL.8:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"

--- a/qemu/tests/cfg/rng_stress.cfg
+++ b/qemu/tests/cfg/rng_stress.cfg
@@ -35,7 +35,7 @@
             start_rngd_service = "service rngd start"
         s390x:
             rng_driver = "virtio-rng-ccw"
-            RHEL.9:
+            !RHEL.7,RHEL.8:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:
         - two_device:

--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -43,7 +43,7 @@
             check_rngd_service = "service rngd status"
             start_rngd_service = "service rngd start"
         s390x:
-            RHEL.9:
+            !RHEL.7,RHEL.8:
                 update_driver = "echo 'virtio_rng.0' > /sys/devices/virtual/misc/hw_random/rng_current"
     variants:
         - before_bg_test:


### PR DESCRIPTION
RNG: for guest report driver added exception for RHEL.7 and RHEL.8 on s390x in cases
"rng_bat", "rng_stress", "rng_hotplug", "viorng_in_use", "rng_host_guest_read", "rng_read_longtime" and "rng_maxbytes_period" 

ID: 2669
Signed-off-by: Bogdan Marcynkov <bmarcynk@redhat.com>