### PR TITLE
rh_kselftests_vm.mm: makes shared machine memory

### DIFF
--- a/qemu/tests/cfg/rh_kselftests_vm.cfg
+++ b/qemu/tests/cfg/rh_kselftests_vm.cfg
@@ -9,5 +9,6 @@
             s390x:
                 kvm_module_parameters = 'hpage=1'
                 whitelist = "hugetlb_fault_after_madv"
+            vm_mem_share = yes
             setup_hugepages = yes
             tests_execution_cmd = "cd ${kselftests_path}/mm && sh run_vmtests.sh -t hugetlb"


### PR DESCRIPTION
rh_kselftests_vm.mm: makes shared machine memory

Implementing a suggestion where it would be better
using shared memory with memory-backend-file.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 3004