### PR TITLE
hotplug_mem_simple: increase VM memory and max memory

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_simple.cfg
+++ b/qemu/tests/cfg/hotplug_mem_simple.cfg
@@ -1,8 +1,8 @@
 - hotplug_mem_simple:
     type = hotplug_mem_simple
-    mem = 2048
+    mem = 4096
     slots_mem = 1
-    maxmem_mem = 4096M
+    maxmem_mem = 8192M
     guest_numa_nodes = "node0"
     mem_devs = "mem0"
     use_mem_mem0 = "no"


### PR DESCRIPTION
hotplug_mem_simple: increase VM memory and max memory

Updates the VM memory from 2G to 4G so the test could
work with Windows guests too. Also updates maxmem to 8G.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 3010