### PR TITLE
delete reload configuration command

### DIFF
--- a/qemu/tests/multi_nics_verify.py
+++ b/qemu/tests/multi_nics_verify.py
@@ -89,7 +89,6 @@ def run(test, params, env):
             session.cmd(
                 "chmod 600 /etc/NetworkManager/system-connections/*.nmconnection"
             )
-            session.cmd("nmcli connection reload")
         else:
             for ifname in ifname_list:
                 eth_config_path = ifcfg_path % ifname


### PR DESCRIPTION
This command will let all the nic device obtain ip address which cuased guest ip route conflict to let guest hang a moment and failed to got the command execution status. Based on test steps the guest will reboot after create networkmanager connection file which can got same result,therefore delete this line.

ID:3014
Signed-off-by: Lei Yang leiyang@redhat.com