### PR TITLE
virtio-mem is not supported on 32-bit system

### DIFF
--- a/qemu/tests/cfg/single_driver_install.cfg
+++ b/qemu/tests/cfg/single_driver_install.cfg
@@ -157,6 +157,7 @@
             vmcoreinfo = yes
         - with_viomem:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+            no i386
             required_virtio_win_prewhql = [0.1.251, )
             required_virtio_win = [1.9.40.0, )
             maxmem_mem = 80G

--- a/qemu/tests/cfg/virtio_driver_sign_check.cfg
+++ b/qemu/tests/cfg/virtio_driver_sign_check.cfg
@@ -69,6 +69,7 @@
         - with_fwcfg:
             tested_driver = fwcfg
         - with_viomem:
+            no i386
             required_virtio_win_prewhql = [0.1.251, )
             required_virtio_win = [1.9.40.0, )
             tested_driver = viomem

--- a/qemu/tests/cfg/win_sigverif.cfg
+++ b/qemu/tests/cfg/win_sigverif.cfg
@@ -98,6 +98,7 @@
             device_name = "VirtIO FS Device"
         - with_viomem:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+            no i386
             required_virtio_win_prewhql = [0.1.251, )
             required_virtio_win = [1.9.40.0, )
             maxmem_mem = 80G


### PR DESCRIPTION
virtio-mem is not supported on 32-bit system,
so remove virtio-mem test from i386.

ID: 2886

Signed-off-by: menli <menli@redhat.com>