### PR TITLE
Fix download failure about wget type

### DIFF
--- a/qemu/tests/stress_kernel_compile.py
+++ b/qemu/tests/stress_kernel_compile.py
@@ -21,7 +21,7 @@ def run(test, params, env):
         ip = vm.get_address()
         path = params.get("download_url")
         test.log.info("kernel path = %s", path)
-        get_kernel_cmd = "wget %s --progress=none" % path
+        get_kernel_cmd = "wget %s" % path
         install_status = utils_package.package_install("wget", session, timeout=60)
         if not install_status:
             test.error("Failed to install wget.")


### PR DESCRIPTION
Change progress type to bar because
invalid progress type 'none' in qemu-kvm-9.1

ID: 2900