### PR TITLE
Update the method to check driver was installed

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_install_from_update.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_from_update.cfg
@@ -26,8 +26,6 @@
     wuauserv_start_cmd = "sc start wuauserv"
     wuauserv_service_cfg_cmd = 'sc config wuauserv start=auto'
     install_driver_cmd = "WIN_UTILS:\AutoIt3\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\windows_update.au3"
-    check_driver_stat = 'wmic sysdriver where PathName="C:\\Windows\\System32'
-    check_driver_stat += '\\drivers\\%s.sys" get State /value | findstr Running'
     vio_driver_chk_cmd = 'driverquery /si | find /i "%s"'
     chk_timeout = 240
     variants:

--- a/qemu/tests/win_virtio_driver_install_from_update.py
+++ b/qemu/tests/win_virtio_driver_install_from_update.py
@@ -48,7 +48,6 @@ def run(test, params, env):
     device_hwid = params["device_hwid"]
     devcon_path = params["devcon_path"]
     install_driver_cmd = params["install_driver_cmd"]
-    check_stat = params["check_driver_stat"] % driver_name
     chk_cmd = params["vio_driver_chk_cmd"] % device_name[0:30]
     chk_timeout = int(params.get("chk_timeout", 240))
 
@@ -69,11 +68,7 @@ def run(test, params, env):
     vm.send_key("meta_l-d")
     time.sleep(30)
     session.cmd(install_driver_cmd)
-    # workaround for viostor and vioscsi as driver status still be running
-    # after uninstall
-    if driver_name in ("viostor", "vioscsi"):
-        time.sleep(120)
-    if not utils_misc.wait_for(lambda: not session.cmd_status(check_stat), 600, 0, 10):
+    if not utils_misc.wait_for(lambda: not session.cmd_status(chk_cmd), 600, 60, 10):
         test.fail(
             "%s Driver can not be installed correctly from "
             "windows update" % driver_name

--- a/qemu/tests/win_virtio_driver_install_from_update.py
+++ b/qemu/tests/win_virtio_driver_install_from_update.py
@@ -1,6 +1,7 @@
 import time
 
 from virttest import error_context, utils_misc
+from virttest.utils_windows import virtio_win
 
 from provider import win_driver_utils
 
@@ -68,7 +69,27 @@ def run(test, params, env):
     vm.send_key("meta_l-d")
     time.sleep(30)
     session.cmd(install_driver_cmd)
-    if not utils_misc.wait_for(lambda: not session.cmd_status(chk_cmd), 600, 60, 10):
+    # workaround for viostor and vioscsi as driver status still be running
+    # after uninstall
+    if driver_name in ("viostor", "vioscsi"):
+        time.sleep(120)
+
+    driver_svc_map = virtio_win.DRIVER_SVC_MAP
+    if driver_svc_map.get(driver_name):
+        driver_svc = driver_svc_map[driver_name]
+    else:
+        driver_svc = driver_name
+
+    driver_check_cmd = (
+        r"powershell -command"
+        r' "Get-WmiObject Win32_SystemDriver | Where-Object'
+        r" { $_.Name -eq '%s' }"
+        r' | Select-Object state | findstr Running"'
+    ) % driver_svc
+
+    if not utils_misc.wait_for(
+        lambda: not session.cmd_status(driver_check_cmd), 600, 60, 10
+    ):
         test.fail(
             "%s Driver can not be installed correctly from "
             "windows update" % driver_name
@@ -84,5 +105,7 @@ def run(test, params, env):
         test.fail(fail_log)
     elif "TRUE" not in chk_output:
         test.error("Device %s is not found in guest" % device_name)
+    ver_list = win_driver_utils._pnpdrv_info(session, device_name, ["DriverVersion"])
+    test.log.info(" %s driver version is %s", device_name, ver_list)
 
     session.close()


### PR DESCRIPTION
For currently win11 and win2025 always fail with
windows update case, the root case is that:
For INF isolation all win11 drivers are moved to DriverStore (C:\WINDOWS\system32\DriverStore\FileRepository).
Each installation creates a new directory in
the DriverStore folder depending on the driver hash. While for win10 drivers, there are no change.
So change the method to check whether the driver was installed. After the test, all guests work normally.

ID: 1726