### PR TITLE
Delete case name because it isn't a support scenario

### DIFF
--- a/qemu/tests/cfg/migrate.cfg
+++ b/qemu/tests/cfg/migrate.cfg
@@ -192,11 +192,6 @@
                     test_timeout = 600
                     guest_stress_test = "autotest"
                     test_type = "stress_memory_heavy"
-        - between_vhost_novhost:
-            no JeOS
-            no Host_RHEL.m6.u1
-            migrate_between_vhost_novhost = "yes"
-            type = migration_with_file_transfer
         - with_netperf:
             no JeOS
             iterations = 1

--- a/qemu/tests/migration_with_file_transfer.py
+++ b/qemu/tests/migration_with_file_transfer.py
@@ -34,7 +34,6 @@ def run(test, params, env):
     guest_path = params.get("guest_path", "/tmp/file")
     file_size = params.get("file_size", "500")
     transfer_timeout = int(params.get("transfer_timeout", "240"))
-    migrate_between_vhost_novhost = params.get("migrate_between_vhost_novhost")
     if mig_protocol == "exec":
         mig_file = os.path.join(
             test.tmpdir, "tmp-%s" % utils_misc.generate_random_string(8)
@@ -50,12 +49,6 @@ def run(test, params, env):
                     test.log.info(
                         "File transfer not ended, starting a round of " "migration..."
                     )
-                    if migrate_between_vhost_novhost == "yes":
-                        vhost_status = vm.params.get("vhost")
-                        if vhost_status == "vhost=on":
-                            vm.params["vhost"] = "vhost=off"
-                        elif vhost_status == "vhost=off":
-                            vm.params["vhost"] = "vhost=on"
                     migration_exec_cmd_src = params.get("migration_exec_cmd_src")
                     migration_exec_cmd_dst = params.get("migration_exec_cmd_dst")
                     if mig_protocol == "exec" and migration_exec_cmd_src:


### PR DESCRIPTION
Delete between_vhost_novhost case name because it isn't a support scenario on libvirt level.

ID:3127
Signed-off-by: Lei Yang leiyang@redhat.com