### PR TITLE
balloon_check: fix the inconsistent comparison

### DIFF
--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -461,7 +461,8 @@ class BallooningTestWin(BallooningTest):
         error_msg = "Wanted to be changed: %s\n" % (expect_value - self.pre_mem)
         if monitor_value:
             error_msg += "Changed in monitor: %s\n" % (monitor_value - self.pre_mem)
-        error_msg += "Changed in guest: %s\n" % (guest_value - self.pre_gmem)
+        # guest_value and pre_gmem is the memory in use in guest.
+        error_msg += "Changed in guest: %s\n" % (self.pre_gmem - guest_value)
         self.test.log.error(error_msg)
 
     def get_memory_status(self):


### PR DESCRIPTION
When balloon memory to a big value, it means balloon deflation, in guest the in use memory would be reduced;
while balloon memory to a small value, it means balloon inflation, in guest the in use memory would be increased.

So the calculation method should be updated.
ID: 1316