### PR TITLE
block_with_iommu.cfg: limit iommu case for windows on Intel CPU only

### DIFF
--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -37,7 +37,7 @@
             only virtio_scsi, virtio_blk
             # Since the iommu does not support on AMD CPU for windows guest.
             # So limits test on Intel CPU only here.
-            only cpu.intel
+            only HostCpuVendor.intel
             no WinXP WinVista Win7 Win8 Win8.1 Win2000 Win2003
             no Win2008 Win2008..r2 Win2012 Win2012..r2
             shutdown_cleanly = yes


### PR DESCRIPTION
For currently we use the wrong limit parameter in the cfg. So we can not filter case on the intel machine. Update to the right parameter.

ID: 3144