### PR TITLE
x86: fix die parameter check

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -135,6 +135,8 @@
                     start_vm = no
                     check_die_id = 'cat /sys/devices/system/cpu/cpu*/topology/die_id | sort | uniq -c'
                     check_die_cpus_list = 'cat /sys/devices/system/cpu/cpu*/topology/die_cpus_list | sort | uniq -c'
+                    RHEL.8, RHEL.9.0, RHEL.9.1, RHEL.9.2, RHEL.9.3, RHEL.9.4, RHEL.9.5:
+                        old_check = yes
                 - nonstop_tsc:
                     type = x86_cpu_flag_nonstop_tsc
                     check_clock = 'cat /sys/devices/system/clocksource/clocksource0/available_clocksource | grep tsc'

--- a/qemu/tests/x86_cpu_test_dies.py
+++ b/qemu/tests/x86_cpu_test_dies.py
@@ -28,14 +28,20 @@ def run(test, params, env):
         check_die_cpus_list = params["check_die_cpus_list"]
         vcpu_sockets = vm.cpuinfo.sockets
         vcpu_dies = vm.cpuinfo.dies
+        old_check = params.get("old_check", "no")
         dies_id = session.cmd_output(check_die_id).strip().split("\n")
         dies_cpus_list = session.cmd_output(check_die_cpus_list).strip().split("\n")
-        if len(dies_id) != int(vcpu_dies):
-            test.fail("die_id is not right: %d != %d" % (len(dies_id), int(vcpu_dies)))
-        if len(dies_cpus_list) != int(vcpu_sockets) * int(vcpu_dies):
+        if old_check == "yes":
+            dies_check = int(vcpu_dies)
+            dies_list_check = int(vcpu_sockets) * int(vcpu_dies)
+        else:
+            dies_check = dies_list_check = int(vcpu_sockets) * int(vcpu_dies)
+        if len(dies_id) != dies_check:
+            test.fail("die_id is not right: %d != %d" % (len(dies_id), dies_check))
+        if len(dies_cpus_list) != dies_list_check:
             test.fail(
                 "die_cpus_list is not right: %d != %d"
-                % (len(dies_cpus_list), int(vcpu_sockets) * int(vcpu_dies))
+                % (len(dies_cpus_list), dies_list_check)
             )
 
     vm.verify_kernel_crash()


### PR DESCRIPTION
ID: 3015

When TGLX rewrote the x86/topology code upstream a change was made to Intel die_id numbering. Previously the die_id was unique per package. After the change the die_id is unique per system.