### PR TITLE
exclude windows vm for details test

### DIFF
--- a/qemu/tests/cfg/cpu_topology_test.cfg
+++ b/qemu/tests/cfg/cpu_topology_test.cfg
@@ -27,6 +27,7 @@
                 RHEL.8:
                     check_siblings_cmd = "awk -F'-' '{print $2 - $1 + 1}' /sys/devices/system/cpu/cpu0/topology/core_siblings_list"
         - check_core_per_sockets:
+            only Linux
             type = cpu_topology_details_test
             start_vm = yes
             check_core_per_socket_cmd = "lscpu --extended | awk 'NR>1 {print $3}'"


### PR DESCRIPTION
ID: 2526

Exclude the CPU topology details test for Windows VM, will cover the basic test for Windows vm