### PR TITLE
Remove un-supported CPU model on s390x

### DIFF
--- a/qemu/tests/cfg/s390x_cpu_model.cfg
+++ b/qemu/tests/cfg/s390x_cpu_model.cfg
@@ -10,6 +10,7 @@
             type = s390x_cpu_model_expansion
             variants:
                 - model_type_z196_z196_2_z114:
+                    only RHEL.7 RHEL.8 RHEL.9
                     cpu_models = "z196 z196.2 z114"
                     props = 'aefsi=True msa4=True msa3=True msa2=True msa1=True sthyi=True edat=True ipter=True bpb=True ppa15=True cmm=True'
                 - model_type_zEC12_zEC12_2_zBC12:
@@ -41,7 +42,7 @@
                 boot_cpu_models = 'z196,z196.2,z114;zEC12,zEC12.2,zBC12;z13,z13.2,z13s;z14,z14.2,z14ZR1;gen15a,gen15b;gen16a,gen16b'
             RHEL.8:
                 boot_cpu_models = 'z13,z13.2,z13s;z14,z14.2,z14ZR1;gen15a,gen15b;gen16a,gen16b'
-            RHEL.9:
+            RHEL.9, RHEL.10:
                 boot_cpu_models = 'z14,z14.2,z14ZR1;gen15a,gen15b;gen16a,gen16b'
         - cpu_baseline:
             type = s390x_cpu_model_baseline
@@ -49,4 +50,6 @@
             props2 = "msa1=True msa2=False msa3=True"
             expected_props = "msa1"
             not_expected_props = "msa2 msa3"
-            cpu_models = "z196 z114 zEC12 zBC12 z13 z13.2 z14 gen15b gen16b"
+            cpu_models = "z14 gen15b gen16b"
+            RHEL.7, RHEL.8, RHEL.9:
+                cpu_models = "z196 z114 zEC12 zBC12 z13 z13.2 z14 gen15b gen16b"


### PR DESCRIPTION
CPU_model: since z196 is deprecated start from 10, remove it

ID: 2646

Signed-off-by: Boqiao Fu <bfu@redhat.com>
