### PR TITLE
blockdev_mirror_firewall:skip unmaintained driver detection

### DIFF
--- a/qemu/tests/cfg/blockdev_mirror_firewall.cfg
+++ b/qemu/tests/cfg/blockdev_mirror_firewall.cfg
@@ -32,6 +32,7 @@
     rebase_mode = unsafe
     #Fixme if no driver deprecated warning in host_dmesg.log
     expected_host_dmesg = Warning: Deprecated Driver is detected
+    expected_host_dmesg += |Warning: Unmaintained driver is detected
 
     nbd:
         nbd_port_data1 = 10831


### PR DESCRIPTION
Update expected_host_dmesg value to skip unmaintained driver detection in host_dmesg

id:3219