### PR TITLE
hugepage_reset: fix memory comparison

### DIFF
--- a/qemu/tests/cfg/hugepage_reset.cfg
+++ b/qemu/tests/cfg/hugepage_reset.cfg
@@ -4,8 +4,8 @@
     pre_command = 'echo 3 > /proc/sys/vm/drop_caches && echo 1 > /proc/sys/vm/compact_memory'
     mem = 4096
     origin_nr = 8
-    # Please set hugepage in kernel command line before this test:
-    # default_hugepagesz=1G hugepagesz=1G hugepages=8
+    # Please set 1G hugepages as the default size at boot time.
+    # Example: default_hugepagesz=1G hugepagesz=1G
     expected_hugepage_size = 1048576
     Windows:
         x86_64:

--- a/qemu/tests/hugepage_reset.py
+++ b/qemu/tests/hugepage_reset.py
@@ -90,8 +90,8 @@ def run(test, params, env):
             node_mem_free = host_numa_node.read_from_node_meminfo(
                 target_node, "MemFree"
             )
-            if int(node_mem_free) > mem:
-                params["target_nodes"] = target_node
+            if int(node_mem_free) > (mem * 1024):
+                params["target_nodes"] = str(target_node)
                 params["qemu_command_prefix"] = "numactl --membind=%s" % target_node
                 params["target_num_node%s" % target_node] = origin_nr
                 break
@@ -104,11 +104,9 @@ def run(test, params, env):
             )
         else:
             test.cancel(
-                "No node on your host has sufficient free memory for " "this test."
+                "No node on your host has sufficient free memory for this test."
             )
     hp_config = test_setup.HugePageConfig(params)
-    hp_config.target_hugepages = origin_nr
-    test.log.info("Setup hugepage number to %s", origin_nr)
     hp_config.setup()
     hugepage_size = utils_memory.get_huge_page_size()
     params["hugepage_path"] = hp_config.hugepage_path


### PR DESCRIPTION
hugepage_reset: fix memory comparison

The comparison between the memory needed by the test
and the free memory from each node was incorrect.
Keep the HugePageConfig setup() function to
properly set the calculated hugepages on the right node.

Adds an informative comment in the cfg about setting
1G hugepages at boot time.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 3254