### PR TITLE
virtio_fs_share_data_hugepage: correct cache argument

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
@@ -65,11 +65,11 @@
         - with_cache:
             variants:
                 - auto:
-                    fs_binary_extra_options += ",cache=auto"
+                    fs_binary_extra_options += " --cache=auto"
                 - always:
-                    fs_binary_extra_options += ",cache=always"
+                    fs_binary_extra_options += " --cache=always"
                 - none:
-                    fs_binary_extra_options += ",cache=none"
+                    fs_binary_extra_options += " --cache=never"
     variants:
         - basic_test:
             cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'


### PR DESCRIPTION
change cache argument of virtiofsd from',cache=' to ' --cache='
and update the cache mode 'none' to 'never' to match with the
latest production behavior.

ID:2917
Signed-off-by: Junyao Zhao junzhao@redhat.com