### PR TITLE
virtio_fs_share_data_hugepage: correct cache argument

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_hugepage.cfg
@@ -65,11 +65,20 @@
         - with_cache:
             variants:
                 - auto:
-                    fs_binary_extra_options += ",cache=auto"
+                    !Host_RHEL.m8:
+                        fs_binary_extra_options += " --cache=auto"
+                    Host_RHEL.m8:
+                        fs_binary_extra_options += " -o cache=auto"
                 - always:
-                    fs_binary_extra_options += ",cache=always"
-                - none:
-                    fs_binary_extra_options += ",cache=none"
+                    !Host_RHEL.m8:
+                        fs_binary_extra_options += " --cache=always"
+                    Host_RHEL.m8:
+                        fs_binary_extra_options += " -o cache=always"
+                - never:
+                    !Host_RHEL.m8:
+                        fs_binary_extra_options += " --cache=never"
+                    Host_RHEL.m8:
+                        fs_binary_extra_options += " -o cache=none"
     variants:
         - basic_test:
             cmd_dd = 'dd if=/dev/urandom of=%s bs=1M count=2048 oflag=direct'


### PR DESCRIPTION
change cache argument of virtiofsd from',cache=' to ' --cache=' and update the cache mode 'none' to 'never' to match with the latest production behavior.

ID:2917
Signed-off-by: Junyao Zhao junzhao@redhat.com