### PR TITLE
virtio_fs_subtest_during_io: fix timeout issue

### DIFF
--- a/qemu/tests/cfg/virtio_fs_subtest_during_io.cfg
+++ b/qemu/tests/cfg/virtio_fs_subtest_during_io.cfg
@@ -11,7 +11,7 @@
     vm_mem_share = yes
     vm_mem_backend = memory-backend-file
     vm_mem_backend_path = /dev/shm
-    io_timeout = 600
+    fs_io_timeout = 600
     fs_dest = '/mnt/${fs_target}'
     fs_source_dir = virtio_fs_test/
     driver_name = viofs


### PR DESCRIPTION
The timeout variable name is fs_io_timeout but nog io_timeout in virtio_fs_utiles.py
ID: 3267