### PR TITLE
block_boot_multi_disks: only adding bootindex to the system image

### DIFF
--- a/qemu/tests/cfg/block_boot_multi_disks.cfg
+++ b/qemu/tests/cfg/block_boot_multi_disks.cfg
@@ -45,3 +45,5 @@
             no i440fx
             login_timeout = 1800
             stg_image_num = 99
+            image_boot = no
+            bootindex_image1 = 0


### PR DESCRIPTION
to avoid the issue of tpm log file being full

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 3298