### PR TITLE
Avoid  calling env_process._get_qemu_version from test cases

### DIFF
--- a/qemu/tests/cpu_info_check.py
+++ b/qemu/tests/cpu_info_check.py
@@ -1,7 +1,5 @@
-import re
-
 from avocado.utils import process
-from virttest import cpu, env_process, error_context, utils_misc
+from virttest import cpu, env_process, error_context, utils_misc, utils_qemu
 from virttest.utils_version import VersionInterval
 
 
@@ -45,9 +43,7 @@ def run(test, params, env):
     list(map(cpu_types.extend, list(cpu.CPU_TYPES.values())))
 
     qemu_path = utils_misc.get_qemu_binary(params)
-    qemu_version = env_process._get_qemu_version(qemu_path)
-    match = re.search(r"[0-9]+\.[0-9]+\.[0-9]+(\-[0-9]+)?", qemu_version)
-    host_qemu = match.group(0)
+    host_qemu = utils_qemu.get_qemu_version(qemu_path)[0]
     remove_list_deprecated = params.get("remove_list_deprecated", "")
     if host_qemu in VersionInterval("[7.0.0-8, )") and remove_list_deprecated:
         params["remove_list"] = remove_list_deprecated

--- a/qemu/tests/thin_write_in_qemu_img_commit.py
+++ b/qemu/tests/thin_write_in_qemu_img_commit.py
@@ -1,7 +1,6 @@
 import json
-import re
 
-from virttest import data_dir, env_process, utils_misc, utils_numeric
+from virttest import data_dir, utils_misc, utils_numeric, utils_qemu
 from virttest.qemu_io import QemuIOSystem
 from virttest.qemu_storage import QemuImg
 from virttest.utils_version import VersionInterval
@@ -44,9 +43,7 @@ def run(test, params, env):
     def _verify_map_output(output):
         """ "Verify qemu map output."""
         qemu_path = utils_misc.get_qemu_binary(params)
-        qemu_version = env_process._get_qemu_version(qemu_path)
-        match = re.search(r"[0-9]+\.[0-9]+\.[0-9]+(\-[0-9]+)?", qemu_version)
-        host_qemu = match.group(0)
+        host_qemu = utils_qemu.get_qemu_version(qemu_path)[0]
         expected = {
             "length": int(utils_numeric.normalize_data_size(params["write_size"], "B")),
             "start": 0,


### PR DESCRIPTION
`_get_qemu_version` was removed from `virttest.env_process` in https://github.com/avocado-framework/avocado-vt/pull/4039/commits/fe5614d78ce74395544d6c2834573e0e6f25eb5e

There were a bunch of test cases that were using the private function, and so affected by this removal, such as the one being fixed in https://github.com/autotest/tp-qemu/pull/4249

This path updates the other test cases so they call the public (and still available) function from virttest instead.

ID: 3313