### PR TITLE
netperf: implements dynamic NUMA binding

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -1,6 +1,7 @@
 - netperf: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu libvirt
     type = netperf
+    not_preprocess = yes
     kill_vm = yes
     image_snapshot = yes
     setup_ksm = no
@@ -32,7 +33,6 @@
     # bridge_force_create=yes
     # bridge_nic1 =
     #numa configration
-    numa_node = -1
     netperf_with_numa = yes
     # configure netperf test parameters, some seconds will be took to
     # wait all the clients work, this wait time should be less than


### PR DESCRIPTION
netperf: implements dynamic NUMA binding

The test was taking the last NUMA node to
bind the VM's memory. In some systems the last
NUMA node could have no memory and/or CPUs
assigned, updates the test to take the first
valid node.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 3321