### PR TITLE
uefishell.check_net_boot_entry: adds new test case

### DIFF
--- a/qemu/tests/cfg/uefishell.cfg
+++ b/qemu/tests/cfg/uefishell.cfg
@@ -51,6 +51,46 @@
                     command_ping6_args = "form_ping6_args()"
                     check_result_show6 = "(\w+::\w+:\w+:\w+:\w+)/64"
                     check_result_ping6 = "0.*packet loss"
+        - check_net_boot_entry:
+            bootindex_nic1 = 1
+            Windows:
+                cdroms = ""
+            test_scenarios = "connect bcfg"
+            command_connect = "connect -r"
+            command_bcfg = "bcfg boot dump"
+            check_result_bcfg = "UEFI\s+PXEv4, UEFI\s+PXEv6, UEFI\s+HTTPv4, UEFI\s+HTTPv6"
+            variants:
+                - with_one_serial:
+                    serials = "vs1"
+                    serial_type_vs1 = isa-serial
+                - with_two_serials:
+                    serials = "vs1 vs2"
+                    serial_type_vs1 = isa-serial
+                    serial_type_vs2 = isa-serial
+            variants:
+                - with_virtio_rng:
+                    no_virtio_rng:
+                        virtio_rngs = "rng0"
+                        backend_rng0 = rng-random
+                        backend_type = passthrough
+                        filename_passthrough = /dev/urandom
+                - with_fallback_rng:
+                    virtio_rngs =
+                    only cpu_without_rdrand
+                    check_message = "WARNING: Pseudo Random Number Generator in use - Pixiefail CVE not mitigated"
+                - without_virtio_rng:
+                    no cpu_without_rdrand
+                    virtio_rngs =
+            variants:
+                - cpu_without_rdrand:
+                    auto_cpu_model = no
+                    HostCpuVendor.intel:
+                        cpu_model_list = "core2duo qemu64 Nehalem"
+                    HostCpuVendor.amd:
+                        cpu_model_list = "core2duo qemu64 Opteron_G4"
+                - cpu_with_rdrand:
+                    check_host_flags = yes
+                    flags = rdrand
         - uefi_cmd:
             test_scenarios = "connect alias attrib dump date dblk devices "
             test_scenarios += "devtree dh dmem dmpstore drivers getmtc help "


### PR DESCRIPTION
covered the following scenarios in the case:
1. cpu without rdrand, with fallback rng and with one or two serial port
2. cpu without rdrand, with virtio-rng and with one or two serial port
3. cpu with rdrand, without virtio-rng and with one or two serial port
4. cpu with rdrand, with virtio-rng and with one or two serial port

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 3328