### PR TITLE
nfs_corrupt: Adapt the pause timeout for rhel10 hosts

### DIFF
--- a/generic/tests/cfg/nfs_corrupt.cfg
+++ b/generic/tests/cfg/nfs_corrupt.cfg
@@ -17,6 +17,8 @@
     kill_vm = yes
     post_command_noncritical = yes
     wait_paused_timeout = 240
+    Host_RHEL.m10:
+        wait_paused_timeout = 2400
     nfs_stat_chk_re = "running"
     nfs_serial = TARGET_DISK
     blk_extra_params_stg += ",serial=${nfs_serial}"


### PR DESCRIPTION
The account of time to wait the VM to get paused in rhel10 hosts is about 40 minutes.

ID: 3341