### PR TITLE
virtio_fs_share_data: Adapt the extra options to all the hosts

### DIFF
--- a/qemu/tests/cfg/virtio_fs_share_data.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data.cfg
@@ -345,7 +345,7 @@
                     variants:
                         - @default:
                             # Clearing the private setting of falocate and support xattr
-                            Host_RHEL.m9:
+                            !Host_RHEL.m8:
                                 # no_killpriv_v2 is set to the default one on RHEL9
                                 fs_binary_extra_options += " --xattr --modcaps=+sys_admin"
                             Host_RHEL.m8:
@@ -354,7 +354,7 @@
                             only with_cache.auto.default
                             # rhel8 kernel does not support FUSE_POSIX_ACL
                             no RHEL.8
-                            Host_RHEL.m9:
+                            !Host_RHEL.m8:
                                 fs_binary_extra_options += " --xattr --posix-acl"
                             Host_RHEL.m8:
                                 fs_binary_extra_options += " -o xattr -o posix_acl"

--- a/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
+++ b/qemu/tests/cfg/virtio_fs_share_data_multi_backend.cfg
@@ -191,7 +191,7 @@
                     mem = 32768
                     size_mem1 = 32G
                     # Clearing the private setting of falocate and support xattr
-                    Host_RHEL.m9:
+                    !Host_RHEL.m8:
                         # no_killpriv_v2 is set to the default one on RHEL9
                         fs_binary_extra_options += " --xattr --modcaps=+sys_admin"
                     Host_RHEL.m8:


### PR DESCRIPTION
virtio_fs_share_data_multi_backend: Adapt the extra options to all the hosts

Update the condition from Host_RHEL.m9 to !Host_RHEL.m8 to let other hosts like rhel10 and later on can run the related cases

ID: 3363