### PR TITLE
balloon_stress: update cmd_output_safe() with cmd_output()

### DIFF
--- a/qemu/tests/balloon_stress.py
+++ b/qemu/tests/balloon_stress.py
@@ -28,7 +28,7 @@ def run(test, params, env):
         """
         if params["os_type"] == "windows":
             list_cmd = params.get("list_cmd", "wmic process get name")
-            output = session.cmd_output_safe(list_cmd, timeout=60)
+            output = session.cmd_output(list_cmd, timeout=60)
             process = re.findall("mplayer", output, re.M | re.I)
             return bool(process)
         else:


### PR DESCRIPTION
cmd_output_safe() use serial session, while in this case, it need a common session.
ID: 3377