### PR TITLE
block_during_io: modify 'iozone' value to ensure the stress alive

### DIFF
--- a/qemu/tests/cfg/block_during_io.cfg
+++ b/qemu/tests/cfg/block_during_io.cfg
@@ -56,7 +56,7 @@
     variants:
         - iozone_stress:
             stress_name = iozone
-            iozone_cmd_opitons = "-azR -r 64k -n 512b -g 4G -M -i 0 -i 1 -I "
+            iozone_cmd_opitons = "-azR -r 4k -n 512b -g 4G -M -i 0 -i 1 -I "
             iozone_timeout = 7200
             Windows:
                 iozone_cmd_opitons += "-f %s:\testfile"


### PR DESCRIPTION
The case purpose is to test shutdown or reboot guest during IO, Sometimes iozone stress test already completed before run the shutdown or reboot, so the case will error.

ID: 3372