### PR TITLE
blockdev_inc_backup_pull_*:Remove data-file for backup image

### DIFF
--- a/qemu/tests/blockdev_inc_backup_pull_mode_test.py
+++ b/qemu/tests/blockdev_inc_backup_pull_mode_test.py
@@ -36,6 +36,9 @@ class BlockdevIncBackupPullModeTest(blockdev_base.BlockdevBaseTest):
         image_params = self.params.object_params(tag)
         bk_tags = image_params.objects("backup_images")
         self.source_images.append("drive_%s" % tag)
+        # fix me if data-file support for backup images are requested
+        if self.params.get("enable_data_file"):
+            del self.params["enable_data_file"]
 
         # fleecing image used for full backup, to be exported by nbd
         self.full_backups.append("drive_%s" % bk_tags[0])

--- a/qemu/tests/blockdev_inc_backup_pull_mode_vm_down.py
+++ b/qemu/tests/blockdev_inc_backup_pull_mode_vm_down.py
@@ -30,6 +30,10 @@ class BlockdevIncBackupPullModePoweroffVMTest(BlockdevLiveBackupBaseTest):
         # the fleecing image to be exported
         self.params["image_name_image1"] = self.params["image_name"]
         self.params["image_format_image1"] = self.params["image_format"]
+        # fix me if data-file for backup images are requested
+        if self.params.get("enable_data_file"):
+            del self.params["enable_data_file"]
+
         self._fleecing_image_obj = self.source_disk_define_by_params(
             self.params, self._full_bk_images[0]
         )

--- a/qemu/tests/blockdev_inc_backup_pull_mode_vm_reboot.py
+++ b/qemu/tests/blockdev_inc_backup_pull_mode_vm_reboot.py
@@ -27,6 +27,10 @@ class BlockdevIncBackupPullModeRebootVMTest(BlockdevLiveBackupBaseTest):
         # the fleecing image to be exported
         self.params["image_name_image1"] = self.params["image_name"]
         self.params["image_format_image1"] = self.params["image_format"]
+        # fix me if data-file for backup images are requested
+        if self.params.get("enable_data_file"):
+            del self.params["enable_data_file"]
+
         self._fleecing_image_obj = self.source_disk_define_by_params(
             self.params, self._full_bk_images[0]
         )


### PR DESCRIPTION
Don't support data-file for backup image, so remove the parameter before creating the backup full/incremental images.

id:3384