### PR TITLE
blockdev_inc_backup_*:remove data-file for backup image

### DIFF
--- a/qemu/tests/blockdev_inc_backup_test.py
+++ b/qemu/tests/blockdev_inc_backup_test.py
@@ -100,6 +100,9 @@ class BlockdevIncreamentalBackupTest(blockdev_base.BlockdevBaseTest):
         self.main_vm.destroy()
         images = self.params["images"]
         clone_params = self.main_vm.params.copy()
+        # fix me if data-file support for backup images are requested
+        if clone_params.get("enable_data_file"):
+            del clone_params["enable_data_file"]
         for tag in self.params.objects("source_images"):
             img_params = self.params.object_params(tag)
             image_chain = img_params.objects("image_backup_chain")


### PR DESCRIPTION
Backup image is not created as data-file, so we can't start it with data-file format. Remove the enable_data _file params before starting the clone VM.

id:3394