### PR TITLE
block_hotplug_with_max_map_count:fix the type of vm.max_map_count

### DIFF
--- a/qemu/tests/block_hotplug_with_max_map_count.py
+++ b/qemu/tests/block_hotplug_with_max_map_count.py
@@ -15,9 +15,11 @@ def run(test, params, env):
     """
 
     try:
+        orig_value = int(
+            process.system_output("sysctl -n vm.max_map_count", shell=True)
+        )
         max_map_value = params.get_numeric("max_map_value", 3072)
         test.log.info("Setting max_map_count to 3072")
-        orig_value = process.system_output("sysctl -n vm.max_map_count", shell=True)
         process.system(f"sysctl vm.max_map_count={max_map_value}", shell=True)
 
         extra_image_number = params.get_numeric("extra_image_number", 15)


### PR DESCRIPTION
The original type is 'types' resulting in can not
set vm.max_map_count as expected.

ID:3391