### PR TITLE
blockdev_live_backup_base:remove data_file for backup image

### DIFF
--- a/provider/blockdev_live_backup_base.py
+++ b/provider/blockdev_live_backup_base.py
@@ -106,6 +106,9 @@ class BlockdevLiveBackupBaseTest(BlockdevBaseTest):
             self.main_vm.destroy()
 
         clone_params = self.main_vm.params.copy()
+        # fix me if data-file support for backup images are requested
+        if clone_params.get("enable_data_file"):
+            del clone_params["enable_data_file"]
         for s, t in zip(self._source_images, self._target_images):
             clone_params["images"] = clone_params["images"].replace(s, t)
 


### PR DESCRIPTION
Backup image was created as non data-file image, so we can't start it with data-file format. Now remove the data-file format when starting vm with backup image.
id:3399