### PR TITLE
virt_target:create target with real path

### DIFF
--- a/provider/virt_storage/virt_target.py
+++ b/provider/virt_storage/virt_target.py
@@ -1,3 +1,6 @@
+import os
+
+
 class PoolTarget(object):
     def __init__(self):
         self.path = None
@@ -6,7 +9,7 @@ class PoolTarget(object):
     @classmethod
     def target_define_by_params(cls, params):
         instance = cls()
-        instance.path = params.get("target_path")
+        instance.path = os.path.realpath(params.get("target_path"))
         instance.format = params.get("target_format")
         return instance
 


### PR DESCRIPTION
"/root/avocado-vt/*" is used as root dir of
the tests, but for an image mode test env,
the /root path links to /var/roothome, if we
still search the target image with imagename
"/root/avocado-vt/$filename", it will cause
"file not exist" error.

id:3426