### PR TITLE
rh_kselftests_vm: adds check for brewkoji package

### DIFF
--- a/qemu/tests/cfg/rh_kselftests_vm.cfg
+++ b/qemu/tests/cfg/rh_kselftests_vm.cfg
@@ -4,6 +4,7 @@
     virt_test_type = qemu
     kernel_path = "/tmp/kernel"
     kselftests_path = "/usr/libexec/kselftests"
+    dependent_pkgs = "brewkoji"
     variants:
         - mm:
             s390x:

--- a/qemu/tests/rh_kselftests_vm.py
+++ b/qemu/tests/rh_kselftests_vm.py
@@ -1,7 +1,7 @@
 import re
 
 from avocado.core import exceptions
-from virttest import error_context
+from virttest import error_context, utils_package
 
 
 @error_context.context_aware
@@ -21,6 +21,10 @@ def run(test, params, env):
     kernel_path = params.get("kernel_path", "/tmp/kernel")
     tests_execution_cmd = params.get("tests_execution_cmd")
     whitelist = params.get("whitelist", "").split()
+
+    dependent_pkgs = params.get_list("dependent_pkgs")
+    if not utils_package.package_install(dependent_pkgs, session):
+        test.cancel("Installing dependent packages in VM failed")
 
     session.cmd("mkdir -p %s" % kernel_path)
     kernel_version = session.cmd_output("uname -r").strip().split("+")[0]


### PR DESCRIPTION
rh_kselftests_vm: adds check for brewkoji package

In case the brewkoji is not installed in the guest,
which is necessary for the test to succeed, tries to
install it or cancel the case.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 3371