### PR TITLE
virtio-mem is not supported on 32-bit system

### DIFF
--- a/qemu/tests/cfg/win_virtio_driver_install_from_update.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_from_update.cfg
@@ -132,6 +132,7 @@
             device_hwid = '"ACPI\VEN_QEMU&DEV_0002"'
         - with_viomem:
             no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+            no i386
             maxmem_mem = 20G
             mem_fixed = 4096
             mem_devs = 'vmem0'


### PR DESCRIPTION
Our Acceptance test encountered a Virtio-mem error on the Win10.i386. But virtio-mem is not supported on 32-bit system, so remove virtio-mem test from i386.

ID: 3446
Signed-off-by: wji <wji@redhat.com>