### PR TITLE
block_with_iommu: improve test case

### DIFF
--- a/qemu/tests/cfg/block_with_iommu.cfg
+++ b/qemu/tests/cfg/block_with_iommu.cfg
@@ -8,12 +8,14 @@
     enable_guest_iommu = yes
     virtio_dev_ats = on
     machine_type_extra_params = "kernel-irqchip=split"
+    clone_master = yes
+    master_images_clone = image1
+    remove_image_image1 = yes
     variants:
         - verify_enabled:
             only Linux
             no RHEL.7
             no Host_RHEL.m7
-            only virtio_scsi
             virtio_dev_disable_legacy = on
             virtio_dev_disable_modern = off
             check_key_words = "DMAR: IOMMU enabled;"
@@ -22,9 +24,6 @@
             variants:
                 - @default:
                 - reload_kernel:
-                    clone_master = yes
-                    master_images_clone = image1
-                    remove_image_image1 = yes
                     force_reset_go_down_check = shell
                     reload_kernel_cmd = 'kexec -l /boot/%s --initrd=/boot/%s --command-line="%s"'
                     cmd_get_kernel_ver = uname -r


### PR DESCRIPTION
1. Using the clone image as os image avoids breaking the original image file.
2. Force killing VM after test avoids the underlying issue and VM recover operation.
3. Support iommu test for virtio-blk device
4. Add debug information

ID:3452,3454,3448