### PR TITLE
uefishell.check_smbios: add support for auto type of entry point

### DIFF
--- a/qemu/tests/cfg/uefishell.cfg
+++ b/qemu/tests/cfg/uefishell.cfg
@@ -5,6 +5,7 @@
     start_vm = no
     last_error = "lasterror.*=.*0x0"
     time_interval = 0.5
+    timeout = 240
     restore_ovmf_vars = yes
     variants:
         - secureboot:
@@ -121,9 +122,16 @@
             command_smbios = "smbiosview"
             variants:
                 - @default:
-                    check_result_smbios = "Version.*:\s+3\.\d+"
-                    Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3:
-                        check_result_smbios = "Version.*:\s+2\.\d+"
+                    check_result_smbios = "Version.*:\s+2\.\d+"
+                    variants:
+                        - with_auto_type_64:
+                            no Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9.u0 Host_RHEL.m9.u1 Host_RHEL.m9.u2 Host_RHEL.m9.u3
+                            timeout = 600
+                            check_result_smbios = "Version.*:\s+3\.\d+"
+                            extra_params += " -global mch.extended-tseg-mbytes=48"
+                            vcpu_maxcpus = 510
+                        - with_auto_type_32:
+                            vcpu_maxcpus = 8
                 - with_entry_point:
                     no Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9.u0 Host_RHEL.m9.u1
                     smbios_output_handler = "handle_smbiosview"

--- a/qemu/tests/uefishell.py
+++ b/qemu/tests/uefishell.py
@@ -108,7 +108,8 @@ class UEFIShellTest(object):
             env_process.preprocess_vm,
         )
         self.vm = self.env.get_vm(params["main_vm"])
-        self.session = self.vm.wait_for_serial_login()
+        timeout = self.params.get_numeric("timeout")
+        self.session = self.vm.wait_for_serial_login(timeout=timeout)
         if under_fs0 == "yes":
             self.send_command("fs0:")
 
@@ -154,7 +155,8 @@ class UEFIShellTest(object):
         :return if check_result is not None, return matched string list
         """
         LOG_JOB.info("Send uefishell command: %s", command)
-        output = self.session.cmd_output(command)
+        timeout = self.params.get_numeric("timeout")
+        output = self.session.cmd_output(command, timeout=timeout)
         time.sleep(interval)
         # Judge if cmd is run successfully via environment variable 'lasterror'
         last_error = self.params["last_error"]


### PR DESCRIPTION
smbios 3.0 uses "auto" type for entry point by default from rhel-9.4. 
"pc-q35-rhel9.4.0" or newer machine type(s) set SMBIOS entry point automatically depending on the configuration.
If VM uses VCPUs with less than 510, a 32-bit SMBIOS entry-point will be generated. Otherwise, QEMU will transparently switch to 64-bit SMBIOS entry-point.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 3350