### PR TITLE
thin_provision_guest_fstrim:fix scsi_debug memory size is small

### DIFF
--- a/qemu/tests/cfg/thin_provision_guest_fstrim.cfg
+++ b/qemu/tests/cfg/thin_provision_guest_fstrim.cfg
@@ -13,7 +13,7 @@
     force_create_image_stg1 = no
     drive_format_stg1 = scsi-block
     remove_image_stg1 = no
-    disk_size = 256
+    disk_size = 512
     pre_command = "modprobe -r scsi_debug; modprobe scsi_debug dev_size_mb=${disk_size} lbpu=1 lbpws=1 lbprz=0"
     post_command = "modprobe -r scsi_debug"
 #   serial port setting


### PR DESCRIPTION
The latest LINUX guest xfs must be larger than 300MB. 
Increase the scsi_debug memory size to meet the requirement.

ID:3460