### PR TITLE
backup_utils: set block jobs timeout to 900s

### DIFF
--- a/qemu/tests/cfg/blockdev_full_backup.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup.cfg
@@ -28,6 +28,7 @@
                     only auto_completed
                 - dst_cluster_size_512:
                     image_cluster_size_dst1 = 512
+                    timeout = 900
                     only auto_compress
                     only auto_completed
                 - dst_cluster_size_2M:

--- a/qemu/tests/cfg/blockdev_full_mirror.cfg
+++ b/qemu/tests/cfg/blockdev_full_mirror.cfg
@@ -26,6 +26,7 @@
         - @dst_default_cluster_size:
         - dst_cluster_size_512:
             image_cluster_size_dst1 = 512
+            timeout = 900
         - dst_cluster_size_2M:
             timeout = 900
             buf-size = 1024


### PR DESCRIPTION
600s is not enough for the block job to reach
ready status when the target image is created
on the 512 disk, so extend the time to 900s to
allow block job to get finished.

id: 3470