### PR TITLE
win_virtio_driver_update_test: remove double quote

### DIFF
--- a/qemu/tests/cfg/viorng_in_use.cfg
+++ b/qemu/tests/cfg/viorng_in_use.cfg
@@ -53,7 +53,7 @@
             suppress_exception = yes
             run_bg_flag = "during_bg_test"
             Windows:
-                read_rng_cmd = for /l %i in (1, 1, 1000) do ${rng_dst}"
+                read_rng_cmd = for /l %i in (1, 1, 1000) do ${rng_dst}
             Linux:
                 read_rng_cmd  = "dd if=/dev/random bs=10 count=1000000 2>/dev/null|hexdump"
             no rng_egd

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -155,7 +155,7 @@
                 driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
                 driver_check_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe status @DRIVER_ID"
             during_bg_test:
-                read_rng_cmd = for /l %i in (1, 1, 1000) do ${rng_dst}"
+                read_rng_cmd = for /l %i in (1, 1, 1000) do ${rng_dst}
                 driver_check_cmd = ""
         - with_pvpanic:
             only before_bg_test


### PR DESCRIPTION
win_virtio_driver_update_test: remove double quote

This is a minor fix, I guess the double quote is harmless
but still not correct. Opportunistically removes also a
single double quote from viorng_in_use.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 3473