### PR TITLE
vdpa_dpdk: Add delay between queries for accurate pps stats

### DIFF
--- a/qemu/tests/vdpa_dpdk.py
+++ b/qemu/tests/vdpa_dpdk.py
@@ -194,6 +194,7 @@ def run_test(forward_mode, guest, host, dpdk_tool_path, queue, pkts, mac=None):
         dpdk_tool_path, guest["cpu"], guest["pci"], forward_mode, queue, pkts
     )
     testpmd_guest.show_port_stats_all()
+    time.sleep(2)
     output = testpmd_guest.show_port_stats_all()
     pps_value = testpmd_guest.extract_pps_value(output, forward_mode)
 


### PR DESCRIPTION
Before, querying PPS statistics twice in quick succession caused the second query to return underestimated values. Adding a 2 second delay ensures that the reported PPS is more accurate.

Signed-off-by: Wenli Quan <wquan@redhat.com>

id: 3481