### PR TITLE
dump_guest_core: fix gdb command

### DIFF
--- a/qemu/tests/cfg/dump_guest_core.cfg
+++ b/qemu/tests/cfg/dump_guest_core.cfg
@@ -14,7 +14,7 @@
     gdb_command_file = "/home/gdb_command"
     crash_script = "/home/crash.cmd"
     vmcore_file = "/tmp/vmcore"
-    gdb_command = "gdb --core ${core_file}%s --command=${gdb_command_file}"
+    gdb_command = "gdb /usr/libexec/qemu-kvm --core ${core_file}%s --command=${gdb_command_file}"
     crash_cmd = "crash -i ${crash_script} /usr/lib/debug/lib/modules/%s/vmlinux ${vmcore_file}"
     dump_guest_memory_file = "/usr/share/qemu-kvm/dump-guest-memory.py"
     check_vmcore = 'yes'


### PR DESCRIPTION
Previously, older versions of gdb did not require specifying the /usr/libexec/qemu-kvm parameter. Now, newer versions require it to avoid errors. This patch updates the configuration accordingly.

ID: 1849

Signed-off-by: Wenkang Ji <wji@redhat.com>