### PR TITLE
blockdev_commit_auto_readonly:not set size for snapshot image

### DIFF
--- a/qemu/tests/cfg/blockdev_commit_auto_readonly.cfg
+++ b/qemu/tests/cfg/blockdev_commit_auto_readonly.cfg
@@ -10,12 +10,10 @@
     storage_pool = default
     snapshot_tags = sn1 sn2
 
-    image_size_sn1 = 20G
     image_name_sn1 = sn1
     image_format_sn1 = qcow2
 
     image_name_sn2 = sn2
-    image_size_sn2 = 20G
     image_format_sn2 = qcow2
     image_auto_readonly_sn2 = off
 


### PR DESCRIPTION
Snapshot image size set to 20G, but under some situation, we start VM with system image size not equal to 20G, so when we do the snapshot/commit with a snapshot image that smaller that system image size, the case will fail with "no ipv4 address" issue. So correct it to let the snapshot image size follow the default system image size.

id:3484