### PR TITLE
blockdev_full_backup:add timeout in backup_options

### DIFF
--- a/qemu/tests/cfg/blockdev_full_backup.cfg
+++ b/qemu/tests/cfg/blockdev_full_backup.cfg
@@ -65,7 +65,7 @@
                 - manual_completed:
                     auto-dismiss = false
                     auto-finalize = true
-            backup_options = "auto-dismiss auto-finalize compress sync"
+            backup_options = "auto-dismiss auto-finalize compress sync timeout"
 
         - during_reboot:
             type = blockdev_full_backup_reboot


### PR DESCRIPTION
timeout set for dst_cluster_size_512, but not
set to backup_options, so no timeout get in
backup_utils.py when doing the backup jobs which
will cause it use the timeout default value 600s.

id:3486