### PR TITLE
iozone_windows: fix iozone error for win11

### DIFF
--- a/generic/tests/cfg/iozone_windows.cfg
+++ b/generic/tests/cfg/iozone_windows.cfg
@@ -1,6 +1,10 @@
 - iozone_windows: install setup image_copy unattended_install.cdrom
     virt_test_type = qemu libvirt
     only Windows
+    Win11:
+        mem = 4096
+    # The remaining disk size of the C drive decreases as the VM memory increases for win11
+    # so if we start the vm on a big memory host, no enough space to iozone for C drive.
     type = iozone_windows
     cdrom_cd1 = isos/windows/winutils.iso
     i386:


### PR DESCRIPTION
The remaining disk size of the C drive decreases
as the VM memory increases for win11. so if we start the vm on a big memory host, no enough space to do iozone on C drive. Adjust the memory for win11 to
4G, then the case will run normally.

ID: 3389