### PR TITLE
Remove device number hardcode for secure execution on s390x

### DIFF
--- a/qemu/tests/cfg/secure_execution.cfg
+++ b/qemu/tests/cfg/secure_execution.cfg
@@ -8,8 +8,6 @@
     kill_vm = yes
     machine_type_extra_params = "usb=off,dump-guest-core=off,confidential-guest-support=lsec0"
     extra_params = "-object s390-pv-guest,id=lsec0"
-    nic_extra_params = "devno=fe.0.0001"
-    virtio_serial_extra_params = "devno=fe.0.0002"
     variants:
         - 247_max_vCPUs:
             smp = 247

--- a/qemu/tests/cfg/secure_img.cfg
+++ b/qemu/tests/cfg/secure_img.cfg
@@ -7,8 +7,6 @@
     kill_vm = yes
     machine_type_extra_params = "usb=off,dump-guest-core=off,confidential-guest-support=lsec0"
     extra_params = "-object s390-pv-guest,id=lsec0"
-    nic_extra_params = "devno=fe.0.0001"
-    virtio_serial_extra_params = "devno=fe.0.0002"
     secure_params_cmd = 'echo "$(cat /proc/cmdline) swiotlb=262144" > /home/parmfile'
     # For HKD.crt in boot_img, it's a private cerfitication for specific s390x machines
     boot_img_cmd = 'genprotimg -k /home/HKD.crt -p /home/parmfile -i %s -r %s -o /boot/secure-linux --no-verify'


### PR DESCRIPTION
Secure exectuion: remove hardcode of device number for secure execution related cases on s390x, cause we are adding device number by default, reference to https://github.com/avocado-framework/avocado-vt/pull/4010

ID: 3491

Signed-off-by: bfu <bfu@redhat.com>