### PR TITLE
transfer_file_over_ipv6: fix color char

### DIFF
--- a/qemu/tests/transfer_file_over_ipv6.py
+++ b/qemu/tests/transfer_file_over_ipv6.py
@@ -89,6 +89,7 @@ def run(test, params, env):
                 params.get("os_type"),
                 ip_version="ipv6",
                 linklocal=link_local_ipv6_addr,
+                ip_options="-color=never",
             )
         else:
             addresses[vm] = utils_net.get_guest_ip_addr(
@@ -97,6 +98,7 @@ def run(test, params, env):
                 params.get("os_type"),
                 ip_version="ipv6",
                 linklocal=link_local_ipv6_addr,
+                ip_options="-color=never",
             )
             if link_local_ipv6_addr is False and addresses[vm] is None:
                 test.cancel("Your guest can not get remote IPv6 address.")


### PR DESCRIPTION
The command might output ip address with color characters which will break the script, like below.
Get ipv6 address of vm1: �[34m2620:52:11:1601:982f:7bff:fe94:1415�[0m

This is to disable the color characters in the outputs.


Signed-off-by: Dan Zheng <dzheng@redhat.com>
