### PR TITLE
fwcfg: update command to make it more accurate and general

### DIFF
--- a/qemu/tests/cfg/fwcfg.cfg
+++ b/qemu/tests/cfg/fwcfg.cfg
@@ -6,7 +6,7 @@
     vmcoreinfo = yes
     start_vm = no
     tmp_dir = "/var/tmp"
-    get_avail_disk = df -h /home | grep home | awk -F "G" '{print $3}'
+    get_avail_disk = df -BG /home | awk 'NR==2 {print $4}' | sed 's/G//'
     unzip_cmd = 'powershell -command "Expand-Archive %s:\Memory.dmp.zip %s:"'
     unzip_timeout = 1800
     dump_file = Memory.dmp

--- a/qemu/tests/cfg/fwcfg_enable.cfg
+++ b/qemu/tests/cfg/fwcfg_enable.cfg
@@ -9,7 +9,7 @@
     start_vm = no
     setup_verifier = no
     tmp_dir = "/home/tmp"
-    get_avail_disk = df -h /home | grep home | awk -F "G" '{print $3}'
+    get_avail_disk = df -BG /home | awk 'NR==2 {print $4}' | sed 's/G//'
     unzip_cmd = 'powershell -command "Expand-Archive %s:\Memory.dmp.zip %s:"'
     unzip_timeout = 1800
     dump_file = Memory.dmp

--- a/qemu/tests/cfg/win_virtio_driver_update_test.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_update_test.cfg
@@ -288,7 +288,7 @@
             device_name = "QEMU FwCfg Device"
             device_hwid = '"ACPI\VEN_QEMU&DEV_0002"'
             tmp_dir = "/home/tmp"
-            get_avail_disk = df -h /home | grep home | awk -F "G" '{print $3}'
+            get_avail_disk = df -BG /home | awk 'NR==2 {print $4}' | sed 's/G//'
             unzip_cmd = 'powershell -command "Expand-Archive %s:\Memory.dmp.zip %s:"'
             unzip_timeout = 1800
             dump_file = Memory.dmp


### PR DESCRIPTION
Currently, this command can not get available disk in bootc host, besides that, this command also not setup the output's units, it will get a wrong number if the command execute in a large system( disk size > 1T).So update the command to fix above errors

ID:3461