### PR TITLE
Remove gpg check when install attr package

### DIFF
--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -91,7 +91,7 @@
                     only virtio_fs_set_capability..with_cache.none
                     capability = cap_sys_admin
                     fs_binary_extra_options += ' -o sandbox=chroot -o xattrmap=':map::user.virtiofsd.:''
-                    cmd_yum_attr = 'yum install -y attr'
+                    cmd_yum_attr = 'yum install -y attr --nogpgcheck'
                     guest_trusted = trusted.test
                     cmd_set_trusted = 'setfattr -n ${guest_trusted} ${fs_dest}'
                     cmd_get_trusted = 'getfattr -m '' ${fs_dest}'


### PR DESCRIPTION
virtio-fs: cause we'll use nightly builds for testing, we should remove gpgcheck for the installation of attr packages

ID: 3845

Signed-off-by: bfu <bfu@redhat.com>