### PR TITLE
check_block_size: fix "Timeout elapsed while waiting for install" error

### DIFF
--- a/qemu/tests/cfg/check_block_size.cfg
+++ b/qemu/tests/cfg/check_block_size.cfg
@@ -10,7 +10,7 @@
     kill_vm_on_error = yes
     index_enable = no
     image_name_stg = "images/check_block_size_image"
-    image_size_stg = 20G
+    image_size_stg = 30G
     image_verify_bootable = no
     force_create_image_stg = yes
     drive_serial_stg = "TARGET_DISK0"


### PR DESCRIPTION
"Timeout elapsed while waiting for install to finish" error for this case as no enough disk space. So extend the image size to 25G, then test it, the case run
normally.

ID: 3805 