### PR TITLE
dump_guest_core: fix qemu-kvm-core debuginfo installed

### DIFF
--- a/qemu/tests/dump_guest_core.py
+++ b/qemu/tests/dump_guest_core.py
@@ -76,6 +76,7 @@ def run(test, params, env):
         "crash",
         "gdb",
         "kernel-debuginfo*",
+        "qemu-kvm-core*",
         "qemu-kvm-debuginfo",
         "qemu-kvm-debugsource",
         "qemu-kvm-core-debuginfo",


### PR DESCRIPTION
The dump feature needs the qemu-kvm-core package.

ID: 3867

Signed-off-by: Wenkang Ji wji@redhat.com