### PR TITLE
[ksm_base]: change the path for query command

### DIFF
--- a/qemu/tests/cfg/ksm_base.cfg
+++ b/qemu/tests/cfg/ksm_base.cfg
@@ -5,7 +5,7 @@
     requires_root = yes
     setup_ksm = yes
     shared_mem = 1024
-    query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing"
+    query_cmd = "cat /proc/QEMU_PID/ksm_merging_pages"
     split = "yes"
     guest_script_overhead = 20
     cmds_installed_host = "ksmtuned"


### PR DESCRIPTION
1.query_cmd = "cat /sys/kernel/mm/ksm/pages_sharing" is
changed to /proc/QEMU_PID/ksm_merging_pages
2.This ensures the correct  check path to the corresponding QEMU process
to ensure the stable operation of the test cases.
3.In the KAR repo the query_cmd will be modified as mentioned for below file
internal_cfg/host-os-setting.cfg

Signed-off-by: meshetty <meshetty@redhat.com>

ID: 3868



