### PR TITLE
Enlarge the sleep time when free-page-reporting is enabled

### DIFF
--- a/qemu/tests/cfg/balloon_check.cfg
+++ b/qemu/tests/cfg/balloon_check.cfg
@@ -30,6 +30,10 @@
             no RHEL.8.3 RHEL.8.2 RHEL.8.1 RHEL.8.0 RHEL.7
             balloon_opt_free_page_reporting = yes
             get_res_cmd = "top -n1 -b -p %s | grep qemu-kvm | awk -F ' ' '{print $6}'"
+            catch_call_trace = "dmesg -T | grep -i "Call Trace" -A 20"
+            s390x:
+                get_res_cmd = "ps -p %s -o rss= | awk '{printf "%%.2fM\n", $1/1024}'"
+                balloon_release_time = 300
             consumed_mem = 2G
             ppc64,ppc64le:
                 consumed_mem = 4G


### PR DESCRIPTION
Virtio-balloon: since there's a product issue on OCP, enlarge the sleep
time on s390x to cover this. Also, since top cannot show unit when res
memory is lower than 1G, switch the command to "ps", also adding call 
trace check for call trace error

ID: 3701

Signed-off-by: Boqiao Fu <bfu@redhat.com>