### PR TITLE
netperf: Windows small fix for host-vm tests

### DIFF
--- a/generic/tests/cfg/netperf.cfg
+++ b/generic/tests/cfg/netperf.cfg
@@ -89,7 +89,7 @@
     #    log_guestinfo_script = scripts/rh_perf_log_guestinfo_script.bat
     #    log_guestinfo_exec = cmd /c
     #    log_guestinfo_path = C:\log_guestinfo.bat
-        server_mtu_cmd = "netsh interface ipv4 set subinterface "%s" mtu=%s"
+        server_mtu_cmd = "netsh interface ipv4 set interface "%s" mtu=%s"
         i386, x86_64:
             cpu_model_flags = ",hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0xfff"
         windows_disable_firewall = "netsh advfirewall set allprofiles state off"

--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -62,6 +62,7 @@ def run(test, params, env):
         server_mtu_cmd = params.get("server_mtu_cmd")
         client_mtu_cmd = params.get("client_mtu_cmd")
         host_mtu_cmd = params.get("host_mtu_cmd")
+        client_physical_nic = params.get("client_physical_nic")
         error_context.context("Changing the MTU of guest", test.log.info)
         if params.get("os_type") == "linux":
             ethname = utils_net.get_linux_ifname(server_ctl, mac)
@@ -73,9 +74,8 @@ def run(test, params, env):
             netperf_base.ssh_cmd(server_ctl, server_mtu_cmd % (connection_id, mtu))
 
         error_context.context("Changing the MTU of client", test.log.info)
-        netperf_base.ssh_cmd(
-            client, client_mtu_cmd % (params.get("client_physical_nic"), mtu)
-        )
+        if client_physical_nic:
+            netperf_base.ssh_cmd(client, client_mtu_cmd % (client_physical_nic, mtu))
 
         netdst = params.get("netdst", "switch")
         host_bridges = utils_net.Bridge()
@@ -300,6 +300,7 @@ def run(test, params, env):
     client = params.get("client", "localhost")
     client_ip = client
     clients = []
+    client_pub_ip = None
     # client session 1 for control, session 2 for data communication
     for i in range(2):
         if client in params.get("vms"):


### PR DESCRIPTION
Fix minor issues in Windows guest tests between host and VM

1. Initialize client_pub_ip as None for safe variable use
2. Changed server_mtu_cmd to use "set interface" instead of "set subinterface" for correct ipv4 interface configuratio
3. Add client_physical_nic check to avoid errors if not set

id: 3891, 3892, 3893
Signed-off-by: Wenli Quan <wquan@redhat.com>