### PR TITLE
fwcfg: fix windbg install check and move fwcfg dmp file path

### DIFF
--- a/provider/win_dump_utils.py
+++ b/provider/win_dump_utils.py
@@ -83,12 +83,13 @@ def install_windbg(test, params, session, timeout=600):
     )
 
     session.cmd(windbg_install_cmd)
-    if not utils_misc.wait_for(
-        lambda: check_windbg_installed(params, session), timeout=timeout, step=5
-    ):
-        test.fail("windbg tool has not been installed")
-    else:
+    windbg_install_log = params["windbg_install_log"]
+    status, output = session.cmd_status_output("type %s"
+                                               % windbg_install_log)
+    if 'package_SDKDebuggers_x86_en_us, state: Present' in output:
         LOG_JOB.info("windbg tool installation completed")
+    else:
+        test.fail("windbg tool has not been installed")
 
 
 def check_windbg_installed(params, session):

--- a/qemu/tests/cfg/fwcfg.cfg
+++ b/qemu/tests/cfg/fwcfg.cfg
@@ -36,7 +36,8 @@
         sdk_setup = winsdksetup_1809.exe
     Win11, Win2022:
         sdk_setup = winsdksetup_11.exe
-    windbg_install_cmd = "WIN_UTILS:\winsdksetup\${sdk_setup} /features %s /q"
+    windbg_install_log = "C:\WindbgInstall.log"
+    windbg_install_cmd = "WIN_UTILS:\winsdksetup\${sdk_setup} /log "${windbg_install_log}" /features %s /q"
     sdk_name = 'Windows Software Development Kit'
     chk_sdk_ins = 'wmic product get name,version | find /i "${sdk_name}"'
     chk_dump_cmd = "WIN_UTILS:\AutoIt3\AutoIt3_%PROCESSOR_ARCHITECTURE%.exe WIN_UTILS:\check_dump_windbg.au3"

--- a/qemu/tests/cfg/fwcfg.cfg
+++ b/qemu/tests/cfg/fwcfg.cfg
@@ -5,7 +5,7 @@
     required_qemu = [6.0.0, )
     vmcoreinfo = yes
     start_vm = no
-    tmp_dir = "/var/tmp"
+    tmp_dir = "/home"
     get_avail_disk = df -BG /home | awk 'NR==2 {print $4}' | sed 's/G//'
     unzip_cmd = 'powershell -command "Expand-Archive %s:\Memory.dmp.zip %s:"'
     unzip_timeout = 1800


### PR DESCRIPTION
This MR includes two commit changes: first, fix an issue where Windbg install was incorrectly reported as successful due to unreliable detection logic. Second, relocate the large fwcfg-generated .dmp file to avoid filling the system disk during our virtio-win-acceptance tests.

ID: 3920

Signed-off-by: wji <wji@redhat.com>

