### PR TITLE
vdpa_sim_blk_test:fix XFS issue

### DIFF
--- a/qemu/tests/cfg/vdpa_sim_blk_test.cfg
+++ b/qemu/tests/cfg/vdpa_sim_blk_test.cfg
@@ -20,11 +20,11 @@
     remove_image_stg1 = no
     remove_image_stg2 = no
     tmp_dir = /var/tmp/vdpa_sim_blk_
-    host_cmd = "mkfs.xfs -f /dev/{0} && mkdir -p ${tmp_dir}{0} && "
-    host_cmd += "mount -t xfs /dev/{0} ${tmp_dir}{0} && touch ${tmp_dir}{0}/test.txt"
+    host_cmd = "mkfs.ext4 -F /dev/{0} && mkdir -p ${tmp_dir}{0} && "
+    host_cmd += "mount -t ext4 /dev/{0} ${tmp_dir}{0} && touch ${tmp_dir}{0}/test.txt"
     host_cmd += " && umount ${tmp_dir}{0}"
     Linux:
-        guest_cmd = "mkdir -p ${tmp_dir}{1} && mount -t xfs {0} ${tmp_dir}{1} && "
+        guest_cmd = "mkdir -p ${tmp_dir}{1} && mount -t ext4 {0} ${tmp_dir}{1} && "
         guest_cmd += "ls ${tmp_dir}{1}/test.txt && umount ${tmp_dir}{1}"
     Windows:
         image_size_data = 120M


### PR DESCRIPTION
The latest XFS require the filesystem size
greater than 300M.
Change XFS to EXT4 to avoid this issue.

ID:2533