### PR TITLE
block_vhost_vdpa_tes:fix XFS issue

### DIFF
--- a/qemu/tests/cfg/block_vhost_vdpa_test.cfg
+++ b/qemu/tests/cfg/block_vhost_vdpa_test.cfg
@@ -33,8 +33,8 @@
     blk_extra_params_stg2 = "serial=stg2"
     Linux:
         tmp_dir = /var/tmp/test
-        guest_cmd = "mkdir -p ${tmp_dir} && mkfs.xfs -f {0}  &&"
-        guest_cmd += " mount -t xfs {0} ${tmp_dir} && dd if=/dev/zero "
+        guest_cmd = "mkdir -p ${tmp_dir} && mkfs.ext4 -F {0}  &&"
+        guest_cmd += " mount -t ext4 {0} ${tmp_dir} && dd if=/dev/zero "
         guest_cmd += " of=${tmp_dir}/test.img bs=1M count=100 oflag=direct && "
         guest_cmd += " umount ${tmp_dir}"
     Windows:


### PR DESCRIPTION
The latest XFS require the filesystem size
greater than 300M.
Change XFS to EXT4 to avoid this issue.

ID:2875