### PR TITLE
block_iothread_test:iothread_vq_mapping support for virtio-scsi-pci

### DIFF
--- a/qemu/tests/cfg/block_iothread_test.cfg
+++ b/qemu/tests/cfg/block_iothread_test.cfg
@@ -1,7 +1,5 @@
 - block_iothread_test:
     type = block_iothread_test
-    # So far only support virtio_blk
-    only virtio_blk
     data_images="stg1 stg2 stg3"
     test_images="stg1 stg2"
     images += " ${data_images}"
@@ -10,8 +8,6 @@
     image_size_stg1 = 1G
     remove_image_stg1 = yes
     force_create_image_stg1 = yes
-    drive_format_stg1 = virtio
-    drive_format_stg2 = virtio
     blk_extra_params_stg2 += ",serial=stg2"
     image_name_stg2 = images/stg2
     image_size_stg2 = 1G
@@ -27,6 +23,12 @@
     num_queues_stg2 = 6
     virtio_blk:
         required_qemu = [8.1.0, )
+        drive_format_stg1 = virtio
+        drive_format_stg2 = virtio
+    virtio_scsi:
+        required_qemu = [10.0.0, )
+        drive_bus_stg1= 1
+        drive_bus_stg2= 2
     Linux:
         tmp_dir = /var/tmp/test
         guest_cmd = "mkdir -p ${tmp_dir} && mkfs.xfs -f {0}  &&"
@@ -47,8 +49,10 @@
             variants:
                 - legacy_cfg:
                     del required_qemu
+                    drive_format_stg1 = virtio
                     drive_format_stg2 = scsi-hd
-                    drive_bus_stg2= 1
+                    drive_bus_stg2 = 1
+                    drive_bus_stg1 =
                     image_iothread_stg1 = t1
                     image_iothread_stg2 = t4
                     image_iothread_stg3 = t4


### PR DESCRIPTION
Support iothread_vq_mapping feature for virtio-scsi-pci.

ID:3949