### PR TITLE
device_option_check:fix sq_inq paremeter error

### DIFF
--- a/qemu/tests/cfg/device_option_check.cfg
+++ b/qemu/tests/cfg/device_option_check.cfg
@@ -32,7 +32,7 @@
                 check_cmds += " sg"
             cmd_ls = ls -l /dev/disk/by-id/wwn*
             pattern_ls = wwn-%s
-            cmd_sg = sg_inq -p 0x83 `ls /dev/[svh]da`
+            cmd_sg = sg_inq -i `ls /dev/[svh]da`
             pattern_sg = \[%s\]
             variants:
                 - default_drive_format:
@@ -56,7 +56,7 @@
                     params_name = blk_extra_params_cd1
                     blk_extra_params_cd1 = wwn=0x5000c50015ea71ad
                     qtree_check_value = cd1
-                    cmd_sg = sg_inq -p 0x83 `ls /dev/sr*`
+                    cmd_sg = sg_inq -p di `ls /dev/sr*`
                     cdrom_cd1 = isos/windows/winutils.iso
                     aarch64, pseries, s390x:
                         only default_drive_format
@@ -86,4 +86,4 @@
             qtree_check_option = serial
             spapr_vscsi:
                 check_cmds += " sg"
-                cmd_sg = sg_inq -p 0x83 `ls /dev/[svh]da`
+                cmd_sg = sg_inq -i `ls /dev/[svh]da`


### PR DESCRIPTION
The --page 0x83 is not expected in latest Linux.

Using --page di or -i directly to get the
device identification.

ID:3925