### PR TITLE
ioquit:fix pidof dd error

### DIFF
--- a/generic/tests/cfg/ioquit.cfg
+++ b/generic/tests/cfg/ioquit.cfg
@@ -4,7 +4,7 @@
     type = ioquit
     backup_image_before_testing = yes
     restore_image_after_testing = yes
-    background_cmd = "for i in 1 2 3 4; do (dd if=/dev/urandom of=/tmp/file bs=102400 count=10000000 &); done"
+    background_cmd = "for i in 1 2 3 4; do (dd if=/dev/urandom of=/tmp/file bs=1M count=5000 oflag=direct &); done"
     check_cmd = ps -a | grep dd
     login_timeout = 360
     image_restore_cmd = "qemu-img check -r leaks %s"

--- a/generic/tests/ioquit.py
+++ b/generic/tests/ioquit.py
@@ -27,6 +27,11 @@ def run(test, params, env):
     session = vm.wait_for_login(timeout=login_timeout)
     session2 = vm.wait_for_login(timeout=login_timeout)
 
+    check_cmd = (
+        "du --max-depth=1 --one-file-system --no-dereference "
+        "-cah /tmp /home /mnt|sort -h;df -H"
+    )
+    session.cmd_output(check_cmd, timeout=60)
     bg_cmd = params.get("background_cmd")
     error_context.context("Add IO workload for guest OS.", test.log.info)
     session.cmd_output(bg_cmd, timeout=60)
@@ -36,7 +41,7 @@ def run(test, params, env):
     session2.cmd(check_cmd, timeout=360)
 
     error_context.context("Sleep for a random time", test.log.info)
-    time.sleep(random.randrange(15, 30))
+    time.sleep(random.randrange(5, 10))
     session2.cmd(check_cmd, timeout=360)
 
     error_context.context("Kill the VM", test.log.info)


### PR DESCRIPTION
The previous require too big space to
execute dd command, if sleep time too long,
it consume the rest space in guest.

1. Add disk size checking to easy debug
2. Decrease IO size requirement.
3. Decrease sleep time

ID:3989