### PR TITLE
chore(pre-commit): update pre-commit hooks and add security check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,19 +10,20 @@ repos:
     name: check cfg
     require_serial: true
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: check-added-large-files
     args: ["--maxkb=5120"]
   - id: check-ast
   - id: check-yaml
+  - id: detect-private-key
   - id: end-of-file-fixer
   - id: mixed-line-ending
     args: ["--fix=lf"]
   - id: no-commit-to-branch
   - id: trailing-whitespace
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.0
+  rev: v0.12.1
   hooks:
     - id: ruff
       args: ["--fix"]

--- a/generic/tests/autotest_regression.py
+++ b/generic/tests/autotest_regression.py
@@ -59,9 +59,9 @@ def run(test, params, env):
         installer_file = "install-autotest-server.sh"
 
         if autotest_repo == github_repo:
-            installer_url = (
-                "https://raw.github.com/autotest/autotest/%s"
-                "/contrib/%s" % (autotest_branch, installer_file)
+            installer_url = "https://raw.github.com/autotest/autotest/%s/contrib/%s" % (
+                autotest_branch,
+                installer_file,
             )
         else:
             installer_url = (

--- a/generic/tests/clock_getres.py
+++ b/generic/tests/clock_getres.py
@@ -38,7 +38,7 @@ def run(test, params, env):
     sub_test = params.get("sub_test")
     if sub_test:
         error_context.context(
-            "Run sub test '%s' after checking" " clock resolution" % sub_test,
+            "Run sub test '%s' after checking clock resolution" % sub_test,
             test.log.info,
         )
         utils_test.run_virt_sub_test(test, params, env, sub_test)

--- a/generic/tests/dd_test.py
+++ b/generic/tests/dd_test.py
@@ -168,9 +168,10 @@ def run(test, params, env):
         error_context.context("Check command exit status and output", test.log.info)
         test.log.debug("Returned dd_status: %s\nReturned output:\n%s", stat, out)
         if stat != dd_stat:
-            err = (
-                "Return code doesn't match (expected=%s, actual=%s)\n"
-                "Output:\n%s" % (dd_stat, stat, out)
+            err = "Return code doesn't match (expected=%s, actual=%s)\nOutput:\n%s" % (
+                dd_stat,
+                stat,
+                out,
             )
             test.fail(err)
         if dd_output not in out:

--- a/generic/tests/ethtool.py
+++ b/generic/tests/ethtool.py
@@ -313,4 +313,4 @@ def run(test, params, env):
             session = vm.wait_for_serial_login(timeout=login_timeout)
             ethtool_restore_params(session, pretest_status)
         except Exception as detail:
-            test.log.warning("Could not restore parameter of" " eth card: '%s'", detail)
+            test.log.warning("Could not restore parameter of eth card: '%s'", detail)

--- a/generic/tests/guest_suspend.py
+++ b/generic/tests/guest_suspend.py
@@ -133,5 +133,5 @@ def run(test, params, env):
         gs.guest_suspend_disk(params)
     else:
         test.error(
-            "Unknown guest suspend type, Check your" " 'guest_suspend_type' config."
+            "Unknown guest suspend type, Check your 'guest_suspend_type' config."
         )

--- a/generic/tests/iofuzz.py
+++ b/generic/tests/iofuzz.py
@@ -107,9 +107,7 @@ def run(test, params, env):
                         qemu_img_check()
                         session = vm.reboot(method="system_reset")
                 else:
-                    test.fail(
-                        "VM has quit abnormally during " "%s: %s" % (wr_op, operand)
-                    )
+                    test.fail("VM has quit abnormally during %s: %s" % (wr_op, operand))
 
     login_timeout = float(params.get("login_timeout", 240))
     vm = env.get_vm(params["main_vm"])

--- a/generic/tests/jumbo.py
+++ b/generic/tests/jumbo.py
@@ -152,7 +152,7 @@ def run(test, params, env):
                 test.fail("Path MTU is not as expected")
             if utils_test.get_loss_ratio(output) != 0:
                 test.log.error(output)
-                test.fail("Packet loss ratio during MTU " "verification is not zero")
+                test.fail("Packet loss ratio during MTU verification is not zero")
 
         def flood_ping():
             test.log.info("Flood with large frames")
@@ -192,7 +192,7 @@ def run(test, params, env):
                     fail_ratio = int(params.get("fail_ratio", 50))
                     if utils_test.get_loss_ratio(output) > fail_ratio:
                         test.fail(
-                            "Ping loss ratio is greater " "than 50% for size %s" % size
+                            "Ping loss ratio is greater than 50% for size %s" % size
                         )
 
         test.log.info("Waiting for the MTU to be OK")
@@ -203,7 +203,7 @@ def run(test, params, env):
                     "ifconfig -a", verbose=False, ignore_status=True, shell=True
                 )
             )
-            test.error("MTU is not as expected even after %s " "seconds" % wait_mtu_ok)
+            test.error("MTU is not as expected even after %s seconds" % wait_mtu_ok)
 
         # Functional Test
         error_context.context("Checking whether MTU change is ok", test.log.info)

--- a/generic/tests/kdump.py
+++ b/generic/tests/kdump.py
@@ -296,7 +296,7 @@ def run(test, params, env):
 
         for vm in vm_list:
             error_context.context(
-                "Kdump Testing, force the Linux kernel" " to crash", test.log.info
+                "Kdump Testing, force the Linux kernel to crash", test.log.info
             )
             crash_cmd = params.get("crash_cmd", "echo c > /proc/sysrq-trigger")
 
@@ -315,7 +315,7 @@ def run(test, params, env):
 
         for i in range(len(vm_list)):
             error_context.context(
-                "Check the vmcore file after triggering" " a crash", test.log.info
+                "Check the vmcore file after triggering a crash", test.log.info
             )
             check_vmcore(test, vm_list[i], session_list[i], crash_timeout)
     finally:

--- a/generic/tests/ksm_services.py
+++ b/generic/tests/ksm_services.py
@@ -35,7 +35,7 @@ def test_setting_params(test, ksmctler, params):
         else:
             set_values[key] = default_values[key] + value_delta
     test.log.debug(
-        "\nDefault parameters:%s\n" "Set parameters:%s", default_values, set_values
+        "\nDefault parameters:%s\nSet parameters:%s", default_values, set_values
     )
 
     try:

--- a/generic/tests/lvm.py
+++ b/generic/tests/lvm.py
@@ -19,7 +19,7 @@ def mount_lv(lv_path, session):
 @error_context.context_aware
 def umount_lv(lv_path, session):
     error_context.context(
-        "umounting filesystem made on logical volume " "%s" % os.path.basename(lv_path),
+        "umounting filesystem made on logical volume %s" % os.path.basename(lv_path),
         LOG_JOB.info,
     )
     session.cmd("umount %s" % lv_path)
@@ -86,15 +86,14 @@ def run(test, params, env):
             )
             session.cmd("lvcreate -L2000 -n %s %s" % (lv_name, vg_name))
             error_context.context(
-                "creating %s filesystem on logical volume" " %s" % (fs_type, lv_name),
+                "creating %s filesystem on logical volume %s" % (fs_type, lv_name),
                 test.log.info,
             )
             session.cmd("yes | mkfs.%s %s" % (fs_type, lv_path), timeout=int(timeout))
             mount_lv(lv_path, session)
             umount_lv(lv_path, session)
             error_context.context(
-                "checking %s filesystem made on logical "
-                "volume %s" % (fs_type, lv_name),
+                "checking %s filesystem made on logical volume %s" % (fs_type, lv_name),
                 test.log.info,
             )
             session.cmd("fsck %s" % lv_path, timeout=int(timeout))

--- a/generic/tests/mac_change.py
+++ b/generic/tests/mac_change.py
@@ -148,7 +148,7 @@ def run(test, params, env):
                 test.error("The new session is not responsive.")
             if params.get("reboot_vm_after_mac_changed") == "yes":
                 error_context.context(
-                    "Reboot guest and check the the mac address by " "monitor",
+                    "Reboot guest and check the the mac address by monitor",
                     test.log.info,
                 )
                 mac_check = new_mac

--- a/generic/tests/netperf.py
+++ b/generic/tests/netperf.py
@@ -101,9 +101,7 @@ def run(test, params, env):
                 )
             except process.CmdError as err:
                 if "SIOCSIFMTU" in err.result.stderr.decode():
-                    test.cancel(
-                        "The ethenet device does not support jumbo," "cancel test"
-                    )
+                    test.cancel("The ethenet device does not support jumbo,cancel test")
 
     pinned_node = 0
     host_numa = utils_misc.NumaInfo()

--- a/generic/tests/netstress_kill_guest.py
+++ b/generic/tests/netstress_kill_guest.py
@@ -133,7 +133,7 @@ def run(test, params, env):
 
         try:
             error_context.context(
-                ("Run subtest netperf_stress between" " host and guest.", test.log.info)
+                ("Run subtest netperf_stress between host and guest.", test.log.info)
             )
             stress_thread = None
             wait_time = int(params.get("wait_bg_time", 60))

--- a/generic/tests/nicdriver_unload.py
+++ b/generic/tests/nicdriver_unload.py
@@ -96,7 +96,7 @@ def run(test, params, env):
     file_checksum = crypto.hash_file(host_path, algorithm="md5")
 
     error_context.context(
-        "Guest test file prepare, Copy file %s from host to " "guest" % host_path,
+        "Guest test file prepare, Copy file %s from host to guest" % host_path,
         test.log.info,
     )
     vm.copy_files_to(host_path, guest_path, timeout=transfer_timeout)
@@ -135,7 +135,7 @@ def run(test, params, env):
 
         time.sleep(5)
         error_context.context(
-            "Repeatedly unload/load NIC driver during file " "transfer", test.log.info
+            "Repeatedly unload/load NIC driver during file transfer", test.log.info
         )
         while not all_threads_done(threads):
             error_context.context(

--- a/generic/tests/ntpd.py
+++ b/generic/tests/ntpd.py
@@ -71,18 +71,18 @@ class NTPTest(object):
 
         # Add server of local clock
         output = self.server_session.cmd_output(
-            "grep '^server %s'" " /etc/ntp.conf" % self.local_clock
+            "grep '^server %s' /etc/ntp.conf" % self.local_clock
         ).strip()
         if not output:
             status = self.server_session.cmd_status(
-                "echo 'server %s' >> " "/etc/ntp.conf" % self.local_clock
+                "echo 'server %s' >> /etc/ntp.conf" % self.local_clock
             )
             if status:
                 self.test.error("config local_clock failed.")
 
         # Add host and guest in restrict
         output = self.server_session.cmd_output(
-            "grep '^restrict %s'" " /etc/ntp.conf" % self.net_range
+            "grep '^restrict %s' /etc/ntp.conf" % self.net_range
         ).strip()
         if not output:
             status = self.server_session.cmd_status(

--- a/generic/tests/ntttcp.py
+++ b/generic/tests/ntttcp.py
@@ -21,7 +21,7 @@ def _verify_vm_driver(vm, test, driver_name, timeout=360):
     """
 
     error_context.context(
-        "Check if driver is installed" " and verified for vm: %s" % vm.name,
+        "Check if driver is installed and verified for vm: %s" % vm.name,
         test.log.info,
     )
     session = vm.wait_for_login(timeout=timeout)

--- a/generic/tests/ping.py
+++ b/generic/tests/ping.py
@@ -33,7 +33,7 @@ def _ping_with_params(
             timeout=timeout,
         )
     if status != 0:
-        test.fail("Ping failed, status: %s," " output: %s" % (status, output))
+        test.fail("Ping failed, status: %s, output: %s" % (status, output))
     if params.get("strict_check", "no") == "yes":
         ratio = utils_test.get_loss_ratio(output)
         if ratio != 0:
@@ -141,8 +141,7 @@ def run(test, params, env):
 
                 # ping to check whether the network is alive
                 error_context.context(
-                    "Ping test after flood ping,"
-                    " Check if the network is still alive",
+                    "Ping test after flood ping, Check if the network is still alive",
                     test.log.info,
                 )
                 _ping_with_params(

--- a/generic/tests/pktgen_perf.py
+++ b/generic/tests/pktgen_perf.py
@@ -162,5 +162,5 @@ def run(test, params, env):
             vdpa_net_test.remove_dev(params.get("netdst_nic2"))
             vdpa_net_test.cleanup()
         error_context.context(
-            "Verify Host and guest kernel no error" "and call trace", test.log.info
+            "Verify Host and guest kernel no errorand call trace", test.log.info
         )

--- a/generic/tests/shutdown.py
+++ b/generic/tests/shutdown.py
@@ -47,7 +47,7 @@ def run(test, params, env):
             # Send a system_powerdown monitor command
             vm.monitor.system_powerdown()
             error_context.context(
-                "waiting VM to go down " "(system_powerdown monitor cmd)", test.log.info
+                "waiting VM to go down (system_powerdown monitor cmd)", test.log.info
             )
 
         if not vm.wait_for_shutdown(360):

--- a/generic/tests/stress_boot.py
+++ b/generic/tests/stress_boot.py
@@ -71,7 +71,7 @@ def run(test, params, env):
                 # Check whether all previous shell sessions are responsive
                 for i, se in enumerate(sessions):
                     error_context.context(
-                        "checking responsiveness of guest" " #%d" % (i + 1),
+                        "checking responsiveness of guest #%d" % (i + 1),
                         test.log.debug,
                     )
                     se.cmd(params.get("alive_test_cmd"))

--- a/generic/tests/unattended_install.py
+++ b/generic/tests/unattended_install.py
@@ -40,7 +40,7 @@ def run(test, params, env):
             error_flag = True
 
     if not params.get("master_images_clone"):
-        test.cancel("provide the param `master_images_clone` to clone" "images for vms")
+        test.cancel("provide the param `master_images_clone` to cloneimages for vms")
 
     trigger_time = int(params.get("install_trigger_time", 0))
     random_trigger = params.get("random_trigger", "no") == "yes"

--- a/generic/tests/vlan.py
+++ b/generic/tests/vlan.py
@@ -120,7 +120,7 @@ def run(test, params, env):
         except aexpect.ExpectError:
             # kill server
             session_ctl[dst].cmd_output_safe("killall -9 nc")
-            test.fail("Fail to receive file" " from vm%s to vm%s" % (src + 1, dst + 1))
+            test.fail("Fail to receive file from vm%s to vm%s" % (src + 1, dst + 1))
         # check MD5 message digest of receive file in dst
         output = sessions[dst].cmd_output("md5sum receive").strip()
         digest_receive = re.findall(r"(\w+)", output)[0]

--- a/generic/tests/whql_client_install.py
+++ b/generic/tests/whql_client_install.py
@@ -33,7 +33,7 @@ def run(test, params, env):
     server_file_transfer_port = int(params.get("server_file_transfer_port"))
     server_studio_path = params.get(
         "server_studio_path",
-        "%programfiles%\\ " "Microsoft Driver Test Manager\\Studio",
+        "%programfiles%\\ Microsoft Driver Test Manager\\Studio",
     )
     server_username = params.get("server_username")
     server_password = params.get("server_password")

--- a/generic/tests/whql_hck_client_install.py
+++ b/generic/tests/whql_hck_client_install.py
@@ -43,7 +43,7 @@ def run_whql_hck_client_install(test, params, env):
     # Join the server's workgroup
     if params.get("join_domain") == "yes":
         error_context.context("Join the workgroup", LOG_JOB.info)
-        cmd = "netdom join %s /domain:%s /UserD:%s " "/PasswordD:%s" % (
+        cmd = "netdom join %s /domain:%s /UserD:%s /PasswordD:%s" % (
             client_name,
             server_domname,
             client_username,

--- a/generic/tests/whql_submission.py
+++ b/generic/tests/whql_submission.py
@@ -43,7 +43,7 @@ def run(test, params, env):
     server_file_transfer_port = int(params.get("server_file_transfer_port"))
     server_studio_path = params.get(
         "server_studio_path",
-        "%programfiles%\\ " "Microsoft Driver Test Manager\\Studio",
+        "%programfiles%\\ Microsoft Driver Test Manager\\Studio",
     )
     dsso_test_binary = params.get("dsso_test_binary", "deps/whql_submission_15.exe")
     dsso_test_binary = utils_misc.get_path(test.virtdir, dsso_test_binary)

--- a/multi_host_migration/tests/migration_multi_host.py
+++ b/multi_host_migration/tests/migration_multi_host.py
@@ -92,7 +92,7 @@ def run(test, params, env):
                 s, o = session.cmd_status_output(self.mig_bg_command)
                 if s != 0:
                     raise error.TestError(
-                        "Failed to run bg cmd in guest," " Output is '%s'." % o
+                        "Failed to run bg cmd in guest, Output is '%s'." % o
                     )
                 time.sleep(5)
 
@@ -110,7 +110,7 @@ def run(test, params, env):
                     s, o = session.cmd_status_output(self.mig_bg_check_command)
                     if s:
                         raise error.TestFail(
-                            "Background command not found," " Output is '%s'." % o
+                            "Background command not found, Output is '%s'." % o
                         )
 
                     logging.info("Kill the background command in the guest.")

--- a/multi_host_migration/tests/migration_multi_host_auto_converge.py
+++ b/multi_host_migration/tests/migration_multi_host_auto_converge.py
@@ -182,7 +182,7 @@ def run(test, params, env):
                 s, o = session.cmd_status_output(get_sar_output_cmd)  # pylint: disable=E0606
                 if s != 0:
                     raise error.TestFail(
-                        "Failed to get sar output in guest." "The detail is: %s" % o
+                        "Failed to get sar output in guest.The detail is: %s" % o
                     )
             session.close()
             self.analysis_sar_output(o)
@@ -360,11 +360,9 @@ def run(test, params, env):
                 logging.info("Migration completed with auto-converge on")
             except virt_vm.VMMigrateTimeoutError:
                 if set_auto_converge == "yes":
-                    raise error.TestFail("Migration failed with " "auto-converge on")
+                    raise error.TestFail("Migration failed with auto-converge on")
                 else:
-                    logging.info(
-                        "migration would never finish with " "auto-converge off"
-                    )
+                    logging.info("migration would never finish with auto-converge off")
                     if self.need_cleanup:
                         self.clean_up(self.kill_bg_stress_cmd, vm)
                     try:
@@ -415,11 +413,9 @@ def run(test, params, env):
                 logging.info("Migration completed with auto-converge on")
             except virt_vm.VMMigrateTimeoutError:
                 if set_auto_converge == "yes":
-                    raise error.TestFail("Migration failed with " "auto-converge on")
+                    raise error.TestFail("Migration failed with auto-converge on")
                 else:
-                    logging.info(
-                        "migration would never finish with " "auto-converge off"
-                    )
+                    logging.info("migration would never finish with auto-converge off")
                     if self.need_cleanup:
                         self.clean_up(self.kill_bg_stress_cmd, vm)
                     try:
@@ -469,12 +465,12 @@ def run(test, params, env):
             try:
                 vm.wait_for_migration(self.migration_timeout)
                 logging.info(
-                    "Migration completed with set auto-converge: " "%s",
+                    "Migration completed with set auto-converge: %s",
                     set_auto_converge,
                 )
             except virt_vm.VMMigrateTimeoutError:
                 raise error.TestFail(
-                    "Migration failed with set auto-converge" ": %s" % set_auto_converge
+                    "Migration failed with set auto-converge: %s" % set_auto_converge
                 )
             finally:
                 if self.session:
@@ -510,11 +506,11 @@ def run(test, params, env):
                         if vm.is_paused():
                             vm.resume()
                         if not utils_test.qemu.guest_active(vm):
-                            raise error.TestFail("Guest not active " "after migration")
+                            raise error.TestFail("Guest not active after migration")
                     if self.need_cleanup:
                         self.clean_up(self.kill_bg_stress_cmd, vm)
                     else:
-                        logging.info("No need to kill the background " "test in guest.")
+                        logging.info("No need to kill the background test in guest.")
                     vm.reboot()
                     vm.destroy()
 

--- a/multi_host_migration/tests/migration_multi_host_downtime_and_speed.py
+++ b/multi_host_migration/tests/migration_multi_host_downtime_and_speed.py
@@ -113,7 +113,7 @@ def run(test, params, env):
                 )
 
             logging.info(
-                "Migration completed with downtime " "is %s seconds.", self.mig_downtime
+                "Migration completed with downtime is %s seconds.", self.mig_downtime
             )
 
             self.check_mig_downtime(vm)
@@ -145,12 +145,12 @@ def run(test, params, env):
                 vm.wait_for_migration(self.mig_timeout)
             except virt_vm.VMMigrateTimeoutError:
                 raise error.TestFail(
-                    "Migration failed with setting " " downtime to %ds." % downtime
+                    "Migration failed with setting  downtime to %ds." % downtime
                 )
 
             self.mig_downtime = downtime - 1
             logging.info(
-                "Migration completed with downtime " "is %s seconds.", self.mig_downtime
+                "Migration completed with downtime is %s seconds.", self.mig_downtime
             )
 
             self.check_mig_downtime(vm)
@@ -182,7 +182,7 @@ def run(test, params, env):
                 vm.wait_for_migration(self.mig_timeout)
             except virt_vm.VMMigrateTimeoutError:
                 raise error.TestFail(
-                    "Migration failed with setting " " mig_speed to %sB." % mig_speed
+                    "Migration failed with setting  mig_speed to %sB." % mig_speed
                 )
 
             logging.debug("Migration passed with mig_speed %sB", mig_speed)

--- a/multi_host_migration/tests/migration_multi_host_firewall_block.py
+++ b/multi_host_migration/tests/migration_multi_host_firewall_block.py
@@ -55,7 +55,7 @@ def run(test, params, env):
             mig_finished, timeout, 2, 2, "Waiting for migration to complete"
         ):
             raise virt_vm.VMMigrateTimeoutError(
-                "Timeout expired while waiting " "for migration to finish"
+                "Timeout expired while waiting for migration to finish"
             )
 
     class TestMultihostMigrationLongWait(base_class):
@@ -73,7 +73,7 @@ def run(test, params, env):
 
         def firewall_block_port(self, port):
             utils.run(
-                "iptables -A INPUT -p tcp --dport %s" " -j REJECT" % (port),
+                "iptables -A INPUT -p tcp --dport %s -j REJECT" % (port),
                 ignore_status=True,
             )
 
@@ -179,7 +179,7 @@ def run(test, params, env):
                     vm.resume()
                     if utils_test.qemu.guest_active(vm):
                         raise error.TestFail(
-                            "Guest can't be active after" " interrupted migration."
+                            "Guest can't be active after interrupted migration."
                         )
                 except (
                     qemu_monitor.MonitorProtocolError,

--- a/multi_host_migration/tests/migration_multi_host_helper_tests.py
+++ b/multi_host_migration/tests/migration_multi_host_helper_tests.py
@@ -119,5 +119,5 @@ def run(test, params, env):
         tests_group()
     else:
         raise error.TestFail(
-            "Test group '%s' is not defined in" " cpuflags test" % test_type
+            "Test group '%s' is not defined in cpuflags test" % test_type
         )

--- a/multi_host_migration/tests/migration_multi_host_ping_pong.py
+++ b/multi_host_migration/tests/migration_multi_host_ping_pong.py
@@ -138,7 +138,7 @@ def run(test, params, env):
         def ping_pong_migrate(self, sync, worker):
             for _ in range(self.migrate_count):
                 logging.info(
-                    "File transfer not ended, starting" " a round of migration..."
+                    "File transfer not ended, starting a round of migration..."
                 )
                 sync.sync(True, timeout=self.migration_timeout)
                 self.migrate_wait([self.vm], self.srchost, self.dsthost)
@@ -169,7 +169,7 @@ def run(test, params, env):
                     test, vm, self.install_path, extra_flags="-msse3 -msse2"
                 )
 
-                cmd = "nohup %s/cpuflags-test --stressmem %d,32" " > %s &" % (
+                cmd = "nohup %s/cpuflags-test --stressmem %d,32 > %s &" % (
                     os.path.join(self.install_path, "cpu_flags"),
                     self.stress_memory,
                     self.cpuflags_test_out,

--- a/multi_host_migration/tests/migration_multi_host_timedrift.py
+++ b/multi_host_migration/tests/migration_multi_host_timedrift.py
@@ -79,7 +79,7 @@ def run(test, params, env):
                         s = current_clocksource != "kvm-clock"
                     if not s:
                         raise error.TestFail(
-                            "Guest didn't use '%s' " "clocksource" % clocksource
+                            "Guest didn't use '%s' clocksource" % clocksource
                         )
 
                 error.context("Check the system time on guest and host.", logging.info)
@@ -110,7 +110,7 @@ def run(test, params, env):
             if time_drifted:
                 difs = ""
                 for vm in mig_data.vms:
-                    difs += "\n            VM=%s  HOST=%ss  GUEST=%ss" " DIFF=%s" % (
+                    difs += "\n            VM=%s  HOST=%ss  GUEST=%ss DIFF=%s" % (
                         vm.name,
                         self.diff_ht[vm.name],
                         self.diff_gt[vm.name],

--- a/multi_host_migration/tests/migration_multi_host_with_file_transfer.py
+++ b/multi_host_migration/tests/migration_multi_host_with_file_transfer.py
@@ -172,7 +172,7 @@ def run(test, params, env):
             try:
                 while bg.is_alive():
                     logging.info(
-                        "File transfer not ended, starting" " a round of migration..."
+                        "File transfer not ended, starting a round of migration..."
                     )
                     sync.sync(True, timeout=d_transfer_timeout)
                     self.migrate_wait([self.vm], self.srchost, self.dsthost)
@@ -199,7 +199,7 @@ def run(test, params, env):
                 if not done:
                     break
                 logging.info(
-                    "File transfer not ended, starting" " a round of migration..."
+                    "File transfer not ended, starting a round of migration..."
                 )
                 self.migrate_wait([self.vm], self.srchost, self.dsthost)
 
@@ -217,8 +217,7 @@ def run(test, params, env):
             if self.hostid == self.master_id():
                 try:
                     utils.run(
-                        "dd if=/dev/zero of=%s bs=1M"
-                        " count=%s" % (host_path, file_size)
+                        "dd if=/dev/zero of=%s bs=1M count=%s" % (host_path, file_size)
                     )
 
                     self.vm_addr = self._prepare_vm(self.vm).get_address()
@@ -256,9 +255,7 @@ def run(test, params, env):
                         check_sum = self.file_check_sums[i]
                         if check_sum != orig_hash:
                             wrong_check_sum = True
-                            logging.error(
-                                "Checksum in transfer number" " %d if wrong.", i
-                            )
+                            logging.error("Checksum in transfer number %d if wrong.", i)
 
                     if wrong_check_sum:
                         raise error.TestFail(

--- a/multi_host_migration/tests/migration_multi_host_with_kdump.py
+++ b/multi_host_migration/tests/migration_multi_host_with_kdump.py
@@ -58,9 +58,9 @@ def run(test, params, env):
             self.kernel_param_cmd = params.get(
                 "kernel_param_cmd", self.def_kernel_param_cmd
             )
-            def_kdump_enable_cmd = "chkconfig kdump on &&" " service kdump restart"
+            def_kdump_enable_cmd = "chkconfig kdump on && service kdump restart"
             self.kdump_enable_cmd = params.get("kdump_enable_cmd", def_kdump_enable_cmd)
-            def_crash_kernel_prob_cmd = "grep -q 1 /sys/kernel/" "kexec_crash_loaded"
+            def_crash_kernel_prob_cmd = "grep -q 1 /sys/kernel/kexec_crash_loaded"
             self.crash_kernel_prob_cmd = params.get(
                 "crash_kernel_prob_cmd", def_crash_kernel_prob_cmd
             )
@@ -124,12 +124,12 @@ def run(test, params, env):
                     if vm.is_paused():
                         vm.resume()
                     if not utils_test.qemu.guest_active(vm):
-                        raise error.TestFail("Guest not active " "after migration")
-                    logging.info("Logging into migrated guest after " "migration")
+                        raise error.TestFail("Guest not active after migration")
+                    logging.info("Logging into migrated guest after migration")
                     session = vm.wait_for_login(timeout=self.login_timeout)
                     error.context("Checking vmcore file in guest", logging.info)
                     if session is not None:
-                        logging.info("kdump completed, no need ping-pong" " migration")
+                        logging.info("kdump completed, no need ping-pong migration")
                         self.stop_migrate = True
                     output = session.cmd_output(vmcore_chk_cmd)
                     session.close()

--- a/multi_host_migration/tests/migration_multi_host_with_reboot.py
+++ b/multi_host_migration/tests/migration_multi_host_with_reboot.py
@@ -65,7 +65,7 @@ def run(test, params, env):
                         )
                         if not reseted:
                             raise error.TestFail(
-                                "Not found RESET event after " "execute 'system_reset'"
+                                "Not found RESET event after execute 'system_reset'"
                             )
                         vm.monitor.clear_event("RESET")
 

--- a/multi_host_migration/tests/migration_multi_host_with_speed_measurement.py
+++ b/multi_host_migration/tests/migration_multi_host_with_speed_measurement.py
@@ -64,8 +64,7 @@ def run(test, params, env):
                 " filling its memory."
             )
             fail_msg = (
-                "Could not determine the transferred memory from"
-                " monitor data: %s" % o
+                "Could not determine the transferred memory from monitor data: %s" % o
             )
             if isinstance(o, six.string_types):
                 if "status: active" not in o:

--- a/multi_host_migration/tests/migration_multi_host_with_stress.py
+++ b/multi_host_migration/tests/migration_multi_host_with_stress.py
@@ -69,7 +69,7 @@ def run(test, params, env):
                     s, o = session.cmd_status_output(kill_bg_stress_cmd)
                     if s:
                         raise error.TestFail(
-                            "Failed to kill the background" " test in guest: %s" % o
+                            "Failed to kill the background test in guest: %s" % o
                         )
                 session.close()
 

--- a/multi_host_migration/tests/migration_multi_host_with_xbzrle.py
+++ b/multi_host_migration/tests/migration_multi_host_with_xbzrle.py
@@ -94,7 +94,7 @@ def run(test, params, env):
             """
 
             error.context(
-                "Get total time, downtime and transferred ram " "after migration.",
+                "Get total time, downtime and transferred ram after migration.",
                 logging.info,
             )
             downtime = int(vm.monitor.info("migrate").get("downtime"))
@@ -122,8 +122,7 @@ def run(test, params, env):
 
             if self.is_src:
                 error.context(
-                    "Check total time, downtime and transferred ram"
-                    " after migration.",
+                    "Check total time, downtime and transferred ram after migration.",
                     logging.info,
                 )
                 logging.info("Total time list: %s", str(mig_total_time_list))
@@ -230,9 +229,7 @@ def run(test, params, env):
             try:
                 vm.wait_for_migration(self.migration_timeout)
             except virt_vm.VMMigrateTimeoutError:
-                raise error.TestFail(
-                    "Migration failed with setting " "xbzrle to false."
-                )
+                raise error.TestFail("Migration failed with setting xbzrle to false.")
             logging.info("Migration completed with xbzrle false")
             self.get_mig_totaltime_downtime_transferred_ram(vm)
             vm.destroy(gracefully=False)
@@ -273,9 +270,9 @@ def run(test, params, env):
                 vm.wait_for_migration(self.mig_timeout)
             except virt_vm.VMMigrateTimeoutError:
                 raise error.TestFail(
-                    "Migration failed with setting cache " "size to %s." % cache_size
+                    "Migration failed with setting cache size to %s." % cache_size
                 )
-            logging.info("Migration completed with cache size %s" "", cache_size)
+            logging.info("Migration completed with cache size %s", cache_size)
             self.get_mig_totaltime_downtime_transferred_ram(vm)
             vm.destroy(gracefully=False)
 
@@ -314,7 +311,7 @@ def run(test, params, env):
                 vm.wait_for_migration(5)
             except virt_vm.VMMigrateTimeoutError:
                 logging.info(
-                    "Set cache size to %s during migration" ".", self.cache_size[1]
+                    "Set cache size to %s during migration.", self.cache_size[1]
                 )
                 self.set_migration_cache_size(int(self.cache_size[1]))
             try:
@@ -324,9 +321,7 @@ def run(test, params, env):
                     "Migration failed with setting cache "
                     "size to %s." % self.cache_size[1]
                 )
-            logging.info(
-                "Migration completed with cache size %s" "", self.cache_size[1]
-            )
+            logging.info("Migration completed with cache size %s", self.cache_size[1])
             self.get_migration_cache_size(1)
             self.get_mig_totaltime_downtime_transferred_ram(vm)
             self.get_migration_info(vm)
@@ -360,11 +355,11 @@ def run(test, params, env):
                         if vm.is_paused():
                             vm.resume()
                         if not utils_test.qemu.guest_active(vm):
-                            raise error.TestFail("Guest not active " "after migration")
+                            raise error.TestFail("Guest not active after migration")
                     if self.need_cleanup:
                         self.clean_up(self.kill_bg_stress_cmd, vm)
                     else:
-                        logging.info("No need to kill the background " "test in guest.")
+                        logging.info("No need to kill the background test in guest.")
                     vm.reboot()
                     vm.destroy()
 

--- a/openvswitch/tests/ovs_basic.py
+++ b/openvswitch/tests/ovs_basic.py
@@ -256,6 +256,4 @@ def run(test, params, env):
         tests_group = locals()[test_type]
         tests_group(test, params, env)
     else:
-        test.fail(
-            "Test type '%s' is not defined in" " OpenVSwitch basic test" % test_type
-        )
+        test.fail("Test type '%s' is not defined in OpenVSwitch basic test" % test_type)

--- a/provider/ansible.py
+++ b/provider/ansible.py
@@ -17,10 +17,8 @@ class SyntaxCheckError(Exception):
         self.output = output
 
     def __str__(self):
-        return (
-            'The ansible-playbook command "{}" cannot pass syntax check: ' "{}".format(
-                self.cmd, self.output
-            )
+        return 'The ansible-playbook command "{}" cannot pass syntax check: {}'.format(
+            self.cmd, self.output
         )
 
 
@@ -112,12 +110,11 @@ class PlaybookExecutor(Expect):
             lambda: not self.is_alive(),
             timeout,
             step=step_time,
-            text="Waiting for the ansible-playbook process to " "complete...",
+            text="Waiting for the ansible-playbook process to complete...",
         ):
             self.kill()
             raise ExecutorTimeoutError(
-                "ansible-playbook cannot complete all "
-                "tasks within the expected time."
+                "ansible-playbook cannot complete all tasks within the expected time."
             )
         LOG_JOB.info("ansible-playbook execution is completed.")
 

--- a/provider/backup_utils.py
+++ b/provider/backup_utils.py
@@ -371,9 +371,9 @@ def blockdev_batch_backup(vm, source_lst, target_lst, bitmap_lst, **extra_option
 
     for idx, src in enumerate(source_lst):
         if sync_mode in ["incremental", "bitmap"]:
-            assert len(bitmap_lst) == len(
-                source_lst
-            ), "must provide a valid bitmap name for 'incremental' sync mode"
+            assert len(bitmap_lst) == len(source_lst), (
+                "must provide a valid bitmap name for 'incremental' sync mode"
+            )
             extra_options["bitmap"] = bitmap_lst[idx]
         backup_cmd, arguments = blockdev_backup_qmp_cmd(
             src, target_lst[idx], **extra_options

--- a/provider/blockdev_backup_base.py
+++ b/provider/blockdev_backup_base.py
@@ -156,9 +156,9 @@ class BlockdevBackupBaseTest(object):
 
     @error_context.context_aware
     def blockdev_backup(self):
-        assert len(self.target_disks) >= len(
-            self.source_disks
-        ), "No enough target disks define in cfg!"
+        assert len(self.target_disks) >= len(self.source_disks), (
+            "No enough target disks define in cfg!"
+        )
         source_lst = list(map(lambda x: "drive_%s" % x, self.source_disks))
         target_lst = list(map(lambda x: "drive_%s" % x, self.target_disks))
         bitmap_lst = list(map(lambda x: "bitmap_%s" % x, range(len(self.source_disks))))

--- a/provider/cpu_utils.py
+++ b/provider/cpu_utils.py
@@ -185,7 +185,7 @@ def check_if_vm_vcpu_match(vcpu_desire, vm):
         vcpu_desire = int(vcpu_desire)
     if vcpu_desire != vcpu_actual:
         LOG_JOB.debug(
-            "CPU quantity mismatched !!! guest said it got %s " "but we assigned %s",
+            "CPU quantity mismatched !!! guest said it got %s but we assigned %s",
             vcpu_actual,
             vcpu_desire,
         )

--- a/provider/hostdev/__init__.py
+++ b/provider/hostdev/__init__.py
@@ -38,9 +38,7 @@ class HostDeviceBindError(HostDeviceError):
         self.error = error
 
     def __str__(self):
-        return (
-            f'Cannot bind "{self.slot_id}" to driver "{self.driver}": ' f"{self.error}"
-        )
+        return f'Cannot bind "{self.slot_id}" to driver "{self.driver}": {self.error}'
 
 
 class HostDeviceUnbindError(HostDeviceBindError):
@@ -49,8 +47,7 @@ class HostDeviceUnbindError(HostDeviceBindError):
 
     def __str__(self):
         return (
-            f'Cannot unbind "{self.slot_id}" from driver "{self.driver}": '
-            f"{self.error}"
+            f'Cannot unbind "{self.slot_id}" from driver "{self.driver}": {self.error}'
         )
 
 
@@ -143,7 +140,7 @@ class PFDevice:
                 override_file.write_text(driver)
             except OSError as e:
                 raise HostDeviceError(
-                    f"Failed to set the driver " f"override for {slot_id}:  {str(e)}"
+                    f"Failed to set the driver override for {slot_id}:  {str(e)}"
                 )
         # For kernels < 3.15 use new_id to add PCI id's to the driver
         else:
@@ -279,7 +276,7 @@ class VFDevice(PFDevice):
             if counts > int((self.slot_path / "sriov_totalvfs").read_text().strip()):
                 raise VFCreateError(
                     self.slot_id,
-                    "Count of VF to be created is " 'larger than "sriov_totalvfs"',
+                    'Count of VF to be created is larger than "sriov_totalvfs"',
                 )
             self.num_vfs = int(self.sriov_numvfs_path.read_text().strip())
             with self.sriov_numvfs_path.open("w") as numvfs_f:

--- a/provider/hostdev/utils.py
+++ b/provider/hostdev/utils.py
@@ -186,7 +186,7 @@ def ssh_login_from_mac(vm, mac, ip_version=4):
         port = vm.params.get("shell_port")
         linesep = vm.params.get("shell_linesep", "\n").encode().decode("unicode_escape")
         log_filename = (
-            f'session-{vm.name}-{time.strftime("%m-%d-%H-%M-%S")}-'
+            f"session-{vm.name}-{time.strftime('%m-%d-%H-%M-%S')}-"
             f"{utils_misc.generate_random_string(4)}.log"
         )
         log_filename = utils_misc.get_log_filename(log_filename)

--- a/provider/input_tests.py
+++ b/provider/input_tests.py
@@ -46,7 +46,7 @@ def key_tap_test(test, params, console, listener, wait_time):
         time.sleep(wait_time)
 
         LOG_JOB.info(
-            "Check guest received %s key event is " "matched with expected key event",
+            "Check guest received %s key event is matched with expected key event",
             key,
         )
         keycode = keys_dict[key]

--- a/provider/message_queuing.py
+++ b/provider/message_queuing.py
@@ -17,7 +17,7 @@ class MessageNotFoundError(Exception):
         self.output = output
 
     def __str__(self):
-        return 'No matching message("{}") was found. ' "Output: {}".format(
+        return 'No matching message("{}") was found. Output: {}'.format(
             self.message, self.output
         )
 

--- a/provider/nbd_image_export.py
+++ b/provider/nbd_image_export.py
@@ -146,9 +146,7 @@ class QemuNBDExportImage(NBDExportImage):
             try:
                 os.kill(self._nbd_server_pid, signal.SIGSTOP)
             except Exception as e:
-                LOG_JOB.warning(
-                    "Error occurred when suspending" "nbd server: %s", str(e)
-                )
+                LOG_JOB.warning("Error occurred when suspendingnbd server: %s", str(e))
 
     def resume_export(self):
         if self._nbd_server_pid is not None:

--- a/provider/qsd.py
+++ b/provider/qsd.py
@@ -489,7 +489,7 @@ class QsdDaemonDev(QDaemonDev):
                 LOG_JOB.warning(e)
                 if not self.is_daemon_alive():
                     LOG_JOB.warning(
-                        "QSD %s down during try to kill it " "by monitor", self.name
+                        "QSD %s down during try to kill it by monitor", self.name
                     )
                     return
             else:

--- a/provider/sgx.py
+++ b/provider/sgx.py
@@ -81,7 +81,7 @@ class SGXHostCapability(object):
         monitor_expect_nodes = int(self._params["monitor_expect_nodes"])
         if len(node_list) < monitor_expect_nodes:
             self._test.cancel(
-                "host numa nodes %s isn't enough for " "testing." % node_list
+                "host numa nodes %s isn't enough for testing." % node_list
             )
 
 
@@ -179,7 +179,7 @@ class SGXChecker(object):
         numa_epc_dict = self.get_config_epc_numa_info()
         if numa_epc_dict == epc_sections_info:
             self._test.fail(
-                "Guest epc sized on each numa mis-matched, " "qmp check failed."
+                "Guest epc sized on each numa mis-matched, qmp check failed."
             )
 
         sgx_sections = guest_sgx_info["sections"]

--- a/provider/slof.py
+++ b/provider/slof.py
@@ -156,8 +156,9 @@ def verify_boot_device(
     if position in devices:
         name = devices[position]
         info = (
-            "Check whether the device({0}@{1}@{2}) is the {3} bootable "
-            "device.".format(parent_bus_type, child_bus_type, child_addr, position)
+            "Check whether the device({0}@{1}@{2}) is the {3} bootable device.".format(
+                parent_bus_type, child_bus_type, child_addr, position
+            )
         )
         if sub_child_addr:
             info = (

--- a/provider/vioinput_basic.py
+++ b/provider/vioinput_basic.py
@@ -58,9 +58,9 @@ def key_tap_test(test, params, vm):
             key_down_lst.append(k)
 
         if len(key_down_lst) != key_num or set(key_down_lst) != set(key_lst):
-            test.fail(
-                "Key down event keycode error, received:{0}," "expect:{1}"
-            ).format(key_down_lst, key_lst)
+            test.fail("Key down event keycode error, received:{0},expect:{1}").format(
+                key_down_lst, key_lst
+            )
 
         key_up_lst = list()
         for k, v in key_event_lst[-key_num:]:
@@ -69,7 +69,7 @@ def key_tap_test(test, params, vm):
             key_up_lst.append(k)
 
         if set(key_up_lst) != set(key_lst):
-            test.fail("Key up event keycode error, received:{0}," "expect:{1}").format(
+            test.fail("Key up event keycode error, received:{0},expect:{1}").format(
                 key_up_lst, key_lst
             )
 
@@ -85,7 +85,7 @@ def key_tap_test(test, params, vm):
         error_context.context("Send %s key tap to guest" % key, test.log.info)
         console.key_tap(key)
         error_context.context(
-            "Check %s key tap event received" "correct in guest" % key, test.log.info
+            "Check %s key tap event receivedcorrect in guest" % key, test.log.info
         )
         time.sleep(wait_time)
         key_check(key)

--- a/provider/virtio_fs_utils.py
+++ b/provider/virtio_fs_utils.py
@@ -20,7 +20,7 @@ def get_virtiofs_driver_letter(test, fs_target, session):
     :return driver_letter: the driver letter of the virtiofs
     """
     error_context.context(
-        "Get driver letter of virtio fs target, " "the driver label is %s." % fs_target,
+        "Get driver letter of virtio fs target, the driver label is %s." % fs_target,
         LOG_JOB.info,
     )
     driver_letter = utils_misc.get_winutils_vol(session, fs_target)
@@ -59,7 +59,7 @@ def basic_io_test(test, params, session):
         else:
             cmd_dd = params.get(
                 "virtio_fs_cmd_dd",
-                "dd if=/dev/urandom of=%s bs=1M " "count=100 iflag=fullblock",
+                "dd if=/dev/urandom of=%s bs=1M count=100 iflag=fullblock",
             )
             fs_dest = params.get("fs_dest", "/mnt/" + fs_target)
         guest_file = os.path.join(fs_dest, test_file)
@@ -106,7 +106,7 @@ def basic_io_test(test, params, session):
             test.fail("The md5 value of host is not same to guest.")
         else:
             error_context.context(
-                "The md5 of host is as same as md5 of " "guest.", LOG_JOB.info
+                "The md5 of host is as same as md5 of guest.", LOG_JOB.info
             )
     finally:
         if not windows:
@@ -128,7 +128,7 @@ def create_sub_folder_test(params, session, guest_dest, host_dir):
     folder_name = params.get("sub_folder_name", "virtio_fs_folder_test")
     try:
         error_context.context(
-            "Create the sub folder on shared directory " "of guest: ", LOG_JOB.info
+            "Create the sub folder on shared directory of guest: ", LOG_JOB.info
         )
         if os_type == "linux":
             session.cmd("mkdir -p %s" % (guest_dest + "/" + folder_name + "/a"))
@@ -137,7 +137,7 @@ def create_sub_folder_test(params, session, guest_dest, host_dir):
             session.cmd("md %s" % (fs_dest + "\\" + folder_name + "\\a"))
 
         error_context.context(
-            "Check the sub folder on shared directory " "of host: ", LOG_JOB.info
+            "Check the sub folder on shared directory of host: ", LOG_JOB.info
         )
         if os.path.exists(host_dir + "/" + folder_name + "/a"):
             error_context.context(
@@ -148,7 +148,7 @@ def create_sub_folder_test(params, session, guest_dest, host_dir):
             LOG_JOB.error("Do NOT find the sub folder on the host.")
     finally:
         error_context.context(
-            "Delete the sub folder on shared directory " "of guest: ", LOG_JOB.info
+            "Delete the sub folder on shared directory of guest: ", LOG_JOB.info
         )
         if os_type == "linux":
             session.cmd("rm -rf %s" % (guest_dest + "/" + folder_name))
@@ -183,7 +183,7 @@ def basic_io_test_via_psexec(test, params, vm, usernm, pwd):
         error_context.context("Running viofs basic io test via psexec", LOG_JOB.info)
         cmd_dd_win = params.get(
             "virtio_fs_cmd_dd_win",
-            "C:\\tools\\dd.exe if=/dev/random of=%s " "bs=1M count=100",
+            "C:\\tools\\dd.exe if=/dev/random of=%s bs=1M count=100",
         )
         test_file = params.get("virtio_fs_test_file", "virtio_fs_test_file")
         io_timeout = params.get_numeric("fs_io_timeout", 120)
@@ -201,7 +201,7 @@ def basic_io_test_via_psexec(test, params, vm, usernm, pwd):
         cmd_io_test = "%systemdrive%\\cmd_io_test.bat"
 
         error_context.context(
-            "Creating the test file(cmd_io_test.bat) " "on guest", LOG_JOB.info
+            "Creating the test file(cmd_io_test.bat) on guest", LOG_JOB.info
         )
         session.cmd("echo " + cmd_dd_win % guest_file + " > " + cmd_io_test, io_timeout)
 
@@ -236,7 +236,7 @@ def basic_io_test_via_psexec(test, params, vm, usernm, pwd):
                 test.fail("The md5 value of host is not same to guest.")
             else:
                 error_context.context(
-                    "The md5 of host is as same as md5 of " "guest.", LOG_JOB.info
+                    "The md5 of host is as same as md5 of guest.", LOG_JOB.info
                 )
         finally:
             error_context.context("Delete the test file from host.", LOG_JOB.info)
@@ -249,7 +249,7 @@ def basic_io_test_via_psexec(test, params, vm, usernm, pwd):
         try:
             session.cmd("echo " + cmd_create_folder + " > " + bat_create_folder_test)
             error_context.context(
-                "Create the sub folder on shared directory " "of guest: ", LOG_JOB.info
+                "Create the sub folder on shared directory of guest: ", LOG_JOB.info
             )
             session.cmd(
                 psexec_path
@@ -262,7 +262,7 @@ def basic_io_test_via_psexec(test, params, vm, usernm, pwd):
                 + bat_create_folder_test
             )
             error_context.context(
-                "Check the sub folder on shared directory " "of host: ", LOG_JOB.info
+                "Check the sub folder on shared directory of host: ", LOG_JOB.info
             )
             if os.path.exists(fs_source + "/" + folder_name + "/a"):
                 error_context.context(
@@ -273,7 +273,7 @@ def basic_io_test_via_psexec(test, params, vm, usernm, pwd):
                 LOG_JOB.error("Do NOT find the sub folder on the host.")
         finally:
             error_context.context(
-                "Delete the sub folder on shared directory " "of guest: ", LOG_JOB.info
+                "Delete the sub folder on shared directory of guest: ", LOG_JOB.info
             )
             session.cmd("rmdir /s /q %s" % (fs_dest + "\\" + folder_name))
 
@@ -328,7 +328,7 @@ def create_viofs_service(test, params, session, service="VirtioFsSvc"):
     viofs_exe_copy_cmd = params.get("viofs_exe_copy_cmd", viofs_exe_copy_cmd_default)
     if service == "VirtioFsSvc":
         error_context.context(
-            "Create virtiofs own service in" " Windows guest.", test.log.info
+            "Create virtiofs own service in Windows guest.", test.log.info
         )
         output = query_viofs_service(test, params, session)
         if "not exist as an installed service" in output:
@@ -346,11 +346,11 @@ def create_viofs_service(test, params, session, service="VirtioFsSvc"):
             sc_create_s, sc_create_o = session.cmd_status_output(viofs_sc_create_cmd)
             if sc_create_s != 0:
                 test.fail(
-                    "Failed to create virtiofs service, " "output is %s" % sc_create_o
+                    "Failed to create virtiofs service, output is %s" % sc_create_o
                 )
     if service == "WinFSP.Launcher":
         error_context.context(
-            "Stop virtiofs own service, " "using WinFsp.Launcher service instead.",
+            "Stop virtiofs own service, using WinFsp.Launcher service instead.",
             test.log.info,
         )
         stop_viofs_service(test, params, session)
@@ -359,7 +359,7 @@ def create_viofs_service(test, params, session, service="VirtioFsSvc"):
         output = session.cmd_output(params["viofs_sc_create_cmd"])
         if "completed successfully" not in output.lower():
             test.fail(
-                "MultiFS: Config WinFsp.Launcher failed, " "the output is %s." % output
+                "MultiFS: Config WinFsp.Launcher failed, the output is %s." % output
             )
 
 
@@ -375,7 +375,7 @@ def delete_viofs_serivce(test, params, session):
     output = query_viofs_service(test, params, session)
     if "not exist as an installed service" in output:
         test.log.info(
-            "The viofs service was NOT found at the guest." " Skipping delete..."
+            "The viofs service was NOT found at the guest. Skipping delete..."
         )
     else:
         status = session.cmd_status(viofs_sc_delete_cmd)

--- a/provider/win_driver_installer_test.py
+++ b/provider/win_driver_installer_test.py
@@ -71,9 +71,7 @@ def install_gagent(session, test, qemu_ga_pkg, gagent_install_cmd, gagent_pkg_in
     gagent_install_cmd = gagent_install_cmd % qemu_ga_pkg_path
     s_inst, o_inst = session.cmd_status_output(gagent_install_cmd)
     if s_inst != 0:
-        test.fail(
-            "qemu-guest-agent install failed," " the detailed info:\n%s." % o_inst
-        )
+        test.fail("qemu-guest-agent install failed, the detailed info:\n%s." % o_inst)
     gagent_version = session.cmd_output(gagent_pkg_info_cmd).split()[-2]
     return gagent_version
 
@@ -148,7 +146,7 @@ def win_installer_test(session, test, params):
     :param params: the dict used for parameters.
     """
     error_context.context(
-        "Check if virtio-win-guest-too.exe " "is signed by redhat", LOG_JOB.info
+        "Check if virtio-win-guest-too.exe is signed by redhat", LOG_JOB.info
     )
     status = session.cmd_status(params["signed_check_cmd"])
     if status != 0:
@@ -259,7 +257,7 @@ def rng_test(test, params, vm):
     error_context.context("Read virtio-rng device to get random number", LOG_JOB.info)
     output = session.cmd_output(read_rng_cmd)
     if len(re.findall(r"0x\w", output, re.M)) < 2:
-        test.fail("Unable to read random numbers " "from guest: %s" % output)
+        test.fail("Unable to read random numbers from guest: %s" % output)
 
 
 @error_context.context_aware

--- a/provider/win_driver_utils.py
+++ b/provider/win_driver_utils.py
@@ -116,7 +116,7 @@ def uninstall_driver(session, test, devcon_path, driver_name, device_name, devic
     # acceptable status: OK(0), REBOOT(1)
     if status > 1:
         test.error(
-            "Failed to uninstall driver '%s', details:\n" "%s" % (driver_name, output)
+            "Failed to uninstall driver '%s', details:\n%s" % (driver_name, output)
         )
 
 
@@ -187,11 +187,11 @@ def install_driver_by_virtio_media(
         # acceptable status: OK(0), REBOOT(1)
         if status > 1:
             test.fail(
-                "Failed to install driver '%s', " "details:\n%s" % (driver_name, output)
+                "Failed to install driver '%s', details:\n%s" % (driver_name, output)
             )
         installed_any |= True
     if not installed_any:
-        test.error("Failed to find target devices " "by hwids: '%s'" % device_hwid)
+        test.error("Failed to find target devices by hwids: '%s'" % device_hwid)
 
 
 def autoit_installer_check(params, session):
@@ -248,15 +248,14 @@ def run_installer(vm, session, test, params, run_installer_cmd):
     if not utils_misc.wait_for(
         lambda: not autoit_installer_check(params, session), 240, 2, 2
     ):
-        test.fail("Autoit exe stop there for 240s," " please have a check.")
+        test.fail("Autoit exe stop there for 240s, please have a check.")
     restart_con_ver = cdrom_virtio_version in VersionInterval(installer_restart_version)
     restart_con_repair = "repair" in run_installer_cmd
     if restart_con_ver or restart_con_repair:
         # Wait for vm re-start by installer itself
         if not utils_misc.wait_for(lambda: not session.is_responsive(), 120, 5, 5):
             test.fail(
-                "The previous session still exists,"
-                "seems that the vm doesn't restart."
+                "The previous session still exists,seems that the vm doesn't restart."
             )
         session = vm.wait_for_login(timeout=360)
     # for the early virtio-win instller, rebooting is needed.
@@ -294,9 +293,7 @@ def copy_file_to_samepath(session, test, params):
     :param test: kvm test object
     :param params: the dict used for parameters
     """
-    LOG_JOB.info(
-        "Copy autoit scripts and virtio-win-guest-tools.exe " "to the same path."
-    )
+    LOG_JOB.info("Copy autoit scripts and virtio-win-guest-tools.exe to the same path.")
     dst_path = r"C:\\"
     vol_virtio_key = "VolumeName like '%virtio-win%'"
     vol_virtio = utils_misc.get_win_disk_vol(session, vol_virtio_key)
@@ -328,7 +325,7 @@ def copy_file_to_samepath(session, test, params):
         copy_cmd = "xcopy %s %s /Y" % (src_file, dst_path)
         status, output = session.cmd_status_output(copy_cmd)
         if status != 0:
-            test.error("Copy file error," " the detailed info:\n%s." % output)
+            test.error("Copy file error, the detailed info:\n%s." % output)
 
 
 def enable_driver(session, test, cmd):
@@ -453,8 +450,7 @@ def memory_leak_check(vm, test, params, load_method="enable"):
     time.sleep(10)
     if vm.is_alive() is False:
         test.fail(
-            "VM is not alive after uninstall driver,"
-            "please check if it is a memory leak"
+            "VM is not alive after uninstall driver,please check if it is a memory leak"
         )
     if load_method != "enable":
         session = vm.reboot(session)

--- a/provider/win_wora.py
+++ b/provider/win_wora.py
@@ -26,7 +26,7 @@ def modify_driver(params, session):
     chk_pat = r"ACPI\\ACPI0010.*\: Generic Bus"
     if not re.search(chk_pat, session.cmd(chk_cmd)):
         error_context.context(
-            "Install 'HID Button over Interrupt Driver' " "to Generic Bus", LOG_JOB.info
+            "Install 'HID Button over Interrupt Driver' to Generic Bus", LOG_JOB.info
         )
         inst_cmd = "%s install %s %s" % (
             devcon_path,

--- a/qemu/deps/win_driver_install/win_driver_install.py
+++ b/qemu/deps/win_driver_install/win_driver_install.py
@@ -21,7 +21,7 @@ def cmd_output(cmd):
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
     except Exception as err:
-        error_msg = f"Failed to execute cmd {cmd}!\n" f"Details refers: {err}"
+        error_msg = f"Failed to execute cmd {cmd}!\nDetails refers: {err}"
         logger.error(error_msg)
         sys.exit(1)
     stdoutput = p.stdout.readlines()

--- a/qemu/tests/ansible_with_responsive_migration.py
+++ b/qemu/tests/ansible_with_responsive_migration.py
@@ -89,7 +89,7 @@ def run(test, params, env):
     mq_publisher = message_queuing.MQPublisher(mq_listen_port)
     try:
         error_context.base_context(
-            "Confirm remote subscriber has accessed to " "activate migrating guests.",
+            "Confirm remote subscriber has accessed to activate migrating guests.",
             test.log.info,
         )
         try:

--- a/qemu/tests/balloon_boot_in_pause.py
+++ b/qemu/tests/balloon_boot_in_pause.py
@@ -85,8 +85,7 @@ class BallooningTestPause(BallooningTest):
         )
         if status is None:
             self.test.fail(
-                "Failed to balloon memory to expect value during "
-                "%ss" % balloon_timeout
+                "Failed to balloon memory to expect value during %ss" % balloon_timeout
             )
 
     def get_memory_boundary(self):
@@ -194,7 +193,7 @@ def run(test, params, env):
         vm = env.get_vm(params["main_vm"])
         if vm.monitor.verify_status("paused"):
             error_context.context(
-                "Running balloon %s test when" " the guest in paused status" % tag,
+                "Running balloon %s test when the guest in paused status" % tag,
                 test.log.info,
             )
         else:
@@ -230,11 +229,11 @@ def run(test, params, env):
         )
         if output is None:
             test.fail(
-                "Check memory status failed after subtest " "after %s seconds" % timeout
+                "Check memory status failed after subtest after %s seconds" % timeout
             )
 
     error_context.context(
-        "Reset guest memory to original one after all the " "test", test.log.info
+        "Reset guest memory to original one after all the test", test.log.info
     )
     balloon_test.reset_memory()
     # for windows guest, disable/uninstall driver to get memory leak based on

--- a/qemu/tests/balloon_check.py
+++ b/qemu/tests/balloon_check.py
@@ -28,7 +28,7 @@ class BallooningTest(MemoryBaseTest):
             else:
                 sleep_time = 90
             self.test.log.info(
-                "Waiting %d seconds for guest's " "applications up", sleep_time
+                "Waiting %d seconds for guest's applications up", sleep_time
             )
             time.sleep(sleep_time)
             self.params["balloon_test_setup_ready"] = True
@@ -56,7 +56,7 @@ class BallooningTest(MemoryBaseTest):
                     ballooned_mem = ballooned_mem / (1024**2)
             else:
                 self.test.log.info(
-                    "could not get balloon_memory, cause " "vm.monitor is None"
+                    "could not get balloon_memory, cause vm.monitor is None"
                 )
                 return 0
         except qemu_monitor.MonitorError as emsg:
@@ -145,7 +145,7 @@ class BallooningTest(MemoryBaseTest):
         check_mem_ratio = float(self.params.get("check_mem_ratio", 0.1))
         check_mem_diff = float(self.params.get("check_mem_diff", 150))
         error_context.context(
-            "Get memory from guest aligned" " with %s." % keyname, self.test.log.info
+            "Get memory from guest aligned with %s." % keyname, self.test.log.info
         )
         if keyname == "stat-free-memory":
             guest_mem = self.get_guest_free_mem(self.vm)
@@ -187,7 +187,7 @@ class BallooningTest(MemoryBaseTest):
 
         stat_enabled = memory_stat_qmp != mem_stat_disabled
         if stat_enabled != enabled:
-            self.test.fail("Memory statistics reporting is not working as" " expected")
+            self.test.fail("Memory statistics reporting is not working as expected")
         elif enabled:
             self._memory_stats_compare(keyname, memory_stat_qmp)
 
@@ -211,7 +211,7 @@ class BallooningTest(MemoryBaseTest):
                 and new_mem != self.get_ballooned_memory()
             ):
                 raise exceptions.TestFail(
-                    "Balloon memory fail with error" " message: %s" % e
+                    "Balloon memory fail with error message: %s" % e
                 )
         if new_mem > self.ori_mem:
             compare_mem = self.ori_mem
@@ -229,8 +229,7 @@ class BallooningTest(MemoryBaseTest):
         )
         if status is None:
             raise exceptions.TestFail(
-                "Failed to balloon memory to expect"
-                " value during %ss" % balloon_timeout
+                "Failed to balloon memory to expect value during %ss" % balloon_timeout
             )
 
     def run_balloon_sub_test(self, test, params, env, test_tag):
@@ -538,7 +537,7 @@ class BallooningTestWin(BallooningTest):
                           uninstall/stop
         """
         error_context.context(
-            "Check Balloon Service status before install" "service", self.test.log.info
+            "Check Balloon Service status before installservice", self.test.log.info
         )
         output = self.operate_balloon_service(session, "status")
         if re.search("running", output.lower(), re.M):

--- a/qemu/tests/balloon_hotplug.py
+++ b/qemu/tests/balloon_hotplug.py
@@ -47,7 +47,7 @@ def run(test, params, env):
         if params["os_type"] != "windows":
             return
         error_context.context(
-            "Install and check balloon service in windows " "guest", test.log.info
+            "Install and check balloon service in windows guest", test.log.info
         )
         session = vm.wait_for_login()
         driver_name = params.get("driver_name", "balloon")
@@ -149,7 +149,7 @@ def run(test, params, env):
     if params.get("os_type") == "windows":
         out = vm.devices.simple_hotplug(new_dev, vm.monitor)
         if out[1] is False:
-            test.fail("Failed to hotplug balloon at last, " "output is %s" % out[0])
+            test.fail("Failed to hotplug balloon at last, output is %s" % out[0])
         win_driver_utils.memory_leak_check(vm, test, params)
     error_context.context("Verify guest alive!", test.log.info)
     vm.verify_kernel_crash()

--- a/qemu/tests/block_check_fds.py
+++ b/qemu/tests/block_check_fds.py
@@ -30,9 +30,9 @@ def run(test, params, env):
         """Hot plug then unplug block devices repeatedly."""
         vm_pid = vm.get_pid()
         plug = BlockDevicesPlug(vm)
-        info = "The number of AIO file descriptors is %s " "after %s block device."
+        info = "The number of AIO file descriptors is %s after %s block device."
         for i in range(times):
-            test.log.info("Iteration %d: Hot plug then unplug " "block device.", i)
+            test.log.info("Iteration %d: Hot plug then unplug block device.", i)
             plug.hotplug_devs_serial()
             orig_fds_num = _get_aio_fds_num(vm_pid)
             test.log.info(info, orig_fds_num, "hot plugging")

--- a/qemu/tests/block_check_max_tranfer_length.py
+++ b/qemu/tests/block_check_max_tranfer_length.py
@@ -36,7 +36,7 @@ def run(test, params, env):
     drive_letter = drive_letter_list[0]
 
     error_context.context(
-        "Check the maximum transfer length if " "VIRTIO_BLK_F_SEG_MAX flag is on",
+        "Check the maximum transfer length if VIRTIO_BLK_F_SEG_MAX flag is on",
         test.log.info,
     )
     output = session.cmd_output(check_cmd % drive_letter)

--- a/qemu/tests/block_check_memory_leak.py
+++ b/qemu/tests/block_check_memory_leak.py
@@ -49,8 +49,7 @@ def run(test, params, env):
         if ver >= 6.3:
             # bz2235228,cancel test due to known product bug.
             test.cancel(
-                "Skip test for xive kvm interrupt guest due to"
-                " known host crash issue."
+                "Skip test for xive kvm interrupt guest due to known host crash issue."
             )
     logger = test.log
     data_images = params["data_images"].split()

--- a/qemu/tests/block_commit_stress.py
+++ b/qemu/tests/block_commit_stress.py
@@ -64,7 +64,7 @@ class BlockCommitStress(blk_commit.BlockCommit):
         backingfile = self.get_backingfile("monitor")
         if backingfile:
             self.test.log.info(
-                "Got backing-file: #%s# by 'info/query block' in #%s# " "monitor",
+                "Got backing-file: #%s# by 'info/query block' in #%s# monitor",
                 backingfile,
                 self.vm.monitor.protocol,
             )

--- a/qemu/tests/block_copy.py
+++ b/qemu/tests/block_copy.py
@@ -225,7 +225,7 @@ class BlockCopy(object):
         )
         if not reseted:
             self.test.fail(
-                "No RESET event received after" "execute system_reset %ss" % timeout
+                "No RESET event received afterexecute system_reset %ss" % timeout
             )
         self.vm.monitor.clear_event("RESET")
         return None

--- a/qemu/tests/block_during_io.py
+++ b/qemu/tests/block_during_io.py
@@ -64,7 +64,7 @@ def run(test, params, env):
         diff_num = len(orig_mount_points) - len(new_mount_points)
         if diff_num != 0:
             test.error(
-                "No found the corresponding drive letters " "in %s disks." % diff_num
+                "No found the corresponding drive letters in %s disks." % diff_num
             )
         return new_mount_points
 

--- a/qemu/tests/block_hotplug_in_pause.py
+++ b/qemu/tests/block_hotplug_in_pause.py
@@ -70,9 +70,7 @@ def run(test, params, env):
         for dev in devs:
             ret = vm.devices.simple_hotplug(dev, vm.monitor)
             if ret[1] is False:
-                test.fail(
-                    "Failed to hotplug device '%s'." "Output:\n%s" % (dev, ret[0])
-                )
+                test.fail("Failed to hotplug device '%s'.Output:\n%s" % (dev, ret[0]))
         dtype = (
             qdevices.QBlockdevNode
             if vm.check_capability(Flags.BLOCKDEV)
@@ -206,9 +204,7 @@ def run(test, params, env):
         for item in index_sizes:
             drive_indexs.append(item.split()[0])
         if not utils_disk.update_windows_disk_attributes(session, drive_indexs):
-            test.fail(
-                "Failed to clear readonly for all disks and online " "them in guest"
-            )
+            test.fail("Failed to clear readonly for all disks and online them in guest")
         error_context.context("Format disk", test.log.info)
         for item in index_sizes:
             did, size = item.split()
@@ -243,7 +239,7 @@ def run(test, params, env):
                 test_cmd, timeout=disk_op_timeout
             )
             if status:
-                test.fail("Check for block device rw failed." "Output: %s" % output)
+                test.fail("Check for block device rw failed.Output: %s" % output)
 
     blk_num = int(params.get("blk_num", 1))
     repeat_times = int(params.get("repeat_times", 3))
@@ -261,7 +257,7 @@ def run(test, params, env):
         device_list = []
         if params.get("need_plug") == "yes":
             error_context.context(
-                "Run block hotplug/unplug for iteration:" "%d" % iteration,
+                "Run block hotplug/unplug for iteration:%d" % iteration,
                 test.log.info,
             )
             error_context.context("Plug device", test.log.info)

--- a/qemu/tests/block_hotplug_negative.py
+++ b/qemu/tests/block_hotplug_negative.py
@@ -51,7 +51,7 @@ def run(test, params, env):
                 try:
                     drive_unplug_plug(drive, vm)
                 except Exception as e:
-                    test.fail("Failed to hotplug/unplug drive with error:" "%s") % e
+                    test.fail("Failed to hotplug/unplug drive with error:%s") % e
 
     error_context.context(
         "Check vm is alive after drive unplug/hotplug test", test.log.info

--- a/qemu/tests/block_hotplug_passthrough.py
+++ b/qemu/tests/block_hotplug_passthrough.py
@@ -47,7 +47,7 @@ def run(test, params, env):
         if ostype == "windows":
             if not utils_disk.update_windows_disk_attributes(session, did):
                 test.fail(
-                    "Failed to clear readonly for all disks and online " "them in guest"
+                    "Failed to clear readonly for all disks and online them in guest"
                 )
         partition = utils_disk.configure_empty_disk(
             session, did, stg_image_size, ostype

--- a/qemu/tests/block_hotplug_scsi_hba.py
+++ b/qemu/tests/block_hotplug_scsi_hba.py
@@ -36,7 +36,7 @@ def run(test, params, env):
     def _get_scsi_host_id(session):
         test.log.info("Get the scsi host id which is hot plugged.")
         output = session.cmd(
-            'dmesg | grep "scsi host" | ' "awk 'END{print}' | awk '{print $4}'"
+            "dmesg | grep \"scsi host\" | awk 'END{print}' | awk '{print $4}'"
         )
         return re.search(r"(\d+)", output).group(1)
 

--- a/qemu/tests/block_multifunction.py
+++ b/qemu/tests/block_multifunction.py
@@ -53,7 +53,7 @@ def io_test(session, disk_op_cmd, disks, windows=False, image_size=None):
         if windows:
             if not utils_disk.update_windows_disk_attributes(session, disk):
                 raise exceptions.TestError(
-                    "Failed to clear readonly for all" " disks and online them in guest"
+                    "Failed to clear readonly for all disks and online them in guest"
                 )
             partition = utils_disk.configure_empty_windows_disk(
                 session, disk, image_size

--- a/qemu/tests/block_scsi_device.py
+++ b/qemu/tests/block_scsi_device.py
@@ -60,8 +60,7 @@ def run(test, params, env):
     delete_scsi_device(scsi_addr)
     if check_scsi_disk_by_address(scsi_addr):
         test.fail(
-            "The scsi disk(@%s) appears in guest "
-            "after disable scsi drive." % scsi_addr
+            "The scsi disk(@%s) appears in guest after disable scsi drive." % scsi_addr
         )
 
     scan_scsi_device(scsi_addr)

--- a/qemu/tests/block_stream.py
+++ b/qemu/tests/block_stream.py
@@ -52,14 +52,14 @@ def run(test, params, env):
         stream_test.create_snapshots()
         backingfile = stream_test.get_backingfile()
         if not backingfile:
-            test.fail("Backing file is not available in the " "backdrive image")
+            test.fail("Backing file is not available in the backdrive image")
         test.log.info("Image file: %s", stream_test.get_image_file())
         test.log.info("Backing file: %s", backingfile)
         stream_test.start()
         stream_test.wait_for_finished()
         backingfile = stream_test.get_backingfile()
         if backingfile:
-            test.fail("Backing file is still available in the " "backdrive image")
+            test.fail("Backing file is still available in the backdrive image")
         target_file = stream_test.get_image_file()
         target_size = stream_test.get_image_size(target_file)
         error_context.context("Compare image size", test.log.info)

--- a/qemu/tests/block_stream_check_backingfile.py
+++ b/qemu/tests/block_stream_check_backingfile.py
@@ -34,7 +34,7 @@ class BlockStreamCheckBackingfile(blk_stream.BlockStream):
             )
             fail |= bool(backingfile)
         if fail:
-            msg = "Unexpected backing file found, there should be " "no backing file"
+            msg = "Unexpected backing file found, there should be no backing file"
             self.test.fail(msg)
 
     def check_backingfile_exist(self):

--- a/qemu/tests/block_stream_drop_backingfile.py
+++ b/qemu/tests/block_stream_drop_backingfile.py
@@ -94,7 +94,7 @@ def run(test, params, env):
         error_context.context("Check backing-file of sn2", test.log.info)
         verify_backingfile(None)
         error_context.context(
-            "check sn1 and base are not opening " "by qemu process", test.log.info
+            "check sn1 and base are not opening by qemu process", test.log.info
         )
         if set([snapshots[0], image_file]).issubset(get_openingfiles()):
             test.fail("%s is opening by qemu" % set([snapshots[0], image_file]))

--- a/qemu/tests/block_stream_negative.py
+++ b/qemu/tests/block_stream_negative.py
@@ -26,7 +26,7 @@ class BlockStreamNegative(blk_stream.BlockStream):
         args = {"device": self.device, "speed": expected_speed}
         response = str(self.vm.monitor.cmd_qmp("block-job-set-speed", args))
         if "(core dump)" in response:
-            self.test.fail("Qemu core dump when reset " "speed to a negative value.")
+            self.test.fail("Qemu core dump when reset speed to a negative value.")
         if match_str not in response:
             self.test.fail(
                 "Fail to get expected result. %s is expected in %s"

--- a/qemu/tests/block_with_iommu.py
+++ b/qemu/tests/block_with_iommu.py
@@ -49,8 +49,7 @@ def run(test, params, env):
             output = session.cmd_output('journalctl -k | grep -i "%s"' % key_words)
             if not output:
                 test.fail(
-                    'No found the info "%s" '
-                    "from the systemd journal log." % key_words
+                    'No found the info "%s" from the systemd journal log.' % key_words
                 )
             test.log.debug(output)
 

--- a/qemu/tests/block_with_write_threshold.py
+++ b/qemu/tests/block_with_write_threshold.py
@@ -41,7 +41,7 @@ def run(test, params, env):
     def set_block_write_threshold(monitor, node_name, size):
         """Set block write threshold for the block drive."""
         error_context.context(
-            "Set block write threshold to %s for the block " "drive in QMP." % size,
+            "Set block write threshold to %s for the block drive in QMP." % size,
             test.log.info,
         )
         monitor.cmd(

--- a/qemu/tests/blockdev_commit_filter_node_name.py
+++ b/qemu/tests/blockdev_commit_filter_node_name.py
@@ -29,8 +29,7 @@ class BlockdevCommitFilter(BlockDevCommitTest):
         block_info = self.main_vm.monitor.info_block()
         if filter_node_name in block_info:
             self.test.fail(
-                "Block info not correct,node-name should not"
-                "be '%s'" % filter_node_name
+                "Block info not correct,node-name should notbe '%s'" % filter_node_name
             )
 
 

--- a/qemu/tests/blockdev_full_backup_nonexist_target.py
+++ b/qemu/tests/blockdev_full_backup_nonexist_target.py
@@ -15,9 +15,9 @@ class BlockdevFullBackupNonexistTargetTest(BlockdevFullBackupBaseTest):
         """
         Backup source image to target image
         """
-        assert len(self.target_disks) >= len(
-            self.source_disks
-        ), "No enough target disks define in cfg!"
+        assert len(self.target_disks) >= len(self.source_disks), (
+            "No enough target disks define in cfg!"
+        )
         src_lst = ["drive_%s" % x for x in self.source_disks]
         dst_lst = ["drive_%s" % x for x in self.target_disks]
         backup_cmd = backup_utils.blockdev_backup_qmp_cmd

--- a/qemu/tests/blockdev_inc_backup_inc_success.py
+++ b/qemu/tests/blockdev_inc_backup_inc_success.py
@@ -82,7 +82,7 @@ class BlockdevIncbkIncSyncSuccBitmapTest(blockdev_base.BlockdevBaseTest):
 
         refresh_timeout = self.params.get_numeric("refresh_timeout", 10)
         if not utils_misc.wait_for(lambda: _check_bitmaps(), refresh_timeout, 0, 1):
-            self.test.fail("count of bitmap should be 0 " "after incremental backup")
+            self.test.fail("count of bitmap should be 0 after incremental backup")
 
     def check_images(self):
         self.verify_data_files()

--- a/qemu/tests/blockdev_inc_backup_migrate_without_bitmap.py
+++ b/qemu/tests/blockdev_inc_backup_migrate_without_bitmap.py
@@ -29,19 +29,17 @@ class BlockdevIncbkMigrateNoBitmap(BlockdevLiveBackupBaseTest):
         )
         if self._bitmap_debugged:
             if bitmap is None:
-                self.test.fail("No persistent bitmap was found " "after migration")
+                self.test.fail("No persistent bitmap was found after migration")
             if bitmap.get("recording") is not False:
-                self.test.fail("Persistent bitmap was not disabled " "after migration")
+                self.test.fail("Persistent bitmap was not disabled after migration")
             v = debug_block_dirty_bitmap_sha256(
                 self.main_vm, self._source_nodes[0], self._bitmaps[0]
             )
             if self._bitmap_sha256 != v:
-                self.test.fail("Persistent bitmap sha256 changed " "after migration")
+                self.test.fail("Persistent bitmap sha256 changed after migration")
         else:
             if bitmap is not None:
-                self.test.fail(
-                    "Got non-persistent bitmap unexpectedly " "after migration"
-                )
+                self.test.fail("Got non-persistent bitmap unexpectedly after migration")
 
     def get_bitmap_sha256(self):
         if self._bitmap_debugged:

--- a/qemu/tests/blockdev_snapshot_multi_disks.py
+++ b/qemu/tests/blockdev_snapshot_multi_disks.py
@@ -60,9 +60,9 @@ class BlockdevSnapshotMultiDisksTest(BlockDevSnapshotTest):
     @error_context.context_aware
     def create_snapshot(self):
         error_context.context("do snaoshot on multi_disks", LOG_JOB.info)
-        assert len(self.target_disks) == len(
-            self.source_disks
-        ), "No enough target disks define in cfg!"
+        assert len(self.target_disks) == len(self.source_disks), (
+            "No enough target disks define in cfg!"
+        )
         source_lst = list(map(lambda x: "drive_%s" % x, self.source_disks))
         target_lst = list(map(lambda x: "drive_%s" % x, self.target_disks))
         arguments = {}

--- a/qemu/tests/boot_from_remote.py
+++ b/qemu/tests/boot_from_remote.py
@@ -112,7 +112,7 @@ def run(test, params, env):
             single_img_memory = _get_memory(vm.get_pid())
             if not single_img_memory:
                 raise exceptions.TestError(
-                    "Failed to get memory when " "booting with one remote image."
+                    "Failed to get memory when booting with one remote image."
                 )
             test.log.debug(
                 "memory consumption(only one remote image): %s", single_img_memory
@@ -130,7 +130,7 @@ def run(test, params, env):
             multi_img_memory = _get_memory(vm.get_pid())
             if not multi_img_memory:
                 raise exceptions.TestError(
-                    "Failed to get memory when booting" " with several remote images."
+                    "Failed to get memory when booting with several remote images."
                 )
             test.log.debug(
                 "memory consumption(total 4 remote images): %s", multi_img_memory

--- a/qemu/tests/boot_from_virtiofs.py
+++ b/qemu/tests/boot_from_virtiofs.py
@@ -41,9 +41,7 @@ def setup_basic_root_fs(test, params):
     install_file_system_cmd = params["install_file_system_cmd"] % virtiofs_root_path
     status, output = process.getstatusoutput(install_file_system_cmd)
     if status:
-        test.fail(
-            "Failed to install basic root file system." "Error message: %s" % output
-        )
+        test.fail("Failed to install basic root file system.Error message: %s" % output)
     return virtiofs_root_path
 
 

--- a/qemu/tests/boot_time.py
+++ b/qemu/tests/boot_time.py
@@ -52,9 +52,7 @@ def run(test, params, env):
             vm.verify_alive()
             vm.wait_for_login(timeout=timeout)
         except Exception:
-            test.log.warning(
-                "Can not restore guest run level, " "need restore the image"
-            )
+            test.log.warning("Can not restore guest run level, need restore the image")
             params["restore_image_after_testing"] = "yes"
 
     if boot_time > expect_time:

--- a/qemu/tests/boot_with_different_vectors.py
+++ b/qemu/tests/boot_with_different_vectors.py
@@ -77,7 +77,7 @@ def run(test, params, env):
                     test.log.info("MSI-X is enabled")
         else:
             error_context.context(
-                "Check if the driver is installed and " "verified", test.log.info
+                "Check if the driver is installed and verified", test.log.info
             )
             driver_verifier = params["driver_verifier"]
             utils_test.qemu.windrv_check_running_verifier(
@@ -102,7 +102,7 @@ def run(test, params, env):
         if vectors == 0 or vectors == 1:
             if not (
                 re.findall(
-                    "IO-APIC.*fasteoi|XICS.*Level|XIVE.*Level|" "GIC.*Level", output
+                    "IO-APIC.*fasteoi|XICS.*Level|XIVE.*Level|GIC.*Level", output
                 )
             ):
                 msg = "Could not find interrupt controller for virito device"

--- a/qemu/tests/boot_with_multiqueue.py
+++ b/qemu/tests/boot_with_multiqueue.py
@@ -67,7 +67,7 @@ def run(test, params, env):
     else:
         # verify driver
         error_context.context(
-            "Check if the driver is installed and " "verified", test.log.info
+            "Check if the driver is installed and verified", test.log.info
         )
         driver_name = params.get("driver_name", "netkvm")
         session = utils_test.qemu.windrv_check_running_verifier(

--- a/qemu/tests/bridge_qinq.py
+++ b/qemu/tests/bridge_qinq.py
@@ -329,7 +329,7 @@ def run(test, params, env):
         error_context.context("Creating %dMB file on host" % file_size, test.log.info)
         process.run(cmd)
         error_context.context(
-            "Transferring file host -> guest, " "timeout: %ss" % transfer_timeout,
+            "Transferring file host -> guest, timeout: %ss" % transfer_timeout,
             test.log.info,
         )
         shell_port = int(params.get("shell_port", 22))

--- a/qemu/tests/bridge_vlan.py
+++ b/qemu/tests/bridge_vlan.py
@@ -92,8 +92,7 @@ def run(test, params, env):
         """
         mac_cmd = "ip link set %s add %s up" % (vlan_if, mac_str)
         error_context.context(
-            "Give a new mac address '%s' for vlan interface "
-            "'%s'" % (mac_str, vlan_if),
+            "Give a new mac address '%s' for vlan interface '%s'" % (mac_str, vlan_if),
             test.log.info,
         )
         session.cmd_output_safe(mac_cmd)
@@ -213,12 +212,10 @@ def run(test, params, env):
             ping_vlan(vm, dest=host_vlan_ip, vlan_if=interface, session=session)
         except NetPingError:
             test.log.info(
-                "Guest ping fail to host as expected with " "interface '%s'", interface
+                "Guest ping fail to host as expected with interface '%s'", interface
             )
         else:
-            test.fail(
-                "Guest ping to host should fail with interface" " '%s'" % interface
-            )
+            test.fail("Guest ping to host should fail with interface '%s'" % interface)
         ifname.append(interface)
         vm_ip.append(inter_ip)
         sessions.append(session)

--- a/qemu/tests/cache_sizes_test.py
+++ b/qemu/tests/cache_sizes_test.py
@@ -18,7 +18,7 @@ def run(test, params, env):
     cache_sizes = params["cache_sizes"].split()
 
     test.log.info(
-        "Boot a guest up from initial image: %s, and create a" " file %s on the disk.",
+        "Boot a guest up from initial image: %s, and create a file %s on the disk.",
         initial_tag,
         file,
     )

--- a/qemu/tests/cdrom.py
+++ b/qemu/tests/cdrom.py
@@ -483,7 +483,7 @@ def run(test, params, env):
             vm.eject_cdrom(qemu_cdrom_device)
             time.sleep(2)
             if get_cdrom_file(vm, qemu_cdrom_device) is not None:
-                test.fail("Device %s was not ejected" " (round %s)" % (iso_image, i))
+                test.fail("Device %s was not ejected (round %s)" % (iso_image, i))
 
             iso_image = iso_image_new
             # On even attempts, try to change the iso image
@@ -491,9 +491,7 @@ def run(test, params, env):
                 iso_image = iso_image_orig
             vm.change_media(qemu_cdrom_device, iso_image)
             if get_cdrom_file(vm, qemu_cdrom_device) != iso_image:
-                test.fail(
-                    "Could not change iso image %s" " (round %s)" % (iso_image, i)
-                )
+                test.fail("Could not change iso image %s (round %s)" % (iso_image, i))
             time.sleep(workaround_eject_time)
 
     def check_tray_status_test(
@@ -532,7 +530,7 @@ def run(test, params, env):
                 session.cmd(params["eject_cdrom_cmd"] % guest_cdrom_device)
                 if not is_tray_opened(vm, qemu_cdrom_device):
                     test.fail(
-                        "Monitor reports tray closed" " when ejecting (round %s)" % i
+                        "Monitor reports tray closed when ejecting (round %s)" % i
                     )
 
                 cmd = params["close_cdrom_cmd"] % guest_cdrom_device
@@ -610,7 +608,7 @@ def run(test, params, env):
         f1_hash = session.cmd(md5sum_cmd % dst_file).split()[0].strip()
         f2_hash = session.cmd(md5sum_cmd % src_file).split()[0].strip()
         if f1_hash != f2_hash:
-            test.fail("On disk and on cdrom files are different, " "md5 mismatch")
+            test.fail("On disk and on cdrom files are different, md5 mismatch")
         session.cmd(remove_file_cmd)
         error_context.context(
             "Mount/Unmount cdrom for %s times" % max_times, test.log.info
@@ -688,7 +686,7 @@ def run(test, params, env):
                     vm, self.session, cdrom_dev_list, serial_num
                 )
                 if vm.check_block_locked(qemu_cdrom_device):
-                    test.fail("Device should not be locked just" " after booting up")
+                    test.fail("Device should not be locked just after booting up")
                 cmd = params["lock_cdrom_cmd"] % guest_cdrom_device
                 self.session.cmd(cmd)
                 if not vm.check_block_locked(qemu_cdrom_device):
@@ -696,14 +694,14 @@ def run(test, params, env):
                 return
 
             error_context.context(
-                "Detecting the existence of a cdrom " "(guest OS side)", test.log.info
+                "Detecting the existence of a cdrom (guest OS side)", test.log.info
             )
             cdrom_dev_list = list_guest_cdroms(self.session)
             guest_cdrom_device = get_testing_cdrom_device(
                 vm, self.session, cdrom_dev_list, serial_num
             )
             error_context.context(
-                "Detecting the existence of a cdrom " "(qemu side)", test.log.info
+                "Detecting the existence of a cdrom (qemu side)", test.log.info
             )
             qemu_cdrom_device = get_device(vm, iso_image)
             if params["os_type"] != "windows":
@@ -713,9 +711,7 @@ def run(test, params, env):
                 if not utils_misc.wait_for(
                     lambda: not vm.check_block_locked(qemu_cdrom_device), 300
                 ):
-                    test.fail(
-                        "Device %s could not be" " unlocked" % (qemu_cdrom_device)
-                    )
+                    test.fail("Device %s could not be unlocked" % (qemu_cdrom_device))
 
             max_test_times = int(params.get("cdrom_max_test_times", 100))
             if params.get("cdrom_test_eject") == "yes":
@@ -751,7 +747,7 @@ def run(test, params, env):
             sub_test = params.get("sub_test")
             if sub_test:
                 error_context.context(
-                    "Run sub test '%s' before doing file" " operation" % sub_test,
+                    "Run sub test '%s' before doing file operation" % sub_test,
                     test.log.info,
                 )
                 utils_test.run_virt_sub_test(test, params, env, sub_test)
@@ -768,13 +764,12 @@ def run(test, params, env):
                 vm.eject_cdrom(qemu_cdrom_device)
                 if get_cdrom_file(vm, qemu_cdrom_device) is not None:
                     test.fail(
-                        "Device %s was not ejected"
-                        " in clearup stage" % qemu_cdrom_device
+                        "Device %s was not ejected in clearup stage" % qemu_cdrom_device
                     )
 
                 vm.change_media(qemu_cdrom_device, self.iso_image_orig)
                 if get_cdrom_file(vm, qemu_cdrom_device) != self.iso_image_orig:
-                    test.fail("It wasn't possible to change" " cdrom %s" % iso_image)
+                    test.fail("It wasn't possible to change cdrom %s" % iso_image)
             post_cmd = params.get("post_cmd")
             if post_cmd:
                 self.session.cmd(post_cmd)
@@ -877,12 +872,10 @@ def run(test, params, env):
 
                 locked = check_cdrom_lock(vm, device)
                 if locked:
-                    test.log.debug(
-                        "Cdrom device stayed locked after " "migration in VM."
-                    )
+                    test.log.debug("Cdrom device stayed locked after migration in VM.")
                 else:
                     test.fail(
-                        "Cdrom device should stayed locked" " after migration in VM."
+                        "Cdrom device should stayed locked after migration in VM."
                     )
 
                 error_context.context("Unlock cdrom from VM.", test.log.info)
@@ -893,7 +886,7 @@ def run(test, params, env):
                 session.cmd(params["unlock_cdrom_cmd"] % guest_cdrom_device)
                 locked = check_cdrom_lock(vm, device)
                 if not locked:
-                    test.log.debug("Cdrom device is successfully unlocked" " from VM.")
+                    test.log.debug("Cdrom device is successfully unlocked from VM.")
                 else:
                     test.fail("Cdrom device should be unlocked in VM.")
 
@@ -904,11 +897,11 @@ def run(test, params, env):
                 locked = check_cdrom_lock(vm, device)
                 if not locked:
                     test.log.debug(
-                        "Cdrom device stayed unlocked after " "migration in VM."
+                        "Cdrom device stayed unlocked after migration in VM."
                     )
                 else:
                     test.fail(
-                        "Cdrom device should stayed unlocked" " after migration in VM."
+                        "Cdrom device should stayed unlocked after migration in VM."
                     )
 
             self.mig._hosts_barrier(
@@ -951,7 +944,7 @@ def run(test, params, env):
                 error_context.context("Change cdrom.", test.log.info)
                 vm.change_media(device, cdrom)
                 if get_cdrom_file(vm, device) != cdrom:
-                    test.fail("It wasn't possible to change " "cdrom %s" % (cdrom))
+                    test.fail("It wasn't possible to change cdrom %s" % (cdrom))
                 time.sleep(workaround_eject_time)
 
             self.mig._hosts_barrier(
@@ -1051,9 +1044,7 @@ def run(test, params, env):
                     md5sum_cmd % src_file, timeout=checksum_timeout
                 ).split()[0]
                 if f1_hash.strip() != f2_hash.strip():
-                    test.fail(
-                        "On disk and on cdrom files are" " different, md5 mismatch"
-                    )
+                    test.fail("On disk and on cdrom files are different, md5 mismatch")
                 session.cmd(remove_file_cmd)
 
             self.mig._hosts_barrier(

--- a/qemu/tests/cgroup.py
+++ b/qemu/tests/cgroup.py
@@ -104,7 +104,7 @@ def run(test, params, env):
                 break
         else:
             raise exceptions.TestFail(
-                "Failed to move all VM threads to new cgroup" " in %d trials" % i
+                "Failed to move all VM threads to new cgroup in %d trials" % i
             )
 
     def distance(actual, reference):
@@ -184,7 +184,7 @@ def run(test, params, env):
         for name in params["vms"].split(" "):
             disk_name = "scsi-debug-" + name
             process.system(
-                "echo 1 > /sys/bus/pseudo/drivers/scsi_debug/" "add_host", shell=True
+                "echo 1 > /sys/bus/pseudo/drivers/scsi_debug/add_host", shell=True
             )
             time.sleep(1)  # Wait for device init
             dev = process.getoutput("ls /dev/sd* | tail -n 1", shell=True)
@@ -559,12 +559,10 @@ def run(test, params, env):
                 no_speeds = len(speeds[0])
                 for speed in speeds:
                     if type(speed) is not list:
-                        test.log.error("One of cgroup_speeds sublists is not " "list")
+                        test.log.error("One of cgroup_speeds sublists is not list")
                         raise TypeError
                     if len(speed) != no_speeds:
-                        test.log.error(
-                            "cgroup_speeds sublists have different " "lengths"
-                        )
+                        test.log.error("cgroup_speeds sublists have different lengths")
                         raise TypeError
             except TypeError:
                 raise exceptions.TestError(
@@ -1206,7 +1204,7 @@ def run(test, params, env):
 
         if len(vcpus) != vm_cpus:
             raise exceptions.TestFail(
-                "Incorrect number of vcpu PIDs; smp=%s vcpus=" "%s" % (vm_cpus, vcpus)
+                "Incorrect number of vcpu PIDs; smp=%s vcpus=%s" % (vm_cpus, vcpus)
             )
 
         if not cpusets:
@@ -1326,8 +1324,7 @@ def run(test, params, env):
             test_time = int(params.get("cgroup_test_time", 60))
         except ValueError:
             raise exceptions.TestError(
-                "Incorrect configuration: param "
-                "cgroup_test_time have to be an integer"
+                "Incorrect configuration: param cgroup_test_time have to be an integer"
             )
 
         test.log.info("Prepare")
@@ -1344,7 +1341,7 @@ def run(test, params, env):
         cpus = SparseRange(cgroup.get_property("cpuset.cpus")[0])
         if len(cpus) < 2:
             raise exceptions.TestFail(
-                "This test needs at least 2 CPUs on " "host, cpuset=%s" % cpus
+                "This test needs at least 2 CPUs on host, cpuset=%s" % cpus
             )
         # Comments are for vm_cpus=2, no_cpus=4, _SC_CLK_TCK=100
         cgroup.mk_cgroup()  # oooo
@@ -1371,8 +1368,7 @@ def run(test, params, env):
                 sessions[i].sendline(cmd)
 
             test.log.info(
-                "Some harmless IOError messages of non-existing "
-                "processes might occur."
+                "Some harmless IOError messages of non-existing processes might occur."
             )
             i = 0
             t_stop = time.time() + test_time  # run for $test_time seconds
@@ -1435,7 +1431,7 @@ def run(test, params, env):
         mems = SparseRange(cgroup.get_property("cpuset.mems")[0])
         if len(mems) < 2:
             raise exceptions.TestSkipError(
-                "This test needs at least 2 memory nodes, " "detected mems %s" % mems
+                "This test needs at least 2 memory nodes, detected mems %s" % mems
             )
         # Create cgroups
         all_cpus = cgroup.get_property("cpuset.cpus")[0]
@@ -1459,11 +1455,10 @@ def run(test, params, env):
         err = ""
         try:
             test.log.info(
-                "Some harmless IOError messages of non-existing "
-                "processes might occur."
+                "Some harmless IOError messages of non-existing processes might occur."
             )
             sessions[0].sendline(
-                "dd if=/dev/zero of=/dev/null bs=%dM " "iflag=fullblock" % size
+                "dd if=/dev/zero of=/dev/null bs=%dM iflag=fullblock" % size
             )
 
             i = 0
@@ -1819,8 +1814,7 @@ def run(test, params, env):
             test_time = int(params.get("cgroup_test_time", 60))
         except ValueError:
             raise exceptions.TestError(
-                "Incorrect configuration: param "
-                "cgroup_test_time have to be an integer"
+                "Incorrect configuration: param cgroup_test_time have to be an integer"
             )
 
         timeout = int(params.get("login_timeout", 360))
@@ -1978,8 +1972,7 @@ def run(test, params, env):
                     details,
                 )
                 raise exceptions.TestSkipError(
-                    "System doesn't support memory.memsw.*"
-                    " or swapaccount is disabled."
+                    "System doesn't support memory.memsw.* or swapaccount is disabled."
                 )
             cgroup.set_property_h("memory.memsw.limit_in_bytes", "%dK" % mem_limit, 0)
 
@@ -2015,7 +2008,7 @@ def run(test, params, env):
             * Checking every 0.1s
             """
             session.sendline(
-                "dd if=/dev/zero of=/dev/null bs=%dK count=1 " "iflag=fullblock" % mem
+                "dd if=/dev/zero of=/dev/null bs=%dK count=1 iflag=fullblock" % mem
             )
 
             max_rss = 0
@@ -2056,7 +2049,7 @@ def run(test, params, env):
                             "Output:%s\n" % (detail, out)
                         )
                     else:
-                        err = "dd command died (should pass): %s\nOutput:" "\n%s" % (
+                        err = "dd command died (should pass): %s\nOutput:\n%s" % (
                             detail,
                             out,
                         )
@@ -2079,9 +2072,9 @@ def run(test, params, env):
                         137,
                     )
                 else:
-                    out = (
-                        "VM terminated as expected. Used rss+swap: %d, "
-                        "limit %s" % (max_rssswap, mem_limit)
+                    out = "VM terminated as expected. Used rss+swap: %d, limit %s" % (
+                        max_rssswap,
+                        mem_limit,
                     )
                     test.log.info(out)
             else:  # only RSS limit
@@ -2171,11 +2164,10 @@ def run(test, params, env):
         try:
             test.log.info("Test")
             test.log.info(
-                "Some harmless IOError messages of non-existing "
-                "processes might occur."
+                "Some harmless IOError messages of non-existing processes might occur."
             )
             sessions[0].sendline(
-                "dd if=/dev/zero of=/dev/null bs=%dM " "iflag=fullblock" % size
+                "dd if=/dev/zero of=/dev/null bs=%dM iflag=fullblock" % size
             )
 
             i = 0
@@ -2298,8 +2290,7 @@ def run(test, params, env):
         fce = locals()[_fce]
     except KeyError:
         raise exceptions.TestSkipError(
-            "Test %s doesn't exist. Check 'cgroup_test' "
-            "variable in subtest.cfg" % _fce
+            "Test %s doesn't exist. Check 'cgroup_test' variable in subtest.cfg" % _fce
         )
     else:
         return fce()

--- a/qemu/tests/chardev_acpi.py
+++ b/qemu/tests/chardev_acpi.py
@@ -33,8 +33,8 @@ def run(test, params, env):
         vm_output = session.cmd_status_output(check_cmd)[1][:35]
         outputs.append(vm_output)
         vm.destroy()
-    assert outputs.count(outputs[0]) == len(
-        outputs
-    ), "Host: {} and VM 1: {} and VM 2: {} are not the same".format(
-        outputs[0], outputs[1], outputs[2]
+    assert outputs.count(outputs[0]) == len(outputs), (
+        "Host: {} and VM 1: {} and VM 2: {} are not the same".format(
+            outputs[0], outputs[1], outputs[2]
+        )
     )

--- a/qemu/tests/check_link_speed_duplex.py
+++ b/qemu/tests/check_link_speed_duplex.py
@@ -122,9 +122,7 @@ def run(test, params, env):
         check_speed_cmd = params["check_speed_cmd"] % ethname
         status, output = session.cmd_status_output(check_speed_cmd)
         if status:
-            test.fail(
-                "Failed to get speed info," "status=%s, ouput=%s" % (status, output)
-            )
+            test.fail("Failed to get speed info,status=%s, ouput=%s" % (status, output))
         test.log.info(output)
         result = re.findall(r"(?:Speed:\s+(\d+)Mb/s)|(?:Duplex:\s+(\w+))", output)
         if len(result) < 2:

--- a/qemu/tests/check_nic_link_status.py
+++ b/qemu/tests/check_nic_link_status.py
@@ -72,7 +72,7 @@ def run(test, params, env):
     guest_interface_operstate_check(session, expect_down_status)
 
     error_context.context(
-        "Reboot guest by '%s' and recheck interface " "operstate" % reboot_method,
+        "Reboot guest by '%s' and recheck interface operstate" % reboot_method,
         test.log.info,
     )
     session = vm.reboot(method=reboot_method, serial=True, timeout=360, session=session)

--- a/qemu/tests/client_guest_shutdown.py
+++ b/qemu/tests/client_guest_shutdown.py
@@ -34,7 +34,7 @@ def run(test, params, env):
             if params.get("shutdown_method") == "shell":
                 # Send a shutdown command to the guest's shell
                 vm_session.sendline(vm.get_params().get("shutdown_command"))
-                error_context.context("waiting VM to go down " "(shutdown shell cmd)")
+                error_context.context("waiting VM to go down (shutdown shell cmd)")
             elif params.get("shutdown_method") == "system_powerdown":
                 # Sleep for a while -- give the guest a chance to finish
                 # booting
@@ -42,7 +42,7 @@ def run(test, params, env):
                 # Send a system_powerdown monitor command
                 vm.monitor.system_powerdown()
                 error_context.context(
-                    "waiting VM to go down " "(system_powerdown monitor cmd)"
+                    "waiting VM to go down (system_powerdown monitor cmd)"
                 )
 
             if not utils_misc.wait_for(vm.is_dead, 240, 0, 1):

--- a/qemu/tests/commit_snapshot_to_raw_backing.py
+++ b/qemu/tests/commit_snapshot_to_raw_backing.py
@@ -44,7 +44,7 @@ def run(test, params, env):
         test.log.info("Verify snapshot's backing file information.")
         res = json.loads(output)
         if res["backing-filename-format"] != b_fmt or res["backing-filename"] != b_name:
-            test.fail("Backing file information is not correct," " got %s." % b_name)
+            test.fail("Backing file information is not correct, got %s." % b_name)
         compat = res["format-specific"]["data"]["compat"]
         expected = _get_compat_version()
         if compat != expected:
@@ -69,7 +69,7 @@ def run(test, params, env):
     )
 
     test.log.info(
-        "Boot a guest up from snapshot image: %s, and create a" " file %s on the disk.",
+        "Boot a guest up from snapshot image: %s, and create a file %s on the disk.",
         snapshot,
         file,
     )
@@ -110,7 +110,7 @@ def run(test, params, env):
     base_qit.start_vm()
     if not base_qit.check_file(file, md5):
         test.fail(
-            "The file %s's md5 on base image and" " snapshot file are different." % file
+            "The file %s's md5 on base image and snapshot file are different." % file
         )
     base_qit.destroy_vm()
 

--- a/qemu/tests/convert_image_from_raw.py
+++ b/qemu/tests/convert_image_from_raw.py
@@ -63,7 +63,7 @@ def run(test, params, env):
     c_tag = params["convert_target"]
 
     test.log.info(
-        "Boot a guest up from initial image: %s, and create a" " file %s on the disk.",
+        "Boot a guest up from initial image: %s, and create a file %s on the disk.",
         initial_tag,
         file,
     )
@@ -96,8 +96,7 @@ def run(test, params, env):
     c_qit.start_vm()
     if not c_qit.check_file(file, md5):
         test.fail(
-            "The file %s's md5 on initial image and"
-            " target file are different." % file
+            "The file %s's md5 on initial image and target file are different." % file
         )
     c_qit.destroy_vm()
 

--- a/qemu/tests/cpu_add.py
+++ b/qemu/tests/cpu_add.py
@@ -111,7 +111,7 @@ def run(test, params, env):
         session.cmd(ntp_sync_cmd)
 
     error_context.context(
-        "Check if cpus in guest match qemu " "cmd before hotplug", test.log.info
+        "Check if cpus in guest match qemu cmd before hotplug", test.log.info
     )
     qemu_guest_cpu_match(vm)
 

--- a/qemu/tests/cpu_device_hotplug.py
+++ b/qemu/tests/cpu_device_hotplug.py
@@ -57,7 +57,7 @@ def run(test, params, env):
             test.fail("CPU quantity mismatch cmd after hotplug and reboot !")
 
     error_context.context(
-        "boot the vm, with '-smp X,maxcpus=Y' option," "thus allow hotplug vcpu",
+        "boot the vm, with '-smp X,maxcpus=Y' option,thus allow hotplug vcpu",
         test.log.info,
     )
 
@@ -93,7 +93,7 @@ def run(test, params, env):
 
     test.log.info("current_cpus=%s, total_cpus=%s", current_cpus, total_cpus)
     error_context.context(
-        "check if CPUs in guest matches qemu cmd " "before hot-plug", test.log.info
+        "check if CPUs in guest matches qemu cmd before hot-plug", test.log.info
     )
     if not cpu.check_if_vm_vcpu_match(current_cpus, vm):
         test.error("CPU quantity mismatch cmd before hotplug !")

--- a/qemu/tests/cpu_device_hotplug_during_boot.py
+++ b/qemu/tests/cpu_device_hotplug_during_boot.py
@@ -54,7 +54,7 @@ def run(test, params, env):
         # 2) Send reboot command directly because it will close the ssh client
         # so we can not get the command status.
         error_context.base_context(
-            "Reboot guest to boot stage, hotunplug the " "vCPU device.", test.log.info
+            "Reboot guest to boot stage, hotunplug the vCPU device.", test.log.info
         )
         vm.wait_for_login().sendline(params["reboot_command"])
 
@@ -65,7 +65,7 @@ def run(test, params, env):
         vm.serial_console.read_until_any_line_matches(boot_patterns)
 
         error_context.context(
-            "Hotunplug vCPU devices, waiting for guest " "alive.", test.log.info
+            "Hotunplug vCPU devices, waiting for guest alive.", test.log.info
         )
         for vcpu_device in reversed(vcpu_devices):
             vm.hotunplug_vcpu_device(vcpu_device)
@@ -76,6 +76,5 @@ def run(test, params, env):
         )
         if not cpu_utils.check_if_vm_vcpus_match_qemu(vm):
             test.fail(
-                "Actual number of guest CPUs is not equal to expected "
-                "after hotunplug."
+                "Actual number of guest CPUs is not equal to expected after hotunplug."
             )

--- a/qemu/tests/cpu_device_hotpluggable.py
+++ b/qemu/tests/cpu_device_hotpluggable.py
@@ -197,4 +197,4 @@ def run(test, params, env):
                 session, os_type, vm.cpuinfo, test, vm.devices
             ):
                 session.close()
-                test.fail("CPU topology of guest is inconsistent with " "expectations.")
+                test.fail("CPU topology of guest is inconsistent with expectations.")

--- a/qemu/tests/cpu_device_hotpluggable_with_numa.py
+++ b/qemu/tests/cpu_device_hotpluggable_with_numa.py
@@ -109,7 +109,7 @@ def run(test, params, env):
                         "Current guest numa info:\n%s", session.cmd_output("numactl -H")
                     )
                     test.fail(
-                        "The cpu obtained by guest is inconsistent with " "we assigned."
+                        "The cpu obtained by guest is inconsistent with we assigned."
                     )
             except KeyError:
                 test.error("Could not find node %s in guest." % node_id)

--- a/qemu/tests/cpu_device_hotpluggable_with_stress.py
+++ b/qemu/tests/cpu_device_hotpluggable_with_stress.py
@@ -125,7 +125,7 @@ def run(test, params, env):
                 # Drift the running stress task to other vCPUs
                 time.sleep(random.randint(5, 10))
             if not cpu_utils.check_if_vm_vcpus_match_qemu(vm):
-                test.fail("Actual number of guest CPUs is not equal to " "expected")
+                test.fail("Actual number of guest CPUs is not equal to expected")
         stress_tool.unload_stress()
         stress_tool.clean()
     else:

--- a/qemu/tests/cpu_hotplug.py
+++ b/qemu/tests/cpu_hotplug.py
@@ -25,7 +25,7 @@ def run(test, params, env):
     :param env: Dictionary with the test environment.
     """
     error_context.context(
-        "boot the vm, with '-smp X,maxcpus=Y' option," "thus allow hotplug vcpu",
+        "boot the vm, with '-smp X,maxcpus=Y' option,thus allow hotplug vcpu",
         test.log.info,
     )
     vm = env.get_vm(params["main_vm"])
@@ -47,7 +47,7 @@ def run(test, params, env):
         total_cpus = current_cpus + n_cpus_add
 
     error_context.context(
-        "check if CPUs in guest matches qemu cmd " "before hot-plug", test.log.info
+        "check if CPUs in guest matches qemu cmd before hot-plug", test.log.info
     )
     if not cpu.check_if_vm_vcpu_match(current_cpus, vm):
         test.error("CPU quantity mismatch cmd before hotplug !")
@@ -68,8 +68,7 @@ def run(test, params, env):
         )
     # Windows is a little bit lazy that needs more secs to recognize.
     error_context.context(
-        "hotplugging finished, let's wait a few sec and"
-        " check CPUs quantity in guest.",
+        "hotplugging finished, let's wait a few sec and check CPUs quantity in guest.",
         test.log.info,
     )
     if not utils_misc.wait_for(

--- a/qemu/tests/cpu_info_check.py
+++ b/qemu/tests/cpu_info_check.py
@@ -24,7 +24,7 @@ def run(test, params, env):
                 cpu_types.remove(model)
             except ValueError:
                 test.log.warning(
-                    "The model to be removed is not" " in the list: %s", model
+                    "The model to be removed is not in the list: %s", model
                 )
                 continue
 
@@ -81,7 +81,7 @@ def run(test, params, env):
     missing = dict.fromkeys(output_list.keys(), [])
     for cpu_model in cpu_types:
         test.log.info(
-            "Check cpu model %s from qemu command output and" " qemu monitor output",
+            "Check cpu model %s from qemu command output and qemu monitor output",
             cpu_model,
         )
         for key, value in output_list.items():
@@ -113,7 +113,7 @@ def run(test, params, env):
     model_name = model.get("name")
     if model_name != vm.cpuinfo.model:
         test.fail(
-            "Command query-cpu-model-expansion return" " wrong model: %s" % model_name
+            "Command query-cpu-model-expansion return wrong model: %s" % model_name
         )
     model_prop = model.get("props")
     for flag in cpu.CPU_TYPES_RE.get(model_name).split(","):
@@ -128,7 +128,7 @@ def run(test, params, env):
     # Check if the flags in qmp output matches qemu command output
     missing = []
     test.log.info(
-        "Check if the flags in qemu monitor output matches" " qemu command output"
+        "Check if the flags in qemu monitor output matches qemu command output"
     )
     for flag in cpu_flags_binary:
         if flag not in str(output):

--- a/qemu/tests/cpu_model_inter_generation.py
+++ b/qemu/tests/cpu_model_inter_generation.py
@@ -25,7 +25,7 @@ def run(test, params, env):
             output = vm.process.get_output()
             if warning_text not in output:
                 test.fail(
-                    "Qemu should output warning for lack flags" " while it does not."
+                    "Qemu should output warning for lack flags while it does not."
                 )
         except Exception as e:
             if boot_expected == "no":
@@ -37,7 +37,7 @@ def run(test, params, env):
         else:
             if boot_expected == "no":
                 test.fail(
-                    "The vm should not boot successfully" " when cpu enforce mode is on"
+                    "The vm should not boot successfully when cpu enforce mode is on"
                 )
         finally:
             if vm and vm.is_alive():

--- a/qemu/tests/cpu_model_negative.py
+++ b/qemu/tests/cpu_model_negative.py
@@ -22,7 +22,7 @@ def run(test, params, env):
     if enforce_flag and "CPU_MODEL" in params["wrong_cmd"]:
         if enforce_flag in cpu.get_host_cpu_models():
             test.cancel(
-                "This case only test on the host without the flag" " %s." % enforce_flag
+                "This case only test on the host without the flag %s." % enforce_flag
             )
         cpu_model = cpu.get_qemu_best_cpu_model(params)
         params["wrong_cmd"] = params["wrong_cmd"].replace("CPU_MODEL", cpu_model)
@@ -66,5 +66,5 @@ def run(test, params, env):
         test.fail("Does not get expected warning message.")
     else:
         test.log.info(
-            "Test passed as qemu does not boot up and" " prompts expected message."
+            "Test passed as qemu does not boot up and prompts expected message."
         )

--- a/qemu/tests/cpuflags.py
+++ b/qemu/tests/cpuflags.py
@@ -444,7 +444,7 @@ def run(test, params, env):
         dd_session = vm.wait_for_login()
         stress_session = vm.wait_for_login()
         dd_session.sendline(
-            "dd if=/dev/[svh]da of=/tmp/stressblock" " bs=10MB count=100 &"
+            "dd if=/dev/[svh]da of=/tmp/stressblock bs=10MB count=100 &"
         )
         try:
             stress_session.cmd(
@@ -538,7 +538,7 @@ def run(test, params, env):
                         "'%s' of command \n%s" % (missing, cmd, result.stdout)
                     )
             else:
-                test.cancel("New qemu does not support -cpu " "?model. (%s)" % qcver)
+                test.cancel("New qemu does not support -cpu ?model. (%s)" % qcver)
 
     # 2) <qemu-kvm-cmd> -cpu ?dump
     class test_qemu_dump(MiniSubtest):
@@ -558,7 +558,7 @@ def run(test, params, env):
                         "'%s' of command \n%s" % (missing, cmd, result.stdout)
                     )
             else:
-                test.cancel("New qemu does not support -cpu " "?dump. (%s)" % qcver)
+                test.cancel("New qemu does not support -cpu ?dump. (%s)" % qcver)
 
     # 3) <qemu-kvm-cmd> -cpu ?cpuid
     class test_qemu_cpuid(MiniSubtest):
@@ -572,7 +572,7 @@ def run(test, params, env):
                         " '%s' of command \n%s" % (cmd, result.stdout)
                     )
             else:
-                test.cancel("New qemu does not support -cpu " "?cpuid. (%s)" % qcver)
+                test.cancel("New qemu does not support -cpu ?cpuid. (%s)" % qcver)
 
     # 1) boot with cpu_model
     class test_boot_cpu_model(Test_temp):
@@ -621,7 +621,7 @@ def run(test, params, env):
                     "Model unsupported flags: %s", str(flags.cpumodel_unsupport_flags)
                 )
                 test.log.error(
-                    "Flags defined on host but not on found " "on guest: %s",
+                    "Flags defined on host but not on found on guest: %s",
                     str(not_enable_flags),
                 )
             test.log.info("Check main instruction sets.")
@@ -635,7 +635,7 @@ def run(test, params, env):
             test.log.info("Woking CPU flags: %s", str(Flags[0]))
             test.log.info("Not working CPU flags: %s", str(Flags[1]))
             test.log.warning(
-                "Flags works even if not defined on guest cpu " "flags: %s",
+                "Flags works even if not defined on guest cpu flags: %s",
                 str(Flags[0] - guest_flags),
             )
             test.log.warning("Not tested CPU flags: %s", str(Flags[2]))
@@ -684,7 +684,7 @@ def run(test, params, env):
                 fwarn_flags -= not_found
                 if fwarn_flags:
                     test.fail(
-                        "Qemu did not warn the use of " "flags %s" % str(fwarn_flags)
+                        "Qemu did not warn the use of flags %s" % str(fwarn_flags)
                     )
 
     # 3) fail boot unsupported flags
@@ -726,15 +726,14 @@ def run(test, params, env):
                 fwarn_flags -= not_found
                 if fwarn_flags:
                     test.fail(
-                        "Qemu did not warn the use of " "flags %s" % str(fwarn_flags)
+                        "Qemu did not warn the use of flags %s" % str(fwarn_flags)
                     )
 
     # 4) check guest flags under load cpu, stress and system (dd)
     class test_boot_guest_and_try_flags_under_load(Test_temp):
         def test(self):
             test.log.info(
-                "Check guest working cpuflags under load "
-                "cpu and stress and system (dd)"
+                "Check guest working cpuflags under load cpu and stress and system (dd)"
             )
             cpu_model, extra_flags = parse_cpu_model()
 
@@ -864,12 +863,12 @@ def run(test, params, env):
                 stress_session.cmd("killall cpuflags-test")
             except aexpect.ShellCmdError:
                 test.fail(
-                    "Stress cpuflags-test should be still " "running after migration."
+                    "Stress cpuflags-test should be still running after migration."
                 )
             try:
-                stress_session.cmd("ls /tmp/stressblock && " "rm -f /tmp/stressblock")
+                stress_session.cmd("ls /tmp/stressblock && rm -f /tmp/stressblock")
             except aexpect.ShellCmdError:
-                test.fail("Background 'dd' command failed to " "produce output file.")
+                test.fail("Background 'dd' command failed to produce output file.")
 
     def net_send_object(socket, obj):
         """
@@ -944,7 +943,7 @@ def run(test, params, env):
                         test.log.info("Woking CPU flags: %s", str(Flags[0]))
                         test.log.info("Not working CPU flags: %s", str(Flags[1]))
                         test.log.warning(
-                            "Flags works even if not defined on" " guest cpu flags: %s",
+                            "Flags works even if not defined on guest cpu flags: %s",
                             str(Flags[0] - flags.guest_flags),
                         )
                         test.log.warning("Not tested CPU flags: %s", str(Flags[2]))
@@ -985,7 +984,7 @@ def run(test, params, env):
                         test.log.info("Woking CPU flags: %s", str(Flags[0]))
                         test.log.info("Not working CPU flags: %s", str(Flags[1]))
                         test.log.warning(
-                            "Flags works even if not defined on" " guest cpu flags: %s",
+                            "Flags works even if not defined on guest cpu flags: %s",
                             str(Flags[0] - flags.guest_flags),
                         )
                         test.log.warning("Not tested CPU flags: %s", str(Flags[2]))
@@ -1038,8 +1037,7 @@ def run(test, params, env):
                 def ping_pong_migrate(self, sync, worker, check_worker):
                     for _ in range(self.migrate_count):
                         test.log.info(
-                            "File transfer not ended, starting"
-                            " a round of migration..."
+                            "File transfer not ended, starting a round of migration..."
                         )
                         sync.sync(True, timeout=mig_timeout)
                         if self.hostid == self.srchost:
@@ -1080,7 +1078,7 @@ def run(test, params, env):
                         test.log.info("Woking CPU flags: %s", str(Flags[0]))
                         test.log.info("Not working CPU flags: %s", str(Flags[1]))
                         test.log.warning(
-                            "Flags works even if not defined on" " guest cpu flags: %s",
+                            "Flags works even if not defined on guest cpu flags: %s",
                             str(Flags[0] - flags.guest_flags),
                         )
                         test.log.warning("Not tested CPU flags: %s", str(Flags[2]))
@@ -1124,7 +1122,7 @@ def run(test, params, env):
                         test.log.info("Woking CPU flags: %s", str(Flags[0]))
                         test.log.info("Not working CPU flags: %s", str(Flags[1]))
                         test.log.warning(
-                            "Flags works even if not defined on" " guest cpu flags: %s",
+                            "Flags works even if not defined on guest cpu flags: %s",
                             str(Flags[0] - flags.guest_flags),
                         )
                         test.log.warning("Not tested CPU flags: %s", str(Flags[2]))
@@ -1159,4 +1157,4 @@ def run(test, params, env):
             if failed != []:
                 test.fail("Test of cpu models %s failed." % (str(failed)))
     else:
-        test.fail("Test group '%s' is not defined in" " cpuflags test" % test_type)
+        test.fail("Test group '%s' is not defined in cpuflags test" % test_type)

--- a/qemu/tests/cpuid.py
+++ b/qemu/tests/cpuid.py
@@ -149,7 +149,7 @@ def run(test, params, env):
         test.log.debug("Got CPUID serial output: %r", test_output)
         if test_output is None:
             test.fail(
-                "Test output signature not found in " "output:\n %s",
+                "Test output signature not found in output:\n %s",
                 vm.serial_console.get_output(),
             )
         vm.destroy(gracefully=False)

--- a/qemu/tests/create_macvtap_device.py
+++ b/qemu/tests/create_macvtap_device.py
@@ -44,7 +44,7 @@ def run(test, params, env):
     ifname = utils_net.get_macvtap_base_iface(ifname)
 
     error_context.context(
-        "Verify no other macvtap share the physical " "network device.", test.log.info
+        "Verify no other macvtap share the physical network device.", test.log.info
     )
     macvtap_devices = get_macvtap_device_on_ifname(ifname)
     for device in macvtap_devices:

--- a/qemu/tests/create_snapshot_on_running_base.py
+++ b/qemu/tests/create_snapshot_on_running_base.py
@@ -35,7 +35,7 @@ def run(test, params, env):
     sync_bin = params.get("sync_bin", "sync")
 
     test.log.info(
-        "Boot a guest up from base image: %s, and create a" " file %s on the disk.",
+        "Boot a guest up from base image: %s, and create a file %s on the disk.",
         base.tag,
         guest_temp_file,
     )

--- a/qemu/tests/device_bit_check.py
+++ b/qemu/tests/device_bit_check.py
@@ -77,9 +77,7 @@ def run(test, params, env):
                     id_pattern = (
                         ccw_id_pattern
                         + re.findall(
-                            "dev:virtio-scsi-ccw.*\n"
-                            '.*\n.*\n.*\ndev_id="'
-                            'fe.0.(.*?)"',
+                            'dev:virtio-scsi-ccw.*\n.*\n.*\n.*\ndev_id="fe.0.(.*?)"',
                             qtree_info.replace(" ", ""),
                         )[0]
                     )
@@ -102,7 +100,7 @@ def run(test, params, env):
                     msg = "bit string in guest: %s" % bitstr
                     msg += "expect bit string: %s" % properties[index]
                     test.log.debug(msg)
-                    test.fail("Properity bit for %s is wrong" " inside guest." % option)
-            test.log.info("Properity bit in qtree is right for %s" " in guest.", option)
+                    test.fail("Properity bit for %s is wrong inside guest." % option)
+            test.log.info("Properity bit in qtree is right for %s in guest.", option)
         session.close()
         vm.destroy()

--- a/qemu/tests/device_option_check.py
+++ b/qemu/tests/device_option_check.py
@@ -104,9 +104,9 @@ def run(test, params, env):
         error_context.context("Check option with command %s" % cmd, test.log.info)
         _, output = session.cmd_status_output(cmd)
         if not re.findall(r"%s" % pattern, output):
-            failed_log += (
-                "Can not find option %s from guest."
-                " Guest output is '%s'" % (params_name, output)
+            failed_log += "Can not find option %s from guest. Guest output is '%s'" % (
+                params_name,
+                output,
             )
 
         if sg_vpd_cmd:

--- a/qemu/tests/dump_guest_memory.py
+++ b/qemu/tests/dump_guest_memory.py
@@ -27,7 +27,7 @@ def run(test, params, env):
         """
         guest_kernel_version = session.cmd("uname -r").strip()
         if host_kernel_version != guest_kernel_version:
-            test.cancel("Please update your host and guest kernel " "to same version")
+            test.cancel("Please update your host and guest kernel to same version")
 
     def check_list(qmp_o, key, val=None, check_item_in_pair=True):
         """

--- a/qemu/tests/edk2_basic.py
+++ b/qemu/tests/edk2_basic.py
@@ -32,12 +32,10 @@ def run(test, params, env):
             )
         except Exception as msg:
             test.log.error(msg)
-            test.fail("No highlighted entry was detected " "the boot was abnormal.")
+            test.fail("No highlighted entry was detected the boot was abnormal.")
         error_context.context("Check edk2 output information", test.log.info)
         if re.findall("start failed", output[1], re.I | re.M):
-            test.fail(
-                "edk2 failed to start, " "please check the serial log for details."
-            )
+            test.fail("edk2 failed to start, please check the serial log for details.")
         if len(output[1].splitlines()) > line_numbers:
             test.fail("Warning edk2 line count exceeds %d." % line_numbers)
         time.sleep(2)

--- a/qemu/tests/edk2_check_mor.py
+++ b/qemu/tests/edk2_check_mor.py
@@ -48,14 +48,14 @@ def run(test, params, env):
     check_cmd = params["check_secure_boot_enabled_cmd"]
     status, output = session.cmd_status_output(check_cmd)
     if status:
-        test.cancel("Secure boot is not enabled," "MOR must run under secure mode")
+        test.cancel("Secure boot is not enabled,MOR must run under secure mode")
     error_context.context("Check whether the guest has been signed.", test.log.info)
     vmlinuz = "/boot/vmlinuz-%s" % session.cmd_output("uname -r")
     check_sign_cmd %= vmlinuz
     sign_info = session.cmd_output(check_sign_cmd)
     signed = _check_signed()
     if not signed:
-        test.fail("The guest is not signed, " "but boot succeed under secure mode.")
+        test.fail("The guest is not signed, but boot succeed under secure mode.")
     session.close()
     vars_dev = vm.devices.get_by_params({"node-name": "file_ovmf_vars"})[0]
     ovmf_vars_file = vars_dev.params["filename"]

--- a/qemu/tests/edk2_stability_test.py
+++ b/qemu/tests/edk2_stability_test.py
@@ -26,5 +26,5 @@ def run(test, params, env):
             )
         except Exception as msg:
             test.log.error(msg)
-            test.fail("No highlighted entry was detected " "the boot was abnormal.")
+            test.fail("No highlighted entry was detected the boot was abnormal.")
         vm.destroy(gracefully=False)

--- a/qemu/tests/enable_scatter_windows.py
+++ b/qemu/tests/enable_scatter_windows.py
@@ -152,7 +152,7 @@ def run(test, params, env):
     vm.send_key("meta_l-d")
     time.sleep(30)
     error_context.context(
-        "Check if the driver is installed and " "verified", test.log.info
+        "Check if the driver is installed and verified", test.log.info
     )
     session = utils_test.qemu.windrv_check_running_verifier(
         session, vm, test, driver_verifier, timeout

--- a/qemu/tests/expose_host_mtu.py
+++ b/qemu/tests/expose_host_mtu.py
@@ -110,7 +110,7 @@ def run(test, params, env):
         guest_mtu_value = line_value[index]
         test.log.info("MTU is %s", guest_mtu_value)
         if not int(guest_mtu_value) == mtu_value:
-            test.fail("Host mtu %s is not exposed to " "guest!" % params["mtu_value"])
+            test.fail("Host mtu %s is not exposed to guest!" % params["mtu_value"])
 
     test.log.info("Ping from guest to host with packet size 3972")
     status, output = utils_test.ping(

--- a/qemu/tests/fio_perf.py
+++ b/qemu/tests/fio_perf.py
@@ -100,7 +100,7 @@ def get_version(
             result_file.write("### guest-kernel-ver :%s" % result)
     else:
         result_file.write(
-            "### guest-kernel-ver : Microsoft Windows " "[Version ide driver format]\n"
+            "### guest-kernel-ver : Microsoft Windows [Version ide driver format]\n"
         )
 
     if vfsd_ver_chk_cmd:
@@ -234,12 +234,12 @@ def run(test, params, env):
         fs_dest = fs_params.get("fs_dest")
         fs_params.get("fs_source_dir")
         error_context.context(
-            "Create a destination directory %s " "inside guest." % fs_dest,
+            "Create a destination directory %s inside guest." % fs_dest,
             test.log.info,
         )
         utils_misc.make_dirs(fs_dest, session)
         error_context.context(
-            "Mount virtiofs target %s to %s inside" " guest." % (fs_target, fs_dest),
+            "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
             test.log.info,
         )
         if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):

--- a/qemu/tests/floppy.py
+++ b/qemu/tests/floppy.py
@@ -135,8 +135,7 @@ def run(test, params, env):
                     md5_source = md5_source.split(" ")[0]
                 except IndexError:
                     test.error(
-                        "Failed to get md5 from source file,"
-                        " output: '%s'" % md5_source
+                        "Failed to get md5 from source file, output: '%s'" % md5_source
                     )
             else:
                 md5_source = None
@@ -144,14 +143,14 @@ def run(test, params, env):
             self.session.cmd("%s %s %s" % (params["copy_cmd"], source_file, dest_file))
             test.log.info("Succeed to copy file '%s' into floppy disk", source_file)
 
-            error_context.context("Checking if the file is unchanged " "after copy")
+            error_context.context("Checking if the file is unchanged after copy")
             if md5_cmd:
                 md5_dest = self.session.cmd("%s %s" % (md5_cmd, dest_file))
                 try:
                     md5_dest = md5_dest.split(" ")[0]
                 except IndexError:
                     test.error(
-                        "Failed to get md5 from dest file," " output: '%s'" % md5_dest
+                        "Failed to get md5 from dest file, output: '%s'" % md5_dest
                     )
                 if md5_source != md5_dest:
                     test.fail("File changed after copy to floppy")
@@ -282,7 +281,7 @@ def run(test, params, env):
                 status = session.cmd_status("kill %s" % pid, timeout=copy_timeout)
                 if status != 0:
                     test.fail(
-                        "Copy process was terminatted with" " error code %s" % (status)
+                        "Copy process was terminatted with error code %s" % (status)
                     )
 
                 session.cmd_status("kill -s SIGINT %s" % (pid), timeout=copy_timeout)
@@ -303,8 +302,7 @@ def run(test, params, env):
                         md5_check = md5_check.split(" ")[0]
                     except IndexError:
                         test.error(
-                            "Failed to get md5 from dst file,"
-                            " output: '%s'" % md5_floppy
+                            "Failed to get md5 from dst file, output: '%s'" % md5_floppy
                         )
                     if md5_check != md5_floppy:
                         test.fail(

--- a/qemu/tests/format_disk.py
+++ b/qemu/tests/format_disk.py
@@ -121,7 +121,7 @@ def run(test, params, env):
             test.fail("Write to file error: %s" % output)
 
         error_context.context(
-            "Read in the file to see whether " "content has changed", test.log.info
+            "Read in the file to see whether content has changed", test.log.info
         )
         md5chk_cmd = params.get("md5chk_cmd")
         if md5chk_cmd:
@@ -142,7 +142,7 @@ def run(test, params, env):
 
     umount_cmd = params.get("umount_cmd", "").format(drive_path)
     if umount_cmd:
-        error_context.context("Unmounting disk(s) after file " "write/read operation")
+        error_context.context("Unmounting disk(s) after file write/read operation")
         status, output = session.cmd_status_output(umount_cmd, timeout=cmd_timeout)
         if status != 0:
             show_mount_cmd = params.get("show_mount_cmd", "").format(drive_path)
@@ -162,7 +162,7 @@ def run(test, params, env):
     output = ""
     try:
         output = session.cmd("dmesg -c")
-        error_context.context("Checking if there are I/O error " "messages in dmesg")
+        error_context.context("Checking if there are I/O error messages in dmesg")
     except aexpect.ShellCmdError:
         pass
 

--- a/qemu/tests/fwcfg.py
+++ b/qemu/tests/fwcfg.py
@@ -43,7 +43,7 @@ def run(test, params, env):
 
     try:
         error_context.context(
-            "Copy the Memory.dmp.zip file " "from host to guest", test.log.info
+            "Copy the Memory.dmp.zip file from host to guest", test.log.info
         )
         vm.copy_files_to(dump_zip_file, "%s:\\Memory.dmp.zip" % disk_letter)
         unzip_cmd = params["unzip_cmd"] % (disk_letter, disk_letter)

--- a/qemu/tests/guest_iommu_test.py
+++ b/qemu/tests/guest_iommu_test.py
@@ -91,8 +91,7 @@ def verify_eim_status(test, params, session):
             output = session.cmd_output('journalctl -k | grep -i "%s"' % key_words)
         if not output:
             test.fail(
-                'journalctl -k | grep -i "%s"'
-                "from the systemd journal log." % key_words
+                'journalctl -k | grep -i "%s"from the systemd journal log.' % key_words
             )
         test.log.debug(output)
 
@@ -105,8 +104,7 @@ def verify_x2apic_status(test, params, session):
             output = session.cmd_output('journalctl -k | grep -i "%s"' % key_words)
         if not output:
             test.fail(
-                'journalctl -k | grep -i "%s"'
-                "from the systemd journal log." % key_words
+                'journalctl -k | grep -i "%s"from the systemd journal log.' % key_words
             )
         test.log.debug(output)
 

--- a/qemu/tests/hdparm.py
+++ b/qemu/tests/hdparm.py
@@ -82,12 +82,12 @@ def run(test, params, env):
             ignore_count = len(re.findall(ignore_string, err.output))
             if failed_count > ignore_count:
                 test.error(
-                    "Fail to setting hard disk to lower " "performance. Output is:%s",
+                    "Fail to setting hard disk to lower performance. Output is:%s",
                     err.output,
                 )
 
         error_context.context(
-            "Checking hard disk keyval under " "lower performance settings"
+            "Checking hard disk keyval under lower performance settings"
         )
         check_setting_result(cmd, timeout)
         low_result = perform_read_timing(disk, timeout)
@@ -106,12 +106,12 @@ def run(test, params, env):
             ignore_count = len(re.findall(ignore_string, err.output))
             if failed_count > ignore_count:
                 test.error(
-                    "Fail to setting hard disk to higher " "performance. Output is:%s",
+                    "Fail to setting hard disk to higher performance. Output is:%s",
                     err.output,
                 )
 
         error_context.context(
-            "Checking hard disk keyval under " "higher performance settings"
+            "Checking hard disk keyval under higher performance settings"
         )
         check_setting_result(cmd, timeout)
         high_result = perform_read_timing(disk, timeout)

--- a/qemu/tests/hotplug_mem_negative.py
+++ b/qemu/tests/hotplug_mem_negative.py
@@ -93,6 +93,6 @@ def run(test, params, env):
         for target_mem in params.objects("target_mems"):
             mem_params = params.object_params(target_mem)
             error_context.context(
-                "Check %s qemu prompt " "message." % target_mem, test.log.info
+                "Check %s qemu prompt message." % target_mem, test.log.info
             )
             check_msg(mem_params["keywords"], msg[target_mem])

--- a/qemu/tests/hugepage_reset.py
+++ b/qemu/tests/hugepage_reset.py
@@ -96,8 +96,7 @@ def run(test, params, env):
                 params["target_num_node%s" % target_node] = origin_nr
                 break
             test.log.info(
-                "The free memory of node %s is %s, is not enough for"
-                " guest memory: %s",
+                "The free memory of node %s is %s, is not enough for guest memory: %s",
                 target_node,
                 node_mem_free,
                 mem,

--- a/qemu/tests/hugepage_specify_node.py
+++ b/qemu/tests/hugepage_specify_node.py
@@ -33,7 +33,7 @@ def run(test, params, env):
 
     for node_id in node_list:
         error_context.base_context(
-            "Check preprocess HugePages Free on host " "numa node %s." % node_id,
+            "Check preprocess HugePages Free on host numa node %s." % node_id,
             test.log.info,
         )
         node_memfree = int(node_meminfo[node_id]["MemFree"])
@@ -44,12 +44,12 @@ def run(test, params, env):
 
     if len(idle_node_list) < 2 or not node_list:
         test.cancel(
-            "Host node does not have enough nodes to run the test, " "skipping test..."
+            "Host node does not have enough nodes to run the test, skipping test..."
         )
 
     for node_id in node_list:
         error_context.base_context(
-            "Specify qemu process only allocate " "HugePages from node%s." % node_id,
+            "Specify qemu process only allocate HugePages from node%s." % node_id,
             test.log.info,
         )
         params["target_nodes"] = "%s" % node_id
@@ -82,7 +82,7 @@ def run(test, params, env):
                 meminfo = host_numa_node.get_all_node_meminfo()
                 for index in check_list:
                     error_context.base_context(
-                        "Check process HugePages Free on host " "numa node %s." % index,
+                        "Check process HugePages Free on host numa node %s." % index,
                         test.log.info,
                     )
                     hugepages_free = int(meminfo[index]["HugePages_Free"])

--- a/qemu/tests/hv_avic.py
+++ b/qemu/tests/hv_avic.py
@@ -54,7 +54,7 @@ def run(test, params, env):
         if status:
             test.error("Fail to install target cpuid")
     error_context.context(
-        "Check the corresponding CPUID entries with " "the flag 'hv-avic'",
+        "Check the corresponding CPUID entries with the flag 'hv-avic'",
         test.log.info,
     )
     output = session.cmd_output(check_cpuid_entry_cmd)

--- a/qemu/tests/hv_check_cpu_utilization.py
+++ b/qemu/tests/hv_check_cpu_utilization.py
@@ -57,7 +57,7 @@ def _stop_service(test, params, session, service):
     service_stop_cmd = params.get("service_stop_cmd")
     s, o = session.cmd_status_output("sc query")
     if s:
-        test.error("Failed to query service list, " "status=%s, output=%s" % (s, o))
+        test.error("Failed to query service list, status=%s, output=%s" % (s, o))
     service_item = re.search(r"SERVICE_NAME:\s+%s" % service, o, re.I | re.M)
     if not service_item:
         return

--- a/qemu/tests/hv_flag_cpuid_check.py
+++ b/qemu/tests/hv_flag_cpuid_check.py
@@ -44,7 +44,7 @@ def run(test, params, env):
 
         """
         error_context.context(
-            "Check the corresponding CPUID entries with " "the flag %s" % hv_flag,
+            "Check the corresponding CPUID entries with the flag %s" % hv_flag,
             test.log.info,
         )
         output = session.cmd_output(check_cpuid_entry_cmd)

--- a/qemu/tests/hv_info_check.py
+++ b/qemu/tests/hv_info_check.py
@@ -13,7 +13,7 @@ def run(test, params, env):
 
     vm = env.get_vm(params["main_vm"])
     error_context.context(
-        "Query supported HyperV Enlightenments " "by host", test.log.info
+        "Query supported HyperV Enlightenments by host", test.log.info
     )
     missing = []
     args = {

--- a/qemu/tests/hv_time.py
+++ b/qemu/tests/hv_time.py
@@ -42,7 +42,7 @@ def run(test, params, env):
             )
         use_pltck = re.search(r"useplatformclock\s+no", o, re.I | re.M)
         if not use_pltck:
-            test.error("The useplatfromclock isn't off after reboot, " "output=%s" % o)
+            test.error("The useplatfromclock isn't off after reboot, output=%s" % o)
 
         test.log.info("Copy the related files to the guest")
         for f in gettime_filenames:

--- a/qemu/tests/image_convert_bypass_host_cache.py
+++ b/qemu/tests/image_convert_bypass_host_cache.py
@@ -52,7 +52,7 @@ def run(test, params, env):
     )
     image_params["convert_target"] = convert_target2
     test.log.debug(
-        ("Convert image from %s to %s with cache mode " "'none', strace log: %s"),
+        ("Convert image from %s to %s with cache mode 'none', strace log: %s"),
         image.tag,
         convert_target2,
         strace_output_file,

--- a/qemu/tests/interrupt_check.py
+++ b/qemu/tests/interrupt_check.py
@@ -35,8 +35,7 @@ def run(test, params, env):
         ]
         if not filtered_result:
             test.fail(
-                "Number of interrupts on the CPUs have not changed after"
-                " test execution"
+                "Number of interrupts on the CPUs have not changed after test execution"
             )
         elif any([int(x[1]) < int(x[0]) for x in filtered_result]):
             test.fail("The number of interrupts has decreased")

--- a/qemu/tests/invalid_cpu_device_hotplug.py
+++ b/qemu/tests/invalid_cpu_device_hotplug.py
@@ -20,9 +20,7 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    not_match_err = (
-        "Hotplug %s failed but the error description does not " "match: '%s'"
-    )
+    not_match_err = "Hotplug %s failed but the error description does not match: '%s'"
     expected_info = "Hotplug %s failed as expected, error description: '%s'"
     hotplug_pass_err = "Still able to hotplug %s via qmp"
 

--- a/qemu/tests/ioeventfd.py
+++ b/qemu/tests/ioeventfd.py
@@ -179,7 +179,7 @@ def run(test, params, env):
                 'should be less than the one with "on".'
             )
         test.log.info(
-            'The number of event fds with "off" ' 'is less than the one with "on".'
+            'The number of event fds with "off" is less than the one with "on".'
         )
 
     params["start_vm"] = "yes"

--- a/qemu/tests/kernel_install.py
+++ b/qemu/tests/kernel_install.py
@@ -184,7 +184,7 @@ def run(test, params, env):
         except Exception as e:
             _clean_up_tmp_files(_tmp_file_list)
             session.close()
-            test.fail("Fail to restore to default kernel," " error message:\n '%s'" % e)
+            test.fail("Fail to restore to default kernel, error message:\n '%s'" % e)
         vm.reboot()
 
     session = vm.wait_for_login(timeout=timeout)

--- a/qemu/tests/kexec.py
+++ b/qemu/tests/kexec.py
@@ -69,7 +69,7 @@ def run(test, params, env):
         if cur_kernel_version not in kernel:
             new_kernel = kernel[7:]
     if not new_kernel:
-        test.error("Could not find new kernel, " "command line output: %s" % output)
+        test.error("Could not find new kernel, command line output: %s" % output)
     msg = "Reboot to kernel %s through kexec" % new_kernel
     error_context.context(msg, test.log.info)
     cmd = params.get("get_kernel_image") % new_kernel

--- a/qemu/tests/ksm_base.py
+++ b/qemu/tests/ksm_base.py
@@ -34,7 +34,7 @@ def run(test, params, env):
         """
         test.log.debug("Starting guest script on guest %s", vm.name)
         session.sendline(
-            "$(command -v python python3 | head -1) " "/tmp/ksm_overcommit_guest.py"
+            "$(command -v python python3 | head -1) /tmp/ksm_overcommit_guest.py"
         )
         try:
             _ = session.read_until_last_line_matches(["PASS:", "FAIL:"], timeout)
@@ -56,7 +56,7 @@ def run(test, params, env):
         :return: Tuple (match index, data)
         """
         test.log.debug(
-            "Executing '%s' on guest script loop, vm: %s, timeout: " "%s",
+            "Executing '%s' on guest script loop, vm: %s, timeout: %s",
             command,
             vm.name,
             timeout,
@@ -67,7 +67,7 @@ def run(test, params, env):
                 ["PASS:", "FAIL:"], timeout
             )
         except aexpect.ExpectProcessTerminatedError as exc:
-            e_str = "Failed to execute command '%s' on guest script, " "vm '%s': %s" % (
+            e_str = "Failed to execute command '%s' on guest script, vm '%s': %s" % (
                 command,
                 vm.name,
                 str(exc),

--- a/qemu/tests/ksm_ksmtuned.py
+++ b/qemu/tests/ksm_ksmtuned.py
@@ -104,7 +104,7 @@ def run(test, params, env):
                 test.fail("KSM should be running")
         else:
             if free_mem_host < ksm_thres:
-                test.error("Host memory is consumed too much more than " "expected")
+                test.error("Host memory is consumed too much more than expected")
             if ksm_status:
                 test.fail("KSM should not be running")
 

--- a/qemu/tests/ksm_overcommit.py
+++ b/qemu/tests/ksm_overcommit.py
@@ -71,7 +71,7 @@ def run(test, params, env):
         """
         test.log.debug("Starting ksm_overcommit_guest.py on guest %s", vm.name)
         session.sendline(
-            "$(command -v python python3 | head -1) " "/tmp/ksm_overcommit_guest.py"
+            "$(command -v python python3 | head -1) /tmp/ksm_overcommit_guest.py"
         )
         try:
             session.read_until_last_line_matches(["PASS:", "FAIL:"], timeout)
@@ -95,7 +95,7 @@ def run(test, params, env):
         :return: Tuple (match index, data)
         """
         test.log.debug(
-            "Executing '%s' on ksm_overcommit_guest.py loop, " "vm: %s, timeout: %s",
+            "Executing '%s' on ksm_overcommit_guest.py loop, vm: %s, timeout: %s",
             command,
             vm.name,
             timeout,
@@ -174,7 +174,7 @@ def run(test, params, env):
                 else:
                     shm = vm.get_shared_meminfo()
                 test.log.debug(
-                    "Shared meminfo for guest %s after " "iteration %s: %s",
+                    "Shared meminfo for guest %s after iteration %s: %s",
                     vm.name,
                     j,
                     shm,
@@ -217,7 +217,7 @@ def run(test, params, env):
         Sequential split of pages on guests up to memory limit
         """
         test.log.info(
-            "Phase 3a: Sequential split of pages on guests up to " "memory limit"
+            "Phase 3a: Sequential split of pages on guests up to memory limit"
         )
         last_vm = 0
         session = None
@@ -235,7 +235,7 @@ def run(test, params, env):
             session = lsessions[i]
             cmd = "mem.static_random_fill()"
             test.log.debug(
-                "Executing %s on ksm_overcommit_guest.py loop, " "vm: %s", cmd, vm.name
+                "Executing %s on ksm_overcommit_guest.py loop, vm: %s", cmd, vm.name
             )
             session.sendline(cmd)
 
@@ -533,9 +533,7 @@ def run(test, params, env):
         mem = host_mem
         # 32bit system adjustment
         if "64" not in params.get("vm_arch_name"):
-            test.log.debug(
-                "Probably i386 guest architecture, " "max allocator mem = 2G"
-            )
+            test.log.debug("Probably i386 guest architecture, max allocator mem = 2G")
             # Guest can have more than 2G but
             # kvm mem + 1MB (allocator itself) can't
             if host_mem > 3100:
@@ -558,9 +556,7 @@ def run(test, params, env):
 
         # 32bit system adjustment
         if params["vm_arch_name"] == "i686":
-            test.log.debug(
-                "Probably i386 guest architecture, " "max allocator mem = 2G"
-            )
+            test.log.debug("Probably i386 guest architecture, max allocator mem = 2G")
             # Guest can have more than 2G but
             # kvm mem + 1MB (allocator itself) can't
             if mem - guest_reserve - 1 > 3100:
@@ -658,7 +654,7 @@ def run(test, params, env):
         lvms[i].create()
         if not lvms[i].is_alive():
             test.error(
-                "VM %s seems to be dead; Test requires a" "living VM" % lvms[i].name
+                "VM %s seems to be dead; Test requires aliving VM" % lvms[i].name
             )
 
         lsessions.append(lvms[i].wait_for_login(timeout=360))

--- a/qemu/tests/kvm_unit_test.py
+++ b/qemu/tests/kvm_unit_test.py
@@ -27,9 +27,7 @@ def run(test, params, env):
     os.chdir(unittest_dir)
     unittest_list = glob.glob("*.flat")
     if not unittest_list:
-        test.cancel(
-            "No unittest files available (did you run the " "build test first?)"
-        )
+        test.cancel("No unittest files available (did you run the build test first?)")
     test.log.debug("Flat file list: %s", unittest_list)
 
     unittest_cfg = os.path.join(unittest_dir, "unittests.cfg")
@@ -72,8 +70,7 @@ def run(test, params, env):
             nfail += 1
             tests_failed.append(t)
             test.log.error(
-                "Unittest config file %s has section %s but no "
-                "mandatory option file",
+                "Unittest config file %s has section %s but no mandatory option file",
                 unittest_cfg,
                 t,
             )
@@ -152,7 +149,7 @@ def run(test, params, env):
                 if testlog is not None:
                     shutil.copy(vm.get_testlog_filename(), testlog_path)
                     test.log.info(
-                        "Unit test log collected and available " "under %s",
+                        "Unit test log collected and available under %s",
                         testlog_path,
                     )
             except (NameError, IOError):

--- a/qemu/tests/larger_buffer_with_none_cache_mode.py
+++ b/qemu/tests/larger_buffer_with_none_cache_mode.py
@@ -29,7 +29,7 @@ def run(test, params, env):
     src_filename = source.image_filename
     process.run("dd if=/dev/urandom of=%s bs=1M count=100" % src_filename)
     test.log.debug(
-        "Convert from %s to %s with cache mode none, strace log: " "%s.",
+        "Convert from %s to %s with cache mode none, strace log: %s.",
         src_filename,
         tgt_image,
         strace_output_file,

--- a/qemu/tests/live_backup_base.py
+++ b/qemu/tests/live_backup_base.py
@@ -98,7 +98,7 @@ class LiveBackup(block_copy.BlockCopy):
                 }
                 self.transaction_add(args_list, "drive-backup", backup_args)
                 LOG_JOB.info(
-                    "Create bitmap and drive-backup with transaction " "for %s",
+                    "Create bitmap and drive-backup with transaction for %s",
                     drive_name,
                 )
                 self.vm.monitor.transaction(args_list)

--- a/qemu/tests/live_snapshot_negative.py
+++ b/qemu/tests/live_snapshot_negative.py
@@ -19,7 +19,7 @@ class LiveSnapshotNegative(LiveSnapshot):
         Generate a non-existed path of snapshot file.
         """
         error_context.context(
-            "Generate a non-existed path of" " snapshot file", LOG_JOB.info
+            "Generate a non-existed path of snapshot file", LOG_JOB.info
         )
         tmp_name = utils_misc.generate_random_string(5)
         dst = os.path.join(data_dir.get_tmp_dir(), tmp_name)

--- a/qemu/tests/live_snapshot_transaction.py
+++ b/qemu/tests/live_snapshot_transaction.py
@@ -34,7 +34,7 @@ def run(test, params, env):
             arg_list.append(args)
 
         error_context.context(
-            "Create multiple live snapshots simultaneously" " with transaction",
+            "Create multiple live snapshots simultaneously with transaction",
             test.log.info,
         )
         output = transaction_test.vm.monitor.transaction(arg_list)

--- a/qemu/tests/macvtap_event_notification.py
+++ b/qemu/tests/macvtap_event_notification.py
@@ -23,7 +23,7 @@ def run(test, params, env):
 
     qemu_binary = utils_misc.get_qemu_binary(params)
     if not utils_misc.qemu_has_option("qmp", qemu_binary):
-        test.cancel("This test case requires a host QEMU with QMP " "monitor support")
+        test.cancel("This test case requires a host QEMU with QMP monitor support")
     if params.get("nettype", "macvtap") != "macvtap":
         test.cancel("This test case test macvtap.")
 
@@ -65,7 +65,7 @@ def run(test, params, env):
     interface_name = utils_net.get_linux_ifname(session, mac)
 
     error_context.context(
-        "In guest, change network interface " "to promisc state.", test.log.info
+        "In guest, change network interface to promisc state.", test.log.info
     )
     event_cmd = params.get("event_cmd") % interface_name
     send_cmd(event_cmd, event_cmd_type)

--- a/qemu/tests/migration.py
+++ b/qemu/tests/migration.py
@@ -199,7 +199,7 @@ def run(test, params, env):
         try:
             check_command = params.get("migration_bg_check_command", "")
             error_context.context(
-                "Checking the background command in the " "guest pre migration",
+                "Checking the background command in the guest pre migration",
                 test.log.info,
             )
             if session2.cmd_status(check_command, timeout=30) != 0:
@@ -266,7 +266,7 @@ def run(test, params, env):
 
             # Make sure the background process is still running
             error_context.context(
-                "Checking the background command in the " "guest post migration",
+                "Checking the background command in the guest post migration",
                 test.log.info,
             )
             session2.cmd(check_command, timeout=30)
@@ -310,7 +310,7 @@ def run(test, params, env):
                             raise
                     except aexpect.ShellTimeoutError:
                         test.log.debug(
-                            "Remote session not responsive, " "shutting down VM %s",
+                            "Remote session not responsive, shutting down VM %s",
                             vm.name,
                         )
                         vm.destroy(gracefully=True)

--- a/qemu/tests/migration_after_vm_paused.py
+++ b/qemu/tests/migration_after_vm_paused.py
@@ -82,7 +82,7 @@ class MigrationAfterVmPaused(object):
             # process is running
             session2 = self.vm.wait_for_login(timeout=self.login_timeout)
             error_context.context(
-                "Checking the background command in " "the guest pre migration",
+                "Checking the background command in the guest pre migration",
                 LOG_JOB.info,
             )
             session2.cmd(self.bg_check_command, timeout=30)
@@ -90,7 +90,7 @@ class MigrationAfterVmPaused(object):
         else:
             # Just migrate on a living guest OS
             self.test.fail(
-                "The guest is not alive," " this test must on a living guest OS."
+                "The guest is not alive, this test must on a living guest OS."
             )
 
     @error_context.context_aware
@@ -99,7 +99,7 @@ class MigrationAfterVmPaused(object):
         session2 = self.vm.wait_for_login(timeout=self.login_timeout)
         LOG_JOB.info("Logged in after migration")
         error_context.context(
-            "Checking the background command in the guest " "post migration",
+            "Checking the background command in the guest post migration",
             LOG_JOB.info,
         )
         session2.cmd(self.bg_check_command, timeout=30)

--- a/qemu/tests/migration_with_dst_problem.py
+++ b/qemu/tests/migration_with_dst_problem.py
@@ -262,7 +262,7 @@ def run(test, params, env):
             ip_dst = vm_ds.get_address()
             process.run("iscsiadm -m discovery -t st -p %s" % (ip_dst))
 
-            server_ident = 'iscsiadm -m node --targetname "%s:dev01"' " --portal %s" % (
+            server_ident = 'iscsiadm -m node --targetname "%s:dev01" --portal %s' % (
                 self.server_name,
                 ip_dst,
             )
@@ -347,9 +347,7 @@ def run(test, params, env):
                 timeout=ro_timeout,
                 first=2,
             ):
-                test.fail(
-                    "The Read-only file system warning not" " come in time limit."
-                )
+                test.fail("The Read-only file system warning not come in time limit.")
 
         def clean(self):
             if os.path.exists(mig_dst):

--- a/qemu/tests/migration_with_file_transfer.py
+++ b/qemu/tests/migration_with_file_transfer.py
@@ -47,7 +47,7 @@ def run(test, params, env):
             try:
                 while bg.is_alive():
                     test.log.info(
-                        "File transfer not ended, starting a round of " "migration..."
+                        "File transfer not ended, starting a round of migration..."
                     )
                     migration_exec_cmd_src = params.get("migration_exec_cmd_src")
                     migration_exec_cmd_dst = params.get("migration_exec_cmd_dst")

--- a/qemu/tests/migration_with_speed_measurement.py
+++ b/qemu/tests/migration_with_speed_measurement.py
@@ -94,8 +94,7 @@ def run(test, params, env):
                 " filling its memory."
             )
             fail_msg = (
-                "Could not determine the transferred memory from"
-                " monitor data: %s" % o
+                "Could not determine the transferred memory from monitor data: %s" % o
             )
             if isinstance(o, six.string_types):
                 if "status: active" not in o:

--- a/qemu/tests/mlock_basic.py
+++ b/qemu/tests/mlock_basic.py
@@ -62,7 +62,7 @@ class MlockBasic(object):
         Start mlock basic test
         """
         error_context.context(
-            "Get nr_mlock and nr_unevictable in host" " before VM start!", LOG_JOB.info
+            "Get nr_mlock and nr_unevictable in host before VM start!", LOG_JOB.info
         )
         self.mlock_pre = read_from_vmstat("nr_mlock")
         self.unevictable_pre = read_from_vmstat("nr_unevictable")
@@ -81,7 +81,7 @@ class MlockBasic(object):
         self.vm.verify_alive()
 
         error_context.context(
-            "Get nr_mlock and nr_unevictable in host" " after VM start!", LOG_JOB.info
+            "Get nr_mlock and nr_unevictable in host after VM start!", LOG_JOB.info
         )
         self.mlock_post = read_from_vmstat("nr_mlock")
         self.unevictable_post = read_from_vmstat("nr_unevictable")

--- a/qemu/tests/monitor_cmds_check.py
+++ b/qemu/tests/monitor_cmds_check.py
@@ -30,7 +30,7 @@ def run(test, params, env):
 
     black_cmds = params.get("black_cmds", "").split()
     error_context.context(
-        "Verify black commands are unavaliable in " "'%s' monitor" % protocol,
+        "Verify black commands are unavaliable in '%s' monitor" % protocol,
         test.log.info,
     )
     test.log.info("Black commands: %s", black_cmds)

--- a/qemu/tests/mq_change_qnum.py
+++ b/qemu/tests/mq_change_qnum.py
@@ -180,7 +180,7 @@ def run(test, params, env):
             if not ext_host:
                 # Fallback to a hardcode host, eg:
                 test.log.warning(
-                    "Can't get specified host," " Fallback to default host '%s'",
+                    "Can't get specified host, Fallback to default host '%s'",
                     default_host,
                 )
                 ext_host = default_host

--- a/qemu/tests/multi_disk.py
+++ b/qemu/tests/multi_disk.py
@@ -135,26 +135,24 @@ def run(test, params, env):
     def _get_data_disks():
         if ostype == "windows":
             error_context.context(
-                "Get windows disk index that to " "be formatted", test.log.info
+                "Get windows disk index that to be formatted", test.log.info
             )
             data_disks = _get_windows_disks_index(stg_image_size)
             if len(data_disks) < stg_image_num:
                 test.fail(
-                    "Fail to list all the volumes" ", %s" % err_msg % len(data_disks)
+                    "Fail to list all the volumes, %s" % err_msg % len(data_disks)
                 )
             if len(data_disks) > drive_letters:
                 black_list.extend(utils_misc.get_winutils_vol(session))
                 data_disks = random.sample(data_disks, drive_letters - len(black_list))
             error_context.context(
-                "Clear readonly for all disks and online " "them in windows guest.",
+                "Clear readonly for all disks and online them in windows guest.",
                 test.log.info,
             )
             if not utils_disk.update_windows_disk_attributes(session, data_disks):
                 test.fail("Failed to update windows disk attributes.")
         else:
-            error_context.context(
-                "Get linux disk that to be " "formatted", test.log.info
-            )
+            error_context.context("Get linux disk that to be formatted", test.log.info)
             data_disks = []
             all_disks = utils_disk.get_linux_disks(session, True)
             for kname, attr in all_disks.items():
@@ -162,7 +160,7 @@ def run(test, params, env):
                     data_disks.append(kname)
             if len(data_disks) < stg_image_num:
                 test.fail(
-                    "Fail to list all the volumes" ", %s" % err_msg % len(data_disks)
+                    "Fail to list all the volumes, %s" % err_msg % len(data_disks)
                 )
         return sorted(data_disks)
 
@@ -314,7 +312,7 @@ def run(test, params, env):
         err += tmp1 + tmp2
 
         if err:
-            test.fail("%s errors occurred while verifying qtree vs." " params" % err)
+            test.fail("%s errors occurred while verifying qtree vs. params" % err)
         if params.get("multi_disk_only_qtree") == "yes":
             return
     try:
@@ -357,7 +355,7 @@ def run(test, params, env):
                     else:
                         partition = partition.split("/")[-1]
                     error_context.context(
-                        "Copy file into / out of partition:" " %s..." % partition,
+                        "Copy file into / out of partition: %s..." % partition,
                         test.log.info,
                     )
                     for cmd_l in cmd_list.split():

--- a/qemu/tests/multi_disk_random_hotplug.py
+++ b/qemu/tests/multi_disk_random_hotplug.py
@@ -134,7 +134,7 @@ def run(test, params, env):
             test.log.error("info qtree:\n%s", info_qtree)
             test.log.error("info block:\n%s", info_block)
             test.log.error(qdev.str_bus_long())
-            test.fail("%s errors occurred while verifying" " qtree vs. params" % err)
+            test.fail("%s errors occurred while verifying qtree vs. params" % err)
 
     def _create_params_matrix():
         matrix = {}
@@ -172,7 +172,7 @@ def run(test, params, env):
             # Set the format
             if len(formats) < 1:
                 if i == 0:
-                    test.error("Fail to add any disks, probably bad" " configuration.")
+                    test.error("Fail to add any disks, probably bad configuration.")
                 test.log.warning(
                     "Can't create desired number '%s' of disk types "
                     "'%s'. Using '%d' no disks.",
@@ -224,7 +224,7 @@ def run(test, params, env):
 
     def verify_qtree_unsupported(params, info_qtree, info_block, qdev):
         return test.log.warning(
-            "info qtree not supported. Can't verify qtree vs. " "guest disks."
+            "info qtree not supported. Can't verify qtree vs. guest disks."
         )
 
     def enable_driver_verifier(driver, timeout=300):
@@ -380,7 +380,7 @@ def run(test, params, env):
         if "I/O error" in out:
             test.log.warning(out)
             test.error(
-                "I/O error messages occured in dmesg, " "check the log for details."
+                "I/O error messages occured in dmesg, check the log for details."
             )
     except Exception as e:
         pid = vm.get_pid()

--- a/qemu/tests/multi_macvtap_devices.py
+++ b/qemu/tests/multi_macvtap_devices.py
@@ -74,7 +74,7 @@ def run(test, params, env):
         ext_host = process.system_output(ext_host_get_cmd, shell=True)
     except process.CmdError:
         test.log.warning(
-            "Can't get specified host with cmd '%s'," " Fallback to default host '%s'",
+            "Can't get specified host with cmd '%s', Fallback to default host '%s'",
             ext_host_get_cmd,
             default_host,
         )

--- a/qemu/tests/multi_vms_file_transfer.py
+++ b/qemu/tests/multi_vms_file_transfer.py
@@ -79,7 +79,7 @@ def run(test, params, env):
         t_end = time.time()
         throughput = filesize / (t_end - t_begin)
         test.log.info(
-            "File transfer host -> VM1 succeed, " "estimated throughput: %.2fMB/s",
+            "File transfer host -> VM1 succeed, estimated throughput: %.2fMB/s",
             throughput,
         )
         md5_check(session_vm1, orig_md5)
@@ -110,7 +110,7 @@ def run(test, params, env):
             t_end = time.time()
             throughput = filesize / (t_end - t_begin)
             test.log.info(
-                "File transfer VM1 -> VM2 succeed, " "estimated throughput: %.2fMB/s",
+                "File transfer VM1 -> VM2 succeed, estimated throughput: %.2fMB/s",
                 throughput,
             )
             md5_check(session_vm2, orig_md5)
@@ -137,7 +137,7 @@ def run(test, params, env):
             t_end = time.time()
             throughput = filesize / (t_end - t_begin)
             test.log.info(
-                "File transfer VM2 -> VM1 succeed, " "estimated throughput: %.2fMB/s",
+                "File transfer VM2 -> VM1 succeed, estimated throughput: %.2fMB/s",
                 throughput,
             )
             md5_check(session_vm1, orig_md5)

--- a/qemu/tests/multi_vms_nics.py
+++ b/qemu/tests/multi_vms_nics.py
@@ -68,7 +68,7 @@ def run(test, params, env):
             if strict_check:
                 ratio = utils_test.get_loss_ratio(output)
                 if ratio != 0:
-                    test.fail("Loss ratio is %s for packet size" " %s" % (ratio, size))
+                    test.fail("Loss ratio is %s for packet size %s" % (ratio, size))
             else:
                 if status != 0:
                     test.fail("Ping returns non-zero value %s" % output)

--- a/qemu/tests/nested_interactive_agent.py
+++ b/qemu/tests/nested_interactive_agent.py
@@ -40,7 +40,7 @@ def run(test, params, env):
 
     try:
         error_context.context(
-            'Receive the "APPROVE" message from MQ publisher ' "to continue the test.",
+            'Receive the "APPROVE" message from MQ publisher to continue the test.',
             test.log.info,
         )
         try:

--- a/qemu/tests/nested_libguestfs_unittest.py
+++ b/qemu/tests/nested_libguestfs_unittest.py
@@ -45,13 +45,14 @@ def run(test, params, env):
 
     try:
         error_context.context(
-            "Execute the libguestfs-test-tool unittest " "directly launching qemu.",
+            "Execute the libguestfs-test-tool unittest directly launching qemu.",
             test.log.info,
         )
         stderr_file = "/tmp/lgf_stderr"
         lgf_cmd = (
-            "LIBGUESTFS_BACKEND=direct libguestfs-test-tool "
-            "--timeout {} 2> {}".format(unittest_timeout, stderr_file)
+            "LIBGUESTFS_BACKEND=direct libguestfs-test-tool --timeout {} 2> {}".format(
+                unittest_timeout, stderr_file
+            )
         )
         lgf_s, lgf_o = session.cmd_status_output(lgf_cmd, timeout=unittest_timeout)
         test.log.debug("libguestfs-test-tool stdout:\n%s", lgf_o)
@@ -77,17 +78,15 @@ def run(test, params, env):
             file_s, file_o = session.cmd_status_output("cat " + nested_file)
             if re.match(r"[1Y]", file_o) and is_kvm_mode:
                 test.log.info(
-                    "Guest runs with nested flag, the nested feature has "
-                    "been enabled."
+                    "Guest runs with nested flag, the nested feature has been enabled."
                 )
             elif file_s == 1 and not is_kvm_mode:
                 test.log.info(
-                    "Guest runs without nested flag, so the nested file "
-                    "does not exist."
+                    "Guest runs without nested flag, so the nested file does not exist."
                 )
             else:
                 test.log.error("Nested file status: %s, output: %s", file_s, file_o)
-                test.fail("Getting the status of nested file has unexpected " "result.")
+                test.fail("Getting the status of nested file has unexpected result.")
     finally:
         session.cmd("rm -f " + stderr_file, ignore_all_errors=True)
         session.close()

--- a/qemu/tests/netkvm_change_param_value_test.py
+++ b/qemu/tests/netkvm_change_param_value_test.py
@@ -66,7 +66,7 @@ def run(test, params, env):
 
     session = vm.wait_for_login(timeout=timeout)
     error_context.context(
-        "Check if the driver is installed and " "verified", test.log.info
+        "Check if the driver is installed and verified", test.log.info
     )
     driver_verifier = params["driver_verifier"]
     session = utils_test.qemu.windrv_check_running_verifier(

--- a/qemu/tests/netkvm_protocol_binding.py
+++ b/qemu/tests/netkvm_protocol_binding.py
@@ -29,7 +29,7 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login(timeout=timeout)
     error_context.context(
-        "Check if the driver is installed and " "verified", test.log.info
+        "Check if the driver is installed and verified", test.log.info
     )
     driver_verifier = params["driver_verifier"]
     session = utils_test.qemu.windrv_check_running_verifier(

--- a/qemu/tests/nfs_perf.py
+++ b/qemu/tests/nfs_perf.py
@@ -36,7 +36,7 @@ def run(test, params, env):
                 func()
         except Exception as e:
             test.log.warning(
-                "Failed to execute function '%s'." " error message:\n%s",
+                "Failed to execute function '%s'. error message:\n%s",
                 func.__name__,
                 e,
             )
@@ -90,8 +90,7 @@ def run(test, params, env):
         session.cmd("echo 3 >/proc/sys/vm/drop_caches")
 
         error_context.context(
-            "test %s size block read performance in guest"
-            " using dd commands" % blk_size,
+            "test %s size block read performance in guest using dd commands" % blk_size,
             test.log.info,
         )
         dd_cmd = "dd"
@@ -110,7 +109,7 @@ def run(test, params, env):
 
     if not hasattr(test, "write_perf_keyval"):
         test.cancel(
-            "There is no 'write_perf_keyval' method in" " test object, skip this test"
+            "There is no 'write_perf_keyval' method in test object, skip this test"
         )
 
     error_context.context("boot guest over virtio driver", test.log.info)
@@ -164,9 +163,7 @@ def run(test, params, env):
 
     if (not nfs_server) or (not nfs_path) or (not mnt_point):
         _clean_up(STEP_2)
-        test.error(
-            "Missing configuration for nfs partition." " Check your config files"
-        )
+        test.error("Missing configuration for nfs partition. Check your config files")
 
     try:
         session.cmd("mkdir -p %s" % mnt_point)
@@ -197,7 +194,7 @@ def run(test, params, env):
         result_file.write("### %s\n" % mnt_cmd_out)
         result_file.write("Category:ALL\n")
     except (IOError, ValueError) as e:
-        test.log.error("Failed to write to result file," " error message:\n%s", e)
+        test.log.error("Failed to write to result file, error message:\n%s", e)
 
     result_list = ["%s|%016s|%016s" % ("blk_size", "Write", "Read")]
     speed_pattern = r"(\d+ bytes).*?([\d\.]+ s).*?([\d\.]+ [KkMmGgTt])B/s"
@@ -213,7 +210,7 @@ def run(test, params, env):
             if not tmp_list:
                 _clean_up(STEP_5)
                 test.error(
-                    "Could not get correct write result." " dd cmd output:\n%s" % out
+                    "Could not get correct write result. dd cmd output:\n%s" % out
                 )
             _, _, speed = tmp_list[0]
             speed = utils_misc.normalize_data_size(speed)
@@ -226,7 +223,7 @@ def run(test, params, env):
             if not tmp_list:
                 _clean_up(STEP_6)
                 test.error(
-                    "Could not get correct read result." " dd cmd output:\n%s" % out
+                    "Could not get correct read result. dd cmd output:\n%s" % out
                 )
             _, _, speed = tmp_list[0]
             speed = utils_misc.normalize_data_size(speed)
@@ -238,6 +235,6 @@ def run(test, params, env):
         try:
             result_file.write("\n".join(result_list))
         except (IOError, ValueError) as e:
-            test.log.error("Failed to write to result file," " error message:\n%s", e)
+            test.log.error("Failed to write to result file, error message:\n%s", e)
 
     _clean_up(STEP_6)

--- a/qemu/tests/nic_bonding.py
+++ b/qemu/tests/nic_bonding.py
@@ -112,7 +112,7 @@ def run(test, params, env):
         current_md5 = crypto.hash_file(host_path, algorithm="md5")
         test.log.info("md5 value of data current: %s", current_md5)
         if original_md5 != current_md5:
-            test.fail("File changed after transfer host -> guest " "and guest -> host")
+            test.fail("File changed after transfer host -> guest and guest -> host")
 
     finally:
         session_serial.sendline("ifenslave -d bond0 " + " ".join(ifnames))

--- a/qemu/tests/nic_bonding_host.py
+++ b/qemu/tests/nic_bonding_host.py
@@ -113,7 +113,7 @@ def run(test, params, env):
     )
 
     error_context.context(
-        "Disable and enable physical " "interfaces in %s" % bond_br_name, test.log.info
+        "Disable and enable physical interfaces in %s" % bond_br_name, test.log.info
     )
     while True:
         for op_iface in op_ifaces:

--- a/qemu/tests/nic_teaming.py
+++ b/qemu/tests/nic_teaming.py
@@ -130,7 +130,7 @@ def run(test, params, env):
         check_ping(status, output)
         # small ping check if the team0 works w/o failover
         error_context.context(
-            "Step3: Start failover testing until " "ping finished", test.log.info
+            "Step3: Start failover testing until ping finished", test.log.info
         )
         failover_thread = utils_misc.InterruptedThread(failover, (ifnames, timeout))
         failover_thread.start()

--- a/qemu/tests/nmi_bsod_catch.py
+++ b/qemu/tests/nmi_bsod_catch.py
@@ -68,7 +68,7 @@ def run(test, params, env):
         # Wait guest create dump file.
         if manual_reboot_cmd:
             bsod_time = params.get("bsod_time", 160)
-            test.log.info("Waiting guest for creating dump file" " (%ssec)", bsod_time)
+            test.log.info("Waiting guest for creating dump file (%ssec)", bsod_time)
             time.sleep(bsod_time)
             error_context.context("Send a system_reset monitor command", test.log.info)
             vm.monitor.send_args_cmd(manual_reboot_cmd)
@@ -77,7 +77,7 @@ def run(test, params, env):
 
         if check_dump_cmd:
             error_context.context(
-                "Verify whether the dump files are " "generated", test.log.info
+                "Verify whether the dump files are generated", test.log.info
             )
             s, o = session.cmd_status_output(check_dump_cmd, 360)
             test.log.debug("Output for check_dump_cmd command: %s", o)

--- a/qemu/tests/nmi_watchdog.py
+++ b/qemu/tests/nmi_watchdog.py
@@ -29,8 +29,7 @@ def run(test, params, env):
     )
 
     error_context.context(
-        "Add 'nmi_watchdog=%d' to guest kernel "
-        "cmdline and reboot" % nmi_watchdog_type
+        "Add 'nmi_watchdog=%d' to guest kernel cmdline and reboot" % nmi_watchdog_type
     )
     session.cmd(update_kernel_cmd)
     time.sleep(int(params.get("sleep_before_reset", 10)))
@@ -44,7 +43,7 @@ def run(test, params, env):
         test.log.debug(output.strip())
         nmi_counter1 = output.split()[1:]
 
-        test.log.info("Waiting 60 seconds to see if guest's NMI counter " "increases")
+        test.log.info("Waiting 60 seconds to see if guest's NMI counter increases")
         time.sleep(60)
 
         error_context.context("Getting guest's NMI counter 2nd time")
@@ -61,6 +60,6 @@ def run(test, params, env):
                 nmi_counter2[i],
             )
             if int(nmi_counter2[i]) <= int(nmi_counter1[i]):
-                test.fail("Guest's NMI counter did not increase " "after 60 seconds")
+                test.fail("Guest's NMI counter did not increase after 60 seconds")
     finally:
         session.close()

--- a/qemu/tests/nonexist_vcpu_hotplug.py
+++ b/qemu/tests/nonexist_vcpu_hotplug.py
@@ -20,14 +20,14 @@ def run(test, params, env):
     hotplug_cmd = "cpu_set %s online"
 
     error_context.context(
-        "boot the vm, with '-smp X,maxcpus=Y' option," "thus allow hotplug vcpu",
+        "boot the vm, with '-smp X,maxcpus=Y' option,thus allow hotplug vcpu",
         test.log.info,
     )
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
 
     error_context.context(
-        "check if CPUs in guest matches qemu cmd " "before hot-plug", test.log.info
+        "check if CPUs in guest matches qemu cmd before hot-plug", test.log.info
     )
     smp_by_cmd = int(params.get("smp"))
     if not cpu.check_if_vm_vcpu_match(smp_by_cmd, vm):
@@ -43,8 +43,7 @@ def run(test, params, env):
             error_context.context("output from monitor is: %s" % output, test.log.info)
     # Windows is a little bit lazy that needs more secs to recognize.
     error_context.context(
-        "hotplugging finished, let's wait a few sec and"
-        " check cpus quantity in guest.",
+        "hotplugging finished, let's wait a few sec and check cpus quantity in guest.",
         test.log.info,
     )
     if not utils_misc.wait_for(

--- a/qemu/tests/numa_basic.py
+++ b/qemu/tests/numa_basic.py
@@ -48,7 +48,7 @@ def run(test, params, env):
                 memory_sz_used_most = memory_status[index]
                 node_used_most = node_list[index]
             test.log.debug(
-                "Qemu used %s pages in node" " %s",
+                "Qemu used %s pages in node %s",
                 memory_status[index],
                 node_list[index],
             )

--- a/qemu/tests/numa_cpu.py
+++ b/qemu/tests/numa_cpu.py
@@ -78,7 +78,7 @@ def run(test, params, env):
             if not utils_package.package_install("acpidump", session):
                 test.cancel("Please install acpidump in guest to proceed")
             content = session.cmd_output(
-                "cd /tmp && acpidump -n SRAT -b && " "iasl -d srat.dat && cat srat.dsl"
+                "cd /tmp && acpidump -n SRAT -b && iasl -d srat.dat && cat srat.dsl"
             )
             pattern = re.compile(
                 r"Proximity Domain Low\(8\)\s+:\s+([0-9A-Fa-f]+)"

--- a/qemu/tests/numa_stress.py
+++ b/qemu/tests/numa_stress.py
@@ -93,7 +93,7 @@ def run(test, params, env):
                 )
                 cmd_mmap = cmd_mmap % (tmp_directory, numa_node_malloc, mmap_size)
                 error_context.context(
-                    "Run mem_mapping on host node " "%s." % numa_node_malloc,
+                    "Run mem_mapping on host node %s." % numa_node_malloc,
                     test.log.info,
                 )
                 process.system(cmd_mmap, shell=True, ignore_bg_processes=True)

--- a/qemu/tests/offload_checksum_windows.py
+++ b/qemu/tests/offload_checksum_windows.py
@@ -52,7 +52,7 @@ def run(test, params, env):
 
     session = vm.wait_for_login(timeout=timeout)
     error_context.context(
-        "Check if the driver is installed and " "verified", test.log.info
+        "Check if the driver is installed and verified", test.log.info
     )
     driver_name = params.get("driver_name", "netkvm")
     session = utils_test.qemu.windrv_check_running_verifier(

--- a/qemu/tests/openflow_test.py
+++ b/qemu/tests/openflow_test.py
@@ -27,8 +27,7 @@ def run(test, params, env):
         if tcpdump_is_alive(bg_session):
             bg_session.cmd("killall -9 tcpdump")
         tcpdump_cmd = (
-            "setsid tcpdump -iany -n -v %s and 'src %s and dst %s'"
-            " -c 1 >/dev/null 2>&1"
+            "setsid tcpdump -iany -n -v %s and 'src %s and dst %s' -c 1 >/dev/null 2>&1"
         )
         bg_session.sendline(tcpdump_cmd % (dump_protocol, addresses[0], addresses[1]))
         if not utils_misc.wait_for(
@@ -300,7 +299,7 @@ def run(test, params, env):
                 br_name, "dump-flows"
             ).stdout.decode()
             if not acl_rules_check(acl_rules, f_options):
-                test.fail("Can not find the rules from" " ovs-ofctl: %s" % acl_rules)
+                test.fail("Can not find the rules from ovs-ofctl: %s" % acl_rules)
 
             error_context.context(
                 "Run tcpdump in guest %s" % vms[1].name, test.log.info

--- a/qemu/tests/pci_bridge.py
+++ b/qemu/tests/pci_bridge.py
@@ -145,7 +145,7 @@ def disk_hotplug(test, params, vm, session, image_name, drive_format, parent_bus
     for dev in devices:
         ret = vm.devices.simple_hotplug(dev, vm.monitor)
         if ret[1] is False:
-            test.fail("Failed to hotplug device '%s'." "Output:\n%s" % (dev, ret[0]))
+            test.fail("Failed to hotplug device '%s'.Output:\n%s" % (dev, ret[0]))
 
     if drive_format == "usb3":
         usb_serial = params["blk_extra_params_%s" % image_name].split("=")[1]
@@ -310,7 +310,7 @@ def run(test, params, env):
         for dev in device_list:
             ret = vm.devices.simple_unplug(dev, vm.monitor)
             if ret[1] is False:
-                test.fail("Failed to unplug device '%s'." "Output:\n%s" % (dev, ret[0]))
+                test.fail("Failed to unplug device '%s'.Output:\n%s" % (dev, ret[0]))
     elif opr == "with_migration":
         error_context.context("Migrating...", test.log.info)
         vm.migrate(float(params.get("mig_timeout", "3600")))

--- a/qemu/tests/pci_hotplug.py
+++ b/qemu/tests/pci_hotplug.py
@@ -88,7 +88,7 @@ def run(test, params, env):
             )
         ]
         test.log.debug(
-            "QEMU reported the following supported devices for " "PCI hotplug: %s",
+            "QEMU reported the following supported devices for PCI hotplug: %s",
             devices_supported,
         )
         return dev in devices_supported
@@ -201,7 +201,7 @@ def run(test, params, env):
         after_add = vm.monitor.info("pci")
         if pci_info[pci_num][1] not in str(after_add):
             test.log.error(
-                "Could not find matched id in monitor:" " %s", pci_info[pci_num][1]
+                "Could not find matched id in monitor: %s", pci_info[pci_num][1]
             )
             test.fail(
                 "Add device failed. Monitor command is: %s"
@@ -366,8 +366,7 @@ def run(test, params, env):
     drive_cmd_type = is_supported_command("drive_add", "__com.redhat_drive_add")
     if not drive_cmd_type:
         test.error(
-            "Could find a suitable method for hotplugging"
-            " drive in this version of qemu"
+            "Could find a suitable method for hotplugging drive in this version of qemu"
         )
 
     local_functions = locals()

--- a/qemu/tests/pci_hotplug_check.py
+++ b/qemu/tests/pci_hotplug_check.py
@@ -110,7 +110,7 @@ def run(test, params, env):
             )
         ]
         test.log.debug(
-            "QEMU reported the following supported devices for " "PCI hotplug: %s",
+            "QEMU reported the following supported devices for PCI hotplug: %s",
             devices_supported,
         )
         return dev in devices_supported
@@ -219,7 +219,7 @@ def run(test, params, env):
         after_add = vm.monitor.info("pci")
         if pci_info[pci_num][1] not in str(after_add):
             test.log.error(
-                "Could not find matched id in monitor:" " %s", pci_info[pci_num][1]
+                "Could not find matched id in monitor: %s", pci_info[pci_num][1]
             )
             test.fail(
                 "Add device failed. Monitor command is: %s"

--- a/qemu/tests/pcie_hotplug_opt.py
+++ b/qemu/tests/pcie_hotplug_opt.py
@@ -129,7 +129,7 @@ def run(test, params, env):
         plug_image, plug_image_params, "disk"
     )
     error_context.context(
-        "Hot-plug the Drive/BlockdevNode first, " "will be used by virtio-blk-pci",
+        "Hot-plug the Drive/BlockdevNode first, will be used by virtio-blk-pci",
         test.log.info,
     )
     for image_dev in image_devs[:-1]:

--- a/qemu/tests/physical_resources_check.py
+++ b/qemu/tests/physical_resources_check.py
@@ -194,7 +194,7 @@ def run(test, params, env):
                 machine_type_map[type_pair[0][0]] = type_pair[0][1]
             else:
                 test.log.warning(
-                    "Unexpect output from qemu-kvm -M " "?: '%s'", machine_type
+                    "Unexpect output from qemu-kvm -M ?: '%s'", machine_type
                 )
         try:
             expect_mtype = machine_type_map[params["machine_type"]].strip()
@@ -344,7 +344,7 @@ def run(test, params, env):
             n_fail.append("\n".join(qdisks.errors))
     else:
         test.log.info(
-            "Images check param skipped (qemu monitor doesn't " "support 'info qtree')"
+            "Images check param skipped (qemu monitor doesn't support 'info qtree')"
         )
 
     error_context.context("Network card MAC check", test.log.info)

--- a/qemu/tests/pktgen.py
+++ b/qemu/tests/pktgen.py
@@ -108,7 +108,7 @@ def run(test, params, env):
         env["pktgen_run"] = False
 
     error_context.context(
-        "Verify Host and guest kernel no error " "and call trace", test.log.info
+        "Verify Host and guest kernel no error and call trace", test.log.info
     )
     vm.verify_kernel_crash()
     utils_misc.verify_dmesg()
@@ -122,8 +122,7 @@ def run(test, params, env):
     if loss_ratio > int(params.get("packet_lost_ratio", 5)) or loss_ratio == -1:
         test.log.debug("Ping %s output: %s", external_host, output)
         test.fail(
-            "Guest network connction unusable, "
-            "packet lost ratio is '%d%%'" % loss_ratio
+            "Guest network connction unusable, packet lost ratio is '%d%%'" % loss_ratio
         )
     if server_session:
         server_session.close()

--- a/qemu/tests/ppc_change_smt.py
+++ b/qemu/tests/ppc_change_smt.py
@@ -47,7 +47,7 @@ def run(test, params, env):
     threads = vm.cpuinfo.threads
 
     error_context.context(
-        "Check if the number of threads on guest is equal to" " SMP threads",
+        "Check if the number of threads on guest is equal to SMP threads",
         test.log.info,
     )
     _check_smt_state(threads)

--- a/qemu/tests/ppc_check_cpu_and_mmu.py
+++ b/qemu/tests/ppc_check_cpu_and_mmu.py
@@ -40,9 +40,9 @@ def run(test, params, env):
         "Assert CPU model and MMU mode of host and guest.", test.log.info
     )
     assert guest_cpu_model == host_cpu_model, (
-        "The CPU model of the host " "and guest do not match"
+        "The CPU model of the host and guest do not match"
     )
     assert guest_mmu_mode == host_mmu_mode, (
-        "The MMU mode of the host and " "guest do not match"
+        "The MMU mode of the host and guest do not match"
     )
     test.log.info("CPU model and MMU mode of host and guest are matched.")

--- a/qemu/tests/ppc_nested_compat.py
+++ b/qemu/tests/ppc_nested_compat.py
@@ -29,7 +29,7 @@ def run(test, params, env):
     except VMCreateError as e:
         if not re.search(error_msg, e.output):
             test.log.error(e.output)
-            test.error("The error message could not be searched at qemu " "outputs.")
+            test.error("The error message could not be searched at qemu outputs.")
         test.log.info("qemu terminated with the expected error message.")
     else:
         test.fail(

--- a/qemu/tests/pvpanic.py
+++ b/qemu/tests/pvpanic.py
@@ -140,7 +140,7 @@ def run(test, params, env):
     session = vm.wait_for_login(timeout=timeout)
     if params.get("os_type") == "windows":
         error_context.context(
-            "Check if the driver is installed and " "verified", test.log.info
+            "Check if the driver is installed and verified", test.log.info
         )
         driver_name = params.get("driver_name", "pvpanic")
         session = utils_test.qemu.windrv_check_running_verifier(

--- a/qemu/tests/pvpanic_memory_leak.py
+++ b/qemu/tests/pvpanic_memory_leak.py
@@ -22,7 +22,7 @@ def run(test, params, env):
     session = vm.wait_for_login()
 
     error_context.context(
-        "Check if the driver is installed and " "verified", test.log.info
+        "Check if the driver is installed and verified", test.log.info
     )
     session = utils_test.qemu.windrv_check_running_verifier(
         session, vm, test, params["driver_name"]

--- a/qemu/tests/qcow2perf.py
+++ b/qemu/tests/qcow2perf.py
@@ -83,7 +83,7 @@ def run(test, params, env):
         output = process.run(iocmd1, shell=True)
 
     error_context.context(
-        "Do one operations to the image and " "measure the time", test.log.info
+        "Do one operations to the image and measure the time", test.log.info
     )
 
     if op_type == "read":

--- a/qemu/tests/qemu_disk_img.py
+++ b/qemu/tests/qemu_disk_img.py
@@ -137,7 +137,7 @@ class QemuImgTest(qemu_storage.QemuImg):
     def check_file(self, dst, md5):
         error_context.context("check file('%s') md5sum in guest" % dst, LOG_JOB.info)
         if md5 != self.__md5sum(dst):
-            err = "Md5 value does not match. " "Expected value: %s Actual value: %s" % (
+            err = "Md5 value does not match. Expected value: %s Actual value: %s" % (
                 md5,
                 self.__md5sum(dst),
             )
@@ -246,6 +246,6 @@ def generate_base_snapshot_pair(image_chain):
     image_chain = image_chain.split()
     n = len(image_chain)
     if n < 2:
-        raise ValueError("Image_chain should contain at" "least 2 items, got %s." % n)
+        raise ValueError("Image_chain should contain atleast 2 items, got %s." % n)
     for i in range(1, n):
         yield [image_chain[i - 1], image_chain[i]]

--- a/qemu/tests/qemu_disk_img_snapshot.py
+++ b/qemu/tests/qemu_disk_img_snapshot.py
@@ -42,7 +42,7 @@ def run(test, params, env):
     output = snapshot_test.snapshot_list()
     if snapshot_tag not in output:
         raise exceptions.TestFail(
-            "Snapshot created failed or missed;" "snapshot list is: \n%s" % output
+            "Snapshot created failed or missed;snapshot list is: \n%s" % output
         )
 
     test.log.info("Step3. change tmp file before apply snapshot")

--- a/qemu/tests/qemu_guest_agent.py
+++ b/qemu/tests/qemu_guest_agent.py
@@ -129,7 +129,7 @@ class QemuGuestAgentTest(BaseVirtTest):
         s, o = session.cmd_status_output(cmd_check_pkg)
         if s == 0 and self.params.get("os_variant", "") == "rhel8":
             error_context.context(
-                "Check if the installed pkg is the specific" " one for rhel8 guest.",
+                "Check if the installed pkg is the specific one for rhel8 guest.",
                 LOG_JOB.info,
             )
             version_list = []
@@ -143,7 +143,7 @@ class QemuGuestAgentTest(BaseVirtTest):
                         version_list.append(qga_v[0])
                 self.qga_v = version_list[-1]
                 LOG_JOB.info(
-                    "The installed and the specific pkg " "version is %s", version_list
+                    "The installed and the specific pkg version is %s", version_list
                 )
             if len(version_list) < 2:
                 self.test.error(
@@ -212,11 +212,11 @@ class QemuGuestAgentTest(BaseVirtTest):
         s_inst, o_inst = session.cmd_status_output(self.gagent_install_cmd)
         if s_inst != 0:
             self.test.fail(
-                "qemu-guest-agent install failed," " the detailed info:\n%s." % o_inst
+                "qemu-guest-agent install failed, the detailed info:\n%s." % o_inst
             )
         if self.params.get("os_variant", "") == "rhel8" and s_check == 0:
             error_context.context(
-                "A new pkg is installed, so restart" " qemu-guest-agent service.",
+                "A new pkg is installed, so restart qemu-guest-agent service.",
                 LOG_JOB.info,
             )
             restart_cmd = self.params["gagent_restart_cmd"]
@@ -257,8 +257,7 @@ class QemuGuestAgentTest(BaseVirtTest):
         # for windows guest,return code is not zero
         if s and "already been started" not in o:
             self.test.fail(
-                "Could not start qemu-ga service in VM '%s',"
-                "detail: '%s'" % (vm.name, o)
+                "Could not start qemu-ga service in VM '%s',detail: '%s'" % (vm.name, o)
             )
 
     @error_context.context_aware
@@ -275,8 +274,7 @@ class QemuGuestAgentTest(BaseVirtTest):
         # for windows guest,return code is not zero.
         if s and "is not started" not in o:
             self.test.fail(
-                "Could not stop qemu-ga service in VM '%s', "
-                "detail: '%s'" % (vm.name, o)
+                "Could not stop qemu-ga service in VM '%s', detail: '%s'" % (vm.name, o)
             )
 
     @error_context.context_aware
@@ -306,9 +304,7 @@ class QemuGuestAgentTest(BaseVirtTest):
         error_context.context("Check if guest agent work.", LOG_JOB.info)
 
         if not self.gagent:
-            self.test.error(
-                "Could not find guest agent object " "for VM '%s'" % vm.name
-            )
+            self.test.error("Could not find guest agent object for VM '%s'" % vm.name)
         self.gagent.verify_responsive()
         LOG_JOB.info(self.gagent.cmd("guest-info"))
 
@@ -333,9 +329,7 @@ class QemuGuestAgentTest(BaseVirtTest):
         get_sebool_cmd = params["getsebool_cmd"]
         value_selinux_bool_guest = session.cmd_output(get_sebool_cmd).strip()
         if value_selinux_bool_guest != value:
-            self.test.error(
-                "Set boolean virt_qemu_ga_read_nonsecurity_files " "failed."
-            )
+            self.test.error("Set boolean virt_qemu_ga_read_nonsecurity_files failed.")
 
     @error_context.context_aware
     def log_persistence(self, params, session):
@@ -353,7 +347,7 @@ class QemuGuestAgentTest(BaseVirtTest):
             self._open_session_list.append(session)
             if self.params.get("os_variant", "") == "rhel8":
                 error_context.context(
-                    "Get the qemu-guest-agent pkg" " for rhel8 guest.", LOG_JOB.info
+                    "Get the qemu-guest-agent pkg for rhel8 guest.", LOG_JOB.info
                 )
                 cmd_check_qga_installlog = params["cmd_check_qga_installlog"]
                 s, o = session.cmd_status_output(cmd_check_qga_installlog)
@@ -608,8 +602,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             try:
                 if "core-dump" in output:
                     test.fail(
-                        "Guest-agent aborts after guest-shutdown"
-                        " detail: '%s'" % output
+                        "Guest-agent aborts after guest-shutdown detail: '%s'" % output
                     )
             finally:
                 session.cmd("rm -rf %s" % params["journal_file"])
@@ -636,7 +629,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             session = self._get_session(self.params, None)
             session.close()
         except Exception as detail:
-            test.fail("Could not login to guest" " detail: '%s'" % detail)
+            test.fail("Could not login to guest detail: '%s'" % detail)
 
     @error_context.context_aware
     def gagent_check_halt(self, test, params, env):
@@ -658,7 +651,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             self.vm.destroy(gracefully=False)
         except Exception as detail:
             LOG_JOB.warning(
-                "Got an exception when force destroying guest:" " '%s'", detail
+                "Got an exception when force destroying guest: '%s'", detail
             )
 
     @error_context.context_aware
@@ -743,11 +736,9 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                             " isn't aligned with what it's in guest."
                         )
                 if vcpu["logical-id"] != 0 and vcpu["can-offline"] is False:
-                    test.fail("The vcpus should be able to offline " "except vcpu0.")
+                    test.fail("The vcpus should be able to offline except vcpu0.")
             if params.get("os_type") == "windows" and vcpu["can-offline"]:
-                test.fail(
-                    "All vcpus should not be able to offline in" " windows guest."
-                )
+                test.fail("All vcpus should not be able to offline in windows guest.")
 
         error_context.context("Check cpu number.", LOG_JOB.info)
         output = session.cmd_output(params["get_cpu_cmd"])
@@ -843,13 +834,12 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         session.cmd(cmd_offline_mem % mem_phys_index)
 
         error_context.context(
-            "Verify it's changed to offline status via" " agent.", LOG_JOB.info
+            "Verify it's changed to offline status via agent.", LOG_JOB.info
         )
         mem_blocks = self.gagent.get_memory_blocks()
         if mem_blocks[mem_list_index]["online"] is not False:
             test.fail(
-                "%s phys-index memory block is still online"
-                " via agent." % mem_phys_index
+                "%s phys-index memory block is still online via agent." % mem_phys_index
             )
 
         error_context.context("Verify the memory block unit size.", LOG_JOB.info)
@@ -863,7 +853,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             )
 
         error_context.context(
-            "Offline some memory blocks which can be" " offline via agent.",
+            "Offline some memory blocks which can be offline via agent.",
             LOG_JOB.info,
         )
         # record the memory blocks which will be offline
@@ -886,7 +876,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         if mem_blocks_list is not None:
             self.gagent.set_memory_blocks(mem_blocks_list)
             error_context.context(
-                "Verify memory size is decreased after" " offline.", LOG_JOB.info
+                "Verify memory size is decreased after offline.", LOG_JOB.info
             )
             mem_size = session.cmd_output(cmd_get_mem)
             mem_size_aft_offline_qga = mem_size.strip().split()[1]
@@ -903,7 +893,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             )
 
         error_context.context(
-            "Recovery the memory blocks which are set to" " offline before.",
+            "Recovery the memory blocks which are set to offline before.",
             LOG_JOB.info,
         )
         # record the memory blocks which will be online
@@ -925,7 +915,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             )
 
         error_context.context(
-            "Offline one memory block which can't be" " offline.", LOG_JOB.info
+            "Offline one memory block which can't be offline.", LOG_JOB.info
         )
         mem_blocks = self.gagent.get_memory_blocks()
         for memory in mem_blocks:
@@ -934,8 +924,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 break
         else:
             LOG_JOB.info(
-                "There is no required memory block that can-offline"
-                " attribute is False."
+                "There is no required memory block that can-offline attribute is False."
             )
             return
         mem_blocks_list = [
@@ -1106,7 +1095,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             session.cmd(time_service_start_cmd)
 
         error_context.context(
-            "Config time resource and restart time" " service.", LOG_JOB.info
+            "Config time resource and restart time service.", LOG_JOB.info
         )
         session.cmd(time_config_cmd)
         session.cmd(time_service_stop_cmd)
@@ -1157,7 +1146,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             return memory_usage
         except Exception:
             raise exceptions.TestError(
-                "Get invalid memory usage by " "cmd '%s' (%s)" % (cmd, output)
+                "Get invalid memory usage by cmd '%s' (%s)" % (cmd, output)
             )
 
     @error_context.context_aware
@@ -1258,7 +1247,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 return genio.read_one_line(path).strip()
             except IOError:
                 LOG_JOB.warning(
-                    "could not get bitmap info, path '%s' is " "not exist", path
+                    "could not get bitmap info, path '%s' is not exist", path
                 )
             return ""
 
@@ -1348,8 +1337,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
 
         if total_block_after_trim > total_block_before_trim:
             test.fail(
-                "the bitmap_after_trim is lager, the command"
-                "guest-fstrim may not work"
+                "the bitmap_after_trim is lager, the commandguest-fstrim may not work"
             )
         if self.vm:
             self.vm.destroy()
@@ -1506,8 +1494,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             status = process.system(params["ssh_keygen_cmd"], shell=True)
             if status:
                 test.error(
-                    "Can not generate ssh key with no "
-                    "interaction, please have a check."
+                    "Can not generate ssh key with no interaction, please have a check."
                 )
             cmd_get_hostkey = params["cmd_get_hostkey"]
             host_key = process.getoutput(cmd_get_hostkey)
@@ -1543,8 +1530,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             for keys_ga in keys_ga_list:
                 if keys_ga not in keys_guest:
                     test.fail(
-                        "Key %s is not same with guest, "
-                        "%s ssh keys failed." % keys_ga,
+                        "Key %s is not same with guest, %s ssh keys failed." % keys_ga,
                         status,
                     )
 
@@ -1579,9 +1565,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         keys_qga, keys_guest = ssh_key_test("remove", guest_user, host_key1, host_key3)
         for key in [host_key1, host_key3]:
             if key in keys_guest.replace("\n", ","):
-                test.fail(
-                    "Key %s is still in guest," "Can not remove key in guest." % key
-                )
+                test.fail("Key %s is still in guest,Can not remove key in guest." % key)
         _login_guest_test(guest_ip_ipv4)
 
         error_context.context("Check whether can reset keys", LOG_JOB.info)
@@ -1608,7 +1592,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self._open_session_list.append(session)
 
         error_context.context(
-            "Check cpustats info of guest and " "number of cpus.", LOG_JOB.info
+            "Check cpustats info of guest and number of cpus.", LOG_JOB.info
         )
         cs_info_qga = self.gagent.get_cpustats()
         cpu_num_guest = int(session.cmd_output(params["cpu_num_guest"]))
@@ -1660,7 +1644,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         key_list = params["diskstats_info_list"].split(",")
         num_arg_def = len(list(key_list))
         if num_arg_guest != num_arg_def:
-            test.error("Diskstats argument numbers may change, " "please take a look.")
+            test.error("Diskstats argument numbers may change, please take a look.")
 
         disk_num_qga = 0
         improper_list = []
@@ -1698,7 +1682,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             disk_num_qga += 1
 
         error_context.context(
-            "Check diskstats arguments whether are " "corresponding.", LOG_JOB.info
+            "Check diskstats arguments whether are corresponding.", LOG_JOB.info
         )
         if improper_list:
             test.fail("Diskstats info is not totally correct: %s" % improper_list)
@@ -1801,18 +1785,18 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         os_type = self.params["os_type"]
 
         error_context.context(
-            "Get the available interface name via" " guest-network-get-interfaces cmd.",
+            "Get the available interface name via guest-network-get-interfaces cmd.",
             LOG_JOB.info,
         )
         ret = self.gagent.get_network_interface()
         if_name, if_index = get_interface(ret, mac_addr)
         if not if_name:
             test.fail(
-                "Did not get the expected interface," " the network info is \n%s." % ret
+                "Did not get the expected interface, the network info is \n%s." % ret
             )
 
         error_context.context(
-            "Check the available interface name %s" " via qga." % if_name, LOG_JOB.info
+            "Check the available interface name %s via qga." % if_name, LOG_JOB.info
         )
         if os_type == "linux":
             if_name_guest = utils_net.get_linux_ifname(session_serial, mac_addr)
@@ -1835,7 +1819,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         #  from guest agent
         if os_type == "linux":
             error_context.context(
-                "Create a new bridge in guest and check the" "result from qga.",
+                "Create a new bridge in guest and check theresult from qga.",
                 LOG_JOB.info,
             )
             add_brige_cmd = "ip link add name br0 type bridge"
@@ -1865,7 +1849,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             session_serial.cmd(self.params["cmd_enable_network"] % if_name)
 
         error_context.context(
-            "Change ipv4 address and check the result " "from qga.", LOG_JOB.info
+            "Change ipv4 address and check the result from qga.", LOG_JOB.info
         )
         # for linux guest, need to delete ip address first
         if os_type == "linux":
@@ -2098,9 +2082,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                             "This is not the desired information: ('%s')" % str(detail)
                         )
                 else:
-                    test.fail(
-                        "agent shutdown command shouldn't succeed for " "freeze FS"
-                    )
+                    test.fail("agent shutdown command shouldn't succeed for freeze FS")
         finally:
             try:
                 gagent.fsthaw(check_status=False)
@@ -2225,7 +2207,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param env: Dictionary with test environment.
         """
         error_context.context(
-            "Change guest-file related cmd to white list" " and get guest file name."
+            "Change guest-file related cmd to white list and get guest file name."
         )
         session, tmp_file = self._guest_file_prepare()
 
@@ -2236,7 +2218,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self.gagent.guest_file_flush(ret_handle)
 
         error_context.context(
-            "Seek to one position and read file with " "file-seek/read cmd.",
+            "Seek to one position and read file with file-seek/read cmd.",
             LOG_JOB.info,
         )
         self.gagent.guest_file_seek(ret_handle, 0, 0)
@@ -2247,7 +2229,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self._read_check(ret_handle, "he", 2)
 
         LOG_JOB.info(
-            "Seek the position to file beginning, offset is 2, and " "read 2 bytes."
+            "Seek the position to file beginning, offset is 2, and read 2 bytes."
         )
         self.gagent.guest_file_seek(ret_handle, 2, 0)
         self._read_check(ret_handle, "ll", 2)
@@ -2256,9 +2238,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self.gagent.guest_file_seek(ret_handle, 2, 1)
         self._read_check(ret_handle, "world", 5)
 
-        LOG_JOB.info(
-            "Seek from the file end position, offset is -5 and " "read 3 byte."
-        )
+        LOG_JOB.info("Seek from the file end position, offset is -5 and read 3 byte.")
         self.gagent.guest_file_seek(ret_handle, -5, 2)
         self._read_check(ret_handle, "orl", 3)
 
@@ -2283,12 +2263,12 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param env: Dictionary with test environment.
         """
         error_context.context(
-            "Change guest-file related cmd to white list" " and get guest file name."
+            "Change guest-file related cmd to white list and get guest file name."
         )
         session, tmp_file = self._guest_file_prepare()
 
         error_context.context(
-            "Create new file with mode 'w' and do file" " write test", LOG_JOB.info
+            "Create new file with mode 'w' and do file write test", LOG_JOB.info
         )
         ret_handle = int(self.gagent.guest_file_open(tmp_file, mode="w+"))
         content = "hello world\n"
@@ -2303,7 +2283,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             self._read_check(ret_handle, content_check)
 
         error_context.context(
-            "Write more than all counts bytes to" " guest file.", LOG_JOB.info
+            "Write more than all counts bytes to guest file.", LOG_JOB.info
         )
         try:
             self.gagent.guest_file_write(ret_handle, content, 15)
@@ -2358,7 +2338,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                     )
 
         error_context.context(
-            "Change guest-file related cmd to white list" " and get guest file name."
+            "Change guest-file related cmd to white list and get guest file name."
         )
         session, tmp_file = self._guest_file_prepare()
         content = "helloworld\n"
@@ -2367,12 +2347,12 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         cmd_create_file = "echo helloworld > %s" % tmp_file
         session.cmd(cmd_create_file)
         error_context.context(
-            "Open guest file via guest-file-open with" " read only mode.", LOG_JOB.info
+            "Open guest file via guest-file-open with read only mode.", LOG_JOB.info
         )
         # default is read mode
         ret_handle = int(self.gagent.guest_file_open(tmp_file))
         error_context.context(
-            "Read the content and check the result via" " guest-file cmd", LOG_JOB.info
+            "Read the content and check the result via guest-file cmd", LOG_JOB.info
         )
         self._read_check(ret_handle, content)
         self.gagent.guest_file_close(ret_handle)
@@ -2382,7 +2362,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self.vm.copy_files_to("/tmp/big_file", tmp_file)
 
         error_context.context(
-            "Open the big guest file via guest-file-open with" " read only mode.",
+            "Open the big guest file via guest-file-open with read only mode.",
             LOG_JOB.info,
         )
         ret_handle = int(self.gagent.guest_file_open(tmp_file))
@@ -2415,8 +2395,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             except guest_agent.VAgentCmdError as detail:
                 if not re.search("invalid for argument count", str(detail)):
                     test.fail(
-                        "Return error but is not the desired info: "
-                        "('%s')" % str(detail)
+                        "Return error but is not the desired info: ('%s')" % str(detail)
                     )
                 else:
                     LOG_JOB.info(
@@ -2428,7 +2407,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 test.fail("Did not get the expected result.")
 
         error_context.context(
-            "Read the file with an valid big count" " number.", LOG_JOB.info
+            "Read the file with an valid big count number.", LOG_JOB.info
         )
         self.gagent.guest_file_seek(ret_handle, 0, 0)
         # if guest os resource is enough, will return no error.
@@ -2451,9 +2430,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             res_linux = "No such file or directory"
             res_windows = "system cannot find the file"
             if res_windows not in str(detail) and res_linux not in str(detail):
-                test.fail(
-                    "This is not the desired information: " "('%s')" % str(detail)
-                )
+                test.fail("This is not the desired information: ('%s')" % str(detail))
         else:
             test.fail("Should not pass with none existing file.")
 
@@ -2475,7 +2452,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param env: Dictionary with test environment.
         """
         error_context.context(
-            "Change guest-file related cmd to white list" " and get guest file name."
+            "Change guest-file related cmd to white list and get guest file name."
         )
         session, tmp_file = self._guest_file_prepare()
 
@@ -2487,18 +2464,14 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         except guest_agent.VAgentCmdError as detail:
             if not re.search("guest-file-open has been disabled", str(detail)):
                 self.test.fail(
-                    "This is not the desired information: " "('%s')" % str(detail)
+                    "This is not the desired information: ('%s')" % str(detail)
                 )
         else:
-            self.test.fail(
-                "guest-file-open command shouldn't succeed " "for freeze FS."
-            )
+            self.test.fail("guest-file-open command shouldn't succeed for freeze FS.")
         finally:
             self.gagent.fsthaw()
 
-        error_context.context(
-            "After thaw fs, try to operate guest" " file.", LOG_JOB.info
-        )
+        error_context.context("After thaw fs, try to operate guest file.", LOG_JOB.info)
         ret_handle = int(self.gagent.guest_file_open(tmp_file, mode="a+"))
         self.gagent.guest_file_write(ret_handle, content)
         self.gagent.guest_file_flush(ret_handle)
@@ -2607,20 +2580,20 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self._change_bl(session)
 
         error_context.context(
-            "Create and write content to temp file and" " non temp file.", LOG_JOB.info
+            "Create and write content to temp file and non temp file.", LOG_JOB.info
         )
         session.cmd("echo 'hello world' > %s" % guest_temp_file)
         session.cmd("echo 'hello world' > %s" % guest_file)
 
         error_context.context(
-            "Set selinux policy to 'Enforcing' mode in" " guest.", LOG_JOB.info
+            "Set selinux policy to 'Enforcing' mode in guest.", LOG_JOB.info
         )
         if session.cmd_output("getenforce").strip() != "Enforcing":
             session.cmd("setenforce 1")
         result_check_enforcing()
 
         error_context.context(
-            "Set selinux policy to 'Permissive' mode in" " guest.", LOG_JOB.info
+            "Set selinux policy to 'Permissive' mode in guest.", LOG_JOB.info
         )
         session.cmd("setenforce 0")
         result_check_permissive()
@@ -2699,30 +2672,26 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                             out_data,
                         )
                     elif "err-data" in result:
-                        test.fail(
-                            "When exitcode is 0, should not return" " error data."
-                        )
+                        test.fail("When exitcode is 0, should not return error data.")
                     else:
                         test.fail("There is no output with capture_output is true.")
                 else:
                     if "out-data" in result:
-                        test.fail(
-                            "When exitcode is 1, should not return" " output data."
-                        )
+                        test.fail("When exitcode is 1, should not return output data.")
                     elif "err-data" in result:
                         err_data = base64.b64decode(result["err-data"]).decode()
                         LOG_JOB.info(
-                            "The guest cmd failed," "the error info is:\n%s", err_data
+                            "The guest cmd failed,the error info is:\n%s", err_data
                         )
                     else:
-                        test.fail("There is no output with capture_output is " "true.")
+                        test.fail("There is no output with capture_output is true.")
             else:
                 # for windows guest,no matter what exitcode is,
                 #  the return key is out-data
                 if "out-data" in result:
                     out_data = base64.b64decode(result["out-data"]).decode()
                     LOG_JOB.info(
-                        "The guest cmd is executed successfully," "the output is:\n%s.",
+                        "The guest cmd is executed successfully,the output is:\n%s.",
                         out_data,
                     )
                 else:
@@ -2891,9 +2860,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 self.gagent.fsthaw(check_status=False)
             except Exception as detail:
                 # Ignore exception for this thaw action.
-                LOG_JOB.warning(
-                    "Finally failed to thaw guest fs," " detail: '%s'", detail
-                )
+                LOG_JOB.warning("Finally failed to thaw guest fs, detail: '%s'", detail)
             raise
         # check after fsthaw
         self._action_after_fsthaw(write_cmd_guest, write_cmd_timeout)
@@ -2967,9 +2934,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 120,
             )
             if disk_index:
-                LOG_JOB.info(
-                    "Clear readonly for disk and online it in" " windows guest."
-                )
+                LOG_JOB.info("Clear readonly for disk and online it in windows guest.")
                 if not utils_disk.update_windows_disk_attributes(session, disk_index):
                     test.error("Failed to update windows disk attributes.")
                 mnt_point_data = utils_disk.configure_empty_disk(
@@ -2995,7 +2960,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             self._fsfreeze(fsfreeze_list=True, mountpoints=mpoint)
 
         error_context.context(
-            "Freeze fs with one valid mountpoint and" " one invalid mountpoint.",
+            "Freeze fs with one valid mountpoint and one invalid mountpoint.",
             LOG_JOB.info,
         )
         if params.get("os_type") == "linux":
@@ -3188,7 +3153,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 )
                 if disk_index:
                     LOG_JOB.info(
-                        "Clear readonly for disk and online it in " "windows guest."
+                        "Clear readonly for disk and online it in windows guest."
                     )
                     if not utils_disk.update_windows_disk_attributes(
                         session, disk_index
@@ -3213,8 +3178,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                         "fsfreeze is limited up to 10 seconds", str(detail)
                     ):
                         test.error(
-                            "guest-fsfreeze-thaw cmd failed with:"
-                            "('%s')" % str(detail)
+                            "guest-fsfreeze-thaw cmd failed with:('%s')" % str(detail)
                         )
             self.vm.verify_alive()
             if params.get("os_type") == "linux":
@@ -3236,13 +3200,13 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         self.gagent_start(session, self.vm)
 
         error_context.context(
-            "Get the default path of fsfreeze-hook in" " qemu-ga help.", LOG_JOB.info
+            "Get the default path of fsfreeze-hook in qemu-ga help.", LOG_JOB.info
         )
         s, o = session.cmd_status_output(params["cmd_get_help_info"])
         help_cmd_hook_path = o.strip().replace(")", "").split()[-1]
 
         error_context.context(
-            "Get the default path of fsfreeze-hook in" " man page.", LOG_JOB.info
+            "Get the default path of fsfreeze-hook in man page.", LOG_JOB.info
         )
         LOG_JOB.info("Export qemu-ga man page to guest file.")
         qga_man_file = "/tmp/man_file"
@@ -3292,8 +3256,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             hook_log = session.cmd_output("cat %s" % log_path)
             if msg not in hook_log.strip().splitlines()[-2]:
                 test.fail(
-                    "Fsfreeze hook test failed\nthe fsfreeze"
-                    " hook log is %s." % hook_log
+                    "Fsfreeze hook test failed\nthe fsfreeze hook log is %s." % hook_log
                 )
 
         session = self._get_session(self.params, None)
@@ -3309,15 +3272,13 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         if "rhel" in os_ver and int(re.findall(pattern, os_ver)[0]) <= 8:
             expect_file_nums = 5
         if len(hook_files.strip().split()) < expect_file_nums:
-            test.fail(
-                "Fsfreeze hook files are missed, the output is" " %s" % hook_files
-            )
+            test.fail("Fsfreeze hook files are missed, the output is %s" % hook_files)
 
         error_context.context(
-            "Checking fsfreeze hook path set in config" " file.", LOG_JOB.info
+            "Checking fsfreeze hook path set in config file.", LOG_JOB.info
         )
         config_file = "/etc/sysconfig/qemu-ga"
-        cmd_get_hook_path = "cat %s | grep" " ^FSFREEZE_HOOK_PATHNAME" % config_file
+        cmd_get_hook_path = "cat %s | grep ^FSFREEZE_HOOK_PATHNAME" % config_file
         o_path = session.cmd_output(cmd_get_hook_path)
         hook_path = o_path.strip().split("=")[1]
 
@@ -3329,7 +3290,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             )
 
         error_context.context(
-            "Checking if agent service is using the" " fsfreeze hook.", LOG_JOB.info
+            "Checking if agent service is using the fsfreeze hook.", LOG_JOB.info
         )
         cmd_get_hook = "ps aux |grep /usr/bin/qemu-ga |grep fsfreeze-hook"
         hook_path_info = session.cmd_output(cmd_get_hook).strip()
@@ -3359,23 +3320,23 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             )
 
         error_context.context(
-            "Create a simple script to verify fsfreeze" " hook.", LOG_JOB.info
+            "Create a simple script to verify fsfreeze hook.", LOG_JOB.info
         )
         cmd_get_user_path = (
-            "rpm -ql qemu-guest-agent |grep fsfreeze-hook.d" " |grep -v /usr/share"
+            "rpm -ql qemu-guest-agent |grep fsfreeze-hook.d |grep -v /usr/share"
         )
         output = session.cmd_output(cmd_get_user_path)
         user_script_path = output.strip().split("\n")[-1]
         user_script_path += "/user_script.sh"
 
         cmd_create_script = (
-            "echo \"printf 'testing %%s:%%s\\n' \\$0 \\$@\"" " > %s" % user_script_path
+            "echo \"printf 'testing %%s:%%s\\n' \\$0 \\$@\" > %s" % user_script_path
         )
         session.cmd(cmd_create_script)
         session.cmd("chmod +x %s" % user_script_path)
 
         error_context.context(
-            "Issue fsfreeze and thaw commands and check" " logs.", LOG_JOB.info
+            "Issue fsfreeze and thaw commands and check logs.", LOG_JOB.info
         )
         cmd_get_log_path = "cat %s |grep ^LOGFILE" % hook_path
         log_path = session.cmd_output(cmd_get_log_path).strip().split("=")[-1]
@@ -3439,14 +3400,14 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                         )
 
         error_context.context(
-            "Execute query-chardev when guest agent service " "is on", LOG_JOB.info
+            "Execute query-chardev when guest agent service is on", LOG_JOB.info
         )
         out = self.vm.monitor.query("chardev")
         check_value_frontend_open(out, True)
         session = self._get_session(params, self.vm)
         self.gagent_stop(session, self.vm)
         error_context.context(
-            "Execute query-chardev when guest agent service " "is off", LOG_JOB.info
+            "Execute query-chardev when guest agent service is off", LOG_JOB.info
         )
         out = self.vm.monitor.query("chardev")
         check_value_frontend_open(out, False)
@@ -3494,19 +3455,17 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             self.gagent.fsfreeze()
         except guest_agent.VAgentCmdError as detail:
             if not re.search(
-                "timeout when try to receive Frozen event from" " VSS provider",
+                "timeout when try to receive Frozen event from VSS provider",
                 str(detail),
             ):
-                test.fail(
-                    "guest-fsfreeze-freeze cmd failed with:" "('%s')" % str(detail)
-                )
+                test.fail("guest-fsfreeze-freeze cmd failed with:('%s')" % str(detail))
         if self.gagent.verify_fsfreeze_status(self.gagent.FSFREEZE_STATUS_FROZEN):
             try:
                 self.gagent.fsthaw(check_status=False)
             except guest_agent.VAgentCmdError as detail:
                 if not re.search("fsfreeze is limited up to 10 seconds", str(detail)):
                     test.error(
-                        "guest-fsfreeze-thaw cmd failed with:" "('%s')" % str(detail)
+                        "guest-fsfreeze-thaw cmd failed with:('%s')" % str(detail)
                     )
 
         self.gagent_verify(self.params, self.vm)
@@ -3564,9 +3523,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             self.gagent.fsthaw()
         except guest_agent.VAgentCmdError as detail:
             if not re.search("fsfreeze is limited up to 10 seconds", str(detail)):
-                test.error(
-                    "guest-fsfreeze-thaw cmd failed with:" "('%s')" % str(detail)
-                )
+                test.error("guest-fsfreeze-thaw cmd failed with:('%s')" % str(detail))
 
     @error_context.context_aware
     def gagent_check_fsinfo(self, test, params, env):
@@ -3623,7 +3580,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 else:
                     # Disk 'C:' and '/' used space usage have a floating interval,
                     # so set a safe value '10485760'.
-                    LOG_JOB.info("Need to check the floating interval for C: " "or /.")
+                    LOG_JOB.info("Need to check the floating interval for C: or /.")
                     if diff_used_qgaguest > 10485760:
                         test.fail(
                             "File System floating interval is too large,"
@@ -3721,7 +3678,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         session = self._get_session(params, None)
         self._open_session_list.append(session)
         error_context.context(
-            "Issue the no existed guest-agent " "cmd via qga.", LOG_JOB.info
+            "Issue the no existed guest-agent cmd via qga.", LOG_JOB.info
         )
         cmd_wrong = params["wrong_cmd"]
         try:
@@ -3730,7 +3687,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             pattern = "command %s has not been found" % cmd_wrong
             if not re.search(pattern, str(detail), re.I):
                 test.fail(
-                    "The error info is not correct, the return is" " %s." % str(detail)
+                    "The error info is not correct, the return is %s." % str(detail)
                 )
         else:
             test.fail("Should return error info.")
@@ -3757,7 +3714,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             log_str = session.cmd_output(get_log_cmd).strip().split("\n")[-1]
             pattern = r"%s" % qga_cmd
             if not re.findall(pattern, log_str, re.M | re.I):
-                test.fail("The %s command is not recorded in agent" " log." % qga_cmd)
+                test.fail("The %s command is not recorded in agent log." % qga_cmd)
 
         get_log_cmd = params["get_log_cmd"]
         session = self._get_session(self.params, self.vm)
@@ -3790,12 +3747,12 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         :param env: Dictionary with test environment.
         """
         error_context.context(
-            "Migrate guest while guest agent service is" " running.", LOG_JOB.info
+            "Migrate guest while guest agent service is running.", LOG_JOB.info
         )
         qemu_migration.set_speed(self.vm, params.get("mig_speed", "1G"))
         self.vm.migrate()
         error_context.context(
-            "Recreate a QemuAgent object after vm" " migration.", LOG_JOB.info
+            "Recreate a QemuAgent object after vm migration.", LOG_JOB.info
         )
         self.gagent = None
         args = [params.get("gagent_serial_type"), params.get("gagent_name")]
@@ -3858,9 +3815,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 120,
             )
             if disk_index:
-                LOG_JOB.info(
-                    "Clear readonly for disk and online it in windows" " guest."
-                )
+                LOG_JOB.info("Clear readonly for disk and online it in windows guest.")
                 if not utils_disk.update_windows_disk_attributes(session, disk_index):
                     test.error("Failed to update windows disk attributes.")
                 mnt_point = utils_disk.configure_empty_disk(
@@ -3884,17 +3839,13 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 try:
                     session.cmd("umount %s" % mnt_point[0])
                 except ShellTimeoutError:
-                    LOG_JOB.info(
-                        "For rhel6 guest, umount fs will fail after" " fsfreeze."
-                    )
+                    LOG_JOB.info("For rhel6 guest, umount fs will fail after fsfreeze.")
                 else:
-                    test.error(
-                        "For rhel6 guest, umount fs should fail after" " fsfreeze."
-                    )
+                    test.error("For rhel6 guest, umount fs should fail after fsfreeze.")
             else:
                 if not utils_disk.umount(src, mnt_point[0], session=session):
                     test.fail(
-                        "For rhel7+ guest, umount fs should success" " after fsfreeze."
+                        "For rhel7+ guest, umount fs should success after fsfreeze."
                     )
         else:
             detail_cmd = " echo detail disk"
@@ -3910,7 +3861,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                     offline_cmd % did, timeout=120
                 )
                 if status != 0:
-                    test.fail("Can not offline disk: %s with" " fsfreeze." % output)
+                    test.fail("Can not offline disk: %s with fsfreeze." % output)
 
         error_context.context("Thaw fs.", LOG_JOB.info)
         try:
@@ -3925,13 +3876,11 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 if not utils_disk.mount(src, mnt_point[0], session=session):
                     if params["os_variant"] != "rhel6":
                         test.fail(
-                            "For rhel7+ guest, mount fs should success" " after fsthaw."
+                            "For rhel7+ guest, mount fs should success after fsthaw."
                         )
                 else:
                     if params["os_variant"] == "rhel6":
-                        test.fail(
-                            "For rhel6 guest, mount fs should fail after" " fsthaw."
-                        )
+                        test.fail("For rhel6 guest, mount fs should fail after fsthaw.")
             finally:
                 self.gagent_setsebool_value("off", params, self.vm)
         else:
@@ -3992,16 +3941,15 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
                 if re.search("%s has been disabled" % qga_cmd, str(detail)):
                     LOG_JOB.info("%s cmd is disabled.", qga_cmd)
                 else:
-                    test.fail("%s cmd failed with:" "('%s')" % (qga_cmd, str(detail)))
+                    test.fail("%s cmd failed with:('%s')" % (qga_cmd, str(detail)))
             else:
-                test.fail("%s cmd is not in blacklist," " pls have a check." % qga_cmd)
+                test.fail("%s cmd is not in blacklist, pls have a check." % qga_cmd)
 
         session = self._get_session(params, None)
         self._open_session_list.append(session)
 
         error_context.context(
-            "Try to execute guest-file-open command which"
-            " is in blacklist by default.",
+            "Try to execute guest-file-open command which is in blacklist by default.",
             LOG_JOB.info,
         )
 
@@ -4010,13 +3958,13 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
         bl_check("guest-file-open")
 
         error_context.context(
-            "Try to execute guest-info command which is" " not in blacklist.",
+            "Try to execute guest-info command which is not in blacklist.",
             LOG_JOB.info,
         )
         self.gagent.cmd("guest-info")
 
         error_context.context(
-            "Change command in blacklist and restart" " agent service.", LOG_JOB.info
+            "Change command in blacklist and restart agent service.", LOG_JOB.info
         )
         session.cmd("cp /etc/sysconfig/qemu-ga /etc/sysconfig/qemu-ga-bk")
         full_qga_ver = self._get_qga_version(session, self.vm, main_ver=False)
@@ -4040,7 +3988,7 @@ class QemuGuestAgentBasicCheck(QemuGuestAgentTest):
             session.cmd(params["gagent_restart_cmd"])
 
             error_context.context(
-                "Try to execute guest-file-open and " "guest-info commands again.",
+                "Try to execute guest-file-open and guest-info commands again.",
                 LOG_JOB.info,
             )
             ret_handle = int(self.gagent.guest_file_open(guest_file, mode="a+"))
@@ -4492,7 +4440,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
                         )
                     except AttributeError:
                         test.error(
-                            "Not supported virtio " "win media type '%s'", media_type
+                            "Not supported virtio win media type '%s'", media_type
                         )
                     vm_infos[chk_point] = get_content_func(session)
                     if not vm_infos[chk_point]:
@@ -4530,7 +4478,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
                     installed_any |= True
                 if not installed_any:
                     test.error(
-                        "Failed to find target devices " "by hwids: '%s'" % device_hwid
+                        "Failed to find target devices by hwids: '%s'" % device_hwid
                     )
 
     @error_context.context_aware
@@ -4580,7 +4528,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
                 )
 
             error_context.context(
-                "Download qemu-ga package from website " "and copy it to guest.",
+                "Download qemu-ga package from website and copy it to guest.",
                 LOG_JOB.info,
             )
             process.system(gagent_download_cmd)
@@ -4685,9 +4633,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
 
             error_context.context("Check disk name", LOG_JOB.info)
             if diskname.upper() != disk_info_guest[0].replace("\\", r"\\"):
-                test.fail(
-                    "Disk %s name is different " "between guest and qga." % diskname
-                )
+                test.fail("Disk %s name is different between guest and qga." % diskname)
 
     @error_context.context_aware
     def gagent_check_fsfreeze_vss_test(self, test, params, env):
@@ -4715,7 +4661,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
             Before freeze or thaw guest file system, start a background test.
             """
             LOG_JOB.info(
-                "Write time stamp to guest file per second " "as a background job."
+                "Write time stamp to guest file per second as a background job."
             )
             fswrite_cmd = utils_misc.set_winutils_letter(
                 session, self.params["gagent_fs_test_cmd"]
@@ -4739,7 +4685,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
             s, o = session.cmd_status_output(k_cmd)
             if s:
                 self.test.error(
-                    "Command '%s' failed, status: %s," " output: %s" % (k_cmd, s, o)
+                    "Command '%s' failed, status: %s, output: %s" % (k_cmd, s, o)
                 )
 
             error_context.context("Check guest FS status.", LOG_JOB.info)
@@ -4757,16 +4703,14 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
             for i in list(range(1, len(list_time))):
                 num_d = float(list_time[i]) - float(list_time[i - 1])
                 if num_d > 8:
-                    LOG_JOB.info(
-                        "Time stamp is not continuous," " so the FS is frozen."
-                    )
+                    LOG_JOB.info("Time stamp is not continuous, so the FS is frozen.")
                     fs_status = "frozen"
                     break
             if not fs_status == flag:
                 self.test.fail("FS is not %s, it's %s." % (flag, fs_status))
 
         error_context.context(
-            "Check guest agent command " "'guest-fsfreeze-freeze/thaw'", LOG_JOB.info
+            "Check guest agent command 'guest-fsfreeze-freeze/thaw'", LOG_JOB.info
         )
         session = self._get_session(self.params, None)
         self._open_session_list.append(session)
@@ -4781,7 +4725,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
             self.gagent.fsthaw(check_status=False)
 
         error_context.context(
-            "Before freeze/thaw the FS, run the background " "job.", LOG_JOB.info
+            "Before freeze/thaw the FS, run the background job.", LOG_JOB.info
         )
         background_start(session)
         error_context.context("Freeze the FS.", LOG_JOB.info)
@@ -4794,7 +4738,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
             result_check("frozen", write_timeout, session)
             # Next, thaw guest fs.
             error_context.context(
-                "Before freeze/thaw the FS, run the background " "job.", LOG_JOB.info
+                "Before freeze/thaw the FS, run the background job.", LOG_JOB.info
             )
             background_start(session)
             error_context.context("Thaw the FS.", LOG_JOB.info)
@@ -4805,7 +4749,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
                     LOG_JOB.info("FS is thaw as it's limited up to 10 seconds.")
                 else:
                     test.fail(
-                        "guest-fsfreeze-thaw cmd failed with:" "('%s')" % str(detail)
+                        "guest-fsfreeze-thaw cmd failed with:('%s')" % str(detail)
                     )
         except Exception:
             # Thaw fs finally, avoid problem in following cases.
@@ -4813,9 +4757,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
                 self.gagent.fsthaw(check_status=False)
             except Exception as detail:
                 # Ignore exception for this thaw action.
-                LOG_JOB.warning(
-                    "Finally failed to thaw guest fs," " detail: '%s'", detail
-                )
+                LOG_JOB.warning("Finally failed to thaw guest fs, detail: '%s'", detail)
             raise
         error_context.context(
             "Waiting %s, then finish writing the time "
@@ -4918,7 +4860,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
         def execute_qga_cmds_loop():
             for i in range(repeats):
                 if os.environ["AVCADO_TP_QEMU_GUEST_AGENT_SIGNAL"] == "True":
-                    LOG_JOB.info("execute 'get-osinfo/devices'" " %s times", (i + 1))
+                    LOG_JOB.info("execute 'get-osinfo/devices' %s times", (i + 1))
                     self.gagent.get_osinfo()
                     self.gagent.get_virtio_device()
                 else:
@@ -5032,8 +4974,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
         kill_qga_program_cmd = params["kill_qga_program_cmd"]
 
         error_context.context(
-            "Check qemu-ga service status and stop it, "
-            "then run qemu-ga as a program",
+            "Check qemu-ga service status and stop it, then run qemu-ga as a program",
             test.log.info,
         )
         if self._check_ga_service(session, params.get("gagent_status_cmd")):
@@ -5085,7 +5026,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
         qga_ver_installer = str(self.gagent.guest_info()["version"])
 
         error_context.context(
-            "Check if qga version is corresponding between" "msi and installer.exe",
+            "Check if qga version is corresponding betweenmsi and installer.exe",
             test.log.info,
         )
         if not qga_ver_installer:
@@ -5119,7 +5060,7 @@ class QemuGuestAgentBasicCheckWin(QemuGuestAgentBasicCheck):
         s, o = session.cmd_status_output(cmd_run_debugview)
         if s:
             test.error(
-                "Debugviewconsole.exe run failed, " "Please check the output is: %s" % o
+                "Debugviewconsole.exe run failed, Please check the output is: %s" % o
             )
         gagent.fsfreeze()
         gagent.fsthaw()

--- a/qemu/tests/qemu_img.py
+++ b/qemu/tests/qemu_img.py
@@ -361,13 +361,11 @@ def run(test, params, env):
         img_info = _info(cmd, image_name)
         test.log.info("Info of image '%s':\n%s", image_name, img_info)
         if image_format not in img_info:
-            test.fail(
-                "Got unexpected format of image '%s'" " in info test" % image_name
-            )
+            test.fail("Got unexpected format of image '%s' in info test" % image_name)
         if not re.search(
             r"%s\s+bytes" % normalize_data_size(image_size, "B"), img_info
         ):
-            test.fail("Got unexpected size of image '%s'" " in info test" % image_name)
+            test.fail("Got unexpected size of image '%s' in info test" % image_name)
 
     def snapshot_test(cmd):
         """
@@ -398,9 +396,7 @@ def run(test, params, env):
         cmd_result = process.run(listcmd, verbose=False, ignore_status=True)
         status, out = cmd_result.exit_status, cmd_result.stdout.decode()
         if not ("snapshot0" in out and "snapshot1" in out and status == 0):
-            test.fail(
-                "Snapshot created failed or missed;" "snapshot list is: \n%s" % out
-            )
+            test.fail("Snapshot created failed or missed;snapshot list is: \n%s" % out)
         for i in range(2):
             sn_name = "snapshot%d" % i
             delcmd = cmd
@@ -480,7 +476,7 @@ def run(test, params, env):
                 test.log.info("Output of %s: %s", file_info_cmd, output)
             except Exception as err:
                 test.fail(
-                    "Could not create commit_testfile in the " "overlay file %s" % err
+                    "Could not create commit_testfile in the overlay file %s" % err
                 )
             vm.destroy()
 
@@ -557,7 +553,7 @@ def run(test, params, env):
             not in process.system_output(cmd + " --help", ignore_status=True).decode()
         ):
             test.cancel(
-                "Current kvm user space version does not" " support 'rebase' subcommand"
+                "Current kvm user space version does not support 'rebase' subcommand"
             )
         sn_fmt = params.get("snapshot_format", "qcow2")
         sn1 = params["image_name_snapshot1"]
@@ -602,7 +598,7 @@ def run(test, params, env):
         status, output = _check(cmd, sn2)
         if not status:
             test.fail(
-                "Check image '%s' failed after rebase;" "got error: %s" % (sn2, output)
+                "Check image '%s' failed after rebase;got error: %s" % (sn2, output)
             )
         remove(sn2)
         remove(sn1)
@@ -659,7 +655,7 @@ def run(test, params, env):
         status, output = _check(cmd, img)
         if not status:
             test.fail(
-                "Check image '%s' failed after rebase;" "got error: %s" % (img, output)
+                "Check image '%s' failed after rebase;got error: %s" % (img, output)
             )
 
     def _boot(img_name, img_fmt):

--- a/qemu/tests/qemu_img_convert_with_backing_file.py
+++ b/qemu/tests/qemu_img_convert_with_backing_file.py
@@ -58,7 +58,7 @@ def run(test, params, env):
     def check_image_size(image):
         """Check image is not fully allocated"""
         test.log.info(
-            "Verify qemu-img does not allocate the " "entire image after image convert"
+            "Verify qemu-img does not allocate the entire image after image convert"
         )
         info = json.loads(image.info(output="json"))
         virtual_size = info["virtual-size"]

--- a/qemu/tests/qemu_img_create_snapshot_on_qcow2_target_from_raw_source.py
+++ b/qemu/tests/qemu_img_create_snapshot_on_qcow2_target_from_raw_source.py
@@ -32,7 +32,7 @@ def run(test, params, env):
     c_tag = params["convert_target"]
 
     test.log.info(
-        "Boot a guest up with initial image: %s, and create a" " file %s on the disk.",
+        "Boot a guest up with initial image: %s, and create a file %s on the disk.",
         initial_tag,
         file,
     )
@@ -58,7 +58,7 @@ def run(test, params, env):
     sn_qit.start_vm()
     if not sn_qit.check_file(file, md5):
         test.fail(
-            "The file %s's md5 on initial image and" " snapshot are different." % file
+            "The file %s's md5 on initial image and snapshot are different." % file
         )
     for qit in (base_qit, sn_qit):
         qit.clean()

--- a/qemu/tests/qemu_img_supports_convert_coroutines_complete.py
+++ b/qemu/tests/qemu_img_supports_convert_coroutines_complete.py
@@ -36,7 +36,7 @@ def run(test, params, env):
     def _create_error_cfg(file):
         test.log.info("Create error cfg %s.", file)
         error_cfg = (
-            '[inject-error]\nevent = "write_aio"\n' 'sector = "819200"\nonce = "on"'
+            '[inject-error]\nevent = "write_aio"\nsector = "819200"\nonce = "on"'
         )
         with open(file, "w") as cfg:
             cfg.write(error_cfg)

--- a/qemu/tests/qemu_io.py
+++ b/qemu/tests/qemu_io.py
@@ -94,7 +94,7 @@ class QemuIOConfig(object):
                     process.run("losetup -d %s" % l)
                 except process.CmdError as e:
                     LOG_JOB.error(
-                        "Failed to liberate loopback %s, " "error msg: '%s'", l, e
+                        "Failed to liberate loopback %s, error msg: '%s'", l, e
                     )
 
         for f in self.raw_files:

--- a/qemu/tests/qemu_io_blkdebug.py
+++ b/qemu/tests/qemu_io_blkdebug.py
@@ -113,7 +113,7 @@ def run(test, params, env):
         try:
             std_msg = os.strerror(int(errn))
         except ValueError:
-            test.error("Can not find error message:\n" "    error code is %s" % errn)
+            test.error("Can not find error message:\n    error code is %s" % errn)
 
         session.close()
         error_context.context("Compare the error message", test.log.info)

--- a/qemu/tests/qemu_no_shutdown.py
+++ b/qemu/tests/qemu_no_shutdown.py
@@ -41,14 +41,14 @@ def run(test, params, env):
             session.close()
         # Check the qemu id is not change
         if not utils_misc.wait_for(lambda: vm.is_alive(), 5, 0, 1):
-            test.fail("VM not responsive after system_powerdown " "with -no-shutdown!")
+            test.fail("VM not responsive after system_powerdown with -no-shutdown!")
         if vm.get_pid() != qemu_process_id:
             test.fail("Qemu pid changed after system_powerdown!")
         test.log.info("Round %s -> System_powerdown successfully.", str(i + 1))
 
         # Send monitor command system_reset and cont
         error_context.context(
-            "Round %s : Send monitor command system_reset " "and cont." % str(i + 1),
+            "Round %s : Send monitor command system_reset and cont." % str(i + 1),
             test.log.info,
         )
         vm.monitor.cmd("system_reset")

--- a/qemu/tests/qemu_nobody.py
+++ b/qemu/tests/qemu_nobody.py
@@ -61,7 +61,7 @@ def run(test, params, env):
     failures = []
     for pid in process.get_children_pids(vm.get_shell_pid()):
         error_context.context(
-            "Get the process '%s' u/gid, using 'cat " "/proc/%s/status'" % (pid, pid),
+            "Get the process '%s' u/gid, using 'cat /proc/%s/status'" % (pid, pid),
             test.log.info,
         )
         qemu_ugid = get_ugid_from_processid(pid)

--- a/qemu/tests/qmp_event_notification.py
+++ b/qemu/tests/qmp_event_notification.py
@@ -21,7 +21,7 @@ def run(test, params, env):
 
     qemu_binary = utils_misc.get_qemu_binary(params)
     if not utils_misc.qemu_has_option("qmp", qemu_binary):
-        test.cancel("This test case requires a host QEMU with QMP " "monitor support")
+        test.cancel("This test case requires a host QEMU with QMP monitor support")
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
 

--- a/qemu/tests/rdtsc_sync_test.py
+++ b/qemu/tests/rdtsc_sync_test.py
@@ -42,7 +42,7 @@ def run(test, params, env):
     )
     time.sleep(5)
     process.run(
-        'echo -e \'{"execute":"qmp_capabilities"}' '{"execute":"quit"}\'|nc -U /tmp/mm',
+        'echo -e \'{"execute":"qmp_capabilities"}{"execute":"quit"}\'|nc -U /tmp/mm',
         shell=True,
         verbose=True,
     )

--- a/qemu/tests/readonly_disk.py
+++ b/qemu/tests/readonly_disk.py
@@ -31,9 +31,7 @@ def run(test, params, env):
     data_image_num = int(
         params.get("data_image_num", len(params.objects("images")) - 1)
     )
-    error_context.context(
-        "Get windows disk index that to " "be formatted", test.log.info
-    )
+    error_context.context("Get windows disk index that to be formatted", test.log.info)
     disk_index_list = utils_disk.get_windows_disks_index(session, data_image_size)
     if len(disk_index_list) < data_image_num:
         test.fail(
@@ -45,7 +43,7 @@ def run(test, params, env):
         session, params["src_file"], label="WIN_UTILS"
     )
     error_context.context(
-        "Clear readonly for all disks and online " "them in guest.", test.log.info
+        "Clear readonly for all disks and online them in guest.", test.log.info
     )
     if not utils_disk.update_windows_disk_attributes(session, disk_index_list):
         test.fail("Failed to update windows disk attributes.")
@@ -75,8 +73,7 @@ def run(test, params, env):
     session = vm.wait_for_login(timeout=timeout)
 
     error_context.context(
-        "TEST STEPS 4: Write to the readonly disk expect:"
-        "The media is write protected",
+        "TEST STEPS 4: Write to the readonly disk expect:The media is write protected",
         test.log.info,
     )
     dst_file_readonly = params["dst_file_readonly"] % drive_letter[0]

--- a/qemu/tests/readonly_floppy.py
+++ b/qemu/tests/readonly_floppy.py
@@ -87,7 +87,7 @@ def run(test, params, env):
                 )
             else:
                 test.log.info(
-                    "Floppy disk %s is Read-only and cannot be" " formatted",
+                    "Floppy disk %s is Read-only and cannot be formatted",
                     floppy_index,
                 )
 

--- a/qemu/tests/reboot_time.py
+++ b/qemu/tests/reboot_time.py
@@ -62,9 +62,7 @@ def run(test, params, env):
             vm.verify_alive()
             vm.wait_for_login(timeout=timeout)
         except Exception:
-            test.log.warning(
-                "Can not restore guest run level, " "need restore the image"
-            )
+            test.log.warning("Can not restore guest run level, need restore the image")
             params["restore_image_after_testing"] = "yes"
 
     if reboot_time > expect_time:

--- a/qemu/tests/remote_server_disconnected.py
+++ b/qemu/tests/remote_server_disconnected.py
@@ -26,9 +26,7 @@ def run(test, params, env):
             test.cancel("2 remote servers at least are required.")
         for h in hosts:
             if os.path.exists(h) or _is_ipv6_addr(h):
-                test.cancel(
-                    "Neither ipv6 nor unix domain" " socket is supported by now."
-                )
+                test.cancel("Neither ipv6 nor unix domain socket is supported by now.")
 
     hosts = []
     if params.get_boolean("enable_gluster"):

--- a/qemu/tests/remove_interface_from_host.py
+++ b/qemu/tests/remove_interface_from_host.py
@@ -51,7 +51,7 @@ def run(test, params, env):
     time.sleep(secs_after_iplink_action)
 
     error_context.context(
-        "After disable the ifname, " "Ping test from host to guest, should fail.",
+        "After disable the ifname, Ping test from host to guest, should fail.",
         test.log.info,
     )
     status, output = utils_test.ping(guest_ip, 30, timeout=20)
@@ -64,7 +64,7 @@ def run(test, params, env):
     time.sleep(secs_after_iplink_action)
 
     error_context.context(
-        "After enable the ifname, " "Ping test from host to guest, should work",
+        "After enable the ifname, Ping test from host to guest, should work",
         test.log.info,
     )
     status, output = utils_test.ping(guest_ip, 30, timeout=20)
@@ -78,7 +78,7 @@ def run(test, params, env):
     time.sleep(secs_after_iplink_action)
 
     error_context.context(
-        "After delete the ifname, " "VM and qemu should not crash, ping should fail",
+        "After delete the ifname, VM and qemu should not crash, ping should fail",
         test.log.info,
     )
     vm.verify_alive()

--- a/qemu/tests/rh_kernel_update.py
+++ b/qemu/tests/rh_kernel_update.py
@@ -205,7 +205,7 @@ def run(test, params, env):
         updated = False
     else:
         test.log.info(
-            "Guest current kernel does not match the " "requirement, processing upgrade"
+            "Guest current kernel does not match the requirement, processing upgrade"
         )
         for pkg in kernel_deps_pkgs:
             pkg_params = params.object_params(pkg)

--- a/qemu/tests/rng_stress.py
+++ b/qemu/tests/rng_stress.py
@@ -64,8 +64,7 @@ def run(test, params, env):
         rng_attached = get_rng_list(vm)
         if len(rng_devices) != len(rng_attached):
             test.fail(
-                "The devices get from rng_arriable"
-                " don't match the rng devices attached"
+                "The devices get from rng_arriable don't match the rng devices attached"
             )
 
         if len(rng_devices) > 1:

--- a/qemu/tests/rv_build_install.py
+++ b/qemu/tests/rv_build_install.py
@@ -155,9 +155,7 @@ def build_install_virtviewer(test, vm_root_session, vm_script_path, params):
     # Get version of remote-viewer after install
     try:
         output = vm_root_session.cmd(
-            "which remote-viewer;"
-            "LD_LIBRARY_PATH=/usr/local/lib"
-            " remote-viewer --version"
+            "which remote-viewer;LD_LIBRARY_PATH=/usr/local/lib remote-viewer --version"
         )
         LOG_JOB.info(output)
     except ShellCmdError as err:
@@ -176,7 +174,7 @@ def build_install_spicegtk(test, vm_root_session, vm_script_path, params):
     # Get version of spice-gtk before install
     try:
         output = vm_root_session.cmd(
-            "LD_LIBRARY_PATH=/usr/local/lib" " remote-viewer --spice-gtk-version"
+            "LD_LIBRARY_PATH=/usr/local/lib remote-viewer --spice-gtk-version"
         )
         LOG_JOB.info(output)
     except:
@@ -226,7 +224,7 @@ def build_install_spicegtk(test, vm_root_session, vm_script_path, params):
     # Get version of spice-gtk after install
     try:
         output = vm_root_session.cmd(
-            "LD_LIBRARY_PATH=/usr/local/lib" " remote-viewer --spice-gtk-version"
+            "LD_LIBRARY_PATH=/usr/local/lib remote-viewer --spice-gtk-version"
         )
         LOG_JOB.info(output)
     except:

--- a/qemu/tests/rv_connect.py
+++ b/qemu/tests/rv_connect.py
@@ -219,7 +219,7 @@ def launch_rv(test, client_vm, guest_vm, params):
 
         if certdb is not None:
             LOG_JOB.debug(
-                "Remote Viewer set to use the following certificate" " database: %s",
+                "Remote Viewer set to use the following certificate database: %s",
                 certdb,
             )
             cmd += " --spice-smartcard-db " + certdb
@@ -320,9 +320,7 @@ def launch_rv(test, client_vm, guest_vm, params):
                 if "SSL_accept failed" in qemulog:
                     return
                 else:
-                    test.fail(
-                        "SSL_accept failed not shown in qemu" "process as expected."
-                    )
+                    test.fail("SSL_accept failed not shown in qemuprocess as expected.")
             is_rv_connected = False
         else:
             test.fail("remote-viewer connection failed")
@@ -341,17 +339,15 @@ def launch_rv(test, client_vm, guest_vm, params):
     # Check to see if ipv6 address is reported back from qemu monitor
     if check_spice_info == "ipv6":
         LOG_JOB.info(
-            "Test to check if ipv6 address is reported" " back from the qemu monitor"
+            "Test to check if ipv6 address is reported back from the qemu monitor"
         )
         # Remove brackets from ipv6 host ip
         if host_ip[1 : len(host_ip) - 1] in output:
-            LOG_JOB.info("Reported ipv6 address found in output from" " 'info spice'")
+            LOG_JOB.info("Reported ipv6 address found in output from 'info spice'")
         else:
-            test.fail(
-                "ipv6 address not found from qemu monitor" " command: 'info spice'"
-            )
+            test.fail("ipv6 address not found from qemu monitor command: 'info spice'")
     else:
-        LOG_JOB.info("Not checking the value of 'info spice'" " from the qemu monitor")
+        LOG_JOB.info("Not checking the value of 'info spice' from the qemu monitor")
 
     # prevent from kill remote-viewer after test finish
     if client_vm.params.get("os_type") == "linux":

--- a/qemu/tests/rv_copyandpaste.py
+++ b/qemu/tests/rv_copyandpaste.py
@@ -86,7 +86,7 @@ def place_img_in_clipboard(
         test.fail("Copying to the clipboard failed")
 
     LOG_JOB.debug(
-        "------------ End of script output of the Copying" " Session ------------"
+        "------------ End of script output of the Copying Session ------------"
     )
 
 
@@ -124,7 +124,7 @@ def verify_img_paste(
         test.fail("Copying to the clipboard failed")
 
     LOG_JOB.debug(
-        "------------ End of script output of the Copying" " Session ------------"
+        "------------ End of script output of the Copying Session ------------"
     )
     # Get the checksum of the file
     cmd = "md5sum %s" % (final_image_path)
@@ -137,7 +137,7 @@ def verify_img_paste(
         test.fail("Couldn't get the size of the file")
 
     LOG_JOB.debug(
-        "------------ End of script output of the Copying" " Session ------------"
+        "------------ End of script output of the Copying Session ------------"
     )
     # Get the size of the copied image, this will be used for
     # verification on the other session that the paste was successful
@@ -179,7 +179,7 @@ def verify_img_paste_success(
             test.fail("Copying to the clipboard failed. %s" % output)
     finally:
         LOG_JOB.info(
-            "------------ End of script output of the Pasting" " Session ------------"
+            "------------ End of script output of the Pasting Session ------------"
         )
     # Get the checksum of the file
     cmd = "md5sum %s" % (final_image_path)
@@ -192,7 +192,7 @@ def verify_img_paste_success(
         test.fail("Copying to the clipboard failed.")
 
     LOG_JOB.info(
-        "------------ End of script output of the Pasting" " Session ------------"
+        "------------ End of script output of the Pasting Session ------------"
     )
     img_checksum = output.split()[0]
     if img_checksum == expected_checksum:
@@ -235,7 +235,7 @@ def verify_img_paste_fails(
         test.fail("Copying to the clipboard failed")
 
     LOG_JOB.debug(
-        "------------ End of script output of the Pasting" " Session ------------"
+        "------------ End of script output of the Pasting Session ------------"
     )
 
 
@@ -276,7 +276,7 @@ def verify_text_copy(
         test.fail("Copying to the clipboard failed")
 
     LOG_JOB.debug(
-        "------------ End of script output of the Copying" " Session ------------"
+        "------------ End of script output of the Copying Session ------------"
     )
     # Get the checksum of the file
     cmd = "md5sum %s" % (final_text_path)
@@ -289,7 +289,7 @@ def verify_text_copy(
         test.fail("Couldn't get the size of the file")
 
     LOG_JOB.debug(
-        "------------ End of script output of the Copying" " Session ------------"
+        "------------ End of script output of the Copying Session ------------"
     )
     # Get the size of the copied image, this will be used for
     # verification on the other session that the paste was successful
@@ -330,7 +330,7 @@ def verify_txt_paste_success(
             test.fail("Copying to the clipboard failed. %s" % output)
     finally:
         LOG_JOB.info(
-            "------------ End of script output of the Pasting" " Session ------------"
+            "------------ End of script output of the Pasting Session ------------"
         )
     # Get the checksum of the file
     cmd = "md5sum %s" % (final_text_path)
@@ -343,7 +343,7 @@ def verify_txt_paste_success(
         test.fail("Copying to the clipboard failed.")
 
     LOG_JOB.info(
-        "------------ End of script output of the Pasting" " Session ------------"
+        "------------ End of script output of the Pasting Session ------------"
     )
     file_checksum = output.split()[0]
     if file_checksum == textfile_checksum:
@@ -386,7 +386,7 @@ def place_text_in_clipboard(
         test.fail("Copying to the clipboard failed")
 
     LOG_JOB.debug(
-        "------------ End of script output of the Copying" " Session ------------"
+        "------------ End of script output of the Copying Session ------------"
     )
 
     # Verify the clipboard of the session that is being copied from,
@@ -436,7 +436,7 @@ def verify_paste_fails(
             )
         else:
             LOG_JOB.info(
-                "PASS: Pasting from the clipboard was not" " successful, as EXPECTED"
+                "PASS: Pasting from the clipboard was not successful, as EXPECTED"
             )
     except aexpect.ShellCmdError:
         test.fail("Pasting from the clipboard failed.")
@@ -468,8 +468,7 @@ def verify_paste_successful(
             LOG_JOB.info("Pasting from the clipboard is successful")
         else:
             test.fail(
-                "Pasting from the clipboard failed, "
-                "nothing copied from other session",
+                "Pasting from the clipboard failed, nothing copied from other session",
                 output,
             )
     except aexpect.ShellCmdError:
@@ -1428,7 +1427,7 @@ def run(test, params, env):
                     )
                 else:
                     test.log.info(
-                        "Copying a String of size %s" " from the Client to Guest",
+                        "Copying a String of size %s from the Client to Guest",
                         testing_text,
                     )
                     copy_and_paste_largetext(
@@ -1469,7 +1468,7 @@ def run(test, params, env):
                     )
                 else:
                     test.log.info(
-                        "Copying a String of size %s" " from the Guest to Client",
+                        "Copying a String of size %s from the Guest to Client",
                         testing_text,
                     )
                     copy_and_paste_largetext(
@@ -1492,7 +1491,7 @@ def run(test, params, env):
         if "client_to_guest" in test_type:
             if "image" in test_type:
                 test.log.info(
-                    "Negative Test Case: Copying an Image from the " "Client to Guest"
+                    "Negative Test Case: Copying an Image from the Client to Guest"
                 )
                 copy_and_paste_image_neg(
                     test, client_session, guest_session, guest_root_session, params
@@ -1508,7 +1507,7 @@ def run(test, params, env):
         if "guest_to_client" in test_type:
             if "image" in test_type:
                 test.log.info(
-                    "Negative Test Case: Copying an Image from the " "Guest to Client"
+                    "Negative Test Case: Copying an Image from the Guest to Client"
                 )
                 copy_and_paste_image_neg(
                     test, guest_session, client_session, guest_root_session, params

--- a/qemu/tests/rv_fullscreen.py
+++ b/qemu/tests/rv_fullscreen.py
@@ -45,13 +45,9 @@ def run(test, params, env):
         client_res_raw = client_session.cmd("cat /tmp/res|awk '{print $1}'")
         client_res = client_res_raw.split()[0]
     except ShellCmdError:
-        test.fail(
-            "Could not get guest resolution, xrandr output:" " %s" % client_res_raw
-        )
+        test.fail("Could not get guest resolution, xrandr output: %s" % client_res_raw)
     except IndexError:
-        test.fail(
-            "Could not get guest resolution, xrandr output:" " %s" % client_res_raw
-        )
+        test.fail("Could not get guest resolution, xrandr output: %s" % client_res_raw)
 
     test.log.info("Getting the Resolution on the guest")
     guest_session.cmd("export DISPLAY=:0.0")
@@ -61,13 +57,9 @@ def run(test, params, env):
         guest_res_raw = guest_session.cmd("cat /tmp/res|awk '{print $1}'")
         guest_res = guest_res_raw.split()[0]
     except ShellCmdError:
-        test.fail(
-            "Could not get guest resolution, xrandr output:" " %s" % guest_res_raw
-        )
+        test.fail("Could not get guest resolution, xrandr output: %s" % guest_res_raw)
     except IndexError:
-        test.fail(
-            "Could not get guest resolution, xrandr output:" " %s" % guest_res_raw
-        )
+        test.fail("Could not get guest resolution, xrandr output: %s" % guest_res_raw)
 
     test.log.info("Here's the information I have: ")
     test.log.info("\nClient Resolution: %s", client_res)

--- a/qemu/tests/rv_input.py
+++ b/qemu/tests/rv_input.py
@@ -443,6 +443,6 @@ def run(test, params, env):
     # do not match with expected keycodes
     result = analyze_results(result_path, test_type)
     if result is not None:
-        test.fail("Testing of sending keys failed:" "  Expected keycode = %s" % result)
+        test.fail("Testing of sending keys failed:  Expected keycode = %s" % result)
 
     guest_session.close()

--- a/qemu/tests/rv_logging.py
+++ b/qemu/tests/rv_logging.py
@@ -71,8 +71,7 @@ def run(test, params, env):
             test.log.info("Redhat Release: %s", release)
         except:
             test.cancel(
-                "Test is only currently supported on "
-                "RHEL and Fedora operating systems"
+                "Test is only currently supported on RHEL and Fedora operating systems"
             )
 
         if "release 7." in release:
@@ -84,7 +83,7 @@ def run(test, params, env):
         else:
             spice_vdagent_loginfo_cmd = "tail -n 10 " + spicevdagent_logfile
 
-        cmd = 'echo "SPICE_VDAGENTD_EXTRA_ARGS=-dd">' "/etc/sysconfig/spice-vdagentd"
+        cmd = 'echo "SPICE_VDAGENTD_EXTRA_ARGS=-dd">/etc/sysconfig/spice-vdagentd'
         guest_root_session.cmd(cmd)
 
         test.log.info("Running the logging test for spice-vdagent daemon")
@@ -130,7 +129,7 @@ def run(test, params, env):
             test.fail("Copying to the clipboard failed try block failed")
 
         test.log.debug(
-            "------------ End of script output of the Copying" " Session ------------"
+            "------------ End of script output of the Copying Session ------------"
         )
 
         output = guest_root_session.cmd(

--- a/qemu/tests/rv_smartcard.py
+++ b/qemu/tests/rv_smartcard.py
@@ -70,7 +70,7 @@ def run(test, params, env):
                 # Send a carriage return for PIN for token
                 listcerts_output = guest_session.cmd("")
             except:
-                test.fail("Test failed trying to get the output" " of pkcs11_listcerts")
+                test.fail("Test failed trying to get the output of pkcs11_listcerts")
 
         test.log.info("Listing Certs available on the guest:  %s", listcerts_output)
 
@@ -97,7 +97,7 @@ def run(test, params, env):
                 # Send a carriage return for PIN for token
                 certsinfo_output = guest_session.cmd("", ok_status=[0, 1])
             except:
-                test.fail("Test failed trying to get the output" " of pklogin_finder")
+                test.fail("Test failed trying to get the output of pklogin_finder")
         testindex = certsinfo_output.find(searchstr)
         if testindex >= 0:
             string_aftercheck = certsinfo_output[testindex:]
@@ -144,12 +144,10 @@ def run(test, params, env):
                         )
 
                 else:
-                    test.fail(
-                        checkstr + " not found in output of " "pklogin on the guest"
-                    )
+                    test.fail(checkstr + " not found in output of pklogin on the guest")
 
         else:
-            test.fail(searchstr + " not found in output of pklogin" " on the guest")
+            test.fail(searchstr + " not found in output of pklogin on the guest")
 
         test.log.info("Certs Info on the guest:  %s", certsinfo_output)
     else:

--- a/qemu/tests/rv_video.py
+++ b/qemu/tests/rv_video.py
@@ -40,7 +40,7 @@ def launch_totem(test, guest_session, params):
         LOG_JOB.info("Redhat Release: %s", release)
     except:
         test.cancel(
-            "Test is only currently supported on " "RHEL and Fedora operating systems"
+            "Test is only currently supported on RHEL and Fedora operating systems"
         )
 
     cmd = "export DISPLAY=:0.0"

--- a/qemu/tests/rv_vmshutdown.py
+++ b/qemu/tests/rv_vmshutdown.py
@@ -58,9 +58,7 @@ def run(test, params, env):
 
     # Determine if the test is to shutdown from cli or qemu monitor
     if shutdownfrom == "cmd":
-        test.log.info(
-            "Shutting down guest from command line:" " %s\n", cmd_cli_shutdown
-        )
+        test.log.info("Shutting down guest from command line: %s\n", cmd_cli_shutdown)
         output = guest_session.cmd(cmd_cli_shutdown)
         test.log.debug("Guest is being shutdown: %s", output)
     elif shutdownfrom == "qemu_monitor":
@@ -68,7 +66,7 @@ def run(test, params, env):
         output = guest_vm.monitor.cmd(cmd_qemu_shutdown)
         test.log.debug("Output of %s: %s", cmd_qemu_shutdown, output)
     else:
-        test.fail("shutdownfrom var not set, valid values are" " cmd or qemu_monitor")
+        test.fail("shutdownfrom var not set, valid values are cmd or qemu_monitor")
 
     # wait for the guest vm to be shutoff
     test.log.info("Waiting for the guest VM to be shutoff")

--- a/qemu/tests/s390x_cpu_model_baseline.py
+++ b/qemu/tests/s390x_cpu_model_baseline.py
@@ -87,5 +87,5 @@ def run(test, params, env):
                 test_failures.append(msg)
     if test_failures:
         test.fail(
-            "Some baselines didn't return as expected." " Details: %s" % test_failures
+            "Some baselines didn't return as expected. Details: %s" % test_failures
         )

--- a/qemu/tests/same_mac_address.py
+++ b/qemu/tests/same_mac_address.py
@@ -25,7 +25,7 @@ def run(test, params, env):
     vm = env.get_vm(params["main_vm"])
     session = vm.wait_for_login(timeout=timeout)
     error_context.context(
-        "Check if the driver is installed and " "verified", test.log.info
+        "Check if the driver is installed and verified", test.log.info
     )
     driver_verifier = params["driver_verifier"]
     session = utils_test.qemu.windrv_check_running_verifier(

--- a/qemu/tests/seabios.py
+++ b/qemu/tests/seabios.py
@@ -102,7 +102,7 @@ def run(test, params, env):
             vm.send_key(str(i))
             break
     else:
-        test.fail("Could not get any boot entry match " "pattern '%s'" % boot_device)
+        test.fail("Could not get any boot entry match pattern '%s'" % boot_device)
 
     error_context.context("Log into the guest to verify it's up")
     session = vm.wait_for_login(timeout=timeout)

--- a/qemu/tests/secure_execution.py
+++ b/qemu/tests/secure_execution.py
@@ -30,7 +30,7 @@ def run(test, params, env):
             output = detail.output
         if error_msg not in output:
             test.fail(
-                "Error message is not expected! " "Expected: {} Actual: {}".format(
+                "Error message is not expected! Expected: {} Actual: {}".format(
                     error_msg, output
                 )
             )

--- a/qemu/tests/set_link.py
+++ b/qemu/tests/set_link.py
@@ -209,14 +209,14 @@ def run(test, params, env):
         reboot_method = params.get("reboot_method", "shell")
 
         error_context.context(
-            "Reboot guest by '%s' and recheck interface " "operstate" % reboot_method,
+            "Reboot guest by '%s' and recheck interface operstate" % reboot_method,
             test.log.info,
         )
         guest_reboot(reboot_method, link_up)
         guest_interface_operstate_check(expect_status, guest_ifname, change_queues)
 
         error_context.context(
-            "Check guest network connecting after reboot " "by '%s'" % reboot_method,
+            "Check guest network connecting after reboot by '%s'" % reboot_method,
             test.log.info,
         )
         guest_netwok_connecting_check(guest_ip, link_up, change_queues)

--- a/qemu/tests/sev_hotplug_mem.py
+++ b/qemu/tests/sev_hotplug_mem.py
@@ -26,10 +26,10 @@ class MemoryHotplugSimple(MemoryHotplugTest):
             abs(vm_mem_size + sev_rom_size - assigned_vm_mem_size)
             > assigned_vm_mem_size * threshold
         ):
-            msg = (
-                "Assigned '%s MB' memory to '%s'"
-                "but, '%s MB' memory detect by OS"
-                % (assigned_vm_mem_size, vm.name, vm_mem_size)
+            msg = "Assigned '%s MB' memory to '%s'but, '%s MB' memory detect by OS" % (
+                assigned_vm_mem_size,
+                vm.name,
+                vm_mem_size,
             )
             raise TestError(msg)
 

--- a/qemu/tests/sgx_cpu.py
+++ b/qemu/tests/sgx_cpu.py
@@ -31,7 +31,7 @@ def run(test, params, env):
                 session.cmd_status("yum -y install %s" % cpuid_pkg)
             except Exception:
                 test.cancel(
-                    "Fail to install package cpuid, please retest" "this case again."
+                    "Fail to install package cpuid, please retestthis case again."
                 )
 
         error_context.context("Check the sgx CPUID features", test.log.info)
@@ -43,7 +43,7 @@ def run(test, params, env):
                 test.fail("Fail to verify sgx feature %s " % i)
         if params.get("cpuid_entry_cmd"):
             error_context.context(
-                "Check the corresponding CPUID entries with" "sgx cpu flags",
+                "Check the corresponding CPUID entries withsgx cpu flags",
                 test.log.info,
             )
             output = session.cmd_output(check_cpuid_entry_cmd)

--- a/qemu/tests/single_driver_install.py
+++ b/qemu/tests/single_driver_install.py
@@ -139,8 +139,7 @@ def run(test, params, env):
         # acceptable status: OK(0), REBOOT(1)
         if status > 1:
             test.error(
-                "Failed to uninstall driver '%s', details:\n"
-                "%s" % (driver_name, output)
+                "Failed to uninstall driver '%s', details:\n%s" % (driver_name, output)
             )
 
         if params.get_boolean("need_destroy"):
@@ -191,7 +190,7 @@ def run(test, params, env):
 
         installed_any |= True
     if not installed_any:
-        test.error("Failed to find target devices " "by hwids: '%s'" % device_hwid)
+        test.error("Failed to find target devices by hwids: '%s'" % device_hwid)
 
     error_context.context("Verifying target driver", test.log.info)
     session = vm.reboot(session)

--- a/qemu/tests/slof_next_entry.py
+++ b/qemu/tests/slof_next_entry.py
@@ -56,7 +56,7 @@ def run(test, params, env):
     test.log.info("Ensure the guest has at least two kernel versions")
     kernel_list = session.cmd_output(get_kernel_list_cmd).splitlines()
     if len(kernel_list) < 2:
-        test.cancel("This test requires at least two kernel versions in the " "guest")
+        test.cancel("This test requires at least two kernel versions in the guest")
     if session.cmd_output("grubby --default-index").strip() != "0":
         test.log.info("Ensure that the default kernel index of the guest is 0.")
         session.cmd("grubby --set-default-index=0")
@@ -64,7 +64,7 @@ def run(test, params, env):
 
     guest_kernels = get_kernels_info()
     error_context.context(
-        "Set a next boot entry other than the default one and" " check it",
+        "Set a next boot entry other than the default one and check it",
         test.log.info,
     )
     next_entry = guest_kernels[1]["title"]
@@ -81,7 +81,7 @@ def run(test, params, env):
         test.fail("The next boot entry is not expected as we set")
 
     error_context.base_context(
-        "Reboot guest, check the kernel version and " "'next_entry'", test.log.info
+        "Reboot guest, check the kernel version and 'next_entry'", test.log.info
     )
     session = vm.reboot(session)
     grub_env = dict(

--- a/qemu/tests/slof_user_interface.py
+++ b/qemu/tests/slof_user_interface.py
@@ -114,7 +114,7 @@ def run(test, params, env):
             lambda: _send_key(_check_menu_info(menu_list), False), ack_timeout, step=0.0
         ):
             test.fail(
-                "Failed to load after selecting boot device " "in %s sec." % ack_timeout
+                "Failed to load after selecting boot device in %s sec." % ack_timeout
             )
 
     def _load_user_interface_test():

--- a/qemu/tests/smbios_table.py
+++ b/qemu/tests/smbios_table.py
@@ -75,15 +75,14 @@ def run(test, params, env):
         params["start_vm"] = "yes"
 
         error_context.context(
-            "Boot the vm using -M option:'-M %s', smbios "
-            "para: '%s'" % (m_type, smbios),
+            "Boot the vm using -M option:'-M %s', smbios para: '%s'" % (m_type, smbios),
             test.log.info,
         )
         env_process.preprocess_vm(test, params, env, params.get("main_vm"))
         vm1 = env.get_vm(params["main_vm"])
         session = vm1.wait_for_login(timeout=login_timeout)
 
-        error_context.context("Check smbios info on guest " "is setted as expected")
+        error_context.context("Check smbios info on guest is setted as expected")
 
         for sm_type in smbios_type.split():
             if sm_type == "Bios":

--- a/qemu/tests/sr_iov_hotplug.py
+++ b/qemu/tests/sr_iov_hotplug.py
@@ -129,9 +129,7 @@ def run(test, params, env):
                 cmd = "mv %s.BACKUP %s" % (iface_script, iface_script)
                 status, output = session.cmd_status_output(cmd)
                 if status:
-                    test.error(
-                        "Failed to cleanup network script in guest: " "%s" % output
-                    )
+                    test.error("Failed to cleanup network script in guest: %s" % output)
         else:
             global iface_scripts
             for iface_script in iface_scripts:
@@ -212,9 +210,7 @@ def run(test, params, env):
                 )
 
             if not utils_misc.wait_for(_find_pci, test_timeout, 3, 3):
-                test.fail(
-                    "New add device not found in guest. " "Command was: lspci -nn"
-                )
+                test.fail("New add device not found in guest. Command was: lspci -nn")
 
             # Assign static IP to the hotplugged interface
             if params.get("assign_static_ip", "no") == "yes":
@@ -251,9 +247,7 @@ def run(test, params, env):
                         )
                         status, output = session.cmd_status_output(cmd)
                         if status:
-                            test.error(
-                                "Failed to set static ip in guest: " "%s" % output
-                            )
+                            test.error("Failed to set static ip in guest: %s" % output)
             # Test the newly added device
             if not utils_misc.wait_for(_check_ip, 120, 3, 3):
                 ifconfig = session.cmd_output("ifconfig -a")
@@ -266,7 +260,7 @@ def run(test, params, env):
                 session.cmd(params["pci_test_cmd"] % (pci_num + 1))
             except aexpect.ShellError as e:
                 test.fail(
-                    "Check device failed after PCI " "hotplug. Output: %r" % e.output
+                    "Check device failed after PCI hotplug. Output: %r" % e.output
                 )
 
         except Exception:
@@ -352,7 +346,7 @@ def run(test, params, env):
 
     local_functions = locals()
 
-    if params.get("enable_set_link" "yes") == "yes":
+    if params.get("enable_set_linkyes") == "yes":
         error_context.context("Disable the primary link(s) of guest", test.log.info)
         for nic in vm.virtnet:
             vm.set_link(nic.device_id, up=False)

--- a/qemu/tests/sr_iov_irqbalance.py
+++ b/qemu/tests/sr_iov_irqbalance.py
@@ -236,7 +236,7 @@ def run(test, params, env):
     bg_stress.start()
     try:
         error_context.context(
-            "Get irq number assigned to attached " "VF/PF in guest", test.log.info
+            "Get irq number assigned to attached VF/PF in guest", test.log.info
         )
         irq_nums_dict = get_guest_irq_info(test, session, devname, cpu_count)
         irqs = []

--- a/qemu/tests/sr_iov_sanity.py
+++ b/qemu/tests/sr_iov_sanity.py
@@ -205,9 +205,7 @@ def run(test, params, env):
                     utils_net.set_guest_ip_addr(session, mac, IP_addr_VF)
                     rc, output = utils_test.ping(str(IP_addr_VF), 30, timeout=60)
                     if rc != 0:
-                        test.fail(
-                            "New nic failed ping test" "with output:\n %s" % output
-                        )
+                        test.fail("New nic failed ping testwith output:\n %s" % output)
                     IP_addr_VF = IP_addr_VF + 1
             else:
                 test.fail(

--- a/qemu/tests/stepmaker.py
+++ b/qemu/tests/stepmaker.py
@@ -74,7 +74,7 @@ class StepMaker(step_editor.StepMakerWindow):
         self.steps_file.flush()
 
         self.vars_file.write(
-            "# This file lists the vars used during recording" " with Step Maker\n"
+            "# This file lists the vars used during recording with Step Maker\n"
         )
         self.vars_file.flush()
 

--- a/qemu/tests/steps.py
+++ b/qemu/tests/steps.py
@@ -113,7 +113,7 @@ def barrier_2(
         # Make sure image is valid
         if not ppm_utils.image_verify_ppm_file(scrdump_filename):
             LOG_JOB.warning(
-                "Got invalid screendump: dimensions: %dx%d, " "data size: %d",
+                "Got invalid screendump: dimensions: %dx%d, data size: %d",
                 w,
                 h,
                 len(data),

--- a/qemu/tests/stop_continue.py
+++ b/qemu/tests/stop_continue.py
@@ -83,8 +83,7 @@ def run(test, params, env):
             s, o = session.cmd_status_output(check_op, timeout=op_timeout)
             if s != 0:
                 test.fail(
-                    "Something wrong after stop continue, "
-                    "check command report: %s" % o
+                    "Something wrong after stop continue, check command report: %s" % o
                 )
     finally:
         try:

--- a/qemu/tests/stress_kernel_compile.py
+++ b/qemu/tests/stress_kernel_compile.py
@@ -33,7 +33,7 @@ def run(test, params, env):
                 test.log.error(output)
                 test.fail("Fail to download the kernel in %s" % vm_name)
             else:
-                test.log.info("Completed download the kernel src" " in %s", vm_name)
+                test.log.info("Completed download the kernel src in %s", vm_name)
             test_cmd = params.get("test_cmd")
             status, output = session.cmd_status_output(test_cmd, timeout=1200)
             if status != 0:
@@ -48,7 +48,7 @@ def run(test, params, env):
 
     if guest_number < 1:
         test.log.warning(
-            "At least boot up one guest for this test," " set up guest number to 1"
+            "At least boot up one guest for this test, set up guest number to 1"
         )
         guest_number = 1
 

--- a/qemu/tests/system_reset_bootable.py
+++ b/qemu/tests/system_reset_bootable.py
@@ -51,7 +51,7 @@ def run(test, params, env):
         if params.get("fixed_interval", "yes") != "yes":
             interval_tmp = random.randint(0, interval * 1000) / 1000.0
 
-        test.log.debug("Reset the system by monitor cmd" " after %ssecs", interval_tmp)
+        test.log.debug("Reset the system by monitor cmd after %ssecs", interval_tmp)
         time.sleep(interval_tmp)
 
     error_context.context("Try to login guest after reset", test.log.info)

--- a/qemu/tests/time_manage.py
+++ b/qemu/tests/time_manage.py
@@ -77,7 +77,7 @@ def run(test, params, env):
             test.log.info("Guest #%d booted up successfully", num)
 
             # Check whether all previous shell sessions are responsive
-            error_context.context("checking responsiveness of the booted" " guest")
+            error_context.context("checking responsiveness of the booted guest")
             for se in sessions:
                 se.cmd(params["alive_test_cmd"])
             num += 1

--- a/qemu/tests/timedrift_check_after_load_vm.py
+++ b/qemu/tests/timedrift_check_after_load_vm.py
@@ -157,7 +157,7 @@ def run(test, params, env):
         gagent.gagent.set_time()
 
         error_context.context(
-            "Execute 'rtc-reset-reinjection' in qmp" " monitor, not for power platform",
+            "Execute 'rtc-reset-reinjection' in qmp monitor, not for power platform",
             test.log.info,
         )
         if arch.ARCH not in ("ppc64", "ppc64le"):

--- a/qemu/tests/timedrift_check_non_event.py
+++ b/qemu/tests/timedrift_check_non_event.py
@@ -83,5 +83,5 @@ def run(test, params, env):
     session.close()
     if (hwclock_st1 - hwclock_st2 - float(time_forward)) > float(drift_threshold):
         test.fail(
-            "Unexpected hwclock drift, " "hwclock: current guest time=%ss" % hwclock_st2
+            "Unexpected hwclock drift, hwclock: current guest time=%ss" % hwclock_st2
         )

--- a/qemu/tests/timedrift_no_net.py
+++ b/qemu/tests/timedrift_no_net.py
@@ -39,7 +39,7 @@ def subw_guest_suspend(test, params, vm, session):
         gs.guest_suspend_disk(params)
     else:
         test.error(
-            "Unknown guest suspend type, Check your" " 'guest_suspend_type' config."
+            "Unknown guest suspend type, Check your 'guest_suspend_type' config."
         )
 
 
@@ -107,7 +107,7 @@ def run(test, params, env):
     error_context.context("Check clock source on guest VM", test.log.info)
     session = vm.wait_for_serial_login(timeout=login_timeout)
     out = session.cmd_output(
-        "cat /sys/devices/system/clocksource/" "clocksource0/current_clocksource"
+        "cat /sys/devices/system/clocksource/clocksource0/current_clocksource"
     )
     if guest_clock_source not in out:
         test.fail(

--- a/qemu/tests/timedrift_no_net_win.py
+++ b/qemu/tests/timedrift_no_net_win.py
@@ -34,7 +34,7 @@ def subw_guest_suspend(test, params, vm, session):
         gs.guest_suspend_disk(params)
     else:
         test.error(
-            "Unknown guest suspend type, Check your" " 'guest_suspend_type' config."
+            "Unknown guest suspend type, Check your 'guest_suspend_type' config."
         )
 
 

--- a/qemu/tests/timedrift_with_cpu_offline.py
+++ b/qemu/tests/timedrift_with_cpu_offline.py
@@ -57,7 +57,7 @@ def run(test, params, env):
         error_context.context("check guest cpu number")
         smp = int(params.get("smp"))
         if smp < 2:
-            test.error("The guest only has %d vcpu," "unsupport cpu offline" % smp)
+            test.error("The guest only has %d vcpu,unsupport cpu offline" % smp)
 
         # Set cpu offline
         error_context.context("set cpu offline ")

--- a/qemu/tests/timer_rtc_sync.py
+++ b/qemu/tests/timer_rtc_sync.py
@@ -104,7 +104,7 @@ def run(test, params, env):
     time.sleep(660)
 
     error_context.context(
-        "check timedrift between guest and host after " "changing RTC time.",
+        "check timedrift between guest and host after changing RTC time.",
         test.log.info,
     )
     verify_timedrift(session)

--- a/qemu/tests/timerdevice_boot.py
+++ b/qemu/tests/timerdevice_boot.py
@@ -118,7 +118,7 @@ def run(test, params, env):
             status, output = session.cmd_status_output(clksrc_cmd, safe=True)
             if status:
                 test.fail(
-                    "fail to update guest's clocksource to %s," "details: %s" % clksrc,
+                    "fail to update guest's clocksource to %s,details: %s" % clksrc,
                     output,
                 )
         else:
@@ -201,7 +201,7 @@ def run(test, params, env):
             time.sleep(sleep_time)
 
         error_context.context(
-            "Check timedrift between guest and host " "after reboot.", test.log.info
+            "Check timedrift between guest and host after reboot.", test.log.info
         )
         vm.reboot(timeout=timeout, serial=True)
         verify_timedrift(session)

--- a/qemu/tests/timerdevice_change_guest_clksource.py
+++ b/qemu/tests/timerdevice_change_guest_clksource.py
@@ -44,7 +44,7 @@ def run(test, params, env):
     try:
         available_clksrc_list = session.cmd(avl_clk).split()
     except Exception as detail:
-        test.fail("Couldn't get guest available clock source." " Detail: '%s'" % detail)
+        test.fail("Couldn't get guest available clock source. Detail: '%s'" % detail)
     try:
         for avl_clksrc in available_clksrc_list:
             if avl_clksrc == "kvm-clock":

--- a/qemu/tests/timerdevice_clock_drift_with_sleep.py
+++ b/qemu/tests/timerdevice_clock_drift_with_sleep.py
@@ -24,10 +24,10 @@ def run(test, params, env):
 
     def verify_elapsed_time():
         sleep_cmd = r'echo "for n in \$(seq 1000);'
-        sleep_cmd += ' do sleep 0.01; done"' " > /tmp/sleep.sh"
+        sleep_cmd += ' do sleep 0.01; done" > /tmp/sleep.sh'
         session.cmd(sleep_cmd)
 
-        guest_cpu = session.cmd_output("grep 'processor' " "/proc/cpuinfo | wc -l")
+        guest_cpu = session.cmd_output("grep 'processor' /proc/cpuinfo | wc -l")
         get_time_cmd = "for (( i=0; i<%s; i+=1 ));" % guest_cpu
         get_time_cmd += ' do /usr/bin/time -f"%e"'
         get_time_cmd += " taskset -c $i sh /tmp/sleep.sh; done"
@@ -99,7 +99,7 @@ def run(test, params, env):
     session.cmd(ntp_sync_cmd, timeout=timeout)
 
     error_context.context(
-        "Sleep a while and check the time drift on guest" " (without any pinned vcpu)",
+        "Sleep a while and check the time drift on guest (without any pinned vcpu)",
         test.log.info,
     )
     verify_elapsed_time()
@@ -116,15 +116,14 @@ def run(test, params, env):
         process.system("taskset -p -c %s %s" % (pcpu, vcpu))
         if not check_one_cpu_pinned:
             error_context.context(
-                "Sleep a while and check the time drift on"
-                "guest (with one pinned vcpu)",
+                "Sleep a while and check the time drift onguest (with one pinned vcpu)",
                 test.log.info,
             )
             verify_elapsed_time()
             check_one_cpu_pinned = True
 
     error_context.context(
-        "Sleep a while and check the time drift on" "guest (with all pinned vcpus)",
+        "Sleep a while and check the time drift onguest (with all pinned vcpus)",
         test.log.info,
     )
     verify_elapsed_time()

--- a/qemu/tests/timerdevice_tscsync_change_host_clksource.py
+++ b/qemu/tests/timerdevice_tscsync_change_host_clksource.py
@@ -70,8 +70,7 @@ def run(test, params, env):
     if tsc_cnt or tod_cnt or clk_cnt:
         msg = output.splitlines()[-5:]
         test.fail(
-            "Get error when running time-warp-test."
-            " Output (last 5 lines): '%s'" % msg
+            "Get error when running time-warp-test. Output (last 5 lines): '%s'" % msg
         )
 
     try:
@@ -81,7 +80,7 @@ def run(test, params, env):
         process.system(cmd, shell=True)
 
         error_context.context(
-            "Run time-warp-test after change the host" " clock source", test.log.info
+            "Run time-warp-test after change the host clock source", test.log.info
         )
         cmd = "$(sleep %d; pkill time-warp-test) &"
         session.sendline(cmd % test_run_timeout)
@@ -90,7 +89,7 @@ def run(test, params, env):
 
         fail_cnt = re.findall(re_str, output)
         if not fail_cnt:
-            test.error("Could not get correct test output." " Output: '%s'" % output)
+            test.error("Could not get correct test output. Output: '%s'" % output)
 
         tsc_cnt, tod_cnt, clk_cnt = [int(_) for _ in fail_cnt[-1]]
         if tsc_cnt or tod_cnt or clk_cnt:
@@ -110,4 +109,4 @@ def run(test, params, env):
         try:
             process.system(cmd, shell=True)
         except Exception as detail:
-            test.log.error("Failed to restore host clocksource." "Detail: %s", detail)
+            test.log.error("Failed to restore host clocksource.Detail: %s", detail)

--- a/qemu/tests/timerdevice_tscsync_longtime.py
+++ b/qemu/tests/timerdevice_tscsync_longtime.py
@@ -67,6 +67,5 @@ def run(test, params, env):
     if tsc_cnt or tod_cnt or clk_cnt:
         msg = output.splitlines()[-5:]
         test.fail(
-            "Get error when running time-warp-test."
-            " Output (last 5 lines): '%s'" % msg
+            "Get error when running time-warp-test. Output (last 5 lines): '%s'" % msg
         )

--- a/qemu/tests/tpm_bind_luks.py
+++ b/qemu/tests/tpm_bind_luks.py
@@ -154,14 +154,14 @@ def run(test, params, env):
     test.log.info("The LUKs device is bound to TPM:\n%s", clevis_list)
 
     error_context.context(
-        "Open the LUKs device using clevis and check the md5" " of the file",
+        "Open the LUKs device using clevis and check the md5 of the file",
         test.log.info,
     )
     session.cmd(clevis_unlock_cmd % extra_disk)
     compare_md5sum()
 
     error_context.context(
-        "Modify crypttab and fstab to enable automatic boot " "unlocking", test.log.info
+        "Modify crypttab and fstab to enable automatic boot unlocking", test.log.info
     )
     auto_boot_unlocking()
     session.cmd(cryptsetup_close_cmd)

--- a/qemu/tests/tpm_with_bitlocker.py
+++ b/qemu/tests/tpm_with_bitlocker.py
@@ -29,7 +29,7 @@ def run(test, params, env):
         session = vm.reboot(session, timeout=480)
 
     error_context.context(
-        "Prepares hard drive for BitLocker Drive " "Encryption inside guest",
+        "Prepares hard drive for BitLocker Drive Encryption inside guest",
         test.log.info,
     )
     cmd_bdehdcfg = session.cmd_output(params.get("cmd_bdehdcfg"))
@@ -37,7 +37,7 @@ def run(test, params, env):
         test.fail("Found error message.")
 
     error_context.context(
-        "Encrypts the volume and turns BitLocker " "protection on inside guest",
+        "Encrypts the volume and turns BitLocker protection on inside guest",
         test.log.info,
     )
     session.cmd(params.get("cmd_manage_bde_on"))

--- a/qemu/tests/tracing_exception_injection.py
+++ b/qemu/tests/tracing_exception_injection.py
@@ -26,7 +26,7 @@ def run(test, params, env):
     if host_cmd_output:
         if host_cmd_output.split()[1] == "0":
             test.fail(
-                "kvm_stat did not provide the expected " "output: %s" % host_cmd_output
+                "kvm_stat did not provide the expected output: %s" % host_cmd_output
             )
         test.log.info("kvm_stat provided the expected output")
     test.log.info("Host cmd output '%s'", host_cmd_output)

--- a/qemu/tests/tsc_drift.py
+++ b/qemu/tests/tsc_drift.py
@@ -98,6 +98,6 @@ def run(test, params, env):
             success = False
 
     if not success:
-        test.fail("TSC drift found for the guest, please check the " "log for details")
+        test.fail("TSC drift found for the guest, please check the log for details")
 
     session.close()

--- a/qemu/tests/uefi_check_debugcon.py
+++ b/qemu/tests/uefi_check_debugcon.py
@@ -56,7 +56,7 @@ def run(test, params, env):
     utils_package.package_install("trace-cmd")
     if params.get("ovmf_log"):
         error_context.context(
-            "Append debugcon parameter to " "qemu command lines.", test.log.info
+            "Append debugcon parameter to qemu command lines.", test.log.info
         )
         ovmf_log = utils_misc.get_path(test.debugdir, params["ovmf_log"])
         params["extra_params"] %= ovmf_log

--- a/qemu/tests/uefi_pkg.py
+++ b/qemu/tests/uefi_pkg.py
@@ -59,7 +59,7 @@ def run(test, params, env):
 
     query_package = params["query_package"]
     error_context.context(
-        "Check edk2-ovmf package has been " "installed already", test.log.info
+        "Check edk2-ovmf package has been installed already", test.log.info
     )
     status, output = process.getstatusoutput(
         query_package, ignore_status=True, shell=True
@@ -88,7 +88,7 @@ def run(test, params, env):
             meta_files,
         )
     error_context.context(
-        "Check the 'filename' elements in both json" " files point to valid files.",
+        "Check the 'filename' elements in both json files point to valid files.",
         test.log.info,
     )
     for meta_file in meta_files:

--- a/qemu/tests/uefi_secureboot.py
+++ b/qemu/tests/uefi_secureboot.py
@@ -78,13 +78,13 @@ def run(test, params, env):
         session = vm.wait_for_serial_login()
     except remote.LoginTimeoutError:
         if signed:
-            test.fail("The guest is signed," " but boot failed under secure mode.")
+            test.fail("The guest is signed, but boot failed under secure mode.")
     else:
         check_cmd = params["check_secure_boot_enabled_cmd"]
         status, output = session.cmd_status_output(check_cmd)
         if status != 0:
             test.fail("Secure boot is not enabled")
         if not signed:
-            test.fail("The guest is not signed," " but boot succeed under secure mode.")
+            test.fail("The guest is not signed, but boot succeed under secure mode.")
     finally:
         vm.destroy()

--- a/qemu/tests/uefishell.py
+++ b/qemu/tests/uefishell.py
@@ -267,18 +267,17 @@ def run(test, params, env):
         smbios_version = re.findall(params["smbios_version"], output[0], re.S)
         if not smbios_version:
             test.fail(
-                "Failed to find smbios version. " "The command output is %s" % output[0]
+                "Failed to find smbios version. The command output is %s" % output[0]
             )
         bios_version = re.findall(params["bios_version"], output[0], re.S)
         if not bios_version:
             test.fail(
-                "Failed to find bios version. " "The command output is %s" % output[0]
+                "Failed to find bios version. The command output is %s" % output[0]
             )
         bios_release_date = re.search(params["bios_release_date"], output[0], re.S)
         if not bios_release_date:
             test.fail(
-                "Failed to find bios_release_date. "
-                "The command output is %s" % output[0]
+                "Failed to find bios_release_date. The command output is %s" % output[0]
             )
         date_year = bios_version[0][:4]
         date_month = bios_version[0][4:6]

--- a/qemu/tests/unsafe_rebase_to_none_existing_backing_file.py
+++ b/qemu/tests/unsafe_rebase_to_none_existing_backing_file.py
@@ -38,7 +38,7 @@ def run(test, params, env):
         test.log.info("Verify snapshot's backing file information.")
         res = json.loads(output)
         if res["backing-filename-format"] != b_fmt or res["backing-filename"] != b_name:
-            test.fail("Backing file information is not correct," " got %s." % b_name)
+            test.fail("Backing file information is not correct, got %s." % b_name)
         compat = res["format-specific"]["data"]["compat"]
         expected = _get_compat_version()
         if compat != expected:

--- a/qemu/tests/usb_host.py
+++ b/qemu/tests/usb_host.py
@@ -135,7 +135,7 @@ def run(test, params, env):
                         " returns: '%s'" % detail
                     )
             else:
-                test.fail("Hotplug operation in negative test" " should not succeed.")
+                test.fail("Hotplug operation in negative test should not succeed.")
         return
 
     usb_hostdev = params["usb_devices"].split()[-1]

--- a/qemu/tests/usb_storage.py
+++ b/qemu/tests/usb_storage.py
@@ -56,7 +56,7 @@ def run(test, params, env):
             ignore_case = True
 
         error_context.context(
-            "Finding matched sub-string with regex" " pattern '%s'" % regex_str,
+            "Finding matched sub-string with regex pattern '%s'" % regex_str,
             test.log.info,
         )
         m = re.findall(regex_str, string, search_opt)

--- a/qemu/tests/vfio_net_plug.py
+++ b/qemu/tests/vfio_net_plug.py
@@ -68,7 +68,7 @@ def run(test, params, env):
                 vm.reboot(method="system_reset", serial=True)
         finally:
             error_context.context(
-                "Verify the VM is still alive without any " "faults", test.log.info
+                "Verify the VM is still alive without any faults", test.log.info
             )
             vm.verify_alive()
             vm.destroy()

--- a/qemu/tests/vhost_with_cgroup.py
+++ b/qemu/tests/vhost_with_cgroup.py
@@ -40,7 +40,7 @@ def run(test, params, env):
     cgroup.initialize(modules)
 
     error_context.context(
-        "Boot guest and attach vhost to cgroup your" " setting(cpu)", test.log.info
+        "Boot guest and attach vhost to cgroup your setting(cpu)", test.log.info
     )
     params["start_vm"] = "yes"
     preprocess(test, params, env)
@@ -60,7 +60,7 @@ def run(test, params, env):
         cgroup.set_cgroup(int(vhost_pid))
 
     error_context.context(
-        "Check whether vhost attached to" " cgroup successfully", test.log.info
+        "Check whether vhost attached to cgroup successfully", test.log.info
     )
     cgroup_tasks = " ".join(cgroup.get_property("tasks"))
     for vhost_pid in vhost_pids.strip().split():

--- a/qemu/tests/virt_firmware_basic_test.py
+++ b/qemu/tests/virt_firmware_basic_test.py
@@ -61,7 +61,7 @@ def run(test, params, env):
                 "the error message is '%s'." % six.text_type(e)
             )
     else:
-        test.log.info("Run the test with package " "'python3-virt-firmware-tests'.")
+        test.log.info("Run the test with package 'python3-virt-firmware-tests'.")
         virt_firmware_dirname = params["virt_firmware_test_package_dir"]
         test_file_black_list = []
     test_file_pattern = params["test_file_pattern"]

--- a/qemu/tests/virt_firmware_check_phys_bits.py
+++ b/qemu/tests/virt_firmware_check_phys_bits.py
@@ -116,17 +116,16 @@ def run(test, params, env):
         phys_bits_msg = params["phys_bits_msg"] % expected_phys_bits
         logs = vm.logsessions["seabios"].get_output()
         error_context.context(
-            "Check the phys-bits message in " "virt firmware log.", test.log.info
+            "Check the phys-bits message in virt firmware log.", test.log.info
         )
         if not re.search(phys_bits_msg, logs, re.S | re.I):
             test.fail(
-                "Not found phys-bits message '%s' in "
-                "virt firmware log." % phys_bits_msg
+                "Not found phys-bits message '%s' in virt firmware log." % phys_bits_msg
             )
         limitation = params.get_numeric("limitation_from_ovmf")
         if limitation and expected_phys_bits > limitation:
             error_context.context(
-                "Check the limitation message in virt " "firmware log.", test.log.info
+                "Check the limitation message in virt firmware log.", test.log.info
             )
             if not re.search(params["limitation_msg"], logs, re.S | re.I):
-                test.fail("Not found the limitation " "message in virt firmware log.")
+                test.fail("Not found the limitation message in virt firmware log.")

--- a/qemu/tests/virtio_blk_with_discard_write_zeroes.py
+++ b/qemu/tests/virtio_blk_with_discard_write_zeroes.py
@@ -36,7 +36,7 @@ def run(test, params, env):
                         )
                     elif _node.qtree.get(name) == excepted_val:
                         test.log.info(
-                            'The "%s" matches with qtree device "%s"' "(%s).",
+                            'The "%s" matches with qtree device "%s"(%s).',
                             name,
                             dev_id,
                             excepted_val,

--- a/qemu/tests/virtio_console.py
+++ b/qemu/tests/virtio_console.py
@@ -194,8 +194,7 @@ def run(test, params, env):
         else:
             if match != 1:  # Multiple open didn't fail:
                 test.fail(
-                    "Unexpended pass of opening the"
-                    " serialport device for the 2nd time."
+                    "Unexpended pass of opening the serialport device for the 2nd time."
                 )
         port.open()
         virtio_test.cleanup(vm, guest_worker)
@@ -372,7 +371,7 @@ def run(test, params, env):
         port.close()
         guest_worker.cmd("virt.clean_port('%s'),1024" % port.name, 10)
         match, tmp = guest_worker._cmd(
-            "virt.send('%s', (1024**3)*3, True, " "is_static=True)" % port.name, 30
+            "virt.send('%s', (1024**3)*3, True, is_static=True)" % port.name, 30
         )
         if match is not None:
             test.fail(
@@ -391,7 +390,7 @@ def run(test, params, env):
                 rlen += len(port.sock.recv((4096)))
             elif rlen != (1024**3 * 3):
                 test.fail(
-                    "Not all data was received," "only %d from %d" % (rlen, 1024**3 * 3)
+                    "Not all data was received,only %d from %d" % (rlen, 1024**3 * 3)
                 )
         guest_worker.cmd("print('PASS: nothing')", 10)
         virtio_test.cleanup(vm, guest_worker)
@@ -413,7 +412,7 @@ def run(test, params, env):
             "virt.recv('%s', 10, 1024, False)" % port.name, 10
         )
         if match == 0:
-            test.fail("Received data even when none was sent\n" "Data:\n%s" % tmp)
+            test.fail("Received data even when none was sent\nData:\n%s" % tmp)
         elif match is not None:
             test.fail("Unexpected fail\nMatch: %s\nData:\n%s" % (match, tmp))
         port.sock.sendall(b"1234567890")
@@ -438,9 +437,9 @@ def run(test, params, env):
             "virt.recv('%s', 10, 1024, False)" % port.name, 10
         )
         if match == 0:
-            test.fail("Received data even when none was sent\n" "Data:\n%s" % tmp)
+            test.fail("Received data even when none was sent\nData:\n%s" % tmp)
         elif match is None:
-            test.fail("Timed out, probably in blocking mode\n" "Data:\n%s" % tmp)
+            test.fail("Timed out, probably in blocking mode\nData:\n%s" % tmp)
         elif match != 1:
             test.fail("Unexpected fail\nMatch: %s\nData:\n%s" % (match, tmp))
         port.sock.sendall(b"1234567890")
@@ -626,7 +625,7 @@ def run(test, params, env):
                 transferred = _transfered
                 if err:
                     test.log.error(
-                        "Error occurred while executing loopback " "(%d out of %ds)",
+                        "Error occurred while executing loopback (%d out of %ds)",
                         test_time - int(end_time - time.time()),
                         test_time,
                     )
@@ -991,9 +990,7 @@ def run(test, params, env):
             send_resume_ev = threading.Event()
             recv_resume_ev = threading.Event()
         else:
-            test.cancel(
-                "virtio_console_interruption = '%s' " "is unknown." % interruption
-            )
+            test.cancel("virtio_console_interruption = '%s' is unknown." % interruption)
 
         send_pt = ports[0]
         recv_pt = ports[1]
@@ -1071,7 +1068,7 @@ def run(test, params, env):
                     test.log.debug("Transfered data2: %s", threads[1].idx)
                     if count == threads[1].idx and threads[1].is_alive():
                         test.log.warning(
-                            "No data received after %ds, extending " "test_time",
+                            "No data received after %ds, extending test_time",
                             test_time,
                         )
                     else:
@@ -1256,7 +1253,7 @@ def run(test, params, env):
                 if thread.ret_code:
                     no_errors += 1
                     test.log.error(
-                        "test_perf: error occurred in thread %s " "(H2G)", thread
+                        "test_perf: error occurred in thread %s (H2G)", thread
                     )
                 elif thread.idx == 0:
                     no_errors += 1
@@ -1270,13 +1267,13 @@ def run(test, params, env):
                         break
                     time.sleep(1)
                 else:
-                    test.fail("Unable to read-out all remaining " "data in 60s.")
+                    test.fail("Unable to read-out all remaining data in 60s.")
 
                 guest_worker.safe_exit_loopback_threads([port], [])
 
                 if _time > time_slice:
                     test.log.error(
-                        "Test ran %fs longer which is more than one " "time slice",
+                        "Test ran %fs longer which is more than one time slice",
                         _time,
                     )
                 else:
@@ -1284,7 +1281,7 @@ def run(test, params, env):
                 stats = _process_stats(stats[1:], time_slice * 1048576)
                 test.log.debug("Stats = %s", stats)
                 test.log.info(
-                    "Host -> Guest [MB/s] (min/med/max) = %.3f/%.3f/" "%.3f",
+                    "Host -> Guest [MB/s] (min/med/max) = %.3f/%.3f/%.3f",
                     stats[0],
                     stats[len(stats) / 2],
                     stats[-1],
@@ -1315,7 +1312,7 @@ def run(test, params, env):
                 if thread.ret_code:
                     no_errors += 1
                     test.log.error(
-                        "test_perf: error occurred in thread %s" "(G2H)", thread
+                        "test_perf: error occurred in thread %s(G2H)", thread
                     )
                 elif thread.idx == 0:
                     no_errors += 1
@@ -1323,7 +1320,7 @@ def run(test, params, env):
                 # Deviation is higher than single time_slice
                 if _time > time_slice:
                     test.log.error(
-                        "Test ran %fs longer which is more than one " "time slice",
+                        "Test ran %fs longer which is more than one time slice",
                         _time,
                     )
                 else:
@@ -1331,7 +1328,7 @@ def run(test, params, env):
                 stats = _process_stats(stats[1:], time_slice * 1048576)
                 test.log.debug("Stats = %s", stats)
                 test.log.info(
-                    "Guest -> Host [MB/s] (min/med/max) = %.3f/%.3f/" "%.3f",
+                    "Guest -> Host [MB/s] (min/med/max) = %.3f/%.3f/%.3f",
                     stats[0],
                     stats[len(stats) / 2],
                     stats[-1],
@@ -1481,9 +1478,7 @@ def run(test, params, env):
                     )
                 else:
                     EXIT_EVENT.set()
-                    test.fail(
-                        "Send thread died unexpectedly in " "migration %d" % (j + 1)
-                    )
+                    test.fail("Send thread died unexpectedly in migration %d" % (j + 1))
             for i in range(0, len(ports[1:])):
                 if not threads[i + 1].is_alive():
                     EXIT_EVENT.set()
@@ -1529,7 +1524,7 @@ def run(test, params, env):
             if thread.ret_code:
                 err += "%s, " % thread
         test.log.info(
-            "test_migrate: %s data received and verified during %d " "migrations",
+            "test_migrate: %s data received and verified during %d migrations",
             tmp[:-2],
             no_migrations,
         )
@@ -1604,7 +1599,7 @@ def run(test, params, env):
         for key, value in {
             "id": port,
             "name": port,
-            "bus": "virtio_serial_pci" "%d.0" % pci_id,
+            "bus": "virtio_serial_pci%d.0" % pci_id,
         }.items():
             new_portdev.set_param(key, value)
         (result, ver_out) = vm.devices.simple_hotplug(new_portdev, vm.monitor)
@@ -1851,8 +1846,7 @@ def run(test, params, env):
             raise inst
         if sent1 != sent2:
             test.log.warning(
-                "Inconsistent behavior: First sent %d bytes and "
-                "second sent %d bytes",
+                "Inconsistent behavior: First sent %d bytes and second sent %d bytes",
                 sent1,
                 sent2,
             )
@@ -1937,9 +1931,7 @@ def run(test, params, env):
             guest_worker.cmd("virt.open('%s')" % (port.name), 2)
             try:
                 process.append(
-                    Popen(
-                        "dd if=/dev/random of='%s' bs=4096 " "&>/dev/null &" % port.path
-                    )
+                    Popen("dd if=/dev/random of='%s' bs=4096 &>/dev/null &" % port.path)
                 )
             except Exception:
                 pass

--- a/qemu/tests/virtio_fs_daemon_readonly.py
+++ b/qemu/tests/virtio_fs_daemon_readonly.py
@@ -53,8 +53,7 @@ def run(test, params, env):
         if os_type == "linux":
             utils_misc.make_dirs(fs_dest, session)
             error_context.context(
-                "Mount virtiofs target %s to %s inside"
-                " guest." % (fs_target, fs_dest),
+                "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
                 test.log.info,
             )
             if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):

--- a/qemu/tests/virtio_fs_dynamic_memslots.py
+++ b/qemu/tests/virtio_fs_dynamic_memslots.py
@@ -69,8 +69,7 @@ def run(test, params, env):
         if os_type == "linux":
             utils_misc.make_dirs(fs_dest, session)
             error_context.context(
-                "Mount virtiofs target %s to %s inside"
-                " guest." % (fs_target, fs_dest),
+                "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
                 test.log.info,
             )
             if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):

--- a/qemu/tests/virtio_fs_group_permission_access.py
+++ b/qemu/tests/virtio_fs_group_permission_access.py
@@ -57,7 +57,7 @@ def run(test, params, env):
                             " pls check on your host."
                         )
                     else:
-                        test.fail("Unknown error when deleting the " "user: %s" % o)
+                        test.fail("Unknown error when deleting the user: %s" % o)
             if (
                 process.system(
                     "grep %s /etc/group" % _username, shell=True, ignore_status=True
@@ -125,14 +125,13 @@ def run(test, params, env):
             virtio_fs_utils.run_viofs_service(test, params, guest_session)
         else:
             error_context.context(
-                "Create a destination directory %s " "inside guest." % fs_dest,
+                "Create a destination directory %s inside guest." % fs_dest,
                 test.log.info,
             )
             if not utils_misc.make_dirs(fs_dest, session=guest_session):
                 test.fail("Creating directory was failed!")
             error_context.context(
-                "Mount virtiofs target %s to %s inside"
-                " guest." % (fs_target, fs_dest),
+                "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
                 test.log.info,
             )
             if not utils_disk.mount(

--- a/qemu/tests/virtio_fs_host_owner_win.py
+++ b/qemu/tests/virtio_fs_host_owner_win.py
@@ -53,7 +53,7 @@ def run(test, params, env):
         if s:
             test.fail("Fail command: %s. Output: %s." % (enable_cmd, o))
         error_context.context(
-            "Restart virtiofs service after modify" " the registry.", test.log.info
+            "Restart virtiofs service after modify the registry.", test.log.info
         )
         virtio_fs_utils.stop_viofs_service(test, params, session)
         virtio_fs_utils.start_viofs_service(test, params, session)
@@ -110,7 +110,7 @@ def run(test, params, env):
                         " pls check on your host."
                     )
                 else:
-                    test.fail("Unknown error when deleting the " "user: %s" % o)
+                    test.fail("Unknown error when deleting the user: %s" % o)
         if (
             process.system(
                 "grep %s /etc/group" % user_name, shell=True, ignore_status=True
@@ -161,7 +161,7 @@ def run(test, params, env):
     session = vm.wait_for_login()
 
     error_context.context(
-        "Change the shared dir's owner and group" " to 'test' on host.", test.log.info
+        "Change the shared dir's owner and group to 'test' on host.", test.log.info
     )
     if params.get("privileged", "") == "yes":
         # get shared dir by qdevices.
@@ -203,7 +203,7 @@ def run(test, params, env):
     # set UID/GID to virtiofs service and check the created file on host.
     for test_value, expect_value in dict_ids.items():
         error_context.context(
-            "Set host UID:GID=%s to viofs" " service." % test_value, test.log.info
+            "Set host UID:GID=%s to viofs service." % test_value, test.log.info
         )
         s, o = session.cmd_status_output(params["viofs_owner_query_cmd"])
         if s == 0:

--- a/qemu/tests/virtio_fs_hotplug.py
+++ b/qemu/tests/virtio_fs_hotplug.py
@@ -67,7 +67,7 @@ def run(test, params, env):
         Only for windows guest, enable driver verifier and install winscp.
         """
         error_context.context(
-            "Do driver verify and winfsp installation" " in windows guest.",
+            "Do driver verify and winfsp installation in windows guest.",
             test.log.info,
         )
         check_installed_cmd = params["check_installed_cmd"] % install_path
@@ -94,12 +94,12 @@ def run(test, params, env):
         Mount virtiofs on linux guest.
         """
         error_context.context(
-            "Create a destination directory %s " "inside guest." % fs_dest,
+            "Create a destination directory %s inside guest." % fs_dest,
             test.log.info,
         )
         utils_misc.make_dirs(fs_dest, session)
         error_context.context(
-            "Mount virtiofs target %s to %s inside" " guest." % (fs_target, fs_dest),
+            "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
             test.log.info,
         )
         if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):
@@ -182,7 +182,7 @@ def run(test, params, env):
         error_context.context("Run io test on the %s." % fs_dest, test.log.info)
         guest_file = os.path.join(fs_dest, test_file)
         error_context.context(
-            "Creating file under %s inside " "guest." % fs_dest, test.log.info
+            "Creating file under %s inside guest." % fs_dest, test.log.info
         )
         session.cmd(cmd_dd % guest_file, io_timeout)
         if os_type == "linux":

--- a/qemu/tests/virtio_fs_map_uid_gid.py
+++ b/qemu/tests/virtio_fs_map_uid_gid.py
@@ -60,7 +60,7 @@ def run(test, params, env):
         )
         guest_file = os.path.join(fs_dest, file_name)
         error_context.context(
-            "Create a file in shared dir " "with %s user." % user_guest, test.log.info
+            "Create a file in shared dir with %s user." % user_guest, test.log.info
         )
         if user_guest != "root":
             if session.cmd_status("id %s" % user_guest) == 0:
@@ -247,7 +247,7 @@ def run(test, params, env):
         if not utils_misc.make_dirs(fs_dest, session):
             test.fail("Creating directory was failed!")
         error_context.context(
-            "Mount virtiofs target %s to %s inside" " guest." % (fs_target, fs_dest),
+            "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
             test.log.info,
         )
         if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):

--- a/qemu/tests/virtio_fs_memory_leak_check.py
+++ b/qemu/tests/virtio_fs_memory_leak_check.py
@@ -28,7 +28,7 @@ def run(test, params, env):
         """Record Mmdi tag memory info in pool monitor to C: volume"""
         status = session.cmd_status(poolmon_mmdi_cmd)
         if status:
-            test.fail("Fail to get Mmdi pool tag memory " "info in pool monitor.")
+            test.fail("Fail to get Mmdi pool tag memory info in pool monitor.")
 
     driver = params["driver_name"]
     driver_verifier = params.get("driver_verifier", driver)
@@ -86,4 +86,4 @@ def run(test, params, env):
     diff_befor = result.split("\n")[0].split()[4]
     diff_aft = result.split("\n")[1].split()[4]
     if int(diff_aft) - int(diff_befor) > 100:
-        test.fail("There are memory leak on virtiofs," " the result is %s" % result)
+        test.fail("There are memory leak on virtiofs, the result is %s" % result)

--- a/qemu/tests/virtio_fs_migration_on_error.py
+++ b/qemu/tests/virtio_fs_migration_on_error.py
@@ -58,8 +58,7 @@ def run(test, params, env):
         if os_type == "linux":
             utils_misc.make_dirs(fs_dest, session)
             error_context.context(
-                "Mount virtiofs target %s to %s inside"
-                " guest." % (fs_target, fs_dest),
+                "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
                 test.log.info,
             )
             if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):

--- a/qemu/tests/virtio_fs_multi_users_access.py
+++ b/qemu/tests/virtio_fs_multi_users_access.py
@@ -79,11 +79,11 @@ def run(test, params, env):
     def switch_ip_to_dynamic(session, eth_name):
         if eth_name:
             restore_ip_cmd = (
-                'netsh interface ip set address name="%s" ' "source=dhcp" % eth_name
+                'netsh interface ip set address name="%s" source=dhcp' % eth_name
             )
             session.cmd(restore_ip_cmd)
             restore_dns_cmd = (
-                'netsh interface ip set dnsservers name="%s" ' "source=dhcp" % eth_name
+                'netsh interface ip set dnsservers name="%s" source=dhcp' % eth_name
             )
             session.cmd(restore_dns_cmd)
 
@@ -120,14 +120,13 @@ def run(test, params, env):
             vm.reboot(session)
         else:
             error_context.context(
-                "Create a destination directory %s " "inside guest." % fs_dest,
+                "Create a destination directory %s inside guest." % fs_dest,
                 test.log.info,
             )
             if not utils_misc.make_dirs(fs_dest, session=session):
                 test.fail("Creating directory was failed!")
             error_context.context(
-                "Mount virtiofs target %s to %s inside"
-                " guest." % (fs_target, fs_dest),
+                "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
                 test.log.info,
             )
             if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):
@@ -155,8 +154,7 @@ def run(test, params, env):
                         test.fail("Failed to join the domain!")
                     elif "is not recognized as an internal" in output:
                         error_context.context(
-                            "The netdom is NOT supported, "
-                            "trying to use powershell...",
+                            "The netdom is NOT supported, trying to use powershell...",
                             test.log.info,
                         )
                         ps_cred = params.get("ps_cred")
@@ -182,8 +180,7 @@ def run(test, params, env):
                     output = session.cmd_output(remove_domain_cmd)
                     if "is not recognized as an internal" in output:
                         error_context.context(
-                            "The netdom is NOT supported, "
-                            "trying to use powershell...",
+                            "The netdom is NOT supported, trying to use powershell...",
                             test.log.info,
                         )
                         ps_cred = params.get("ps_cred")

--- a/qemu/tests/virtio_fs_readonly.py
+++ b/qemu/tests/virtio_fs_readonly.py
@@ -36,7 +36,7 @@ def run(test, params, env):
 
     try:
         error_context.context(
-            "Create file under the destination " "directory inside guest.",
+            "Create file under the destination directory inside guest.",
             test.log.info,
         )
         output = session.cmd_output(params.get("cmd_create_file"))

--- a/qemu/tests/virtio_fs_sandbox.py
+++ b/qemu/tests/virtio_fs_sandbox.py
@@ -30,7 +30,7 @@ def run(test, params, env):
     process.system(params["add_user_cmd"], shell=True)
 
     error_context.context(
-        "Switch to the common user and create the" " shared dir in home dir.",
+        "Switch to the common user and create the shared dir in home dir.",
         test.log.info,
     )
     # set fs shared dir
@@ -90,13 +90,12 @@ def run(test, params, env):
         if not is_windows:
             # mount virtiofs
             error_context.context(
-                "Create a destination directory %s " "inside guest." % fs_dest,
+                "Create a destination directory %s inside guest." % fs_dest,
                 test.log.info,
             )
             utils_misc.make_dirs(fs_dest, session)
             error_context.context(
-                "Mount virtiofs target %s to %s inside"
-                " guest." % (fs_target, fs_dest),
+                "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
                 test.log.info,
             )
             if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):

--- a/qemu/tests/virtio_fs_set_capability.py
+++ b/qemu/tests/virtio_fs_set_capability.py
@@ -161,13 +161,12 @@ def run(test, params, env):
     try:
         if not is_windows:
             error_context.context(
-                "Create a destination directory %s " "inside guest." % fs_dest,
+                "Create a destination directory %s inside guest." % fs_dest,
                 test.log.info,
             )
             utils_misc.make_dirs(fs_dest, session)
             error_context.context(
-                "Mount virtiofs target %s to %s inside"
-                " guest." % (fs_target, fs_dest),
+                "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
                 test.log.info,
             )
             if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):

--- a/qemu/tests/virtio_fs_share_data.py
+++ b/qemu/tests/virtio_fs_share_data.py
@@ -135,7 +135,7 @@ def run(test, params, env):
         output = session.cmd_output(viofs_sc_query_cmd)  # pylint: disable=E0606
         if expect_status not in output:
             test.fail(
-                "Could not %s VirtioFsSvc service, " "detail: '%s'" % (action, output)
+                "Could not %s VirtioFsSvc service, detail: '%s'" % (action, output)
             )
 
     def start_multifs_instance():
@@ -326,7 +326,7 @@ def run(test, params, env):
             try:
                 utils_selinux.set_status(se_mode)
             except Exception as err_msg:
-                test.cancel("Setting selinux failed on host with" " %s." % str(err_msg))
+                test.cancel("Setting selinux failed on host with %s." % str(err_msg))
     try:
         vm = None
         if (
@@ -351,7 +351,7 @@ def run(test, params, env):
         if security_label_test and os_type == "linux":
             # make sure selinux is enabled on guest.
             error_context.context(
-                "Set selinux to %s status on" " guest." % se_mode, test.log.info
+                "Set selinux to %s status on guest." % se_mode, test.log.info
             )
             se_mode_guest_before = session.cmd_output("getenforce").strip()
             if se_mode_guest_before != se_mode:
@@ -391,7 +391,7 @@ def run(test, params, env):
 
             if os_type == "linux":
                 error_context.context(
-                    "Create a destination directory %s " "inside guest." % fs_dest,
+                    "Create a destination directory %s inside guest." % fs_dest,
                     test.log.info,
                 )
                 utils_misc.make_dirs(fs_dest, session)
@@ -418,7 +418,7 @@ def run(test, params, env):
                     virtio_fs_utils.start_viofs_service(test, params, session)
                 else:
                     error_context.context(
-                        "Start winfsp.launcher" " instance in guest.", test.log.info
+                        "Start winfsp.launcher instance in guest.", test.log.info
                     )
                     start_multifs_instance()
 
@@ -444,7 +444,7 @@ def run(test, params, env):
             try:
                 if cmd_dd:
                     error_context.context(
-                        "Creating file under %s inside " "guest." % fs_dest,
+                        "Creating file under %s inside guest." % fs_dest,
                         test.log.info,
                     )
                     # for windows, after virtiofs service start up, should wait
@@ -498,7 +498,7 @@ def run(test, params, env):
 
                 if folder_test == "yes":
                     error_context.context(
-                        "Folder test under %s inside " "guest." % fs_dest, test.log.info
+                        "Folder test under %s inside guest." % fs_dest, test.log.info
                     )
                     session.cmd(cmd_new_folder % fs_dest)
                     try:
@@ -519,9 +519,7 @@ def run(test, params, env):
                     def file_check(cmd):
                         s, o = session.cmd_status_output(cmd, io_timeout)
                         if s:
-                            test.fail(
-                                "Case insensitive failed," " the output is %s" % o
-                            )
+                            test.fail("Case insensitive failed, the output is %s" % o)
 
                     error_context.context(
                         "Check if case insensitive is set in registry.", test.log.info
@@ -549,7 +547,7 @@ def run(test, params, env):
                     session.cmd("echo hello > %s" % guest_file, io_timeout)
 
                     error_context.context(
-                        "check the file with" " uppercase letter name.", test.log.info
+                        "check the file with uppercase letter name.", test.log.info
                     )
                     guest_file_full_path = (
                         volume_letter + ":\\" + test_file_guest.upper()
@@ -568,7 +566,7 @@ def run(test, params, env):
                     process.system("touch %s" % host_data, io_timeout)
                     time.sleep(2)
                     error_context.context(
-                        "check the file with" " lowercase letter name.", test.log.info
+                        "check the file with lowercase letter name.", test.log.info
                     )
                     guest_file_full_path = (
                         volume_letter + ":\\" + test_file_host.lower()
@@ -580,7 +578,7 @@ def run(test, params, env):
 
                 if cmd_symblic_file:
                     error_context.context(
-                        "Symbolic test under %s inside " "guest." % fs_dest,
+                        "Symbolic test under %s inside guest." % fs_dest,
                         test.log.info,
                     )
                     cmd_create_file = params["cmd_create_file"]
@@ -593,7 +591,7 @@ def run(test, params, env):
                         test.fail("Creat symbolic folders failed.")
 
                     error_context.context(
-                        "Compare symbolic link info in " "the host and guest",
+                        "Compare symbolic link info in the host and guest",
                         test.log.info,
                     )
 
@@ -749,7 +747,7 @@ def run(test, params, env):
 
                 if cmd_get_stdev:
                     error_context.context(
-                        "Create files in local device and" " nfs device ", test.log.info
+                        "Create files in local device and nfs device ", test.log.info
                     )
                     file_in_local_host = os.path.join(fs_source, "file_test")
                     file_in_nfs_host = os.path.join(
@@ -761,7 +759,7 @@ def run(test, params, env):
                     )
                     process.run(cmd_touch_file)
                     error_context.context(
-                        "Check if the two files' st_dev are" " the same on guest.",
+                        "Check if the two files' st_dev are the same on guest.",
                         test.log.info,
                     )
                     file_in_local_guest = os.path.join(fs_dest, "file_test")
@@ -808,7 +806,7 @@ def run(test, params, env):
 
                 if create_dir_winapi_cmd:
                     error_context.context(
-                        "Create new directory with WinAPI's " "CreateDirectory.",
+                        "Create new directory with WinAPI's CreateDirectory.",
                         test.log.info,
                     )
                     session.cmd(create_dir_winapi_cmd % fs_dest)
@@ -906,12 +904,12 @@ def run(test, params, env):
                     time.sleep(1)
 
                     error_context.context(
-                        "Check new file's security label" " on guest.", test.log.info
+                        "Check new file's security label on guest.", test.log.info
                     )
                     check_security_label(file_new_in_guest, fs_dest, selinux_xattr_name)
 
                     error_context.context(
-                        "Check new file's attribute on" " host.", test.log.info
+                        "Check new file's attribute on host.", test.log.info
                     )
                     check_attribute(
                         file_share_in_host,
@@ -949,7 +947,7 @@ def run(test, params, env):
                 if winfsp_test_cmd:
                     # only for windows guest.
                     error_context.context(
-                        "Run winfsp-tests suit on windows" " guest.", test.log.info
+                        "Run winfsp-tests suit on windows guest.", test.log.info
                     )
                     winfsp_copy_cmd = utils_misc.set_winutils_letter(
                         session, winfsp_copy_cmd
@@ -971,14 +969,13 @@ def run(test, params, env):
                     repeats = int(params.get("stop_start_repeats", 1))
                     for i in range(repeats):
                         error_context.context(
-                            "Repeat stop/start VirtioFsSvc:"
-                            " %d/%d" % (i + 1, repeats),
+                            "Repeat stop/start VirtioFsSvc: %d/%d" % (i + 1, repeats),
                             test.log.info,
                         )
                         viofs_svc_stop_start("stop", viofs_sc_stop_cmd, "STOPPED")
                         viofs_svc_stop_start("start", viofs_sc_start_cmd, "RUNNING")
                     error_context.context(
-                        "Basic IO test after" " repeat stop/start virtiofs" " service.",
+                        "Basic IO test after repeat stop/start virtiofs service.",
                         test.log.info,
                     )
                     s, o = session.cmd_status_output(cmd_dd % guest_file, io_timeout)
@@ -987,7 +984,7 @@ def run(test, params, env):
 
                 if cmd_run_sesuit:
                     error_context.context(
-                        "Run selinux_testsuits based on selinux label" "is enabled.",
+                        "Run selinux_testsuits based on selinux labelis enabled.",
                         test.log.info,
                     )
                     host_path = os.path.join(
@@ -1113,12 +1110,10 @@ def run(test, params, env):
                 try:
                     utils_selinux.set_status(se_mode_host_before)
                 except Exception as err_msg:
-                    test.fail(
-                        "Restore selinux failed with %s on" "host." % str(err_msg)
-                    )
+                    test.fail("Restore selinux failed with %s onhost." % str(err_msg))
             if os_type == "linux" and not se_mode_guest_before == se_mode:
                 test.log.info(
-                    "Need to change selinux mode back to" " %s.", se_mode_guest_before
+                    "Need to change selinux mode back to %s.", se_mode_guest_before
                 )
                 if se_mode_guest_before.lower() == "disabled":
                     cmd = (

--- a/qemu/tests/virtio_fs_subtest_during_io.py
+++ b/qemu/tests/virtio_fs_subtest_during_io.py
@@ -57,13 +57,13 @@ def run(test, params, env):
         virtio_fs_utils.run_viofs_service(test, params, session)
     else:
         error_context.context(
-            "Create a destination directory %s " "inside guest." % fs_dest,
+            "Create a destination directory %s inside guest." % fs_dest,
             test.log.info,
         )
         if not utils_misc.make_dirs(fs_dest, session=session):
             test.fail("Creating directory was failed!")
         error_context.context(
-            "Mount virtiofs target %s to %s inside" " guest." % (fs_target, fs_dest),
+            "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
             test.log.info,
         )
         if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):

--- a/qemu/tests/virtio_fs_supp_group_transfer.py
+++ b/qemu/tests/virtio_fs_supp_group_transfer.py
@@ -63,7 +63,7 @@ def run(test, params, env):
             else:
                 cmd_dd = params.get(
                     "virtio_fs_cmd_dd",
-                    "dd if=/dev/urandom of=%s bs=1M " "count=100 iflag=fullblock",
+                    "dd if=/dev/urandom of=%s bs=1M count=100 iflag=fullblock",
                 )
             guest_file = os.path.join(fs_dest, test_file)
             error_context.context(
@@ -93,7 +93,7 @@ def run(test, params, env):
                 test.fail("The md5 value of host is not same to guest.")
             else:
                 error_context.context(
-                    "The md5 of host is as same as md5 of " "guest.", LOG_JOB.info
+                    "The md5 of host is as same as md5 of guest.", LOG_JOB.info
                 )
         finally:
             if not windows:
@@ -130,13 +130,13 @@ def run(test, params, env):
         guest_root_session = vm.wait_for_login()
 
         error_context.context(
-            "Create a destination directory %s " "inside guest." % fs_dest,
+            "Create a destination directory %s inside guest." % fs_dest,
             test.log.info,
         )
         if not utils_misc.make_dirs(fs_dest, session=guest_root_session):
             test.fail("Creating directory was failed!")
         error_context.context(
-            "Mount virtiofs target %s to %s inside" " guest." % (fs_target, fs_dest),
+            "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
             test.log.info,
         )
         if not utils_disk.mount(
@@ -150,7 +150,7 @@ def run(test, params, env):
         guest_root_session.cmd("usermod -G wheel %s" % username)
 
         error_context.context(
-            "Create a dir inside the virtiofs and " "change it's group to wheel",
+            "Create a dir inside the virtiofs and change it's group to wheel",
             test.log.info,
         )
         guest_root_session.cmd("cd %s && mkdir -m 770 %s" % (fs_dest, testdir))

--- a/qemu/tests/virtio_fs_write_same_space.py
+++ b/qemu/tests/virtio_fs_write_same_space.py
@@ -42,12 +42,12 @@ def run(test, params, env):
         guest_addr = vm.get_address()
 
         error_context.context(
-            "Create a destination directory %s" "inside guest." % fs_dest, test.log.info
+            "Create a destination directory %sinside guest." % fs_dest, test.log.info
         )
         utils_misc.make_dirs(fs_dest, session)
 
         error_context.context(
-            "Mount virtiofs target %s to %s inside " "guest." % (fs_target, fs_dest),
+            "Mount virtiofs target %s to %s inside guest." % (fs_target, fs_dest),
             test.log.info,
         )
         if not utils_disk.mount(fs_target, fs_dest, "virtiofs", session=session):
@@ -57,7 +57,7 @@ def run(test, params, env):
         test.log.info("The guest file in shared dir is %s", guest_file)
 
         error_context.context(
-            "write to the same space of" " a file with mmap.", test.log.info
+            "write to the same space of a file with mmap.", test.log.info
         )
         test.log.info("Copy the mmap script to guest.")
         host_path = os.path.join(data_dir.get_deps_dir("virtio_fs"), script_create_file)

--- a/qemu/tests/virtio_win_installer_version_check.py
+++ b/qemu/tests/virtio_win_installer_version_check.py
@@ -26,7 +26,7 @@ def run(test, params, env):
     pkg_status = process.getstatusoutput(params["rpm_install_chk_cmd"], shell=True)[0]
     if pkg_status:
         test.cancel(
-            "Pls check the test env: whether virtio-win pkg is " "installed on host."
+            "Pls check the test env: whether virtio-win pkg is installed on host."
         )
 
     pkg_ver = (

--- a/qemu/tests/virtual_nic_stress.py
+++ b/qemu/tests/virtual_nic_stress.py
@@ -71,13 +71,13 @@ def run(test, params, env):
         unload_stress(session)
 
     error_context.context(
-        "Ping test after flood ping," " Check if the network is still alive",
+        "Ping test after flood ping, Check if the network is still alive",
         test.log.info,
     )
     count = params["count"]
     timeout = float(count) * 2
     status, output = utils_net.ping(guest_ip, count, timeout=timeout)
     if status != 0:
-        test.fail("Ping failed, status: %s," " output: %s" % (status, output))
+        test.fail("Ping failed, status: %s, output: %s" % (status, output))
 
     session.close()

--- a/qemu/tests/vnc.py
+++ b/qemu/tests/vnc.py
@@ -145,7 +145,7 @@ def run(test, params, env):
         vm.monitor.send_args_cmd(change_passwd_cmd % (password, timeout))
 
         error_context.context(
-            "Connect to VNC server after setting password" " to '%s'" % password
+            "Connect to VNC server after setting password to '%s'" % password
         )
         vnc = VNC(port=port, rfb_version=rfb_version)
         status = vnc.hand_shake(password)

--- a/qemu/tests/vsock_hotplug.py
+++ b/qemu/tests/vsock_hotplug.py
@@ -43,7 +43,7 @@ def run(test, params, env):
         dev_vsock = qdevices.QDevice("vhost-vsock-pci", vsock_params)
     vm.devices.simple_hotplug(dev_vsock, vm.monitor)
     error_context.context(
-        "Check vsock device exist in guest lspci and " "dmesg output.", test.log.info
+        "Check vsock device exist in guest lspci and dmesg output.", test.log.info
     )
     addr_pattern = params["addr_pattern"]
     device_pattern = params["device_pattern"]

--- a/qemu/tests/vsock_negative_test.py
+++ b/qemu/tests/vsock_negative_test.py
@@ -77,7 +77,7 @@ def run(test, params, env):
         raise ValueError(f"unexpected test tool: {vsock_test_tool}")
     connected_str = "Connection reset by peer"
     error_context.context(
-        "Connect vsock from host without" " listening on guest.", test.log.info
+        "Connect vsock from host without listening on guest.", test.log.info
     )
     try:
         process.system_output(conn_cmd)

--- a/qemu/tests/watchdog.py
+++ b/qemu/tests/watchdog.py
@@ -46,7 +46,7 @@ def run(test, params, env):
         # when wDT is 6300esb need check pci info
         if watchdog_device == "i6300esb":
             error_context.context(
-                "checking pci info to ensure have WDT" " device", test.log.info
+                "checking pci info to ensure have WDT device", test.log.info
             )
             session.cmd("echo 1 > /sys/bus/pci/rescan")
             o = session.cmd_output("lspci")
@@ -99,8 +99,7 @@ def run(test, params, env):
 
         response_timeout = int(params.get("response_timeout", "240"))
         error_context.context(
-            "Check whether or not watchdog action '%s' took"
-            " effect" % watchdog_action,
+            "Check whether or not watchdog action '%s' took effect" % watchdog_action,
             test.log.info,
         )
         if watchdog_action == "inject-nmi":
@@ -182,8 +181,7 @@ def run(test, params, env):
 
         # check the host support watchdog types.
         error_context.context(
-            "Checking whether or not the host support"
-            " WDT '%s'" % watchdog_device_type,
+            "Checking whether or not the host support WDT '%s'" % watchdog_device_type,
             test.log.info,
         )
         watchdog_device = process.system_output(
@@ -273,7 +271,7 @@ def run(test, params, env):
         _trigger_watchdog(session, trigger_cmd)
 
         error_context.context(
-            "Do migration(protocol:%s),Watchdog have" " been triggered." % mig_protocol,
+            "Do migration(protocol:%s),Watchdog have been triggered." % mig_protocol,
             test.log.info,
         )
         args = (mig_timeout, mig_protocol, mig_cancel_delay)
@@ -325,7 +323,7 @@ def run(test, params, env):
         vm.monitor.send_args_cmd(watchdog_device_del)
 
         error_context.context(
-            "Resume the guest, check the WDT have" " been removed", test.log.info
+            "Resume the guest, check the WDT have been removed", test.log.info
         )
         vm.resume()
         session = vm.wait_for_login(timeout=timeout)
@@ -355,8 +353,7 @@ def run(test, params, env):
                 "VM." % watchdog_action
             )
         test.log.info(
-            "Watchdog action '%s' didn't take effect after pausing "
-            "VM, it is expected.",
+            "Watchdog action '%s' didn't take effect after pausing VM, it is expected.",
             watchdog_action,
         )
         vm.resume()
@@ -418,7 +415,7 @@ def run(test, params, env):
         reload_module_cmd = params["reload_module_cmd"]
         _watchdog_device_check(test, session, watchdog_device_type)
         error_context.context(
-            "set heartbeat value and reload the i6300esb " "module", test.log.info
+            "set heartbeat value and reload the i6300esb module", test.log.info
         )
         session.cmd(del_module_cmd)
         heartbeat = params["heartbeat"]
@@ -433,7 +430,7 @@ def run(test, params, env):
             o = session.cmd_output("dmesg | grep -i 'i6300esb.*invalid'")
             if o:
                 test.log.info(
-                    "Heartbeat value %s is out of range, it is " "expected.", heartbeat
+                    "Heartbeat value %s is out of range, it is expected.", heartbeat
                 )
             else:
                 test.fail("No invalid heartbeat info in dmesg.")
@@ -441,7 +438,7 @@ def run(test, params, env):
             o = session.cmd_output("dmesg | grep -i 'heartbeat=30'")
             if not o:
                 test.fail(
-                    "Heartbeat value isn't default 30 sec in dmesg, it " "should be."
+                    "Heartbeat value isn't default 30 sec in dmesg, it should be."
                 )
             heartbeat = 30
         elif 1 <= heartbeat <= 2046:

--- a/qemu/tests/win_nics_teaming.py
+++ b/qemu/tests/win_nics_teaming.py
@@ -105,7 +105,7 @@ def run(test, params, env):
         current_md5 = crypto.hash_file(host_path, algorithm="md5")
         test.log.info("md5 value of data current: %s", current_md5)
         if original_md5 != current_md5:
-            test.fail("File changed after transfer host -> guest " "and guest -> host")
+            test.fail("File changed after transfer host -> guest and guest -> host")
     finally:
         os.remove(host_path)
         session_serial.cmd(

--- a/qemu/tests/win_sigverif.py
+++ b/qemu/tests/win_sigverif.py
@@ -49,7 +49,7 @@ def run(test, params, env):
 
     try:
         error_context.context(
-            "Open sigverif logs and check driver signature" " status", test.log.info
+            "Open sigverif logs and check driver signature status", test.log.info
         )
         output = session.cmd_output(check_sigverif_cmd)
         pattern = r"%s.sys.*\s{2,}Signed" % driver_name

--- a/qemu/tests/win_virtio_driver_install_from_update.py
+++ b/qemu/tests/win_virtio_driver_install_from_update.py
@@ -91,8 +91,7 @@ def run(test, params, env):
         lambda: not session.cmd_status(driver_check_cmd), 600, 60, 10
     ):
         test.fail(
-            "%s Driver can not be installed correctly from "
-            "windows update" % driver_name
+            "%s Driver can not be installed correctly from windows update" % driver_name
         )
 
     error_context.context("%s Driver Check" % driver_name, test.log.info)

--- a/qemu/tests/win_virtio_update.py
+++ b/qemu/tests/win_virtio_update.py
@@ -29,7 +29,7 @@ def run(test, params, env):
                 if nic_idx < 0:
                     raise
                 test.log.warning(
-                    "Unable to login guest, " "try to login via nic %d", nic_idx
+                    "Unable to login guest, try to login via nic %d", nic_idx
                 )
 
     def check_cdrom(timeout):

--- a/qemu/tests/x86_cpu_L3_cache.py
+++ b/qemu/tests/x86_cpu_L3_cache.py
@@ -32,7 +32,7 @@ def run(test, params, env):
             params["smp"] = params["vcpu_maxcpus"] = "128"
         L3_existence = "present" if check_L3 else "not present"
         test.log.info(
-            "Boot guest with machine type %s and expect L3 cache %s" " inside guest",
+            "Boot guest with machine type %s and expect L3 cache %s inside guest",
             machine_type,
             L3_existence,
         )
@@ -60,7 +60,7 @@ def run(test, params, env):
         old_ver = re.findall(r"\d+\.\d+", old_machine)[0]
         if latest_ver <= old_ver:
             test.cancel(
-                "The latest supported machine type does not" " support this test case."
+                "The latest supported machine type does not support this test case."
             )
 
     old_machine = params["old_machine"]

--- a/qemu/tests/x86_cpu_asyncpf.py
+++ b/qemu/tests/x86_cpu_asyncpf.py
@@ -56,7 +56,7 @@ def run(test, params, env):
         old_ver = re.findall(r"\d+\.\d+", old_machine)[0]
         if latest_ver <= old_ver:
             test.cancel(
-                "The latest supported machine type does not" " support this test case."
+                "The latest supported machine type does not support this test case."
             )
 
     old_machine = params["old_machine"]

--- a/qemu/tests/yonit_bitmap.py
+++ b/qemu/tests/yonit_bitmap.py
@@ -43,11 +43,11 @@ def run(test, params, env):
     # running while the the foreground detecting is on going.
     error_context.context("run benchmark test in background", test.log.info)
     params["test_timeout"] = test_timeout * 2 + sec_per_day
-    test.log.info("set Yonit bitmap test timeout to" " %ss", params["test_timeout"])
+    test.log.info("set Yonit bitmap test timeout to %ss", params["test_timeout"])
     pid = guest_test.run_guest_test_background(test, params, env)
     if pid < 0:
         session.close()
-        test.error("Could not create child process to execute " "guest_test background")
+        test.error("Could not create child process to execute guest_test background")
 
     def is_yonit_benchmark_launched():
         if session.cmd_status('tasklist | find /I "compress_benchmark_loop"') != 0:
@@ -56,7 +56,7 @@ def run(test, params, env):
         return True
 
     error_context.context(
-        "Watching Yonit bitmap benchmark is" " running until timeout", test.log.info
+        "Watching Yonit bitmap benchmark is running until timeout", test.log.info
     )
     try:
         # Start detecting whether the benchmark is started a few mins

--- a/qemu/tests/zero_copy.py
+++ b/qemu/tests/zero_copy.py
@@ -49,7 +49,7 @@ def run(test, params, env):
 
     error_context.context("Boot vm with 'vhost=on'", test.log.info)
     if params.get("nettype") == "user":
-        test.cancel("Unable start test with user networking, please " "change nettype.")
+        test.cancel("Unable start test with user networking, please change nettype.")
     params["vhost"] = "vhost=on"
     params["start_vm"] = "yes"
     login_timeout = int(params.get("login_timeout", 360))


### PR DESCRIPTION
- Upgrade pre-commit-hooks from v4.6.0 to v5.0.0
- Add detect-private-key hook to prevent accidental private key commits
- Update ruff-pre-commit from v0.7.0 to v0.12.1

The updates ensure we're using the latest versions of pre-commit hooks
with bug fixes and improvements. The new detect-private-key hook adds an
important security check to prevent sensitive data from being committed.
Ruff update brings newer linting rules and fixes.

Signed-off-by: Yihuang Yu <yihyu@redhat.com>