### PR TITLE
qemu_guest_agent: add logic to determine whether install openssl

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -138,6 +138,7 @@
             image_snapshot = yes
             ppc64le:
                 image_snapshot = no
+            required_pkgs = "openssl"
             variants:
                 - no_crypto:
                     new_password = "Abc_123"


### PR DESCRIPTION
openssl sometimes isn't installed by default, it will cause case get failed.

ID: 3332
Signed-off-by: Dehan Meng [demeng@redhat.com](mailto:demeng@redhat.com)