### PR TITLE
block_during_io.cfg: fix iozone error on system disk

### DIFF
--- a/qemu/tests/cfg/block_during_io.cfg
+++ b/qemu/tests/cfg/block_during_io.cfg
@@ -44,6 +44,10 @@
             command_opts = shell,${command_shell}
     variants:
         - system_disk:
+            Win11:
+                mem = 4096
+            # The remaining disk size of the C drive decreases as the VM memory increases for win11
+            # so if we start the vm on a big memory host, no enough space to iozone for C drive.
             with_data_disks = no
             memory_leak_check = no
         - data_disks:

--- a/qemu/tests/cfg/virtio_storage_in_use.cfg
+++ b/qemu/tests/cfg/virtio_storage_in_use.cfg
@@ -52,6 +52,10 @@
             migration_test_command = ver && vol
     variants:
         - system_disk:
+            Win11:
+                mem = 4096
+                # The remaining disk size of the C drive decreases as the VM memory increases for win11
+                # so if we start the vm on a big memory host, no enough space to iozone for C drive.
             Windows:
                 disk_letter = C
             memory_leak_check = no


### PR DESCRIPTION

The remaining disk size of the C drive decreases
as the VM memory increases for win11. so if we start the vm on a big memory host, no enough space to do iozone on C drive. Adjust the memory for win11 to
4G, then the case will run normally.

ID: 4100