### PR TITLE
mlock_on_fault: adds threshold and removes try block

### DIFF
--- a/qemu/tests/cfg/mlock_on_fault.cfg
+++ b/qemu/tests/cfg/mlock_on_fault.cfg
@@ -10,3 +10,4 @@
     memhog_extra_options = "-m %dG -object memory-backend-ram,id=mem0,size=%dG,prealloc=on"
     qemu_cmd_memhog = "${qemu_cmd_memlock} ${memhog_extra_options} ${extra_qemu_options}"
     memhog_cmd = "memhog %dG"
+    threshold = 1024


### PR DESCRIPTION
mlock_on_fault: adds threshold and removes try block

Adds a threshold that considers memory being released, because
of a less proccess consumption. Moreover, removes teh try block
which is not fulfulling its purpose.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 4115