### PR TITLE
fix(ansible): add --user flag to pip install command

### DIFF
--- a/provider/ansible.py
+++ b/provider/ansible.py
@@ -144,7 +144,7 @@ def check_ansible_playbook(params):
         """
         if packages is None:
             packages = ["ansible"]
-        install_cmd = f"{sys.executable} -m pip install {' '.join(packages)}"
+        install_cmd = f"{sys.executable} -m pip install --user {' '.join(packages)}"
         status, output = process.getstatusoutput(install_cmd, verbose=True)
         if status != 0:
             LOG_JOB.error("Install python packages failed as: %s", output)


### PR DESCRIPTION
The change ensures pip installs packages in the user space rather than system-wide, preventing permission-related failures when users don't have root/sudo access. This makes the installation process more reliable across different environments.