### PR TITLE
chore(pre-commit): disable autofix_prs in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_prs: true
+  autofix_prs: false
   autoupdate_schedule: weekly
   skip: [no-commit-to-branch]
 default_stages: [pre-commit, pre-push]


### PR DESCRIPTION
The autofix_prs feature is disabled to prevent unexpected automatic code modifications during pull requests, giving developers more control over changes and requiring explicit review of formatting/linting fixes.