### PR TITLE
netkvm: add netkvm_poll_mode test case

### DIFF
--- a/qemu/tests/cfg/netkvm_poll_mode.cfg
+++ b/qemu/tests/cfg/netkvm_poll_mode.cfg
@@ -1,0 +1,39 @@
+- netkvm_poll_mode:
+    type = netkvm_poll_mode
+    clone = yes
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
+    # this case only tested on prewhql255 or higher version
+    cdroms += " virtio"
+    required_virtio_win_prewhql = [0.1.255, )
+    required_virtio_win = [1.9.49.0, )
+    # boot with virtio-net-pci device
+    only Win11, Win2025
+    only virtio_net
+    mq = on
+    enable_rss = '"*RSS" 1'
+    rss_queue_name = "*NumRssQueues"
+    setup_rss_queues = '"${rss_queue_name}" %s'
+    poll_mode_name = "*NdisPoll"
+    keyword = "Poll mode tried and"
+    variants:
+        - queue4_smp4:
+            smp = 4
+            queues = ${smp}
+            variants:
+                - rss_16:
+                    rss_queues = 16
+                    keyword = "${keyword} enabled"
+                - rss_2:
+                    rss_queues = 2
+                    keyword = "${keyword} disabled"
+        - queue4_smp2:
+            queues = 4
+            smp = 2
+            rss_queues = 2
+            keyword = "${keyword} enabled"
+        - queue32_smp20:
+            queues = 32
+            smp = 20
+            rss_queues = 16
+            keyword = "${keyword} disabled"

--- a/qemu/tests/netkvm_poll_mode.py
+++ b/qemu/tests/netkvm_poll_mode.py
@@ -1,0 +1,43 @@
+import re
+
+from virttest import utils_net
+
+
+def run(test, params, env):
+    """
+    Test net adapter after set NetAdapterrss, this case will:
+
+    1) Boot up VM with specific smp and queues
+    2) Configure RSS in VM
+    3) Check ndis Poll Mode state
+    4) Check traceview output
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+
+    # Enable RSS and setup RSS Queues value
+    rss_queues_count = params["rss_queues"]
+    rss, rss_value = params["enable_rss"].split(" ")
+    rss_queues_param, rss_queues_value = (
+        params["setup_rss_queues"] % rss_queues_count
+    ).split(" ")
+    utils_net.set_netkvm_param_value(vm, rss, rss_value)
+    utils_net.set_netkvm_param_value(vm, rss_queues_param, rss_queues_value)
+
+    # Check ndis poll mode state
+    poll_mode_param = params["poll_mode_name"]
+    output = utils_net.get_netkvm_param_value(vm, poll_mode_param)
+    test.log.info("ndis poll mode is %s", output)
+
+    # Check the traceview content
+    keyword = params["keyword"]
+    result = utils_net.dump_traceview_log_windows(params, vm)
+    test.log.info("Traceview log result: %s", result)
+    mapping_output = re.findall(keyword, result)
+    if not mapping_output:
+        test.error("Can't get %s from traceview", keyword)
+    test.log.info("Found keyword matches: %s", mapping_output)


### PR DESCRIPTION
Poll mode is a must-have feature for Windows Server 2025 and Windows 11.

ID: 2267

Signed-off-by: Wenkang Ji <wji@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests verifying netkvm poll-mode state and trace output keyword checks.
  * Expanded coverage with multiple RSS, queue, and SMP variants (different queue counts, RSS enabled/disabled) to validate behavior across configurations.
  * Added configuration variants to exercise polling behavior across Windows versions and virtualization settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->