### PR TITLE
hotplug_virtio_mem.cfg: Remove the test for older PC machine types

### DIFF
--- a/qemu/tests/cfg/hotplug_virtio_mem.cfg
+++ b/qemu/tests/cfg/hotplug_virtio_mem.cfg
@@ -31,3 +31,7 @@
     Windows:
         required_virtio_win_prewhql = [0.1.251, )
         required_virtio_win = [1.9.40.0, )
+        i440fx:
+            # For older PC machine types,"unplugged-inaccessible" defaults to "off"
+            # we don't have to test it on Windows.
+            no Host_RHEL.m9


### PR DESCRIPTION
For older PC machine types, eg: pc-i440fx-rhel7.6.0 "unplugged-inaccessible" defaults to "off".
We don't need to test it.

ID: 4103