### PR TITLE
hotplug_mem_stress_ng: Updates iomix-bytes argument in stress_ng call

### DIFF
--- a/qemu/tests/cfg/hotplug_mem_stress_ng.cfg
+++ b/qemu/tests/cfg/hotplug_mem_stress_ng.cfg
@@ -1,8 +1,10 @@
 - hotplug_mem_stress_ng:
     type = hotplug_mem_stress_ng
     mem_fixed = 4096
+    iomix_bytes = 2G
     x86_64:
         mem_fixed = 8192
+        iomix_bytes = 4G
     slots_mem = 4
     maxmem_mem = 32G
     pre_command = "sync && echo 3 > /proc/sys/vm/drop_caches"
@@ -32,4 +34,4 @@
     stress_ng_args = "--page-in -r 4 -t 60s"
     stress_ng_args += ";--malloc 4 -t 60s"
     stress_ng_args += ";--mmap 4 -t 60s"
-    stress_ng_args += ";--cpu 5 --vm 9 --vm-bytes 40% --iomix 6 --iomix-bytes 40% --memcpy 2 --cache-prefetch -t 1200s"
+    stress_ng_args += ";--cpu 5 --vm 9 --vm-bytes 40% --iomix 6 --iomix-bytes ${iomix_bytes} --memcpy 2 --cache-prefetch -t 1200s"


### PR DESCRIPTION
hotplug_mem_stress_ng: Updates iomix-bytes argument in stress_ng call

The stress_ng tool has been updated, so now the --iomix-bytes argument
does not support a percentage but a memory value, e.g. 4G.
Updates the cfg to provide this kind of value directly to the command.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 4224