### PR TITLE
uefi_check_resolution: add support for BootManagerMenuApp

### DIFF
--- a/qemu/tests/cfg/uefi_check_resolution.cfg
+++ b/qemu/tests/cfg/uefi_check_resolution.cfg
@@ -6,6 +6,8 @@
     boot_menu = on
     enable_sga = yes
     boot_menu_hint = "Boot Options"
+    restore_ovmf_vars = yes
+    boot_option_efi_setup = "EFI Firmware Setup"
     enter_change_preferred = "esc;down;kp_enter;down;down;down;down;kp_enter"
     default_resolution_key = "f9;y"
     ! Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0:


### PR DESCRIPTION
Failed to change resolution due to newly added BootManagerMenuApp, pressing ESC in the splash screen enter the BootManagerMenuApp instead of firmware configuration app on the latest system, so need to update the value of parameter enter_change_preferred in test case.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 4209
