### PR TITLE
uefi_boot_from_device: add supprot for BootManagerMenuApp

### DIFF
--- a/qemu/tests/cfg/uefi_boot_from_device.cfg
+++ b/qemu/tests/cfg/uefi_boot_from_device.cfg
@@ -8,6 +8,7 @@
     enable_sga = yes
     boot_menu_key = "esc;down;down;kp_enter"
     boot_menu_hint = "Boot Options"
+    boot_option_efi_setup = "EFI Firmware Setup"
     images = "stg"
     image_name_stg = "images/stg"
     image_size_stg = 100M

--- a/qemu/tests/uefi_boot_from_device.py
+++ b/qemu/tests/uefi_boot_from_device.py
@@ -71,6 +71,13 @@ def run(test, params, env):
                 test.fail("Could not get boot menu message")
 
             # Navigate to boot manager menu
+            boot_option_efi_setup = params.get("boot_option_efi_setup")
+            if boot_option_efi_setup and boot_check(boot_option_efi_setup):
+                vm.send_key("esc")
+                for i in range(count_of_move_step(boot_option_efi_setup)):
+                    vm.send_key("down")
+                vm.send_key("kp_enter")
+                del boot_menu_key[0]
             for i in boot_menu_key:
                 vm.send_key(i)
 


### PR DESCRIPTION
Failed to boot from the specific device due to newly added BootManagerMenuApp, pressing ESC in the splash screen enter the BootManagerMenuApp instead of firmware configuration app on the latest system, so need to update the value of parameter boot_menu_key in test case.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 4210