### PR TITLE
uefi_direct_kernel_boot: creates a new test case

### DIFF
--- a/qemu/tests/cfg/uefi_direct_kernel_boot.cfg
+++ b/qemu/tests/cfg/uefi_direct_kernel_boot.cfg
@@ -1,0 +1,37 @@
+- uefi_direct_kernel_boot:
+    type = uefi_direct_kernel_boot
+    only ovmf
+    only Linux
+    required_qemu = [10.0.0, )
+    restore_ovmf_vars = yes
+    backup_image_before_testing = yes
+    restore_image_after_testing = yes
+    start_vm = no
+    kill_vm = no
+    force_create_image = yes
+    guest_port_unattended_install = 12323
+    kernel = vmlinuz
+    initrd = initrd.img
+    inactivity_watcher = error
+    inactivity_treshold = 1800
+    image_verify_bootable = no
+    image_copy_on_error = no
+    lowest_mem = 512
+    image_aio = threads
+    check_secure_boot_enabled_cmd = 'dmesg|grep -i "Secure boot enabled"'
+    hd_info_pattern = 'HD\\([^)]+\\)(?=.*\\.efi)'
+    efiboot_output_cmd = 'command -v efibootmgr >/dev/null && (efibootmgr -v) || (dnf install -y efibootmgr && efibootmgr -v)'
+    unattended_delivery_method = cdrom
+    cdroms += ' unattended'
+    drive_index_unattended = 1
+    drive_index_cd1 = 2
+    boot_once = d
+    medium = cdrom
+    redirs += ' unattended_install'
+    extra_params += " -fw_cfg name=opt/org.tianocore/EnableLegacyLoader,string=no"
+    boot_efi_file = "BOOTX64.EFI"
+    append_option = "root=/dev/mapper/rhel-root ro console=tty0 rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap net.ifnames=0 console=ttyS0,115200"
+    variants:
+        - @with_installation:
+    variants:
+        - @extra_cdrom_ks:

--- a/qemu/tests/uefi_direct_kernel_boot.py
+++ b/qemu/tests/uefi_direct_kernel_boot.py
@@ -1,0 +1,70 @@
+import re
+
+from avocado.utils import download
+from virttest import data_dir, env_process, error_context, remote, utils_misc
+from virttest.tests import unattended_install
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    Direct secure kernel boot with -shim.
+
+    1. Install guest by OVMF environment(With OVMF_VARS.fd)
+    2. Shutdown and reboot the guest with file OVMF_VARS.secboot.fd
+       And add parameters -kernel, -initrd, -append and -shim
+    3. Check if secure boot is enabled inside guest
+    4. Check if the guest truly direct kernel boot
+       If yes, no HD info in efiboot output
+
+    :param test: Kvm test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    error_context.context("Install the guest with secure boot disabled.", test.log.info)
+    unattended_install.run(test, params, env)
+    params["cdroms"] = ""
+    params["boot_once"] = ""
+    params["force_create_image"] = "no"
+    params["start_vm"] = "yes"
+    guest_name = params["guest_name"]
+    params["kernel"] = f"images/{guest_name}/vmlinuz"
+    params["initrd"] = f"images/{guest_name}/initrd.img"
+    boot_efi_file = params["boot_efi_file"]
+    boot_efi_dst_path = f"images/{guest_name}/{boot_efi_file}"
+    boot_efi_dst_path = utils_misc.get_path(data_dir.get_data_dir(), boot_efi_dst_path)
+    download_boot_efi_url = params["download_boot_efi_url"]
+    download.get_file(download_boot_efi_url, boot_efi_dst_path)
+    params["extra_params"] += f" -shim {boot_efi_dst_path}"
+    params["kernel_params"] = params["append_option"]
+    params["image_boot"] = "yes"
+    params["ovmf_vars_filename"] = "OVMF_VARS.secboot.fd"
+    vm = env.get_vm(params["main_vm"])
+    if vm:
+        vm.destroy()
+    error_context.context("Direct secure kernel boot with -shim.", test.log.info)
+    env_process.preprocess_vm(test, params, env, params["main_vm"])
+    vm = env.get_vm(params["main_vm"])
+    vm.verify_alive()
+    try:
+        session = vm.wait_for_serial_login()
+    except remote.LoginTimeoutError:
+        test.fail("The guest boots failed under secure mode.")
+    else:
+        check_cmd = params["check_secure_boot_enabled_cmd"]
+        status = session.cmd_status(check_cmd)
+        if status != 0:
+            test.fail("Secure boot is not enabled")
+        hd_info_pattern = params["hd_info_pattern"]
+        efiboot_output_cmd = params["efiboot_output_cmd"]
+        efiboot_output = session.cmd_output(efiboot_output_cmd)
+        match = re.search(hd_info_pattern, efiboot_output)
+        if match:
+            hd_info = match.group(0)
+            test.fail(
+                "The guest does not truly implement direct kernel boot."
+                " Get the HD info '%s' from efiboot output." % hd_info
+            )
+    finally:
+        vm.destroy()


### PR DESCRIPTION
A new test case to verify the functionality of
direct secure kernel boot with -shim

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 4361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added a new UEFI direct kernel boot test scenario with Secure Boot (shim-based).
  - Covers unattended installation, kernel/initrd boot parameters, EFI boot file handling, and direct-boot validation via EFI entries.
  - Verifies Secure Boot status inside the guest and asserts direct kernel boot behavior.
  - Includes variants for installation and extra CD-ROM kickstart flows to broaden coverage.
  - Enhances reliability with controlled image handling, VM lifecycle management, and inactivity monitoring to reduce flakes during automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->