### PR TITLE
Change SNP policy to hex format

### DIFF
--- a/qemu/tests/cfg/snp_basic_config.cfg
+++ b/qemu/tests/cfg/snp_basic_config.cfg
@@ -22,12 +22,12 @@
     host_script = sev-snp/${attestation_script}
     variants:
         - policy_default:
-            snp_policy = 196608
-            vm_secure_guest_object_options = "policy=${snp_policy}"
+            snp_policy = 0x30000
+            vm_secure_guest_object_options = policy=${snp_policy}
         - policy_debug:
-            snp_policy = 720896
-            vm_secure_guest_object_options = "policy=${snp_policy}"
+            snp_policy = 0xB0000
+            vm_secure_guest_object_options = policy=${snp_policy}
         - policy_singlesocket:
             socket_count_cmd = 'lscpu |grep Socket|head -1 | cut -d ":" -f 2 | tr -d " "'
-            snp_policy = 77824
-            vm_secure_guest_object_options = "policy=${snp_policy}"
+            snp_policy = 0x130000
+            vm_secure_guest_object_options = policy=${snp_policy}

--- a/qemu/tests/snp_basic_config.py
+++ b/qemu/tests/snp_basic_config.py
@@ -48,7 +48,7 @@ def run(test, params, env):
     vm.verify_alive()
     session = vm.wait_for_login(timeout=timeout)
     verify_dmesg()
-    vm_policy = vm.params.get_numeric("snp_policy")
+    vm_policy = int(vm.params.get("snp_policy"), 0)
     guest_check_cmd = params["snp_guest_check"]
     sev_guest_info = vm.monitor.query_sev()
     if sev_guest_info["snp-policy"] != vm_policy:


### PR DESCRIPTION
ID: 4377
After applying https://github.com/avocado-framework/avocado-vt/pull/4212 , need to change snp policy to hex format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tests now accept SNP policy values in both hexadecimal and decimal formats for greater flexibility.
- Bug Fixes
  - Prevents misinterpretation of SNP policy values during test runs by auto-detecting numeric base.
- Tests
  - Updated snp_basic_config variants to use unquoted policy values and hex literals.
  - Parsing logic now converts policy strings with automatic base detection for accurate comparison with guest info.
- Chores
  - Minor configuration cleanup to keep fields consistent across variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->