### PR TITLE
stress: updates test cases to not install stress tool

### DIFF
--- a/generic/tests/cfg/linux_stress.cfg
+++ b/generic/tests/cfg/linux_stress.cfg
@@ -4,6 +4,7 @@
     stress_shell_timeout = 1200
     stress_wait_for_timeout = 60
     stress_duration = 10
+    stress_package = stress
     variants:
         - @default:
             stress_duration = 60

--- a/generic/tests/cfg/trans_hugepage.cfg
+++ b/generic/tests/cfg/trans_hugepage.cfg
@@ -33,6 +33,7 @@
         - memory_stress:
             type = trans_hugepage_memory_stress
             del stress_args
+            stress_package = stress
             mem_ratio = 0.8
             test_timeout = 600
             qemu_mem = 128

--- a/qemu/tests/cfg/balloon_in_use.cfg
+++ b/qemu/tests/cfg/balloon_in_use.cfg
@@ -36,6 +36,7 @@
         # Use a low stress to make sure guest can response during stress
         driver_name = "virtio_balloon"
         stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"
+        stress_package = stress
         migration_test_command = help
     variants:
         - before_bg_test:

--- a/qemu/tests/cfg/balloon_stress.cfg
+++ b/qemu/tests/cfg/balloon_stress.cfg
@@ -23,3 +23,4 @@
     Linux:
         # Use a low stress to make sure guest can response during stress
         stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M"
+        stress_package = stress

--- a/qemu/tests/cfg/hotplug_mem_migration.cfg
+++ b/qemu/tests/cfg/hotplug_mem_migration.cfg
@@ -32,6 +32,7 @@
     numa_test = 'numactl -m %s dd if=/dev/urandom of=/tmp/numa_test/test '
     numa_test += 'bs=1k count=%d && rm -rf /tmp/numa_test/'
     stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 4096M'
+    stress_package = stress
     variants with_cache:
         - @default:
         - enable_dirty_ring:

--- a/qemu/tests/cfg/hotplug_memory.cfg
+++ b/qemu/tests/cfg/hotplug_memory.cfg
@@ -207,6 +207,7 @@
             Linux:
                 sub_type = linux_stress
                 test_timeout = 1800
+                stress_package = stress
             only backend_ram.policy_default backend_file.policy_bind
     variants stage:
         - before:

--- a/qemu/tests/cfg/hugepage_reset.cfg
+++ b/qemu/tests/cfg/hugepage_reset.cfg
@@ -7,6 +7,7 @@
     # Please set 1G hugepages as the default size at boot time.
     # Example: default_hugepagesz=1G hugepagesz=1G
     expected_hugepage_size = 1048576
+    stress_package = stress
     Windows:
         x86_64:
             install_path = "C:\Program Files (x86)\JAM Software\HeavyLoad"

--- a/qemu/tests/cfg/ksm_ksmtuned.cfg
+++ b/qemu/tests/cfg/ksm_ksmtuned.cfg
@@ -14,6 +14,7 @@
     cmd_start_ksmtuned = 'systemctl start ksmtuned.service '
     cmd_stop_ksmtuned = 'systemctl stop ksmtuned.service'
     cmd_restart_ksmtuned = 'systemctl restart ksmtuned.service'
+    stress_package = stress
     Windows:
         x86_64:
             install_path = "C:\Program Files (x86)\JAM Software\HeavyLoad"

--- a/qemu/tests/cfg/migration_virtio_mem_ignore_shared.cfg
+++ b/qemu/tests/cfg/migration_virtio_mem_ignore_shared.cfg
@@ -6,6 +6,7 @@
     required_qemu = [8.1.0,)
     type = migration_virtio_mem_ignore_shared
     virt_test_type = qemu
+    stress_package = stress
     threshold = 0.025
     mem_threshold = 0.01
     aarch64:


### PR DESCRIPTION
stress: updates test cases to not install stress tool

These bunch of tests cases were trying to install the stress
tool in the VM because of the absence of stress_package cfg.
Updates the cfgs, so now test shouldn't do tool installation
if stress is present, especially for Image Mode.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 4011