### PR TITLE
uefi_disable_firmware_config: set image_boot=no for virtio_blk

### DIFF
--- a/qemu/tests/cfg/uefi_disable_firmware_config.cfg
+++ b/qemu/tests/cfg/uefi_disable_firmware_config.cfg
@@ -3,6 +3,8 @@
     type = uefi_disable_firmware_config
     only q35
     only ovmf
+    virtio_blk:
+        image_boot = no
     no Host_RHEL.m7 Host_RHEL.m8 Host_RHEL.m9 Host_RHEL.m10.u0
     boot_menu_key = esc
     boot_menu_hint = "Boot Options"


### PR DESCRIPTION
virtio_blk always set the image_boot true, and cause the bootindex be added in qemu command lines. The bootindex parameter can not be added in this test case, so set image_boot=no for virtio_blk.

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 4470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated UEFI test configuration to prevent booting from virtio block device images in scenarios restricted to q35/OVMF.
  - Aligns test boot path with expected firmware behavior, improving reliability and reducing false positives.
  - No runtime product changes; impact is limited to test stability and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->