### PR TITLE
dump_guest_memory: set fixed memory size to avoid timeout

### DIFF
--- a/qemu/tests/cfg/dump_guest_memory.cfg
+++ b/qemu/tests/cfg/dump_guest_memory.cfg
@@ -2,6 +2,7 @@
     type = dump_guest_memory
     virt_test_type = qemu
     no Windows
+    mem = 8192
     monitors = 'qmp1'
     monitor_type_qmp1 = qmp
     dump_file_timeout = 90


### PR DESCRIPTION
The dump_guest_memory test can fail on large-memory VMs because the vmcore dump may exceed the original timeout, resulting in truncated dump files and test failure.
    
Set the guest memory to a fixed 8 GB for this test so the dump time remains predictable and timeout-related failures are avoided.

ID: 4239

Signed-off-by: Wenkang Ji <wji@redhat.com>