### PR TITLE
qemu_guest_agent: Add test for QGA install without virtio-serial

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -666,6 +666,10 @@
             remove_image_image1 = yes
             cmd_run_debugview = 'start WIN_UTILS:\Debugviewconsole.exe -d C:\debug.dbglog'
             cmd_check_string_VSS = 'type C:\debug.dbglog | findstr /i "QEMU Guest Agent VSS Provider\[[0-9]*\]"'
+        - gagent_install_no_device:
+            only Windows
+            only no_serial
+            gagent_check_type = install_no_device
     variants:
         - virtio_serial:
             gagent_serial_type = virtio
@@ -689,3 +693,7 @@
                 gagent_start_cmd = "cd C:\Program Files\Qemu-ga & start /b qemu-ga.exe -m isa-serial -p COM2 -l c:\qga.log -v > nul"
                 gagent_status_cmd = "tasklist |findstr /i /r qemu-ga.exe.*Console"
                 gagent_restart_cmd = "taskkill /f /t /im qemu-ga.exe & ${gagent_start_cmd}"
+        - no_serial:
+            only gagent_install_no_device
+            gagent_serial_type = none
+            check_vioser = no


### PR DESCRIPTION
Add a new test case `gagent_install_no_device` to verify that 'QEMU Guest Agent (QGA)' can be successfully installed on a VM booted without a virtio-serial device.

Changes:
- cfg: Add `gagent_install_no_device` test variant and `no_serial` serial variant.
- py:
 - Implement `gagent_check_install_no_device` using direct MSI install command.
 - Update `setup` to skip agent creation when serial type is `none`.
 - Update `run_once` to skip verification for `install_no_device` case.

ID: 4506
Signed-off-by: Dehan Meng <demeng@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Windows-specific test variant for guest-agent installation without a virtio-serial device.
  * Added a corresponding no-serial variant to cover device-less scenarios.
  * Introduced dedicated test paths that bypass serial-device checks to validate installation behavior without serial support.
  * Expanded coverage for no-serial configurations across Linux and Windows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->