### PR TITLE
Balloon: Check WMI-Activity after restarting balloon service

### DIFF
--- a/deps/balloon/check_wmi_5858.ps1
+++ b/deps/balloon/check_wmi_5858.ps1
@@ -1,0 +1,40 @@
+# Check for WMI-Activity Event ID 5858 errors since blnsvr.exe started
+# Exit codes:
+#   0 - No WMI 5858 events found (NONE)
+#   1 - WMI 5858 event found (HIT)
+#   2 - Balloon service process not running (NO_PID)
+
+$ErrorActionPreference = 'SilentlyContinue'
+$log = 'Microsoft-Windows-WMI-Activity/Operational'
+
+# Get the balloon service process
+$p = Get-Process -Name blnsvr -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $p) {
+    Write-Output 'NO_PID'
+    exit 2
+}
+
+$blnPid = $p.Id
+$start = $p.StartTime.ToUniversalTime()
+
+# Query for WMI 5858 events since the process started
+$events = Get-WinEvent -FilterHashtable @{
+    LogName   = $log
+    Id        = 5858
+    StartTime = $start
+} -MaxEvents 50 -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.Level -eq 2 -and
+        $_.Message -match ('ClientProcessId = ' + $blnPid)
+    }
+
+$e = $events | Select-Object -First 1
+
+if ($null -ne $e) {
+    Write-Output 'HIT'
+    ($e | Format-List -Property TimeCreated, Id, Message | Out-String).Trim() | Write-Output
+    exit 1
+} else {
+    Write-Output 'NONE'
+    exit 0
+}

--- a/qemu/tests/balloon_service.py
+++ b/qemu/tests/balloon_service.py
@@ -89,12 +89,19 @@ def run(test, params, env):
         mem_stat_working = False
         for bln_oper in blnsrv_operation:
             error_context.context("%s balloon service" % bln_oper, test.log.info)
+            windows_run = params.get("os_type") == "windows" and bln_oper == "run"
             balloon_test.operate_balloon_service(session, bln_oper)
 
             error_context.context(
                 "Balloon vm memory after %s balloon service" % bln_oper, test.log.info
             )
             balloon_memory(vm, mem_check, min_sz, max_sz)
+            if windows_run:
+                error_context.context(
+                    "Check Windows Event Log for WMI 5858 after service restart",
+                    test.log.info,
+                )
+                balloon_test.assert_no_wmi_error_5858(session)
             mem_stat_working = True
         # for windows guest, disable/uninstall driver to get memory leak based on
         # driver verifier is enabled

--- a/qemu/tests/cfg/balloon_service.cfg
+++ b/qemu/tests/cfg/balloon_service.cfg
@@ -69,6 +69,10 @@
             only Windows
             repeat_times = 1
             blnsrv_operation = "stop run"
+            # WMI 5858 check script (copied from deps/balloon/)
+            wmi_check_script = "check_wmi_5858.ps1"
+            wmi_script_guest_path = "C:\check_wmi_5858.ps1"
+            wmi_5858_check_cmd = "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File %s"
         - sc_interrogate:
             type = balloon_sc_interrogate
             only Windows


### PR DESCRIPTION
Check for WMI-Activity Event ID 5858 since blnsvr.exe start.

id: 1315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Windows balloon-service validation by adding a post-operation WMI Event 5858 check after balloon "run" to detect related errors, handle missing service, command failures, and unexpected results with clear pass/fail outcomes.

* **New Features**
  * Added a Windows PowerShell check and new configuration options to invoke it (Windows-only) for improved error detection and logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->