### PR TITLE
win_driver_installer_test: Add viogpudo support for installer tests

### DIFF
--- a/provider/win_driver_installer_test.py
+++ b/provider/win_driver_installer_test.py
@@ -28,6 +28,7 @@ driver_name_list = [
     "vioinput",
     "fwcfg",
     "viomem",
+    "viogpudo",
 ]
 
 device_hwid_list = [
@@ -42,6 +43,7 @@ device_hwid_list = [
     '"PCI\\VEN_1AF4&DEV_1052"',
     '"ACPI\\VEN_QEMU&DEV_0002"',
     r'"PCI\VEN_1AF4&DEV_1002" "PCI\VEN_1AF4&DEV_1058"',
+    r'"PCI\VEN_1AF4&DEV_1050&SUBSYS_11001AF4&REV_01"',
 ]
 
 device_name_list = [
@@ -56,6 +58,7 @@ device_name_list = [
     "VirtIO Input Driver",
     "QEMU FwCfg Device",
     "VirtIO Viomem Driver",
+    "Red Hat VirtIO GPU DOD controller",
 ]
 
 
@@ -449,3 +452,28 @@ def viomem_test(test, params, vm):
             virtio_mem_utils.check_memory_devices(
                 device_id, requested_size, threshold, vm, test
             )
+
+
+def viogpudo_test(test, params, vm):
+    """
+    viogpudo driver function test.
+
+    :param test: kvm test object.
+    :param params: the dict used for parameters.
+    :param vm: vm object.
+    """
+    session = vm.wait_for_login()
+    error_context.context("Check viogpudo device status", LOG_JOB.info)
+
+    # Check if the device is working properly
+    cmd = params["viogpudo_status_check_cmd"]
+    output = session.cmd_output(cmd).strip()
+    if "OK" not in output:
+        test.fail("viogpudo device status is not OK: %s" % output)
+
+    # Check if resolution is detected (indicates driver is active)
+    cmd = params["viogpudo_resolution_check_cmd"]
+    output = session.cmd_output(cmd).strip()
+    # Output usually contains the number, e.g. "1024"
+    if not any(char.isdigit() for char in output):
+        test.warn("Could not retrieve resolution for viogpudo device: %s" % output)

--- a/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
@@ -45,6 +45,8 @@
     gagent_install_cmd = "start /wait %s /quiet"
     gagent_pkg_info_cmd = 'wmic product where name="Qemu guest agent"'
     gagent_uninstall_cmd = "wmic product where name='Qemu guest agent' call uninstall"
+    viogpudo_status_check_cmd = 'powershell -command "Get-CimInstance Win32_VideoController | Where-Object {$_.Name -like \"*Red Hat VirtIO GPU*\"} | Select-Object -ExpandProperty Status"'
+    viogpudo_resolution_check_cmd = 'powershell -command "Get-CimInstance Win32_VideoController | Where-Object {$_.Name -like \"*Red Hat VirtIO GPU*\"} | Select-Object -ExpandProperty CurrentHorizontalResolution"'
     threshold = 0.025
     nic_model_nic1 = rtl8139
     q35:
@@ -58,6 +60,7 @@
         - @all_drivers:
             nics += " nic2"
             nic_model_nic2 = virtio
+            vga = "virtio"
             no_virtio_rng:
                 virtio_rngs += " rng0"
                 backend_rng0 = rng-builtin
@@ -103,7 +106,7 @@
             numa_memdev_shm0 = mem-mem1
             numa_nodeid_shm0 = 0
             fs_binary_extra_options = " -o cache=auto"
-            test_drivers = 'balloon viostor vioscsi viorng viofs'
+            test_drivers = 'balloon viostor vioscsi viorng viofs viogpudo'
             driver_test_name_viorng = 'rng'
             driver_test_name_viostor = 'iozone'
             driver_test_params_viostor = {'images': 'stg0'}
@@ -111,6 +114,7 @@
             driver_test_params_vioscsi = {'images': 'stg1'}
             driver_test_name_viofs = "viofs_basic_io"
             driver_test_name_balloon = "balloon"
+            driver_test_name_viogpudo = "viogpudo"
             iozone_cmd_opitons = " -azR -r 64k -n 512M -g 1G -M -I -i 0 -i 1 -b iozone.xls -f %s:\testfile"
             read_rng_cmd = "WIN_UTILS:\\random_%PROCESSOR_ARCHITECTURE%.exe"
             x86_64:
@@ -190,6 +194,12 @@
                     tmp_dir = %TEMP%
                     host_script = serial_host_send_receive.py
                     python_bin = python
+                - with_viogpudo:
+                    driver_name = viogpudo
+                    device_name = "Red Hat VirtIO GPU DOD controller"
+                    device_hwid = '"PCI\\VEN_1AF4&DEV_1050&SUBSYS_11001AF4&REV_01"'
+                    vga = "virtio"
+                    driver_test_names = 'viogpudo'
                 - with_netkvm:
                     nics += " nic2"
                     nic_model_nic2 = virtio


### PR DESCRIPTION
win_driver_installer_test: Add viogpudo support for installer tests

This patch adds support for testing the 
'Red Hat VirtIO GPU DOD controller' (viogpudo) 
in the Windows driver installer test suite
(install, repair, update, uninstall).

ID: 4817
Signed-off-by: Dehan Meng [demeng@redhat.com](mailto:demeng@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Red Hat VirtIO GPU DOD (viogpudo) and a virtio VGA variant, enabling installer-time configuration and automatic detection.

* **Tests**
  * Added automated checks that verify the GPU device is present, reports an OK status, and retrieves display resolution (emits a warning if resolution appears non-numeric).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->