### PR TITLE
netkvm: Make NIC hotplug memory leak test configurable

### DIFF
--- a/qemu/tests/cfg/memory_leak_after_nichotplug.cfg
+++ b/qemu/tests/cfg/memory_leak_after_nichotplug.cfg
@@ -3,3 +3,12 @@
     pci_model = virtio-net-pci
     enable_msix_vectors = no
     start_vm = no
+    # Wait time for device initialization (seconds)
+    hotplug_sleep = 3
+    hotunplug_sleep = 3
+    variants:
+        - @default:
+            Windows:
+                mem_leak_threshold_percent = 1.0
+            Linux:
+                mem_leak_threshold_percent = 0.2


### PR DESCRIPTION
Refactor the test to use a percentage-based memory leak threshold instead of a fixed value, making it more reliable for VMs with different memory sizes. The wait times for hotplug and unplug events are also now configurable parameters.

ID: 1480
Signed-off-by: Wenkang Ji <wji@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable sleep timing parameters for network interface hotplug and hotunplug operations.
  * Implemented per-operating system memory leak detection thresholds using percentage-based evaluation metrics.
  * Enhanced memory leak reporting to include both absolute and relative measurements for improved analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->