### PR TITLE
Support testing vsock driver in installer related test cases

### DIFF
--- a/provider/win_driver_installer_test.py
+++ b/provider/win_driver_installer_test.py
@@ -4,8 +4,9 @@ import random
 import re
 import time
 
+import aexpect
 from avocado.utils import process
-from virttest import error_context, utils_disk, utils_misc, utils_net
+from virttest import error_context, utils_disk, utils_logfile, utils_misc, utils_net
 from virttest.utils_misc import normalize_data_size
 
 from provider import virtio_fs_utils, virtio_mem_utils, win_driver_utils
@@ -28,6 +29,7 @@ driver_name_list = [
     "vioinput",
     "fwcfg",
     "viomem",
+    "viosock",
 ]
 
 device_hwid_list = [
@@ -42,6 +44,7 @@ device_hwid_list = [
     '"PCI\\VEN_1AF4&DEV_1052"',
     '"ACPI\\VEN_QEMU&DEV_0002"',
     r'"PCI\VEN_1AF4&DEV_1002" "PCI\VEN_1AF4&DEV_1058"',
+    r'"PCI\VEN_1AF4&DEV_1053" "PCI\VEN_1AF4&DEV_1012"',
 ]
 
 device_name_list = [
@@ -56,6 +59,7 @@ device_name_list = [
     "VirtIO Input Driver",
     "QEMU FwCfg Device",
     "VirtIO Viomem Driver",
+    "VirtIO Socket Driver",
 ]
 
 
@@ -449,3 +453,53 @@ def viomem_test(test, params, vm):
             virtio_mem_utils.check_memory_devices(
                 device_id, requested_size, threshold, vm, test
             )
+
+
+def viosock_test(test, params, vm):
+    """
+    Connect VM via vsock bridge service
+
+    :param test: kvm test object.
+    :param params: the dict used for parameters.
+    :param vm: vm object.
+    """
+    session = vm.wait_for_login()
+
+    LOG_JOB.info("Install and start openssh server service in guest")
+    openssh_src_path = utils_misc.set_winutils_letter(
+        session, params["openssh_src_path"]
+    )
+    openssh_dst_path = params["openssh_dst_path"]
+    session.cmd_status_output(
+        "xcopy %s %s /s /e /i /y" % (openssh_src_path, openssh_dst_path)
+    )
+    session.cmd_status_output(params["install_config_openssh"])
+
+    # Installer will install the service by default
+    LOG_JOB.info("Start vstbridge service in guest")
+    session.cmd_status_output(params["start_bridge_service"])
+
+    LOG_JOB.info("Start OpenSSH service after reboot VM")
+    session.cmd_status_output(params["start_openssh_service"])
+
+    LOG_JOB.info("Connect VM via vsock bridge service")
+    vsock_dev = params["vsocks"].split()[0]
+    guest_cid = vm.devices.get(vsock_dev).get_param("guest-cid")
+    conn_cmd = params["conn_cmd"] % (params["password"], guest_cid)
+    vsock_session = aexpect.Expect(
+        conn_cmd,
+        auto_close=False,
+        output_func=utils_logfile.log_line,
+        output_params=("vsock_%s_%s" % (guest_cid, 22),),
+    )
+    try:
+        time.sleep(10)
+        output = vsock_session.get_output()
+        if params["expect_output"] not in output:
+            test.fail("Connect to vsock bridge service failed,output is %s" % output)
+        else:
+            test.log.info("Connect to VM via vsock bridge successfully")
+    except Exception as e:
+        test.fail("Can not connect to VM via vsock bridge service due to %s" % e)
+    vsock_session.close()
+    session.close()

--- a/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
+++ b/qemu/tests/cfg/win_virtio_driver_install_by_installer.cfg
@@ -113,6 +113,10 @@
             driver_test_name_balloon = "balloon"
             iozone_cmd_opitons = " -azR -r 64k -n 512M -g 1G -M -I -i 0 -i 1 -b iozone.xls -f %s:\testfile"
             read_rng_cmd = "WIN_UTILS:\\random_%PROCESSOR_ARCHITECTURE%.exe"
+            vsocks = vhost_vsock0
+            boot_with_viosock = yes
+            Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3, Host_RHEL.m9.u4, Host_RHEL.m9.u5, Host_RHEL.m9.u6, Host_RHEL.m9.u7, Host_RHEL.m10.u0, Host_RHEL.m10.u1:
+                boot_with_viosock = no
             x86_64:
                 # virtio-mem is not supported on 32-bit systems
                 # and viomem is supported from 1.9.40-0
@@ -265,6 +269,32 @@
                     device_name = "VirtIO Viomem Driver"
                     device_hwid = '"PCI\VEN_1AF4&DEV_1002" "PCI\VEN_1AF4&DEV_1058"'
                     driver_test_names = 'viomem'
+                - with_viosock:
+                    no Host_RHEL.m6 Host_RHEL.m7 Host_RHEL.m8
+                    # The installer currently does not support Win10
+                    no Win10
+                    required_virtio_win = [1.9.57.0, )
+                    boot_with_viosock = yes
+                    Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3, Host_RHEL.m9.u4, Host_RHEL.m9.u5, Host_RHEL.m10.u0:
+                        boot_with_viosock = no
+                    vsocks = vhost_vsock0
+                    driver_name = viosock
+                    device_name = VirtIO Socket Driver
+                    device_hwid = '"PCI\VEN_1AF4&DEV_1053" "PCI\VEN_1AF4&DEV_1012"'
+                    driver_test_names = ${driver_name}
+                    test_tool = "vstbridge.exe"
+                    i386:
+                        openssh_src_path = WIN_UTILS:\OpenSSH-Win32
+                    x86_64:
+                        openssh_src_path = WIN_UTILS:\OpenSSH-Win64
+                    openssh_dst_path = "C:\OpenSSH"
+                    install_config_openssh = 'powershell -command "${openssh_dst_path}\install-sshd.ps1"'
+                    start_openssh_service = sc start sshd
+                    start_bridge_service = 'sc config VsockTcpBridge start=demand && sc start VsockTcpBridge'
+                    install_openssh = yes
+                    conn_cmd = 'sshpass -p %s ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="socat - VSOCK-CONNECT:%s:22" Administrator@0.0.0.0'
+                    expect_output = "C:\Users\Administrator"
+
     variants:
         - installer_version_check:
             only all_drivers

--- a/qemu/tests/win_virtio_driver_installer_uninstall.py
+++ b/qemu/tests/win_virtio_driver_installer_uninstall.py
@@ -96,6 +96,9 @@ def run(test, params, env):
     if params.get("boot_with_viomem", "no") == "no":
         no_need_uninstall_dev_list.append("VirtIO Viomem Driver")
 
+    if params.get("boot_with_viosock", "no") == "no":
+        no_need_uninstall_dev_list.append("VirtIO Socket Driver")
+
     need_uninstall_dev_list = [
         item for item in device_name_list if item not in no_need_uninstall_dev_list
     ]

--- a/qemu/tests/win_virtio_driver_update_by_installer.py
+++ b/qemu/tests/win_virtio_driver_update_by_installer.py
@@ -123,6 +123,9 @@ def run(test, params, env):
             if params.get("boot_with_viomem", "no") == "no":
                 if driver_name == "viomem":
                     continue
+            if params.get("boot_with_viosock", "no") == "no":
+                if driver_name == "viosock":
+                    continue
             win_driver_utils.install_driver_by_virtio_media(
                 session, test, devcon_path, media_type, driver_name, device_hwid
             )


### PR DESCRIPTION
1.repaire virtio-win drivers via installer.
2.uninstall virtio-win drivers via installer.
3.Check viosock device works well if driver installed via installer. 
4.Upgrade virtio-win drivers via installer from the old driver version. 
5.Upgrade virtio-win drivers via installer from the previous installer version.

ID:4312,4877,4878,4879,4883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VirtIO Socket (viosock) support and expanded device recognition for the VirtIO Socket Driver.
  * Added per-host boot-time toggle to enable/disable viosock behavior.

* **Tests**
  * Added a VirtIO Socket test variant and a VSock test stub.
  * Test flows updated to skip install/update/uninstall of the viosock driver when the boot-with-viosock toggle is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->