### PR TITLE
virtio_fs_set_capability: adding --inode-file-handle=never

### DIFF
--- a/qemu/tests/cfg/virtio_fs_set_capability.cfg
+++ b/qemu/tests/cfg/virtio_fs_set_capability.cfg
@@ -87,6 +87,7 @@
                 - cap_dac_read_search:
                     only virtio_fs_set_capability..with_cache.auto
                     capability = cap_dac_read_search
+                    fs_binary_extra_options += ' --inode-file-handles=never'
                 - cap_sys_admin:
                     only virtio_fs_set_capability..with_cache.none
                     capability = cap_sys_admin


### PR DESCRIPTION
production changed the default of -inode-file-handles from never to prefer, so to have the previous behavior you need to pass --inode-file-handle=never

ID: 4839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for a virtual filesystem capability variant to add an extra runtime option that disables inode file handles for that specific case, improving how the scenario is exercised.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->