### PR TITLE
Enhance avocado_guest test to run host tests in guest

### DIFF
--- a/generic/tests/avocado_guest.py
+++ b/generic/tests/avocado_guest.py
@@ -13,11 +13,12 @@ def run(test, params, env):
     vm.verify_alive()
     timeout = int(params.get("test_timeout", 3600))
     testlist = []
-    avocadoinstalltype = params.get("avocadoinstalltype", "pip")
+    avocadoinstalltype = params.get("avocadoinstalltype", "git")
     avocadotestrepo = params.get(
         "avocadotestrepo",
         "https://github.com/avocado-framework-tests/avocado-misc-tests.git",
     )
+    avocadotestbranch = params.get("avocadotestbranch", "master")
     avocadotest = params.get("avocadotest", "cpu/ebizzy.py")
     avocadomux = params.get("avocadomux", "")
     avocadotestargs = params.get("avocadotestargs", "")
@@ -35,9 +36,12 @@ def run(test, params, env):
         testlist,
         timeout=timeout,
         testrepo=avocadotestrepo,
+        testbranch=avocadotestbranch,
         installtype=avocadoinstalltype,
         reinstall=False,
         add_args=avocadotestargs,
-        ignore_result=False,
+        ignore_result=True,
     )
-    avocado_obj.run_avocado()
+    result = avocado_obj.run_avocado()
+    if not result:
+        test.fail("Avocado test failed. Please look into debug.log")


### PR DESCRIPTION
avocado_guest test runs any avocado-misc host test in the guest. This patch adds test repo branch parameter, and adds logic to parse test results and fails accordingly.

Depends on https://github.com/avocado-framework/avocado-vt/pull/4319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to select which Avocado test branch to use (defaults to 'master').

* **Bug Fixes**
  * Improved test failure detection and clearer diagnostic messages when tests fail.

* **Chores**
  * Changed the default test installation method from pip to git.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->