### PR TITLE
fio_perf: Add VBS support before fio runner

### DIFF
--- a/qemu/tests/cfg/fio_perf.cfg
+++ b/qemu/tests/cfg/fio_perf.cfg
@@ -35,6 +35,55 @@
         guest_result_file = "C:\fio_result"
         fio_options = '--rw=%s --bs=%s --iodepth=%s --runtime=1m --direct=1 --filename=I\:%s --name=job1 --ioengine=windowsaio --thread --group_reporting --numjobs=%s --size=512MB --time_based --output=${guest_result_file}'
     variants:
+        - default:
+            vbs_support = no
+        - vbs:
+            vbs_support = yes
+            only Windows
+            only q35
+            only ovmf
+            login_timeout = 720
+            start_vm = no
+            auto_cpu_model = yes
+            clone_master = yes
+            master_images_clone = image1
+            force_image_clone = yes
+            remove_image_image1 = yes
+            restore_ovmf_vars = yes
+            ovmf_vars_filename = "OVMF_VARS.secboot.fd"
+            # support nested virtualization
+            HostCpuVendor.intel:
+                cpu_model_flags += ',vmx=on'
+            HostCpuVendor.amd:
+                cpu_model_flags += ',svm=on'
+            check_secure_boot_enabled_cmd = 'powershell -command "Confirm-SecureBootUEFI"'
+            dst_path = "C:\dgreadiness"
+            dgreadiness_path_cmd = "cd ${dst_path}\dgreadiness"
+            vbs_enable_cmd = 'powershell -command "Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force; .\DG_Readiness_Tool_v3.6.ps1 -Enable"'
+            vbs_disable_cmd = 'powershell -command "Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force; .\DG_Readiness_Tool_v3.6.ps1 -Disable"'
+            vbs_ready_cmd = 'powershell -command "Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force; .\DG_Readiness_Tool_v3.6.ps1 -Ready"'
+            vbs_enable_info = 'Enabling Hyper-V and IOMMU successful'
+            vbs_disable_info = 'Disabling Hyper-V and IOMMU successful'
+            vbs_ready_info = 'HVCI, Credential-Guard, and Config-CI are enabled and running'
+            variants:
+                - no_iommu:
+                - with_iommu:
+                    # common iommu params
+                    machine_type_extra_params = "kernel-irqchip=split"
+                    iommu_device_iotlb = on
+                    iommu_intremap = on
+                    iommu_aw_bits = 48
+                    # vendor-specific iommu device
+                    HostCpuVendor.intel:
+                        intel_iommu = yes
+                        iommu_eim = off
+                    HostCpuVendor.amd:
+                        amd_iommu = yes
+                    # virtio device
+                    virtio_dev_iommu_platform = on
+                    virtio_dev_filter = '^(?:(?:virtio-)|(?:vhost-))(?!(?:user)|(?:iommu))'
+                    virtio_dev_ats = on
+    variants:
         - file_system_block:
             image_size_disk1 = 40G
             force_create_image_disk1 = yes

--- a/qemu/tests/fio_perf.py
+++ b/qemu/tests/fio_perf.py
@@ -8,6 +8,7 @@ import six
 from avocado.utils import process
 from virttest import (
     data_dir,
+    env_process,
     error_context,
     utils_disk,
     utils_misc,
@@ -109,6 +110,68 @@ def get_version(
         result_file.write("### virtiofsd_version : %s\n" % virtiofsd_ver)
 
 
+def setup_vbs(vm, session, params, test, login_timeout):
+    """
+    Setup and verify VBS (Virtualization-Based Security) in Windows guest.
+
+    This function performs the following steps:
+    1. Verify Secure Boot is enabled
+    2. Copy DG Readiness Tool to guest
+    3. Configure PowerShell execution policy
+    4. Check VBS readiness status
+    5. Enable VBS if not already enabled (requires reboot)
+    6. Verify VBS is properly enabled after reboot
+
+    :param vm: Virtual machine object
+    :param session: VM session object
+    :param params: Dictionary with test parameters
+    :param test: QEMU test object
+    :param login_timeout: Login timeout in seconds
+    :return: Updated session object (may be new session after reboot)
+    """
+    check_cmd = params["check_secure_boot_enabled_cmd"]
+    dgreadiness_path_command = params["dgreadiness_path_cmd"]
+    enable_command = params["vbs_enable_cmd"]
+    ready_command = params["vbs_ready_cmd"]
+    vbs_ready_info = params["vbs_ready_info"]
+    vbs_enable_info = params["vbs_enable_info"]
+    dst_path = params["dst_path"]
+
+    # Verify Secure Boot is enabled
+    output = session.cmd_output(check_cmd)
+    if "false" in output.lower():
+        test.fail("Secure Boot is not enabled: %s" % output)
+
+    # Copy DG Readiness Tool to guest
+    dgreadiness_host_path = data_dir.get_deps_dir("dgreadiness")
+    session.cmd_status_output("mkdir %s" % dst_path)
+    vm.copy_files_to(dgreadiness_host_path, dst_path)
+
+    # Enable vbs and check vbs status
+    session.cmd(dgreadiness_path_command)
+    status, output = session.cmd_status_output(ready_command)
+    if status != 0:
+        test.fail("Failed to check VBS status: %s" % output)
+    if vbs_ready_info not in output:
+        LOG_JOB.info("VBS not ready, enabling VBS features (Hyper-V and IOMMU)")
+        session.cmd_output(enable_command, 360)
+        if vbs_enable_info not in output:
+            test.fail("Failed to enable VBS: %s" % output)
+        vm.reboot(timeout=login_timeout)
+        session = vm.wait_for_login(timeout=login_timeout)
+
+        LOG_JOB.info("Verifying VBS status after reboot")
+        session.cmd(dgreadiness_path_command)
+        output = session.cmd_output(ready_command)
+        if vbs_ready_info not in output:
+            test.fail("VBS is not enabled after reboot. Output: %s" % output)
+        LOG_JOB.info("VBS successfully enabled and verified")
+    else:
+        LOG_JOB.info("VBS already enabled and ready")
+
+    return session
+
+
 @error_context.context_aware
 def run(test, params, env):
     """
@@ -161,11 +224,32 @@ def run(test, params, env):
                 node = utils_misc.NumaNode(int(node))
             utils_test.qemu.pin_vm_threads(vm, node)
 
+    # check if VBS is supported, prepare the environment for VBS test
+    vbs_support = params.get("vbs_support") == "yes"
+    if vbs_support:
+        error_context.context(
+            "Config the parameters to start vm with VBS.", logging.info
+        )
+        params["ovmf_vars_filename"] = "OVMF_VARS.secboot.fd"
+        # Force the image name to use the cloned version
+        vm_name = params["main_vm"]
+        image_name = params.get("image_name", "image")
+        cloned_image_name = f"{image_name}_{vm_name}"
+        params["image_name"] = cloned_image_name
+        params["start_vm"] = "yes"
+        env_process.preprocess_vm(test, params, env, params["main_vm"])
+
     # login virtual machine
     vm = env.get_vm(params["main_vm"])
     vm.verify_alive()
     login_timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=login_timeout)
+
+    # Setup VBS if enabled
+    if vbs_support:
+        error_context.context("Setup VBS (Virtualization-Based Security)", LOG_JOB.info)
+        session = setup_vbs(vm, session, params, test, login_timeout)
+
     process.system_output("numactl --hardware")
     process.system_output("numactl --show")
     _pin_vm_threads(params.get("numa_node"))
@@ -377,4 +461,10 @@ def run(test, params, env):
         fs_dest = fs_params.get("fs_dest")
         utils_disk.umount(fs_target, fs_dest, "virtiofs", session=session)
         utils_misc.safe_rmdir(fs_dest, session=session)
+
+    if params.get("vbs_support") == "yes":
+        LOG_JOB.info("Cleaning up VBS configuration")
+        session.cmd(params["dgreadiness_path_cmd"])
+        session.cmd_output(params["vbs_disable_cmd"], 360)
+
     session.close()


### PR DESCRIPTION
Added Virtualization-Based Security (VBS) testing support for Windows guests with both Intel and AMD IOMMU configurations:

- Added VBS variant with Secure Boot and nested virtualization
- Extracted setup_vbs() function for VBS initialization and verification workflow
- Added VBS cleanup logic to disable VBS after test completion

The VBS variant includes two sub-variants (no_iommu and with_iommu) to test performance impact of VBS-enabled systems.

ID: 4990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows-specific VBS test configuration with Secure Boot checks and nested virtualization support (Intel/AMD).
  * Added IOMMU variants (with/without) and vendor-specific IOMMU options for broader coverage.
  * Enabled automated VBS enablement, readiness checks, image cloning/readiness tooling, extended VM lifecycle controls, and cleanup during Windows test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->