### PR TITLE
qemu_guest_agent: Replace deprecated wmic

### DIFF
--- a/qemu/tests/cfg/qemu_guest_agent.cfg
+++ b/qemu/tests/cfg/qemu_guest_agent.cfg
@@ -101,7 +101,7 @@
             gagent_check_type = sync
         - check_guest_info:
             gagent_check_type = guest_info
-            cmd_qga_build = wmic product where Name="QEMU guest agent" get Version | findstr /v Version
+            cmd_qga_build = powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -eq 'QEMU guest agent' } | ForEach-Object { $_.DisplayVersion }"
         - check_powerdown:
             gagent_check_type = powerdown
             journal_file = /var/log/journal


### PR DESCRIPTION
qemu_guest_agent: Replace deprecated wmic
Replace the legacy wmic command used to obtain the QEMU guest agent
version with a PowerShell-based implementation.

WMIC is deprecated in recent Windows versions and may be removed in
future releases, which could cause automation failures.


ID: 5079
Signed-off-by: Bhanuja Bhatt <bhbhatt@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QEMU Guest Agent version detection on Windows systems by switching to a more reliable registry-based retrieval method, enhancing accuracy of reported agent versions and reducing detection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->