### PR TITLE
Add TDX guest VFIO passthrough test

### DIFF
--- a/provider/tdx.py
+++ b/provider/tdx.py
@@ -6,11 +6,14 @@ import hashlib
 import json
 import logging
 import os
+import re
 
 from avocado.core import exceptions
 from avocado.utils import process
 from avocado.utils.network.ports import is_port_available
-from virttest import error_context
+from virttest import error_context, utils_misc
+
+from provider.hostdev import utils as hostdev_utils
 
 LOG_JOB = logging.getLogger("avocado.test")
 
@@ -19,6 +22,26 @@ class TDXError(Exception):
     """General TDX error"""
 
     pass
+
+
+def _expand_cartesian_placeholders(value, params):
+    """
+    Expand ${key} the same way as cartesian cfg, using final merged params.
+
+    Cartesian substitution only sees keys present when each cfg line is parsed.
+    Params added later (profile, --extra-params, job config) stay as literal
+    ${key} unless expanded here.
+    """
+    if "${" not in value:
+        return value
+
+    def _repl(match):
+        key = match.group(1)
+        if params.get(key) is None:
+            return match.group(0)
+        return str(params[key])
+
+    return re.sub(r"\$\{(.+?)\}", _repl, value)
 
 
 class TDXHostCapability(object):
@@ -102,11 +125,14 @@ class TDXDcap(object):
             self._test.cancel("Missing guest_script for attestation.")
         guest_dir = self._params["guest_dir"]
         host_script = self._params["host_script"]
-        guest_cmd = self._params["guest_cmd"]
+        guest_cmd = _expand_cartesian_placeholders(
+            self._params["guest_cmd"], self._params
+        )
         host_file = os.path.join(deps_dir, host_script)
+        guest_script_path = guest_cmd.split(None, 1)[0]
         try:
             self._vm.copy_files_to(host_file, guest_dir)
-            session.cmd_output("chmod 755 %s" % guest_cmd)
+            session.cmd_output("chmod 755 %s" % guest_script_path)
         except Exception as e:
             self._test.fail("Guest test preparation fail: %s" % str(e))
         s = session.cmd_status(guest_cmd, timeout=360)
@@ -268,3 +294,216 @@ class TDXDcap(object):
                 if fail_on_inactive:
                     self._test.log.info("Service %s is active", service)
         return True
+
+
+class TDXPassthroughNet(object):
+    """
+    Find network device(s) suitable for VFIO pass-through to a TDX guest, and
+    verify passed-through devices in the guest via lspci.
+
+    Guarantees:
+    - All returned PCI devices are in the same IOMMU group (from one group only).
+    - All are "safe" for passthrough: the seed is a PF-backed net iface with
+      operstate down; every PCI in the same IOMMU group must have a netdev in
+      sysfs and that netdev must be down. (No netdev for a member rejects the
+      whole group; any net iface up also rejects the group.)
+    """
+
+    SYS_NET_PATH = "/sys/class/net"
+
+    def __init__(self, test):
+        """
+        :param test: avocado test instance (for cancel when no device found).
+        """
+        self._test = test
+
+    @staticmethod
+    def _net_iface_is_down(iface_path):
+        """True if operstate is 'down'."""
+        try:
+            with open(os.path.join(iface_path, "operstate"), "r") as f:
+                return f.read().strip() == "down"
+        except IOError:
+            return False
+
+    @classmethod
+    def _get_net_iface_path_for_pci(cls, pci_address):
+        """
+        Return ``/sys/class/net/<iface>`` for the PCI BDF, or None.
+        Uses ``hostdev_utils.get_ifname_from_pci`` (``.../pci/devices/<BDF>/net/``).
+        """
+        ifname = hostdev_utils.get_ifname_from_pci(pci_address)
+        if not ifname:
+            return None
+        return os.path.join(cls.SYS_NET_PATH, ifname)
+
+    @classmethod
+    def _pci_safe_for_passthrough(cls, pci_address):
+        """
+        True if this PCI device is safe to pass through: it has a net interface
+        in sysfs and operstate is down. Missing netdev returns False (reject
+        mixed-function groups where some BDFs are not net-backed in
+        /sys/class/net).
+        """
+        iface_path = cls._get_net_iface_path_for_pci(pci_address)
+        if iface_path is None:
+            return False  # reject mixed-function groups
+        return cls._net_iface_is_down(iface_path)
+
+    @staticmethod
+    def _pci_device_info(device_link):
+        """
+        Return (full_pci, short_pci, driver_name) for the device.
+        short_pci strips domain.
+        """
+        pci_bus_info = os.path.basename(os.path.realpath(device_link))
+        short_pci = re.sub(r"^0000:", "", pci_bus_info)
+        driver_link = os.path.join(device_link, "driver")
+        driver_name = (
+            os.path.basename(os.path.realpath(driver_link))
+            if os.path.exists(driver_link)
+            else "unknown"
+        )
+        return pci_bus_info, short_pci, driver_name
+
+    @classmethod
+    def _passthrough_group_for_down_iface(cls, iface, iface_path):
+        """
+        If this down PF-backed iface's IOMMU group is all passthrough-safe, return
+        ``(pci_list, driver_name)``; otherwise return None.
+
+        :param iface: interface name under /sys/class/net
+        :param iface_path: full path to that interface
+        :return: ``(pci_list, driver_name)`` or None
+        """
+        device_link = os.path.join(iface_path, "device")
+        iommu_group_path = os.path.join(device_link, "iommu_group", "devices")
+        try:
+            pci_list = sorted(os.listdir(iommu_group_path))
+        except OSError:
+            LOG_JOB.warning(
+                "Interface %s has no IOMMU group. Check BIOS/Kernel settings.",
+                iface,
+            )
+            return None
+        if not pci_list:
+            return None
+        if not all(cls._pci_safe_for_passthrough(p) for p in pci_list):
+            return None
+        _pci_bus_info, _short_pci, driver_name = cls._pci_device_info(device_link)
+        return pci_list, driver_name
+
+    @classmethod
+    def find(cls):
+        """
+        Find network device(s) suitable for VFIO pass-through to a TDX guest.
+
+        - Iterate network PFs via ``hostdev_utils.get_pci_by_dev_type('pf','network')``
+          (sorted BDF order), require ``.../net`` ifname and operstate down.
+        - Require the device to have an IOMMU group; collect all PCI devices
+          in that group.
+        - Require every PCI in the group to have a net iface in sysfs and down.
+          (If any member has no netdev or any net iface is up, skip the group.)
+        - Return the first group that passes. All returned devices are in the same
+          IOMMU group and are safe for passthrough.
+
+        :return: tuple (pci_list, driver) e.g.
+                 (['0000:22:00.0', '0000:22:00.1'], 'tg3'), or (None, None) if
+                 none. On success pci_list is a non-empty list[str] (all BDFs
+                 in one IOMMU group).
+        """
+        if not os.path.exists(cls.SYS_NET_PATH):
+            LOG_JOB.warning("/sys/class/net does not exist")
+            return None, None
+
+        for pci in hostdev_utils.get_pci_by_dev_type("pf", "network"):
+            ifname = hostdev_utils.get_ifname_from_pci(pci)
+            if not ifname:
+                continue
+            iface_path = os.path.join(cls.SYS_NET_PATH, ifname)
+            if not cls._net_iface_is_down(iface_path):
+                continue
+            found = cls._passthrough_group_for_down_iface(ifname, iface_path)
+            if found is None:
+                continue
+            pci_list, driver_name = found
+            LOG_JOB.info(
+                "Found passthrough-capable net device(s) in same IOMMU group "
+                "(all net down): seed_pci=%s ifname=%s pci_list=%s driver=%s",
+                pci,
+                ifname,
+                pci_list,
+                driver_name,
+            )
+            return pci_list, driver_name
+
+        return None, None
+
+    def find_passthrough_net_device_for_tdx(self):
+        """
+        Find VFIO-capable net device(s) for TDX passthrough.
+
+        All returned devices are in the same IOMMU group; every member has a
+        net iface in sysfs and down. Safe to pass the whole list to one guest
+        iommufd.
+        If no capable device is found, cancels the test (does not return).
+
+        :return: ``(pci_list, driver)`` where ``pci_list`` is always a non-empty
+                 ``list`` of PCI BDF strings, and ``driver`` is the driver name
+                 for the seed net device.
+        """
+        pci_list, driver = self.find()
+        if pci_list is None or len(pci_list) == 0:
+            self._test.cancel(
+                "No VFIO-capable device found (link down, same IOMMU group)"
+            )
+        return list(pci_list), driver
+
+    def verify_vfio_devices_in_guest_lspci(
+        self, session, params, pci_slots, guest_lspci_cmd, visible
+    ):
+        """
+        :param session: guest shell session
+        :param params: test params
+        :param pci_slots: host PCI BDF list
+        :param guest_lspci_cmd: shell command with one ``%s`` for vendor:device
+        :param visible: if True expect count ``len(pci_slots)``; if False expect 0
+        :return: None
+        """
+        if not pci_slots:
+            self._test.fail("pci_slots is empty for guest lspci verify")
+        parent_slot = hostdev_utils.get_parent_slot(pci_slots[0])
+        mgr = params.get("hostdev_manager_%s" % parent_slot)
+        if mgr is None:
+            self._test.fail("Host device manager not found for slot %s" % parent_slot)
+        grep = "%s:%s" % (mgr.vendor_id, mgr.device_id)
+        expected = len(pci_slots) if visible else 0
+        if visible:
+            ctx = "Verify %d VFIO device(s) in guest (lspci -nn | grep -c %s)" % (
+                len(pci_slots),
+                grep,
+            )
+        else:
+            ctx = "Verify VFIO device(s) gone in guest (grep -c %s == 0)" % grep
+        error_context.context(ctx, self._test.log.info)
+        cmd = guest_lspci_cmd % grep
+        st, out, count = 1, "", None
+
+        def verify_pci():
+            nonlocal st, out, count
+            st, out = session.cmd_status_output(cmd, timeout=60)
+            try:
+                count = int(out.strip())
+            except ValueError:
+                count = None
+            return count == expected
+
+        if not utils_misc.wait_for(verify_pci, 10, 2, 2):
+            self._test.fail(
+                "Guest lspci verify failed (visible=%s): expected count %s, "
+                "got st=%s count=%s out=%r cmd=%r"
+                % (visible, expected, st, count, out.strip(), cmd)
+            )
+        self._test.log.info(
+            "Guest lspci count OK (visible=%s): count=%s", visible, count
+        )

--- a/qemu/tests/cfg/tdx_vfio.cfg
+++ b/qemu/tests/cfg/tdx_vfio.cfg
@@ -1,0 +1,36 @@
+# TDX guest with VFIO device passthrough (iommufd).
+# nic1: virtual NIC for management/login; hostdev1 (and hostdev2 ...): VFIO passthrough PF(s).
+# All devices in the same host IOMMU group are passed together to one guest iommufd.
+- tdx_vfio:
+    only Linux
+    only x86_64
+    only HostCpuVendor.intel
+    kill_vm = yes
+    login_timeout = 360
+    start_vm = no
+    image_snapshot = yes
+    nics = nic1
+    # TDX VM
+    vm_secure_guest_type = tdx
+    vm_secure_guest_object_options = attributes=268435456 quote-generation-socket.type=unix quote-generation-socket.path=/run/tdx-qgs/qgs.socket
+    machine_type_extra_params = "kernel-irqchip=split"
+    bios_path = /usr/share/edk2/ovmf/OVMF.inteltdx.fd
+    tdx_module_path = "/sys/module/kvm_intel/parameters/tdx"
+    module_status = Y y 1
+    tdx_guest_check = "journalctl|grep -i -w tdx"
+    # Guest lspci: tdx_vfio_guest_lspci_cmd has one %-placeholder (vendor:device).
+    # Expected grep -c: len(pci_list) when devices visible, 0 after unplug.
+    tdx_vfio_guest_lspci_cmd = "lspci -nn | grep -c '%s'"
+    vm_hostdev_iommufd = iommufd0
+    vm_hostdev_driver = vfio-pci
+    hostdev_bind_driver = vfio-pci
+    hostdev_assignment_type = pf
+    variants:
+        - static:
+            type = tdx_vfio_static
+            smp = 8
+            mem = 4096
+        - hotplug:
+            type = tdx_vfio_hotplug
+            smp = 8
+            mem = 4096

--- a/qemu/tests/tdx_vfio_hotplug.py
+++ b/qemu/tests/tdx_vfio_hotplug.py
@@ -1,0 +1,100 @@
+from virttest import error_context
+
+from provider.hostdev.dev_setup import hostdev_setup
+from provider.tdx import TDXHostCapability, TDXPassthroughNet
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    TDX VFIO passthrough test (hotplug only, single main_vm).
+
+    1. Check host TDX capability
+    2. Find VFIO-capable net device(s) (same IOMMU group); record setup_hostdev_slots
+    3. Boot TDX VM without hostdev on cmdline (PF stays on host driver until hotplug)
+    4. Bind PF(s) to vfio-pci (hostdev_setup), hotplug, verify lspci, unplug,
+       verify gone
+    5. Verify TDX in guest
+
+    Sets ``pcie_extra_root_port`` to ``len(pci_list) + 2`` before ``vm.create``
+    (virttest multi-PF vfio hotplug needs spare pcie-root-port slots).
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    error_context.context("Start TDX VFIO passthrough test", test.log.info)
+    timeout = int(params.get("login_timeout", 360))
+    guest_lspci_cmd = params.get("tdx_vfio_guest_lspci_cmd", "lspci -nn | grep -c '%s'")
+
+    tdx_host_cap = TDXHostCapability(test, params)
+    tdx_host_cap.validate_tdx_cap()
+    tdx_passthrough_net = TDXPassthroughNet(test)
+    pci_list, driver = tdx_passthrough_net.find_passthrough_net_device_for_tdx()
+    params["setup_hostdev_slots"] = " ".join(pci_list)
+    test.log.info("TDX VFIO hotplug: pci_list=%s driver=%s", pci_list, driver)
+    params["pcie_extra_root_port"] = str(len(pci_list) + 2)
+
+    vm = env.get_vm(params["main_vm"])
+    vm_hostdevs = [f"hostdev{i + 1}" for i in range(len(pci_list))]
+
+    error_context.base_context(f"Setting hostdevs for {vm.name}", test.log.info)
+    error_context.context(
+        "Boot TDX VM without hostdev (hotplug at runtime)", test.log.info
+    )
+    vm.create()
+    vm.verify_alive()
+
+    try:
+        session = vm.wait_for_login(timeout=timeout)
+
+        error_context.context(
+            "Verify TDX enabled in guest before hotplug", test.log.info
+        )
+        session.cmd_output(params["tdx_guest_check"], timeout=240)
+        test.log.info("TDX guest check passed (before hotplug)")
+
+        with hostdev_setup(params) as params:
+            for dev, pci in zip(vm_hostdevs, pci_list):
+                vm.params[f"vm_hostdev_host_{dev}"] = pci
+
+            error_context.context("Hotplug VFIO hostdev(s) at runtime", test.log.info)
+            hotplug_order = []
+            for dev in vm_hostdevs:
+                dev_params = vm.params.object_params(dev)
+                batch = vm.devices.hostdev_define_by_params(dev, dev_params)
+                for qdev in batch:
+                    out, _ = vm.devices.simple_hotplug(qdev, vm.monitor)
+                    if out:
+                        test.fail("Failed to hotplug %s at runtime: %s" % (dev, out))
+                    hotplug_order.append(qdev)
+            test.log.info(
+                "VFIO hotplug done: %d PCI, %d qdev steps",
+                len(vm_hostdevs),
+                len(hotplug_order),
+            )
+
+            tdx_passthrough_net.verify_vfio_devices_in_guest_lspci(
+                session, params, pci_list, guest_lspci_cmd, visible=True
+            )
+
+            error_context.context(
+                "Hot-unplug VFIO hostdev(s) at runtime", test.log.info
+            )
+            for qdev in reversed(hotplug_order):
+                out, _ = vm.devices.simple_unplug(qdev, vm.monitor)
+                if out:
+                    test.fail("Failed to hot-unplug VFIO hostdev at runtime: %s" % out)
+            test.log.info("VFIO hostdev(s) hot-unplugged at runtime")
+
+            tdx_passthrough_net.verify_vfio_devices_in_guest_lspci(
+                session, params, pci_list, guest_lspci_cmd, visible=False
+            )
+
+            error_context.context(
+                "Verify TDX enabled in guest after hot-unplug", test.log.info
+            )
+            session.cmd_output(params["tdx_guest_check"], timeout=240)
+            test.log.info("TDX guest check passed (after hot-unplug)")
+    finally:
+        vm.destroy()

--- a/qemu/tests/tdx_vfio_static.py
+++ b/qemu/tests/tdx_vfio_static.py
@@ -1,0 +1,68 @@
+from virttest import error_context
+
+from provider.hostdev import utils as hostdev_utils
+from provider.hostdev.dev_setup import hostdev_setup
+from provider.tdx import TDXHostCapability, TDXPassthroughNet
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    TDX VFIO passthrough test (static hostdev at boot).
+
+    1. Check host TDX capability
+    2. Find VFIO-capable net device(s) (same IOMMU group)
+    3. Bind to vfio-pci (hostdev_setup), boot TDX VM with hostdev on cmdline
+    4. Verify TDX and VFIO device(s) visible in guest (lspci)
+
+    :param test: QEMU test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    error_context.context("Start TDX VFIO passthrough test", test.log.info)
+    timeout = int(params.get("login_timeout", 360))
+    guest_lspci_cmd = params.get("tdx_vfio_guest_lspci_cmd")
+
+    tdx_host_cap = TDXHostCapability(test, params)
+    tdx_host_cap.validate_tdx_cap()
+    tdx_passthrough_net = TDXPassthroughNet(test)
+    pci_list, driver = tdx_passthrough_net.find_passthrough_net_device_for_tdx()
+    params["setup_hostdev_slots"] = " ".join(pci_list)
+    error_context.base_context(f"Setting hostdev: {pci_list} {driver}", test.log.info)
+
+    with hostdev_setup(params) as params:
+        hostdev_driver = params.get("vm_hostdev_driver", "vfio-pci")
+        assignment_type = params.get("hostdev_assignment_type")
+        available_pci_slots = hostdev_utils.get_pci_by_dev_type(
+            assignment_type, "network", hostdev_driver
+        )
+        vm = env.get_vm(params["main_vm"])
+        vm_hostdevs_list = [f"hostdev{i + 1}" for i in range(len(pci_list))]
+        vm.params["vm_hostdevs"] = " ".join(vm_hostdevs_list)
+        vm_hostdevs = vm.params.objects("vm_hostdevs")
+        pci_slots = []
+        for dev, pci_slot in zip(vm_hostdevs, pci_list):
+            if pci_slot not in available_pci_slots:
+                test.fail(
+                    f"Discovered slot {pci_slot} not in available vfio-pci slots"
+                )
+            vm.params[f"vm_hostdev_host_{dev}"] = pci_slot
+            pci_slots.append(pci_slot)
+
+        error_context.context(
+            "Boot TDX VM with VFIO hostdev and iommufd (static)", test.log.info
+        )
+        vm.create()
+        vm.verify_alive()
+        try:
+            session = vm.wait_for_login(timeout=timeout)
+
+            error_context.context("Verify TDX enabled in guest", test.log.info)
+            session.cmd_output(params["tdx_guest_check"], timeout=240)
+            test.log.info("TDX guest check passed")
+
+            tdx_passthrough_net.verify_vfio_devices_in_guest_lspci(
+                session, params, pci_slots, guest_lspci_cmd, visible=True
+            )
+        finally:
+            vm.destroy()


### PR DESCRIPTION
1. Static iommufd host pf
2. Hot plug/unplug pf devices

ID: 4860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TDX VFIO passthrough: automated discovery of safe network devices and in-guest verification of VFIO device visibility; supports static (boot-time) and hotplug (runtime) flows.

* **Tests**
  * Added end-to-end TDX VFIO test scenarios and a VM profile validating static and hotplug workflows, including guest-side checks and runtime hotplug/hot-unplug verification.

* **Chores**
  * Removed a Pylint configuration block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->