### PR TITLE
block_4k_discard:add discard=on on virtio-blk

### DIFF
--- a/qemu/tests/cfg/block_4k_discard.cfg
+++ b/qemu/tests/cfg/block_4k_discard.cfg
@@ -32,6 +32,9 @@
             blk_extra_params_stg1 = "serial=${serial_stg1}"
             drive_format_stg1 = virtio
             expected_results = 0 0 0 0 0
+            i440fx:
+                blk_extra_params_stg1 += ",discard=on"
+
         - with_hd:
             serial_stg1 = stg1
             sec_size = 512


### PR DESCRIPTION
In i440fx, the virtio-blk need to set discard=on
for the disk discard feature

ID:5171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test configuration variant for block device discard functionality on i440fx systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->