### PR TITLE
Fix device removal order in unplug_backend_devices for raw images

### DIFF
--- a/qemu/tests/block_hotplug_in_pause.py
+++ b/qemu/tests/block_hotplug_in_pause.py
@@ -124,6 +124,7 @@ def run(test, params, env):
                         format_node = vm.devices[drive]
                         nodes = [format_node]
                         nodes.extend((n for n in format_node.get_child_nodes()))
+                        vm.devices.remove(dev, True)
                         for node in nodes:
                             if not node.verify_unplug(
                                 node.unplug(vm.monitor), vm.monitor
@@ -133,15 +134,17 @@ def run(test, params, env):
                                 )
                             vm.devices.remove(
                                 node,
-                                True
-                                if isinstance(node, qdevices.QBlockdevFormatNode)
-                                else False,
+                                isinstance(node, qdevices.QBlockdevFormatNode),
                             )
-                            if not isinstance(node, qdevices.QBlockdevFormatNode):
+                            if node is not format_node and not isinstance(
+                                node, qdevices.QBlockdevFormatNode
+                            ):
                                 format_node.del_child_node(node)
                     else:
                         vm.devices.remove(drive)
-                vm.devices.remove(dev, True)
+                        vm.devices.remove(dev, True)
+                else:
+                    vm.devices.remove(dev, True)
 
             except (DeviceError, KeyError) as exc:
                 dev.unplug_unhook()


### PR DESCRIPTION
When unplugging a block device backed by a raw file (no format wrapper), the frontend device (e.g., virtio-blk-pci) remains on the protocol node's QDriveBus. Attempting to remove the protocol node with recursive=False raises DeviceRemoveError("Child bus contains devices").

Fix by removing the frontend device before iterating over backend blockdev nodes, and guard del_child_node against the case where the protocol node is the format_node itself (no format wrapper scenario).

ID: KVMAUTOMA-5170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test logic for block device hotplug scenarios by refining control flow for device removal operations, ensuring more reliable test execution and clearer handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->