### PR TITLE
unattended_install: add shim parameter

### DIFF
--- a/generic/tests/cfg/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install.cfg
@@ -13,6 +13,10 @@
     guest_port_unattended_install = 12323
     kernel = vmlinuz
     initrd = initrd.img
+    x86_64:
+        shim = BOOTX64.EFI
+    RHEL.7, RHEL.8, RHEL.9, RHEL.10.0, RHEL.10.1:
+        shim =
     # Throw errors if guest screen is inactive
     inactivity_watcher = error
     # Inactivity treshold to error the test


### PR DESCRIPTION
to support direct kernel boot with secure boot protection

Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
ID: 5099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated unattended-install test configuration to add architecture-specific UEFI shim handling: x86_64 now uses BOOTX64.EFI.
  * Added explicit (empty) shim entries for RHEL 7/8/9/10 series to enforce version-specific behavior and override prior implicit selection.
  * All other unattended-install test settings and control flow remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->