### PR TITLE
KVMAUTOMA-5299: edk2_basic: update check_message

### DIFF
--- a/qemu/tests/cfg/edk2_basic.cfg
+++ b/qemu/tests/cfg/edk2_basic.cfg
@@ -8,7 +8,7 @@
     start_vm = no
     login_timeout = 240
     reboot_count = 5
-    check_message = "enter to boot the selected OS | Press 'e' to edit the selected item"
+    check_message = "enter to boot the selected OS"
     skip_image_processing = yes
     line_numbers = 40
     variants:


### PR DESCRIPTION
grub output has changed.  Fix that by using a less specific match, simliar to edk2_stability_test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined boot-selection test configuration by simplifying the boot confirmation message matching. The verification now focuses solely on the essential “enter to boot the selected OS” text, removing extra appended instruction content to improve consistency and reliability during boot sequence confirmation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->