### PR TITLE
check smbios: use the non-SMM builds for the 510 vcpu test case

### DIFF
--- a/qemu/tests/cfg/uefishell.cfg
+++ b/qemu/tests/cfg/uefishell.cfg
@@ -130,6 +130,8 @@
                             check_result_smbios = "Version.*:\s+3\.\d+"
                             extra_params += " -global mch.extended-tseg-mbytes=48"
                             vcpu_maxcpus = 510
+                            ovmf_path = "/usr/share/edk2/ovmf"
+                            ovmf_code_filename = "OVMF_CODE.fd"
                         - with_auto_type_32:
                             vcpu_maxcpus = 8
                 - with_entry_point:


### PR DESCRIPTION
The SMM-enabled secboot builds are very bad
at handling massive vcpu overcommit.

This depends on https://github.com/avocado-framework/avocado-vt/pull/4358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the UEFI shell test configuration to explicitly specify the firmware directory and firmware code filename, improving consistency and reliability across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->