### PR TITLE
fio_linux: fio_filename cannot be a directory

### DIFF
--- a/qemu/tests/cfg/fio_linux.cfg
+++ b/qemu/tests/cfg/fio_linux.cfg
@@ -18,7 +18,7 @@
     s390x:
         fio_install_timeout = 600
     nvme_direct:
-        fio_filename = '/home/test'
+        fio_filename = '/home/test/test.img'
         boot_drive_stg0 = no
         force_create_image_stg0 = no
     variants:


### PR DESCRIPTION
fio fails because /home/test is a directory and not a file:

  fio: pid=0, err=21/file:filesetup.c: 150, func=unlink, error=Is a directory

When the fio_linux test runs with the QEMU userspace NVMe block driver (the test calls this "nvme_direct"), the guest is started with a single disk (typically virtio-blk or virtio-scsi) containing the root file system. The fio benchmark runs against the root file system (which is on the host's NVMe device) and it needs to put the benchmark data in a file. Give fio a file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fio test configuration to target a different file path for test execution on Linux systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autotest/tp-qemu/pull/4461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->