### PR TITLE
Fixes for EDK2 and SeaBIOS testing (RHEL 10.2 / RHEL 9.8 cycle)

### DIFF
--- a/qemu/tests/cfg/uefi_pkg.cfg
+++ b/qemu/tests/cfg/uefi_pkg.cfg
@@ -14,10 +14,14 @@
     variants:
         - check_descriptor_meta_files:
             file_suffix = ".json"
-            number_of_files = 5
+            number_of_files = 9
             Host_RHEL.m7:
                 number_of_files = 2
             Host_RHEL.m8:
                 number_of_files = 3
+            Host_RHEL.m9:
+                number_of_files = 5
             Host_RHEL.m9.u0, Host_RHEL.m9.u1:
                 number_of_files = 4
+            Host_RHEL.m10.0, Host_RHEL.m10.u1:
+                number_of_files = 5

--- a/qemu/tests/cfg/uefi_pkg.cfg
+++ b/qemu/tests/cfg/uefi_pkg.cfg
@@ -13,7 +13,7 @@
         ovmf_package_name = "edk2-ovmf.*el\d+.*"
     variants:
         - check_descriptor_meta_files:
-            file_suffix = ".json"
+            file_regex = "^/usr/share/qemu/firmware/.*\.json$"
             number_of_files = 9
             Host_RHEL.m7:
                 number_of_files = 2

--- a/qemu/tests/seabios_hotplug_unplug.py
+++ b/qemu/tests/seabios_hotplug_unplug.py
@@ -52,12 +52,14 @@ def run(test, params, env):
             test.fail("Could not get boot menu list")
         return (boot_list, boot_menu)
 
-    def check_in_guest():
+    def check_in_guest(nic_index=0):
         session = vm.wait_for_serial_login(timeout=timeout, restart_network=True)
         error_context.context("Check kernel crash message!", test.log.info)
         vm.verify_kernel_crash()
         error_context.context("Ping guest!", test.log.info)
-        guest_ip = vm.get_address()
+        guest_ip = vm.wait_for_get_address(nic_index, timeout=60)
+        if guest_ip is None:
+            test.fail(f"Failed to get address of nic {nic_index}")
         status, output = utils_test.ping(guest_ip, count=10, timeout=20)
         if status:
             test.fail("Ping guest failed!")
@@ -139,8 +141,9 @@ def run(test, params, env):
 
     test.log.info("Hotplug '%s' nic named '%s'", nic_model, nic_name)
     hotplug_nic = vm.hotplug_nic(**nic_params)
+    hotplug_nic_index = len(vm.virtnet) - 1
 
-    check_in_guest()
+    check_in_guest(hotplug_nic_index)
 
     error_context.context("Restart guest after hotplug", test.log.info)
     vm.system_reset()
@@ -158,7 +161,7 @@ def run(test, params, env):
         test.fail("Hotplugged virtio nic is not in boot menu list")
 
     vm.send_key(str(boot_device))
-    check_in_guest()
+    check_in_guest(hotplug_nic_index)
 
     error_context.context("Hotunplugging", test.log.info)
     for dev in disk_hotplugged:

--- a/qemu/tests/uefi_pkg.py
+++ b/qemu/tests/uefi_pkg.py
@@ -74,11 +74,11 @@ def run(test, params, env):
             "The actual output is '%s'" % output
         )
     query_files = params["query_files"] % ovmf_package[0]
-    file_suffix = params["file_suffix"]
+    file_regex = params["file_regex"]
     meta_files = []
     output = process.getoutput(query_files, shell=True)
     for line in output.splitlines():
-        if line.endswith(file_suffix):
+        if re.match(file_regex, line):
             meta_files.append(line)
     if len(meta_files) > int(params["number_of_files"]):
         test.fail(

--- a/qemu/tests/uefi_pkg.py
+++ b/qemu/tests/uefi_pkg.py
@@ -83,9 +83,8 @@ def run(test, params, env):
     if len(meta_files) > int(params["number_of_files"]):
         test.fail(
             "The number of JSON files should be less than or "
-            "equal to %s. The actual file list is %s",
-            params["number_of_files"],
-            meta_files,
+            "equal to %s. The actual file list is %s"
+            % (params["number_of_files"], meta_files)
         )
     error_context.context(
         "Check the 'filename' elements in both json files point to valid files.",


### PR DESCRIPTION
Fixes that I needed to complete the EDK2 and SeaBIOS compose testing for RHEL 10.2 and 9.8,
in addition to #4459, #4460.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware metadata detection by using regex-based matching to select the correct descriptor meta-files more precisely.
  * Updated expected firmware descriptor file counts across multiple host versions to align with current package contents.
  * Made guest network validation in hotplug/unplug testing more reliable by targeting the correct NIC index when retrieving and verifying the guest IP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->