### PR TITLE
pxe_boot: use libvirt bridge with boot config

### DIFF
--- a/generic/tests/cfg/pxe_boot.cfg
+++ b/generic/tests/cfg/pxe_boot.cfg
@@ -11,6 +11,8 @@
     remove_image_pxe = yes
     kill_vm_on_error = yes
     network = bridge
+    # see infra_config/net-pxeboot.xml in envutils
+    netdst = virpxe0
     restart_vm = yes
     pxe_timeout = 360
     image_verify_bootable = no


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/KVMAUTOMA-5301

This depends on https://gitlab.cee.redhat.com/kvm-qe/envutils/-/merge_requests/53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the network boot configuration to set the correct network destination for PXE booting, improving compatibility with intended interfaces.
  * Added a brief configuration note to clarify the setup for easier troubleshooting and understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->