### PR TITLE
uefishell.network: use libvirt ipv6 bridge

### DIFF
--- a/qemu/tests/cfg/uefishell.cfg
+++ b/qemu/tests/cfg/uefishell.cfg
@@ -35,6 +35,8 @@
             time_interval = 9
             variants:
                 - with_ipv4:
+                    netdst = virbr0
+                    network = bridge
                     test_scenarios = "connect config show ping"
                     command_connect = "connect -r"
                     command_config = "ifconfig -s eth0 dhcp"
@@ -44,6 +46,9 @@
                     check_result_show = "ipv4.*address.*:.*(\d+.\d+.\d+.\d+)"
                     check_result_ping = "0.*packet loss"
                 - with_ipv6:
+                    # see infra_config/net-default6.xml in envutils
+                    netdst = virbr6
+                    network = bridge
                     test_scenarios = "connect config6 ping6"
                     command_connect = "connect -r"
                     command_config6 = "ifconfig6 -s eth0 auto"


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/KVMAUTOMA-5300

Depends on https://gitlab.cee.redhat.com/kvm-qe/envutils/-/merge_requests/53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv4 and IPv6 network configuration for UEFI shell test environments.
  * Network variants now explicitly target the correct bridge destinations and network backend for more reliable connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->