### PR TITLE
cpu_info_check: fix CPU model parsing for QEMU >= 9.0

### DIFF
--- a/qemu/tests/cfg/cpu_info_check.cfg
+++ b/qemu/tests/cfg/cpu_info_check.cfg
@@ -14,3 +14,5 @@
     Host_RHEL.m7, Host_RHEL.m6:
         remove_list = ${cpu_model_8}
     remove_list_deprecated = 'Icelake-Client Icelake-Client-noTSX'
+    remove_list_deprecated += ' Opteron_G1 Opteron_G2 Opteron_G3 Penryn Conroe'
+    cpu_model_9_0_0 = 'SapphireRapids-v3 Icelake-Server-v7'

--- a/qemu/tests/cpu_info_check.py
+++ b/qemu/tests/cpu_info_check.py
@@ -61,18 +61,29 @@ def run(test, params, env):
         )
     qemu_binary = utils_misc.get_qemu_binary(params)
     test.log.info("Query cpu models by qemu command")
-    # QEMU < 9.0: "x86 ModelName  description" (model is $2)
-    # QEMU >= 9.0: "  ModelName  description"   (model is $1)
-    query_cmd = (
-        "%s -cpu ? | awk '/^x86 /{print $2; next} /CPUID/{print $2; next}"
-        " {print $1}'" % qemu_binary
-    )
     qemu_binary_output = (
-        process.system_output(query_cmd, shell=True).decode().splitlines()
+        process.system_output("%s -cpu ?" % qemu_binary, shell=True)
+        .decode()
+        .splitlines()
     )
-    cpuid_index = qemu_binary_output.index("CPUID")
-    cpu_models_binary = qemu_binary_output[1 : cpuid_index - 1]
-    cpu_flags_binary = qemu_binary_output[cpuid_index + 1 :]
+    cpu_models_binary = []
+    cpu_flags_binary = []
+    in_flags = False
+    for line in qemu_binary_output:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("Available CPU"):
+            continue
+        if "CPUID" in stripped:
+            in_flags = True
+            continue
+        if in_flags:
+            cpu_flags_binary.extend(stripped.split())
+        else:
+            parts = line.split()
+            if parts[0] == "x86":
+                cpu_models_binary.append(parts[1])
+            else:
+                cpu_models_binary.append(parts[0])
     params["start_vm"] = "yes"
     vm_name = params["main_vm"]
     env_process.preprocess_vm(test, params, env, vm_name)

--- a/qemu/tests/cpu_info_check.py
+++ b/qemu/tests/cpu_info_check.py
@@ -54,6 +54,11 @@ def run(test, params, env):
         remove_models(params.objects("cpu_model_3_1_0"))
     if host_qemu in VersionInterval("[,2.12.0)"):
         remove_models(params.objects("cpu_model_2_12_0"))
+    if host_qemu in VersionInterval("[,9.0.0)"):
+        remove_models(
+            params.objects("cpu_model_9_0_0")
+            or ["SapphireRapids-v3", "Icelake-Server-v7"]
+        )
     qemu_binary = utils_misc.get_qemu_binary(params)
     test.log.info("Query cpu models by qemu command")
     # QEMU < 9.0: "x86 ModelName  description" (model is $2)

--- a/qemu/tests/cpu_info_check.py
+++ b/qemu/tests/cpu_info_check.py
@@ -56,7 +56,12 @@ def run(test, params, env):
         remove_models(params.objects("cpu_model_2_12_0"))
     qemu_binary = utils_misc.get_qemu_binary(params)
     test.log.info("Query cpu models by qemu command")
-    query_cmd = "%s -cpu ? | awk '{print $2}'" % qemu_binary
+    # QEMU < 9.0: "x86 ModelName  description" (model is $2)
+    # QEMU >= 9.0: "  ModelName  description"   (model is $1)
+    query_cmd = (
+        "%s -cpu ? | awk '/^x86 /{print $2; next} /CPUID/{print $2; next}"
+        " {print $1}'" % qemu_binary
+    )
     qemu_binary_output = (
         process.system_output(query_cmd, shell=True).decode().splitlines()
     )


### PR DESCRIPTION
## Summary
- Fix CPU model name parsing from `qemu-kvm -cpu ?` output for QEMU >= 9.0
- Add version-gated exclusion lists for models removed/added across QEMU versions
- Replace awk-based parsing with native Python for robustness

## Problem
QEMU commit 4984321436 (April 2024, QEMU 9.0) removed the `x86` prefix from
`-cpu ?` output. The test used `awk '{print $2}'` which broke on the new format
(column 2 became the description instead of the model name).

Additionally, CPU models were added (`SapphireRapids-v3`, `Icelake-Server-v7`)
and removed (`Opteron_G1/G2/G3`, `Penryn`, `Conroe`) across QEMU versions,
causing false failures on both old and new QEMU.

The awk pipeline also only extracted one token per line from the CPUID flags
section, silently skipping validation of remaining flags on multi-token lines.

## Fix
- Replace awk with native Python parsing that handles both old and new formats
- Extract all flags per line using `split()` instead of single-token awk
- Version-gated model exclusion for QEMU < 9.0 and deprecated models

## Testing
Verified with KAR on bare-metal hosts across 4 RHEL versions:

| RHEL | QEMU | Format | Result |
|------|------|--------|--------|
| 9.4 | 8.2 | old (`x86` prefix) | PASS |
| 9.8 | 10.1 | new (no prefix) | PASS |
| 9.9 | 10.1 | new (no prefix) | PASS |
| 10.1 | 10.1 | new (no prefix) | PASS |