### PR TITLE
x86_cpu_flags: split arch_capabilities and mds-no into separate tests

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -28,8 +28,17 @@
                 - arch_capabilities:
                     # support RHEL.7 guest or later
                     no RHEL.6
+                    cpu_model_flags += ",arch-capabilities=on"
+                    flags = "arch_capabilities"
+                - mds_no:
+                    # mds-no is not available on all hosts, check host
+                    # vulnerability status before running with enforce
+                    no RHEL.6
                     cpu_model_flags += ",arch-capabilities=on,+mds-no"
                     flags = "arch_capabilities"
+                    check_cmd = "cat /sys/devices/system/cpu/vulnerabilities/%s"
+                    check_items = "mds"
+                    expect_result = 'Not affected'
                     check_guest_cmd = "cat /sys/devices/system/cpu/vulnerabilities/mds | grep '%s'"
                     expect_items = 'Not affected'
                 - intel_pt:

--- a/qemu/tests/x86_cpu_flags.py
+++ b/qemu/tests/x86_cpu_flags.py
@@ -1,3 +1,4 @@
+from avocado.utils import process
 from virttest import cpu, env_process, error_context
 
 from provider.cpu_utils import check_cpu_flags
@@ -20,6 +21,19 @@ def run(test, params, env):
     check_host_flags = params.get_boolean("check_host_flags")
     if check_host_flags:
         check_cpu_flags(params, flags, test)
+
+    check_cmd = params.get("check_cmd")
+    if check_cmd:
+        check_items = params["check_items"].split()
+        expect_result = params["expect_result"]
+        for item in check_items:
+            cmd = check_cmd % item if "%s" in check_cmd else check_cmd
+            out = process.getoutput(cmd).strip()
+            if expect_result not in out:
+                test.cancel(
+                    "Host '%s' status is '%s', expected '%s'"
+                    % (item, out or "unknown", expect_result)
+                )
 
     unsupported_models = params.get("unsupported_models", "")
     cpu_model = params.get("cpu_model")


### PR DESCRIPTION
## Summary
Split the `arch_capabilities` test variant into two separate tests to fix
false ERROR on hosts where mds-no is not available.

## Problem
The `arch_capabilities` test added `+mds-no` with `enforce` mode, causing
QEMU to refuse to start on hosts that don't have mds-no. The test
only checked for the `arch_capabilities` flag on the host but not
`mds-no`, so it ran on hosts without mds-no and QEMU refused to start.

## Fix
- **arch_capabilities**: tests only `arch-capabilities=on`, runs on any
  CPU with the `arch_capabilities` flag
- **mds_no** (new): tests `arch-capabilities=on,+mds-no`, checks host
  MDS vulnerability status via `/sys/devices/system/cpu/vulnerabilities/mds`
  and cancels if not "Not affected"

Also adds host vulnerability sysfs check support to `x86_cpu_flags.py`
using the same `check_cmd`/`check_items`/`expect_result` pattern as
`x86_cpu_model`.

## Testing
Verified on bare-metal hosts with RHEL 10.0:

| Host | CPU | Stepping | MDS status | arch_capabilities | mds_no |
|------|-----|----------|------------|-------------------|--------|
| Skylake Gold 6152 | stepping 4 | Mitigation | PASS | CANCEL |
| Cascade Lake Silver 4216 | stepping 7 | Not affected | PASS | PASS |