### PR TITLE
x86_cpu_flags: fix virt-ssbd test for hosts with AMD_SSBD

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -81,8 +81,10 @@
                     cpu_model_flags += ",+xsaveerptr,+clzero"
                     flags = "clzero xsaveerptr"
                 - virt-ssbd:
-                    fallback_models_map = "{'EPYC-Milan':'EPYC-Rome'}"
-                    cpu_model_flags += ",+virt-ssbd"
+                    # Disable amd-ssbd so the guest kernel doesn't clear
+                    # virt_ssbd from cpuinfo (BZ#1983714, kernel commit
+                    # 6ac2f49edb1e).
+                    cpu_model_flags += ",+virt-ssbd,-amd-ssbd"
                     flags = "ssbd"
                     guest_flags = "virt_ssbd"
                     check_guest_cmd = "cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass | grep '%s'"


### PR DESCRIPTION
When the guest CPU model includes amd-ssbd, the guest kernel clears
virt_ssbd from cpuinfo (kernel commit 6ac2f49edb1e, since v4.18).
EPYC-Rome-v2+ and EPYC-Milan+ models define amd-ssbd, so the test
fails on those hosts.

Disable amd-ssbd in the guest CPU model flags so virt_ssbd remains
visible in guest cpuinfo.

Tested on AMD EPYC 9335 (Turin) with RHEL 9.9 — test passes with the fix.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1983714