### PR TITLE
guest_iommu_test: fix x2apic check_key_words filter for RHEL 7 guests

### DIFF
--- a/qemu/tests/cfg/guest_iommu_test.cfg
+++ b/qemu/tests/cfg/guest_iommu_test.cfg
@@ -66,3 +66,5 @@
             iommu_eim = on
             cpu_model_flags += ",+x2apic"
             check_key_words = "x2apic enabled"
+            RHEL.7:
+                check_key_words = "Enabled x2apic"


### PR DESCRIPTION
RHEL 7 prints "Enabled x2apic" instead of "x2apic enabled" in the
kernel log. Add an override using a guest OS filter for RHEL.7.

Resolves: <https://redhat.atlassian.net/browse/KVMAUTOMA-5302>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded guest IOMMU validation coverage for RHEL 7.
  * Added checks confirming that x2APIC is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->