### PR TITLE
cpu_device_hotplug_time_jump: fix dmesg regex for kernel >= 6.11

### DIFF
--- a/qemu/tests/cpu_device_hotplug_time_jump.py
+++ b/qemu/tests/cpu_device_hotplug_time_jump.py
@@ -42,11 +42,17 @@ def run(test, params, env):
     time1 = float(
         re.findall(r"^\[\s*(\d+\.?\d+)\].*CPU.*has been hot-added$", output, re.M)[0]
     )
-    time2 = float(
-        re.findall(
-            r"^\[\s*(\d+\.?\d+)\].*Will online and init " "hotplugged CPU", output, re.M
-        )[0]
+    # Kernel >= 6.11 (c1385c1f0ba3) removed "Will online and init
+    # hotplugged CPU" message; also match "Booting Node" from smpboot.
+    matches = re.findall(
+        r"^\[\s*(\d+\.?\d+)\].*(?:Will online and init hotplugged CPU"
+        r"|Booting Node.*Processor.*APIC)",
+        output,
+        re.M,
     )
+    if not matches:
+        test.error("Could not find CPU online message in dmesg")
+    time2 = float(matches[0])
     time_gap = time2 - time1
     test.log.info("The time gap is %.6fs", time_gap)
     expected_gap = params.get_numeric("expected_gap", target_type=float)


### PR DESCRIPTION
## Summary
- Kernel commit c1385c1f0ba3 (merged in v6.11) removed the "Will online and init hotplugged CPU" `pr_info` from `drivers/acpi/processor_driver.c`
- This causes `IndexError` on RHEL 9.8+ and RHEL 10.x kernels that backported or include the change
- Use alternation regex to also match "Booting Node ... Processor ... APIC" from `arch/x86/kernel/smpboot.c`, which is still printed during CPU hotplug bringup
- Backward compatible: on older kernels both messages are present; the regex matches whichever comes first

## Test plan
- [x] Verified regex matches on RHEL 9.4 guest (kernel 5.14.0-427, both messages present)
- [x] Verified regex matches on RHEL 9.8 guest (kernel 5.14.0-687, only "Booting Node")
- [x] Verified regex matches on RHEL 10.2 guest (kernel 6.12.0-211, only "Booting Node")
- [ ] KAR cpu_hotplug test run with RHEL 9.4 guest (in progress)
- [ ] KAR cpu_hotplug test run with RHEL 9.9 guest (pending)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU hotplug timing test compatibility across different kernel log formats.
  * Added clearer error reporting when expected CPU online events are not detected.
  * Preserved time-gap validation using the earliest matching CPU startup event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->