### PR TITLE
cpu_device_hotplug_time_jump: fix dmesg regex for kernel >= 6.11

### DIFF
--- a/qemu/tests/cpu_device_hotplug_time_jump.py
+++ b/qemu/tests/cpu_device_hotplug_time_jump.py
@@ -42,11 +42,17 @@ def run(test, params, env):
     time1 = float(
         re.findall(r"^\[\s*(\d+\.?\d+)\].*CPU.*has been hot-added$", output, re.M)[0]
     )
-    time2 = float(
-        re.findall(
-            r"^\[\s*(\d+\.?\d+)\].*Will online and init " "hotplugged CPU", output, re.M
-        )[0]
+    # Kernel >= 6.11 (c1385c1f0ba3) removed "Will online and init
+    # hotplugged CPU" message; also match "Booting Node" from smpboot.
+    matches = re.findall(
+        r"^\[\s*(\d+\.?\d+)\].*(?:Will online and init hotplugged CPU"
+        r"|Booting Node.*Processor.*APIC)",
+        output,
+        re.M,
     )
+    if not matches:
+        test.error("Could not find CPU online message in dmesg")
+    time2 = float(matches[0])
     time_gap = time2 - time1
     test.log.info("The time gap is %.6fs", time_gap)
     expected_gap = params.get_numeric("expected_gap", target_type=float)


### PR DESCRIPTION
The dmesg format for CPU hotplug messages changed in kernel 6.11.
Update the regex patterns to match both old and new formats.

Tested on RHEL 10.3 (kernel 6.12) and RHEL 9.9 (kernel 5.14).

Signed-off-by: Igor Mammedov <imammedo@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of CPU hotplug startup timestamps across different kernel log message formats.
  * Added clearer failure handling when no matching timestamp is found.
  * Ensured timing comparisons use the earliest detected startup event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->