### PR TITLE
x86_cpu_flag_disable: exclude x86-64-v3 flags on RHEL 10 guests

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -117,7 +117,12 @@
                 - flag_disable:
                     only Linux
                     type = x86_cpu_flag_disable
+                    # RHEL 10 glibc requires x86-64-v3 (avx avx2 bmi1 bmi2
+                    # f16c fma lzcnt/abm movbe xsave). Disabling any of
+                    # those crashes init. Restrict to non-v3 flags on el10.
                     flags_list = "rdrand ssbd fsgsbase bmi1 bmi2 rdtscp movbe f16c abm kvmclock"
+                    RHEL.10:
+                        flags_list = "rdrand ssbd fsgsbase rdtscp kvmclock"
                     check_clock = 'cat /sys/devices/system/clocksource/clocksource0/available_clocksource'
                 - test_smap:
                     # support RHEL.7 guest or later


### PR DESCRIPTION
RHEL 10 glibc is built with -march=x86-64-v3 and checks the CPU
feature level at init. Disabling any v3 baseline flag (bmi1, bmi2,
f16c, movbe, abm/lzcnt) causes glibc to abort with 'CPU does not
support x86-64-v3', crashing init before the guest boots.

Restrict the flags_list on RHEL 10 guests to flags outside the
v3 baseline: rdrand, ssbd, fsgsbase, rdtscp, kvmclock.

Signed-off-by: Igor Mammedov <imammedo@redhat.com>