### PR TITLE
Use virttest cpudetect

### DIFF
--- a/qemu/tests/sev_direct_kernel_boot.py
+++ b/qemu/tests/sev_direct_kernel_boot.py
@@ -1,9 +1,9 @@
 import os
 
-from avocado.utils import cpu
 from virttest import data_dir as virttest_data_dir
 from virttest import env_process, error_context
 from virttest.utils_misc import verify_dmesg
+from virttest.vt_utils import cpu as vt_cpu
 
 
 @error_context.context_aware
@@ -30,22 +30,11 @@ def run(test, params, env):
         guest_check_cmd = params["sev_guest_check"]
         guest_fail_msg = "Guest sev verify fail"
 
-    family_id = int(cpu.get_family())
-    model_id = int(cpu.get_model())
-    dict_cpu = {
-        "milan": [25, 0, 15],
-        "genoa": [25, 16, 31],
-        "bergamo": [25, 160, 175],
-        "turin": [26, 0, 31],
-    }
-    host_cpu_model = None
-    for platform, values in dict_cpu.items():
-        if values[0] == family_id:
-            if model_id >= values[1] and model_id <= values[2]:
-                host_cpu_model = platform
-    if not host_cpu_model:
-        test.cancel("Unsupported platform. Requires milan or above.")
-    test.log.info("Detected platform: %s", host_cpu_model)
+    try:
+        host_cpu_model = vt_cpu.verify_min_cpu_codename("milan")
+    except OSError as e:
+        test.cancel(str(e))
+    test.log.info("Detected codename: %s", host_cpu_model)
 
     params["start_vm"] = "yes"
     guest_name = params["guest_name"]

--- a/qemu/tests/snp_basic_config.py
+++ b/qemu/tests/snp_basic_config.py
@@ -5,6 +5,7 @@ from virttest import data_dir as virttest_data_dir
 from virttest import error_context
 from virttest.staging import utils_memory
 from virttest.utils_misc import verify_dmesg
+from virttest.vt_utils import cpu as vt_cpu
 
 
 @error_context.context_aware
@@ -50,23 +51,11 @@ def run(test, params, env):
             "Insufficient host memory. Required: %d MB, "
             "Available: %d MB" % (required_mem, available_mem_mb)
         )
-
-    family_id = int(cpu.get_family())
-    model_id = int(cpu.get_model())
-    dict_cpu = {
-        "milan": [25, 0, 15],
-        "genoa": [25, 16, 31],
-        "bergamo": [25, 160, 175],
-        "turin": [26, 0, 31],
-    }
-    host_cpu_model = None
-    for platform, values in dict_cpu.items():
-        if values[0] == family_id:
-            if model_id >= values[1] and model_id <= values[2]:
-                host_cpu_model = platform
-    if not host_cpu_model:
-        test.cancel("Unsupported platform. Requires milan or above.")
-    test.log.info("Detected platform: %s", host_cpu_model)
+    try:
+        host_cpu_model = vt_cpu.verify_min_cpu_codename("milan")
+    except OSError as e:
+        test.cancel(str(e))
+    test.log.info("Detected codename: %s", host_cpu_model)
     vm_name = params["main_vm"]
     vm = env.get_vm(vm_name)
     vm.create()

--- a/qemu/tests/snp_cpu_model.py
+++ b/qemu/tests/snp_cpu_model.py
@@ -2,10 +2,11 @@ import json
 import os
 import re
 
-from avocado.utils import cpu, process
+from avocado.utils import process
 from virttest import data_dir as virttest_data_dir
 from virttest import error_context, utils_misc
 from virttest.utils_misc import verify_dmesg
+from virttest.vt_utils import cpu as vt_cpu
 
 
 @error_context.context_aware
@@ -68,23 +69,12 @@ def run(test, params, env):
     else:
         test.log.info("Supported models: %s", ",".join(models))
         test.cancel("This host doesn't support cpu model %s" % model)
+    try:
+        host_cpu_model = vt_cpu.verify_min_cpu_codename("milan")
+    except OSError as e:
+        test.cancel(str(e))
 
-    family_id = int(cpu.get_family())
-    model_id = int(cpu.get_model())
-    dict_cpu = {
-        "milan": [25, 0, 15],
-        "genoa": [25, 16, 31],
-        "bergamo": [25, 160, 175],
-        "turin": [26, 0, 31],
-    }
-    host_cpu_model = None
-    for platform, values in dict_cpu.items():
-        if values[0] == family_id:
-            if model_id >= values[1] and model_id <= values[2]:
-                host_cpu_model = platform
-    if not host_cpu_model:
-        test.cancel("Unsupported platform. Requires milan or above.")
-    test.log.info("Detected platform: %s", host_cpu_model)
+    test.log.info("Detected codename: %s", host_cpu_model)
 
     vm = env.get_vm(params["main_vm"])
     vm.params["cpu_model"] = cpu_model  # pylint: disable=E0606

--- a/qemu/tests/snp_multi_vm.py
+++ b/qemu/tests/snp_multi_vm.py
@@ -1,9 +1,9 @@
 import os
 
-from avocado.utils import cpu
 from virttest import data_dir as virttest_data_dir
 from virttest import env_process, error_context
 from virttest.utils_misc import get_mem_info, normalize_data_size, verify_dmesg
+from virttest.vt_utils import cpu as vt_cpu
 
 
 @error_context.context_aware
@@ -24,22 +24,11 @@ def run(test, params, env):
     error_context.context("Start sev-snp test", test.log.info)
     timeout = params.get_numeric("login_timeout", 240)
 
-    family_id = int(cpu.get_family())
-    model_id = int(cpu.get_model())
-    dict_cpu = {
-        "milan": [25, 0, 15],
-        "genoa": [25, 16, 31],
-        "bergamo": [25, 160, 175],
-        "turin": [26, 0, 31],
-    }
-    host_cpu_model = None
-    for platform, values in dict_cpu.items():
-        if values[0] == family_id:
-            if model_id >= values[1] and model_id <= values[2]:
-                host_cpu_model = platform
-    if not host_cpu_model:
-        test.cancel("Unsupported platform. Requires milan or above.")
-    test.log.info("Detected platform: %s", host_cpu_model)
+    try:
+        host_cpu_model = vt_cpu.verify_min_cpu_codename("milan")
+    except OSError as e:
+        test.cancel(str(e))
+    test.log.info("Detected codename: %s", host_cpu_model)
 
     snp_module_path = params["snp_module_path"]
     if os.path.exists(snp_module_path):


### PR DESCRIPTION
Replace per-test inline CPU family/model lookup tables with the shared
get_amd_platform() utility from virttest.vt_utils.cpu. This removes
duplicate platform detection logic and keeps platform checks consistent
across SEV/SNP tests.

This updates the following tests:
  - sev_direct_kernel_boot
  - snp_basic_config
  - snp_cpu_model
  - snp_multi_vm