### PR TITLE
x86_cpu_flags: exclude ssbd from flag_disable on AMD hosts

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -134,6 +134,13 @@
                     flags_list = "rdrand ssbd fsgsbase bmi1 bmi2 rdtscp movbe f16c abm kvmclock"
                     RHEL.10:
                         flags_list = "rdrand ssbd fsgsbase rdtscp kvmclock"
+                    # On AMD, disabling ssbd via QEMU -ssbd doesn't remove it
+                    # from guest cpuinfo — the kernel derives it from amd-ssbd
+                    # (BZ#1983714, kernel commit 6ac2f49edb1e).
+                    HostCpuVendor.amd:
+                        flags_list = "rdrand fsgsbase bmi1 bmi2 rdtscp movbe f16c abm kvmclock"
+                        RHEL.10:
+                            flags_list = "rdrand fsgsbase rdtscp kvmclock"
                     check_clock = 'cat /sys/devices/system/clocksource/clocksource0/available_clocksource'
                 - test_smap:
                     # support RHEL.7 guest or later


### PR DESCRIPTION
## Summary
On AMD, disabling `ssbd` via QEMU's `-ssbd` flag removes the SPEC_CTRL MSR
SSBD bit, but the guest kernel still reports `ssbd` in cpuinfo because it
derives it from `amd-ssbd` (BZ#1983714, kernel commit `6ac2f49edb1e`).

This causes `flag_disable` test to randomly fail on AMD hosts when it picks
`ssbd` to disable — the flag remains visible in guest cpuinfo despite being
disabled in QEMU.

Remove `ssbd` from the AMD `flags_list`, including the RHEL.10 variant that
restricts the list to non-x86-64-v3 flags.

## Test plan
- [x] Milan cpu-model el10 (RHEL-10.3-20260714.1): 49 PASS, 0 FAIL
- [x] Turin cpu-model el10 (RHEL-10.3-20260714.1): 49 PASS, 0 FAIL