### PR TITLE
thin_provision_guest_fstrim: add missing dd conv=fsync

### DIFF
--- a/qemu/tests/cfg/thin_provision_guest_fstrim.cfg
+++ b/qemu/tests/cfg/thin_provision_guest_fstrim.cfg
@@ -37,5 +37,5 @@
     guest_mount_point = "/home/test"
     guest_test_file = "${guest_mount_point}/test.img"
     guest_format_command = "mkdir -p ${guest_mount_point};mkfs.${format} {0} && mount {0} ${guest_mount_point}"
-    guest_dd_command = "dd if=/dev/zero of=${guest_test_file}"
+    guest_dd_command = "dd if=/dev/zero of=${guest_test_file} conv=fsync"
     guest_rm_command = "rm -rf ${guest_test_file};sync"


### PR DESCRIPTION
The thin_provision_guest_fstrim test case is unreliable because the dd command inside the guest does not fsync. Although the test is supposed to fill up the SCSI disk and cause blocks to be allocated, whether that actually happens is left up to chance since the guest page cache may not be written out immediately.

Use the dd conv=fsync flag to force the blocks to be written to disk.

Resolves: https://redhat.atlassian.net/browse/KVMAUTOMA-5305