### PR TITLE
x86_cpu_model: log unavailable features when model is not supported

### DIFF
--- a/qemu/tests/x86_cpu_model.py
+++ b/qemu/tests/x86_cpu_model.py
@@ -50,6 +50,16 @@ def run(test, params, env):
         name_ib = " \\(with IBPB\\)"
 
     models = [x["name"] for x in out if not x["unavailable-features"]]
+    for x in out:
+        if x["name"] in (model, "%s-IBRS" % model, "%s-IBPB" % model):
+            if x["unavailable-features"]:
+                test.log.info(
+                    "Model %s unavailable features: %s",
+                    x["name"],
+                    x["unavailable-features"],
+                )
+            else:
+                test.log.info("Model %s: all features available", x["name"])
     if model_ib in models:
         cpu_model = model_ib
         guest_model = model_pattern % name_ib


### PR DESCRIPTION
When query-cpu-definitions reports a model as having unavailable
features, log which features are missing before cancelling the test.

This helps debug cases where a CPU model is unexpectedly cancelled
on a host that should support it — e.g. EPYC-Milan cancelled on
Milan hosts due to erms/fsrm not being exposed on some SKUs [1],
or SapphireRapids/Cooperlake cancelled due to hle/rtm/taa-no
on hosts with TSX disabled.

[1] https://lists.gnu.org/archive/html/qemu-devel/2022-01/msg06747.html

Signed-off-by: Igor Mammedov <imammedo@redhat.com>