### PR TITLE
x86_cpu_model: document erms/fsrm issue on EPYC-Milan

### DIFF
--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -39,6 +39,10 @@
                 flags = ""
         - EPYC-Milan:
             only HostCpuVendor.amd
+            # erms/fsrm may be missing on some Milan SKUs/steppings,
+            # it might be possible to enable them in BIOS (ADVANCED > AMD CBS)
+            # https://lists.gnu.org/archive/html/qemu-devel/2022-01/msg06747.html
+            optional_features = "erms fsrm"
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
             model_pattern = "AMD EPYC-Milan Processor%s"
             # support 'pcid' since RHEL.8.3
@@ -46,6 +50,7 @@
                 flags = ""
         - EPYC-Milan-v1:
             only HostCpuVendor.amd
+            optional_features = "erms fsrm"
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
             model_pattern = "AMD EPYC-Milan Processor%s"
             # support 'pcid' since RHEL.8.3
@@ -53,6 +58,7 @@
                 flags = ""
         - EPYC-Milan-v2:
             only HostCpuVendor.amd
+            optional_features = "erms fsrm"
             required_qemu = [8.0.0,)
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
             model_pattern = "AMD EPYC-Milan-v2 Processor%s"
@@ -140,16 +146,19 @@
         - SapphireRapids:
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
+            optional_features = "hle rtm taa-no"
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
             model_pattern = "Intel Xeon Processor \(SapphireRapids\)"
         - SapphireRapids-v1:
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
+            optional_features = "hle rtm taa-no"
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
             model_pattern = "Intel Xeon Processor \(SapphireRapids\)"
         - SapphireRapids-v2:
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
+            optional_features = "hle rtm taa-no"
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
             model_pattern = "Intel Xeon Processor \(SapphireRapids\)"
         - Snowridge:
@@ -200,6 +209,7 @@
             only HostCpuVendor.intel
             # support 'BFloat16' with RHEL8.2 guest or later
             no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
+            optional_features = "hle rtm taa-no"
             flags = "avx512_bf16 stibp arch_capabilities"
             model_pattern = "Intel Xeon Processor \(Cooperlake%s\)"
             check_cmd = "cat /sys/devices/system/cpu/vulnerabilities/%s"
@@ -210,12 +220,14 @@
             only HostCpuVendor.intel
             # support 'BFloat16' with RHEL8.2 guest or later
             no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
+            optional_features = "hle rtm taa-no"
             flags = "avx512_bf16 stibp arch_capabilities"
             model_pattern = "Intel Xeon Processor \(Cooperlake%s\)"
         - Cooperlake-v2:
             only HostCpuVendor.intel
             # support 'BFloat16' with RHEL8.2 guest or later
             no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
+            optional_features = "hle rtm taa-no"
             # support XSAVES
             flags = "avx512_bf16 stibp arch_capabilities"
             model_pattern = "Intel Xeon Processor \(Cooperlake%s\)"

--- a/qemu/tests/x86_cpu_model.py
+++ b/qemu/tests/x86_cpu_model.py
@@ -50,6 +50,32 @@ def run(test, params, env):
         name_ib = " \\(with IBPB\\)"
 
     models = [x["name"] for x in out if not x["unavailable-features"]]
+    models_map = {x["name"]: x for x in out}
+    optional_features = params.get("optional_features", "").split()
+
+    def _try_model(name):
+        """Check if model can run, possibly with optional features disabled."""
+        if name not in models_map:
+            return None, []
+        unavailable = models_map[name].get("unavailable-features", [])
+        if not unavailable:
+            return name, []
+        unexpected = [f for f in unavailable if f not in optional_features]
+        if unexpected:
+            test.log.info(
+                "Model %s has unexpected unavailable features: %s",
+                name,
+                unexpected,
+            )
+            return None, unavailable
+        test.log.warning(
+            "Model %s: host missing optional features %s, disabling them for this run",
+            name,
+            unavailable,
+        )
+        return name, unavailable
+
+    disabled = []
     if model_ib in models:
         cpu_model = model_ib
         guest_model = model_pattern % name_ib
@@ -58,7 +84,21 @@ def run(test, params, env):
         cpu_model = model
         guest_model = model_pattern % ""
     else:
-        test.cancel("This host doesn't support cpu model %s" % model)
+        cpu_model, disabled = _try_model(model_ib)
+        if cpu_model:
+            guest_model = model_pattern % name_ib
+            flags += flag_ib
+        else:
+            cpu_model, disabled = _try_model(model)
+            if cpu_model:
+                guest_model = model_pattern % ""
+            else:
+                test.cancel("This host doesn't support cpu model %s" % model)
+
+    if disabled:
+        disable_flags = ",".join("-%s" % f for f in disabled)
+        params["cpu_model_flags"] += "," + disable_flags
+        flags = " ".join(f for f in flags.split() if f not in disabled)
 
     params["cpu_model"] = cpu_model  # pylint: disable=E0606
     params["start_vm"] = "yes"


### PR DESCRIPTION
Some Milan SKUs/steppings don't expose erms and fsrm CPUID features,
causing QEMU's query-cpu-definitions to report EPYC-Milan model as
having unavailable features on those hosts. This results in the test
being cancelled on hosts that otherwise support the Milan model.

Observed on:
- AMD Eng Sample 100-000000508 (no erms/fsrm)
- AMD EPYC 7543 (no erms/fsrm)
- AMD EPYC 7713 (has erms/fsrm) — test passes

Add reference to the upstream QEMU discussion about this issue.

Ref: https://lists.gnu.org/archive/html/qemu-devel/2022-01/msg06747.html

Signed-off-by: Igor Mammedov <imammedo@redhat.com>