### PR TITLE
x86_cpu_model: skip unnecessary reboot after flag check

### DIFF
--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -4,7 +4,6 @@
     auto_cpu_model = no
     kill_vm_on_error = yes
     start_vm = no
-    reboot_method = "shell"
     only i386, x86_64
     Windows:
         get_model_cmd = "wmic cpu get name"


### PR DESCRIPTION
The reboot step in x86_cpu_model adds ~30-60s per model variant
for no additional CPU model coverage — CPUID can't change without
restarting QEMU.

Saves ~40 minutes per cpu_model run per host, ~13 hours of machine
time across all ~20 CPU generations tested in CTC.

Signed-off-by: Igor Mammedov <imammedo@redhat.com>