### PR TITLE
x86_cpu_flags: remove kvmclock from flag_disable list

### DIFF
--- a/qemu/tests/cfg/x86_cpu_flags.cfg
+++ b/qemu/tests/cfg/x86_cpu_flags.cfg
@@ -131,16 +131,16 @@
                     # RHEL 10 glibc requires x86-64-v3 (avx avx2 bmi1 bmi2
                     # f16c fma lzcnt/abm movbe xsave). Disabling any of
                     # those crashes init. Restrict to non-v3 flags on el10.
-                    flags_list = "rdrand ssbd fsgsbase bmi1 bmi2 rdtscp movbe f16c abm kvmclock"
+                    flags_list = "rdrand ssbd fsgsbase bmi1 bmi2 rdtscp movbe f16c abm"
                     RHEL.10:
-                        flags_list = "rdrand ssbd fsgsbase rdtscp kvmclock"
+                        flags_list = "rdrand ssbd fsgsbase rdtscp"
                     # On AMD, disabling ssbd via QEMU -ssbd doesn't remove it
                     # from guest cpuinfo — the kernel derives it from amd-ssbd
                     # (BZ#1983714, kernel commit 6ac2f49edb1e).
                     HostCpuVendor.amd:
-                        flags_list = "rdrand fsgsbase bmi1 bmi2 rdtscp movbe f16c abm kvmclock"
+                        flags_list = "rdrand fsgsbase bmi1 bmi2 rdtscp movbe f16c abm"
                         RHEL.10:
-                            flags_list = "rdrand fsgsbase rdtscp kvmclock"
+                            flags_list = "rdrand fsgsbase rdtscp"
                     check_clock = 'cat /sys/devices/system/clocksource/clocksource0/available_clocksource'
                 - test_smap:
                     # support RHEL.7 guest or later


### PR DESCRIPTION
## Summary
kvmclock is a KVM paravirt feature that only appears in guest cpuinfo.
The host never has kvmclock in cpuinfo, so when `flag_disable` randomly
picks it, `check_host_flags` cancels the test every time.

## Test plan
- [x] Verified kvmclock is not in host `/proc/cpuinfo` or `lscpu` output on any host
- [x] Cascade Lake CTC run: flag_disable cancelled with "This host doesn't support flag ['kvmclock']"