### PR TITLE
x86_cpu_model: handle hosts with optional CPU features disabled

### DIFF
--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -140,17 +140,17 @@
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
-            model_pattern = "Intel Xeon Processor \(SapphireRapids\)"
+            model_pattern = "Intel Xeon Processor \(SapphireRapids%s\)"
         - SapphireRapids-v1:
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
-            model_pattern = "Intel Xeon Processor \(SapphireRapids\)"
+            model_pattern = "Intel Xeon Processor \(SapphireRapids%s\)"
         - SapphireRapids-v2:
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
-            model_pattern = "Intel Xeon Processor \(SapphireRapids\)"
+            model_pattern = "Intel Xeon Processor \(SapphireRapids%s\)"
         - Snowridge:
             only HostCpuVendor.intel
             only RHEL.7, RHEL.8, RHEL.9, Win10, Win11, Win2016, Win2019, Win2022, Win2025

--- a/qemu/tests/cfg/x86_cpu_model.cfg
+++ b/qemu/tests/cfg/x86_cpu_model.cfg
@@ -38,6 +38,10 @@
                 flags = ""
         - EPYC-Milan:
             only HostCpuVendor.amd
+            # erms/fsrm may be missing on some Milan SKUs/steppings,
+            # it might be possible to enable them in BIOS (ADVANCED > AMD CBS)
+            # https://lists.gnu.org/archive/html/qemu-devel/2022-01/msg06747.html
+            optional_features = "erms fsrm"
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
             model_pattern = "AMD EPYC-Milan Processor%s"
             # support 'pcid' since RHEL.8.3
@@ -45,6 +49,7 @@
                 flags = ""
         - EPYC-Milan-v1:
             only HostCpuVendor.amd
+            optional_features = "erms fsrm"
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
             model_pattern = "AMD EPYC-Milan Processor%s"
             # support 'pcid' since RHEL.8.3
@@ -52,6 +57,7 @@
                 flags = ""
         - EPYC-Milan-v2:
             only HostCpuVendor.amd
+            optional_features = "erms fsrm"
             required_qemu = [8.0.0,)
             flags = "movbe rdrand rdtscp fxsr_opt cr8_legacy osvw fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 arat f16c xsaveerptr clzero rdpid perfctr_core ibpb wbnoinvd stibp clwb umip xsaves pcid ibrs ssbd erms fsrm invpcid pku"
             model_pattern = "AMD EPYC-Milan-v2 Processor%s"
@@ -139,16 +145,19 @@
         - SapphireRapids:
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
+            optional_features = "hle rtm taa-no"
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
             model_pattern = "Intel Xeon Processor \(SapphireRapids%s\)"
         - SapphireRapids-v1:
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
+            optional_features = "hle rtm taa-no"
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
             model_pattern = "Intel Xeon Processor \(SapphireRapids%s\)"
         - SapphireRapids-v2:
             only HostCpuVendor.intel
             required_qemu = [8.0.0,)
+            optional_features = "hle rtm taa-no"
             flags = "serialize tsxldtrk amx_bf16 amx_tile amx_int8 avx512_bf16 avx_vnni avx512_fp16"
             model_pattern = "Intel Xeon Processor \(SapphireRapids%s\)"
         - Snowridge:
@@ -199,6 +208,7 @@
             only HostCpuVendor.intel
             # support 'BFloat16' with RHEL8.2 guest or later
             no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
+            optional_features = "hle rtm taa-no"
             flags = "avx512_bf16 stibp arch_capabilities"
             model_pattern = "Intel Xeon Processor \(Cooperlake%s\)"
             check_cmd = "cat /sys/devices/system/cpu/vulnerabilities/%s"
@@ -209,17 +219,20 @@
             only HostCpuVendor.intel
             # support 'BFloat16' with RHEL8.2 guest or later
             no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
+            optional_features = "hle rtm taa-no"
             flags = "avx512_bf16 stibp arch_capabilities"
             model_pattern = "Intel Xeon Processor \(Cooperlake%s\)"
         - Cooperlake-v2:
             only HostCpuVendor.intel
             # support 'BFloat16' with RHEL8.2 guest or later
             no RHEL.6 RHEL.7 RHEL.8.0 RHEL.8.1
+            optional_features = "hle rtm taa-no"
             # support XSAVES
             flags = "avx512_bf16 stibp arch_capabilities"
             model_pattern = "Intel Xeon Processor \(Cooperlake%s\)"
         - Icelake-Server:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "la57 wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512_bitalg avx512_vpopcntdq clflushopt pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Icelake%s\)"
             RHEL.7:
@@ -234,6 +247,7 @@
                 flags = ""
         - Icelake-Server-v1:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "la57 wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512_bitalg avx512_vpopcntdq clflushopt pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Icelake%s\)"
             RHEL.7:
@@ -286,6 +300,7 @@
             only HostCpuVendor.intel
             only RHEL.7, RHEL.8, Win10, Win11, Win2016, Win2019
             required_qemu = (, 5.2.0)
+            optional_features = "hle rtm"
             flags = "wbnoinvd avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512_bitalg avx512_vpopcntdq"
             model_pattern = "Intel Core Processor \(Icelake%s\)"
             RHEL.7:
@@ -301,6 +316,7 @@
                 flags = ""
         - Cascadelake-Server:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "avx512_vnni clflushopt ibrs ibpb pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Cascadelake%s\)"
             RHEL.6:
@@ -315,12 +331,14 @@
                 flags = ""
         - Cascadelake-Server-v1:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "avx512_vnni clflushopt ibrs ibpb pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Cascadelake%s\)"
             RHEL.6:
                 flags = ""
         - Cascadelake-Server-v2:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             # support "arch-capabilities", "rdctl-no", "ibrs-all", "skip-l1dfl-vmentry", "mds-no"
             flags = "avx512_vnni clflushopt ibrs ibpb pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Cascadelake%s\)"
@@ -351,6 +369,7 @@
                 flags = ""
         - Skylake-Server:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Skylake%s\)"
         - Skylake-Server-noTSX:
@@ -361,10 +380,12 @@
             no_flags = "hle rtm"
         - Skylake-Server-v1:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Skylake%s\)"
         - Skylake-Server-v2:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "pdpe1gb clwb avx512f avx512dq avx512bw avx512cd avx512vl"
             model_pattern = "Intel Xeon Processor \(Skylake, IBRS%s\)"
             no_flags = "clflushopt"
@@ -387,6 +408,7 @@
             no_flags = "hle rtm"
         - Skylake-Client:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "xsavec xgetbv1"
             model_pattern = "Intel Core Processor \(Skylake%s\)"
         - Skylake-Client-noTSX:
@@ -397,10 +419,12 @@
             no_flags = "hle rtm"
         - Skylake-Client-v1:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             flags = "xsavec xgetbv1"
             model_pattern = "Intel Core Processor \(Skylake%s\)"
         - Skylake-Client-v2:
             only HostCpuVendor.intel
+            optional_features = "hle rtm"
             # support "spec-ctrl"
             flags = "xsavec xgetbv1"
             model_pattern = "Intel Core Processor \(Skylake, IBRS%s\)"

--- a/qemu/tests/x86_cpu_model.py
+++ b/qemu/tests/x86_cpu_model.py
@@ -94,14 +94,18 @@ def run(test, params, env):
             check_items = params.get("check_items").split()
             expect_result = params.get("expect_result")
             for item in vulnerabilities:
-                h_out = re.search(
-                    "Vulnerable|Mitigation|Not affected",
-                    process.getoutput(check_cmd % item),
-                )[0]
-                g_out = re.search(
-                    "Vulnerable|Mitigation|Not affected",
-                    session.cmd_output(check_cmd % item),
-                )[0]
+                h_raw = process.getoutput(check_cmd % item)
+                g_raw = session.cmd_output(check_cmd % item)
+                test.log.info("'%s': host='%s' guest='%s'", item, h_raw, g_raw)
+                h_match = re.search("Vulnerable|Mitigation|Not affected", h_raw)
+                g_match = re.search("Vulnerable|Mitigation|Not affected", g_raw)
+                if not h_match or not g_match:
+                    test.error(
+                        "Unrecognized vulnerability status for '%s':"
+                        " host='%s' guest='%s'" % (item, h_raw, g_raw)
+                    )
+                h_out = h_match[0]
+                g_out = g_match[0]
                 if h_out != g_out:
                     test.fail("Guest is not equal to Host with '%s'" % item)
                 if item in check_items and g_out != expect_result:

--- a/qemu/tests/x86_cpu_model.py
+++ b/qemu/tests/x86_cpu_model.py
@@ -50,6 +50,9 @@ def run(test, params, env):
         name_ib = " \\(with IBPB\\)"
 
     models = [x["name"] for x in out if not x["unavailable-features"]]
+    models_map = {x["name"]: x for x in out}
+    optional_features = params.get("optional_features", "").split()
+
     for x in out:
         if x["name"] in (model, "%s-IBRS" % model, "%s-IBPB" % model):
             if x["unavailable-features"]:
@@ -60,6 +63,30 @@ def run(test, params, env):
                 )
             else:
                 test.log.info("Model %s: all features available", x["name"])
+
+    def _try_model(name):
+        """Check if model can run, possibly with optional features disabled."""
+        if name not in models_map:
+            return None, []
+        unavailable = models_map[name].get("unavailable-features", [])
+        if not unavailable:
+            return name, []
+        unexpected = [f for f in unavailable if f not in optional_features]
+        if unexpected:
+            test.log.info(
+                "Model %s has unexpected unavailable features: %s",
+                name,
+                unexpected,
+            )
+            return None, unavailable
+        test.log.warning(
+            "Model %s: host missing optional features %s, disabling them for this run",
+            name,
+            unavailable,
+        )
+        return name, unavailable
+
+    disabled = []
     if model_ib in models:
         cpu_model = model_ib
         guest_model = model_pattern % name_ib
@@ -68,7 +95,21 @@ def run(test, params, env):
         cpu_model = model
         guest_model = model_pattern % ""
     else:
-        test.cancel("This host doesn't support cpu model %s" % model)
+        cpu_model, disabled = _try_model(model_ib)
+        if cpu_model:
+            guest_model = model_pattern % name_ib
+            flags += flag_ib
+        else:
+            cpu_model, disabled = _try_model(model)
+            if cpu_model:
+                guest_model = model_pattern % ""
+            else:
+                test.cancel("This host doesn't support cpu model %s" % model)
+
+    if disabled:
+        disable_flags = ",".join("-%s" % f for f in disabled)
+        params["cpu_model_flags"] += "," + disable_flags
+        flags = " ".join(f for f in flags.split() if f not in disabled)
 
     params["cpu_model"] = cpu_model  # pylint: disable=E0606
     params["start_vm"] = "yes"


### PR DESCRIPTION
## Summary
Three fixes for x86_cpu_model test on hosts where some CPU features
are disabled (e.g. TSX disabled due to TAA microcode mitigation,
erms/fsrm missing on some Milan steppings).

Commits 1 and 2 fix pre-existing bugs that were never hit because
affected models always cancelled before reaching the buggy code.
Commit 3 lets those models actually run by removing optional features
that are disabled on the host — which exposes the bugs fixed in 1
and 2. All three are bundled because 3 depends on 1 and 2 being
in place.

### Commits

1. **Add missing %s to SapphireRapids model_pattern**
   All other model_pattern values include a %s placeholder for the
   IBRS/IBPB suffix. SapphireRapids was the only model missing it,
   causing a crash when the formatting code runs.

2. **Fix crash on unrecognized vulnerability status**
   The vulnerability check does `re.search(...)[0]` without guarding
   against None. Newer vulnerability files like `gather_data_sampling`
   report "Unknown: Dependent on hypervisor status" inside a VM guest,
   which doesn't match the expected patterns. Report both host and
   guest status via `test.error()` instead of crashing.

3. **Handle hosts with optional features disabled**
   Instead of cancelling when a model has unavailable features, check
   if all unavailable features are in an `optional_features` list from
   the cfg. If so, disable those features on the QEMU command line
   and remove them from expected guest flags — running the test with
   the remaining model features instead of skipping it entirely.