### PR TITLE
Fix iozone completing before stress check in block_during_io test

### DIFF
--- a/qemu/tests/cfg/block_during_io.cfg
+++ b/qemu/tests/cfg/block_during_io.cfg
@@ -60,7 +60,7 @@
     variants:
         - iozone_stress:
             stress_name = iozone
-            iozone_cmd_opitons = "-azR -r 4k -n 512b -g 4G -M -i 0 -i 1 -I "
+            iozone_cmd_opitons = "-azR -r 4k -n 512b -g 4G -M -i 0 -i 1 -i 2 -i 3 -I "
             iozone_timeout = 7200
             Windows:
                 iozone_cmd_opitons += "-f %s:\testfile"


### PR DESCRIPTION
On Windows Server guests (Win2022), iozone completes in ~28 seconds with only `-i 0` (write) and `-i 1` (read) modes. The test sleeps for 30 seconds then checks if iozone is still alive — it's not — and ERRORs before the actual test action (system_reset/reboot/shutdown) is ever sent.

`  avocado.core.exceptions.TestError: The iozone stress is not alive after 30.
`

This only affects server editions where disk I/O is faster; client Windows (Win10/Win11) runs long enough.

**Fix:**

Add `-i 2` (re-read) and `-i 3` (random read) modes to the iozone parameters. This increases runtime from ~28s to ~72s without changing the nature of the test. The additional modes exercise the same disk under the same auto-mode sweep.

**Tests:**
  - [x] Manually timed iozone on Win2022: 28s with `-i 0 -i 1`, 72s with `-i 0 -i 1 -i 2 -i 3`
  - [x] Ran `block_during_io.iozone_stress.system_disk.send_qmp.with_system_reset.q35` on Win2022 — PASS (system_reset sent and VM rebooted successfully)

Resolves: VIRTWINKVM-2274